### PR TITLE
[SEQ354-ISS354] Payment email triggers

### DIFF
--- a/app/api/admin/payments/[id]/route.ts
+++ b/app/api/admin/payments/[id]/route.ts
@@ -24,9 +24,45 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     .from('payments')
     .update({ admin_status, admin_note: admin_note ?? null })
     .eq('id', id)
-    .select()
+    .select('*, profile:profiles(first_name, contact_email), trips(title), payable_items(title)')
     .single()
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
+
+  // Trigger email asynchronously
+  const paymentProfile = data.profile as any
+  const tripsData = data.trips as any
+  const itemsData = data.payable_items as any
+  const itemTitle = tripsData?.title || itemsData?.title || 'Unknown Item'
+  const emailStatus = admin_status === 'rejected' ? 'denied' : 'approved'
+
+  if (paymentProfile?.contact_email) {
+    import('@/lib/email/send').then(({ sendEmail }) => {
+      import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
+        import('@/lib/email/templates/PaymentStatusEmail').then(({ PaymentStatusEmail }) => {
+          renderEmailTemplate(
+            PaymentStatusEmail({
+              firstName: paymentProfile.first_name || 'Member',
+              amount: data.amount,
+              currency: data.currency,
+              transactionDate: data.transaction_date,
+              adminStatus: emailStatus,
+              itemTitle,
+              adminNote: admin_note,
+            })
+          ).then(html => {
+            sendEmail({
+              to: paymentProfile.contact_email,
+              subject: `Payment ${emailStatus === 'approved' ? 'Approved ✓' : 'Declined'}`,
+              html,
+              template: 'payment_status',
+              meta: { payment_id: data.id, profile_id: data.profile_id },
+            }).catch(console.error)
+          }).catch(console.error)
+        }).catch(console.error)
+      }).catch(console.error)
+    }).catch(console.error)
+  }
+
   return Response.json(data)
 }

--- a/app/api/profile/payments/route.ts
+++ b/app/api/profile/payments/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: Request): Promise<Response> {
   const supabase = createServiceClient()
 
   const { data: profile } = await supabase
-    .from('profiles').select('id, role').eq('clerk_id', userId).single()
+    .from('profiles').select('id, role, first_name').eq('clerk_id', userId).single()
   if (!profile?.id) return Response.json({ error: 'Profile not found' }, { status: 404 })
   if (profile.role === 'guest') return Response.json({ error: 'Forbidden' }, { status: 403 })
 
@@ -85,9 +85,44 @@ export async function POST(req: Request): Promise<Response> {
       member_status:    'approved',
       admin_status:     'pending',
     })
-    .select()
+    .select('*, trips(title), payable_items(title)')
     .single()
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
+
+  // Trigger admin alert asynchronously
+  const tripsData = data.trips as any
+  const itemsData = data.payable_items as any
+  const itemTitle = tripsData?.title || itemsData?.title || 'Unknown Item'
+
+  import('@/lib/email/send').then(({ sendEmail, getEmailConfig }) => {
+    getEmailConfig().then(config => {
+      if (!config.alert_recipient) return
+
+      import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
+        import('@/lib/email/templates/PaymentSubmittedEmail').then(({ PaymentSubmittedEmail }) => {
+          renderEmailTemplate(
+            PaymentSubmittedEmail({
+              memberName: profile.first_name || 'Member',
+              amount: data.amount,
+              currency: data.currency,
+              transactionDate: data.transaction_date,
+              itemTitle,
+              paymentMethod: data.payment_method,
+            })
+          ).then(html => {
+            sendEmail({
+              to: config.alert_recipient,
+              subject: `New Payment Logged by ${profile.first_name || 'Member'}`,
+              html,
+              template: 'payment_status',
+              meta: { payment_id: data.id, profile_id: profile.id },
+            }).catch(console.error)
+          }).catch(console.error)
+        }).catch(console.error)
+      }).catch(console.error)
+    }).catch(console.error)
+  }).catch(console.error)
+
   return Response.json(data, { status: 201 })
 }

--- a/lib/email/send.ts
+++ b/lib/email/send.ts
@@ -21,7 +21,7 @@ export type EmailConfig = {
   alert_recipient: string
 }
 
-async function getEmailConfig(): Promise<EmailConfig> {
+export async function getEmailConfig(): Promise<EmailConfig> {
   const now = Date.now()
   if (_configCache && now - _configFetchedAt < CONFIG_TTL_MS) return _configCache
 

--- a/lib/email/templates/PaymentSubmittedEmail.tsx
+++ b/lib/email/templates/PaymentSubmittedEmail.tsx
@@ -1,0 +1,58 @@
+import { Section, Text } from '@react-email/components'
+import * as React from 'react'
+import { EmailShell, bodyPadding } from './_shell'
+
+export type PaymentSubmittedEmailProps = {
+  memberName: string
+  amount: number
+  currency: string
+  transactionDate: string
+  itemTitle: string
+  paymentMethod: string | null
+}
+
+export function PaymentSubmittedEmail({
+  memberName,
+  amount,
+  currency,
+  transactionDate,
+  itemTitle,
+  paymentMethod,
+}: PaymentSubmittedEmailProps) {
+  const formatted = new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(amount)
+
+  return (
+    <EmailShell
+      preview={`New payment logged by ${memberName}`}
+      title="New Payment Logged"
+    >
+      <Section style={{ ...bodyPadding }}>
+        <Text style={{ margin: '0 0 16px', fontSize: 15, color: '#111827' }}>
+          Hello Admin,
+        </Text>
+        <Text style={{ margin: '0 0 20px', fontSize: 15, color: '#374151' }}>
+          <strong>{memberName}</strong> has logged a new payment of <strong>{formatted}</strong> for <strong>{itemTitle}</strong>.
+        </Text>
+        <Section
+          style={{
+            backgroundColor: `#f3f4f6`,
+            border: `1px solid #e5e7eb`,
+            borderRadius: 8,
+            padding: '12px 16px',
+            marginBottom: 20,
+          }}
+        >
+          <Text style={{ margin: '0 0 8px', fontSize: 14 }}>
+            <strong>Date:</strong> {transactionDate}
+          </Text>
+          <Text style={{ margin: '0 0 8px', fontSize: 14 }}>
+            <strong>Method:</strong> {paymentMethod || 'Not specified'}
+          </Text>
+        </Section>
+        <Text style={{ margin: 0, fontSize: 14, color: '#6b7280' }}>
+          Please review this payment in the admin portal to approve or reject it.
+        </Text>
+      </Section>
+    </EmailShell>
+  )
+}


### PR DESCRIPTION
## Summary
Implements email triggers for the payments domain (SEQ354).

## What's included
- Fired `PaymentStatusEmail` to `profile.contact_email` when payment status is updated to approved or rejected by an admin (`PATCH /api/admin/payments/[id]/route.ts`).
- Created a new `PaymentSubmittedEmail` template for admin notifications.
- Fired `PaymentSubmittedEmail` (admin notification) to the email config's `alert_recipient` when a member logs a new payment (`POST /api/profile/payments/route.ts`).
- Exported `getEmailConfig` in `lib/email/send.ts`.

## Testing
- `npx tsc --noEmit` checks pass.
- Verified asynchronous fire-and-forget dispatch.