### PR TITLE
feat: Add email triggers for Verification & Role Requests (SEQ355, SEQ356)

### DIFF
--- a/app/api/admin/event-role-requests/[id]/route.ts
+++ b/app/api/admin/event-role-requests/[id]/route.ts
@@ -23,8 +23,39 @@ export async function PATCH(
     .from('event_role_requests')
     .update({ status })
     .eq('id', id)
-    .select()
+    .select('id, role_label, profile_id, profile:profiles!profile_id(first_name, contact_email), event:calendar_events!event_id(title, start_time)')
     .single()
+
+  if (!error && data?.profile) {
+    const profileData = data.profile as any
+    const eventData = data.event as any
+
+    if (profileData.contact_email) {
+      import('@/lib/email/send').then(({ sendEmail }) => {
+        import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
+          import('@/lib/email/templates/EventRoleRequestEmail').then(({ EventRoleRequestEmail }) => {
+            renderEmailTemplate(
+              EventRoleRequestEmail({
+                firstName: profileData.first_name || 'Member',
+                eventTitle: eventData?.title || 'Event',
+                eventDate: eventData?.start_time ? new Date(eventData.start_time).toLocaleDateString() : 'TBD',
+                roleLabel: data.role_label,
+                status: status as 'approved' | 'denied',
+              })
+            ).then(html => {
+              sendEmail({
+                to: profileData.contact_email,
+                subject: `Event Role Request ${status === 'approved' ? 'Approved ✓' : 'Declined'}`,
+                html,
+                template: 'event_role_request_result',
+                meta: { request_id: data.id, profile_id: data.profile_id },
+              }).catch(console.error)
+            }).catch(console.error)
+          }).catch(console.error)
+        }).catch(console.error)
+      }).catch(console.error)
+    }
+  }
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
   return Response.json(data)

--- a/app/api/admin/members/verify/[id]/route.ts
+++ b/app/api/admin/members/verify/[id]/route.ts
@@ -22,7 +22,7 @@ export async function PATCH(
   // Fetch the request — needed for Clerk sync and notification copy after approval
   const { data: verReq } = await supabase
     .from('abo_verification_requests')
-    .select('*')
+    .select('*, profile:profiles(id, role, first_name, contact_email)')
     .eq('id', id)
     .single()
 
@@ -61,9 +61,7 @@ export async function PATCH(
     }
 
     // Notify the user. Best-effort: failure here does not affect approval state.
-    const { data: profile } = await supabase
-      .from('profiles').select('first_name').eq('id', verReq.profile_id).single()
-
+    const profile = verReq.profile as any
     const notifMessage = verReq.request_type === 'manual'
       ? `Welcome ${profile?.first_name ?? ''}! Your manual verification has been approved. You are now a Member.`
       : `Welcome ${profile?.first_name ?? ''}! Your ABO number ${verReq.claimed_abo} has been verified. You are now a Member.`
@@ -75,6 +73,46 @@ export async function PATCH(
       message: notifMessage,
       action_url: '/profile',
     })
+
+    if (profile?.contact_email) {
+      import('@/lib/email/send').then(({ sendEmail }) => {
+        import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
+          import('@/lib/email/templates/AboVerificationEmail').then(({ AboVerificationEmail }) => {
+            renderEmailTemplate(
+              AboVerificationEmail({
+                firstName: profile.first_name || 'Member',
+                claimedAbo: verReq.claimed_abo,
+                status: 'approved',
+                adminNote: admin_note,
+              })
+            ).then(html => {
+              sendEmail({
+                to: profile.contact_email,
+                subject: `ABO Verification Approved ✓`,
+                html,
+                template: 'abo_verification_result',
+                meta: { request_id: id, profile_id: verReq.profile_id },
+              }).catch(console.error)
+            }).catch(console.error)
+          }).catch(console.error)
+
+          if (profile.role === 'guest') {
+            import('@/lib/email/templates/WelcomeEmail').then(({ WelcomeEmail }) => {
+              renderEmailTemplate(WelcomeEmail({ firstName: profile.first_name || 'Member' }))
+                .then(html => {
+                  sendEmail({
+                    to: profile.contact_email,
+                    subject: 'Welcome to Team Enjoy VD!',
+                    html,
+                    template: 'abo_verification_result',
+                    meta: { request_id: id, profile_id: verReq.profile_id },
+                  }).catch(console.error)
+                }).catch(console.error)
+            }).catch(console.error)
+          }
+        }).catch(console.error)
+      }).catch(console.error)
+    }
 
     // Read back the resolved request for the response
     const { data, error } = await supabase
@@ -103,6 +141,32 @@ export async function PATCH(
       .update({ status: 'denied', resolved_at: new Date().toISOString(), admin_note: admin_note ?? null })
       .eq('id', id)
       .select().single()
+
+    const profile = verReq.profile as any
+    if (!error && profile?.contact_email) {
+      import('@/lib/email/send').then(({ sendEmail }) => {
+        import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
+          import('@/lib/email/templates/AboVerificationEmail').then(({ AboVerificationEmail }) => {
+            renderEmailTemplate(
+              AboVerificationEmail({
+                firstName: profile.first_name || 'Member',
+                claimedAbo: verReq.claimed_abo,
+                status: 'denied',
+                adminNote: admin_note,
+              })
+            ).then(html => {
+              sendEmail({
+                to: profile.contact_email,
+                subject: `ABO Verification Declined`,
+                html,
+                template: 'abo_verification_result',
+                meta: { request_id: id, profile_id: verReq.profile_id },
+              }).catch(console.error)
+            }).catch(console.error)
+          }).catch(console.error)
+        }).catch(console.error)
+      }).catch(console.error)
+    }
 
     if (error) return Response.json({ error: error.message }, { status: 500 })
     return Response.json(data)

--- a/app/api/admin/verify/route.ts
+++ b/app/api/admin/verify/route.ts
@@ -18,6 +18,13 @@ export async function POST(req: Request) {
     return Response.json({ error: 'profile_id and upline_abo_number are required' }, { status: 400 })
   }
 
+  // Fetch target profile first to know its current role and contact info
+  const { data: targetProfile } = await supabase
+    .from('profiles')
+    .select('role, first_name, contact_email')
+    .eq('id', profile_id)
+    .single()
+
   // Promote to member and store upline
   const { error: profileErr } = await supabase
     .from('profiles')
@@ -30,7 +37,7 @@ export async function POST(req: Request) {
   await supabase.from('role_change_audit').insert({
     profile_id,
     changed_by: userId,
-    old_role: 'guest',
+    old_role: targetProfile?.role || 'guest',
     new_role: 'member',
     note: 'direct verify (Path C)',
   })
@@ -69,6 +76,46 @@ export async function POST(req: Request) {
       { onConflict: 'profile_id' }
     )
     .select().single()
+
+  if (!reqErr && targetProfile?.contact_email) {
+    import('@/lib/email/send').then(({ sendEmail }) => {
+      import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
+        import('@/lib/email/templates/AboVerificationEmail').then(({ AboVerificationEmail }) => {
+          renderEmailTemplate(
+            AboVerificationEmail({
+              firstName: targetProfile.first_name || 'Member',
+              claimedAbo: null,
+              status: 'approved',
+              adminNote: 'Direct verification by admin',
+            })
+          ).then(html => {
+            sendEmail({
+              to: targetProfile.contact_email!,
+              subject: `ABO Verification Approved ✓`,
+              html,
+              template: 'abo_verification_result',
+              meta: { profile_id },
+            }).catch(console.error)
+          }).catch(console.error)
+        }).catch(console.error)
+
+        if (targetProfile.role === 'guest') {
+          import('@/lib/email/templates/WelcomeEmail').then(({ WelcomeEmail }) => {
+            renderEmailTemplate(WelcomeEmail({ firstName: targetProfile.first_name || 'Member' }))
+              .then(html => {
+                sendEmail({
+                  to: targetProfile.contact_email!,
+                  subject: 'Welcome to Team Enjoy VD!',
+                  html,
+                  template: 'abo_verification_result',
+                  meta: { profile_id },
+                }).catch(console.error)
+              }).catch(console.error)
+          }).catch(console.error)
+        }
+      }).catch(console.error)
+    }).catch(console.error)
+  }
 
   if (reqErr) return Response.json({ error: reqErr.message }, { status: 500 })
   return Response.json(data, { status: 201 })

--- a/lib/email/templates/WelcomeEmail.tsx
+++ b/lib/email/templates/WelcomeEmail.tsx
@@ -1,0 +1,54 @@
+import { Section, Text, Button } from '@react-email/components'
+import * as React from 'react'
+import { EmailShell, bodyPadding } from './_shell'
+
+export type WelcomeEmailProps = {
+  firstName: string
+}
+
+export function WelcomeEmail({ firstName }: WelcomeEmailProps) {
+  return (
+    <EmailShell
+      preview="Welcome to Team Enjoy VD!"
+      title="Welcome to the Portal 👋"
+    >
+      <Section style={{ ...bodyPadding }}>
+        <Text style={{ margin: '0 0 16px', fontSize: 15, color: '#111827' }}>
+          Welcome, {firstName}!
+        </Text>
+        <Text style={{ margin: '0 0 16px', fontSize: 15, color: '#374151' }}>
+          Your account has been officially verified. You are now a full member of Team Enjoy VD.
+        </Text>
+        <Text style={{ margin: '0 0 16px', fontSize: 15, color: '#374151' }}>
+          As a member, you now have access to:
+        </Text>
+        <ul style={{ margin: '0 0 20px', paddingLeft: 20, color: '#374151', fontSize: 15 }}>
+          <li style={{ marginBottom: 8 }}><strong>Trips & Events</strong> – Register for upcoming trips and view the event calendar.</li>
+          <li style={{ marginBottom: 8 }}><strong>Payments</strong> – Manage and log your payments securely.</li>
+          <li style={{ marginBottom: 8 }}><strong>Resources</strong> – Access exclusive member resources and documents.</li>
+        </ul>
+        
+        <Section style={{ textAlign: 'center', marginTop: 32, marginBottom: 32 }}>
+          <Button
+            href="https://tevd.app/profile"
+            style={{
+              backgroundColor: '#1E40AF',
+              color: '#ffffff',
+              padding: '12px 24px',
+              borderRadius: 6,
+              fontWeight: 600,
+              textDecoration: 'none',
+              display: 'inline-block',
+            }}
+          >
+            Go to Your Profile
+          </Button>
+        </Section>
+        
+        <Text style={{ margin: 0, fontSize: 14, color: '#6b7280' }}>
+          We are thrilled to have you with us. If you have any questions, reach out to an administrator.
+        </Text>
+      </Section>
+    </EmailShell>
+  )
+}


### PR DESCRIPTION
Fixes #355
Fixes #356

This PR finalizes automated email triggers for:
- ABO Verification workflows (Approval/Denial)
- Welcome Emails for initial member promotions
- Event Role Requests (Approval/Denial)

As per requirements, all email dispatching is asynchronous and handles its own background resolution.

I also fixed the missing profile field access for event role requests response.