### PR TITLE
[SEQ353-ISS353] Trip registrations email triggers

### DIFF
--- a/app/api/admin/registrations/[id]/route.ts
+++ b/app/api/admin/registrations/[id]/route.ts
@@ -1,5 +1,8 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { sendEmail } from '@/lib/email/send'
+import { renderEmailTemplate } from '@/lib/email/templates/render'
+import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -20,9 +23,34 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     .from('trip_registrations')
     .update({ status })
     .eq('id', id)
-    .select()
+    .select('*, profile:profiles(id, first_name, contact_email), trip:trips(id, title, destination, start_date, end_date)')
     .single()
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
+
+  // Trigger email asynchronously
+  const regProfile = data.profile as any
+  const regTrip = data.trip as any
+  if (regProfile?.contact_email) {
+    renderEmailTemplate(
+      TripRegistrationEmail({
+        firstName: regProfile.first_name || 'Member',
+        tripTitle: regTrip.title,
+        destination: regTrip.destination,
+        startDate: regTrip.start_date,
+        endDate: regTrip.end_date,
+        status: status as 'approved' | 'denied',
+      })
+    ).then((html) => {
+      sendEmail({
+        to: regProfile.contact_email,
+        subject: `Trip Registration ${status === 'approved' ? 'Approved ✓' : 'Declined'}`,
+        html,
+        template: 'trip_registration_status',
+        meta: { registration_id: data.id, trip_id: data.trip_id, profile_id: data.profile_id },
+      }).catch(console.error)
+    }).catch(console.error)
+  }
+
   return Response.json(data)
 }

--- a/app/api/admin/trips/registrations/[id]/cancel/route.ts
+++ b/app/api/admin/trips/registrations/[id]/cancel/route.ts
@@ -1,5 +1,8 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { sendEmail } from '@/lib/email/send'
+import { renderEmailTemplate } from '@/lib/email/templates/render'
+import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
 
 export async function POST(_req: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
   const { userId } = await auth()
@@ -31,9 +34,34 @@ export async function POST(_req: Request, { params }: { params: Promise<{ id: st
       cancelled_by: adminProfile.id,
     })
     .eq('id', registrationId)
-    .select()
+    .select('*, profile:profiles(id, first_name, contact_email), trip:trips(id, title, destination, start_date, end_date)')
     .single()
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
+
+  // Trigger email asynchronously
+  const regProfile = data.profile as any
+  const regTrip = data.trip as any
+  if (regProfile?.contact_email) {
+    renderEmailTemplate(
+      TripRegistrationEmail({
+        firstName: regProfile.first_name || 'Member',
+        tripTitle: regTrip.title,
+        destination: regTrip.destination,
+        startDate: regTrip.start_date,
+        endDate: regTrip.end_date,
+        status: 'cancelled',
+      })
+    ).then((html) => {
+      sendEmail({
+        to: regProfile.contact_email,
+        subject: `Trip Registration Cancelled`,
+        html,
+        template: 'trip_registration_status',
+        meta: { registration_id: data.id, trip_id: data.trip_id, profile_id: data.profile_id },
+      }).catch(console.error)
+    }).catch(console.error)
+  }
+
   return Response.json(data)
 }

--- a/lib/email/templates/TripRegistrationEmail.tsx
+++ b/lib/email/templates/TripRegistrationEmail.tsx
@@ -2,17 +2,19 @@ import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'
 
-type Status = 'pending' | 'approved' | 'denied'
+type Status = 'pending' | 'approved' | 'denied' | 'cancelled'
 
 const STATUS_LABEL: Record<Status, string> = {
   pending:  'Pending approval',
   approved: 'Approved ✓',
   denied:   'Declined',
+  cancelled: 'Cancelled',
 }
 const STATUS_COLOR: Record<Status, string> = {
   pending:  '#7a5c00',
   approved: '#1a3c2e',
   denied:   '#bc4749',
+  cancelled: '#6b7280',
 }
 
 export type TripRegistrationEmailProps = {


### PR DESCRIPTION
## Summary
Wires the email infrastructure into the trip registrations admin endpoints.

## What's included
- **SEQ353**: 
  - Triggers the `trip_registration_status` template via `sendEmail()` in `PATCH /api/admin/registrations/[id]`.
  - Triggers the same template in `POST /api/admin/trips/registrations/[id]/cancel` for the "cancelled" status.
  - Adds the `cancelled` status to `TripRegistrationEmail` layout variations.
- Includes `profile.contact_email` via joined Postgrest `select()` parameter.

## Testing
- `npx tsc --noEmit` passes.
- Ensures DB writes are completely independent of email dispatch to prevent blocking.