### PR TITLE
[SEQ360-ISS360] Fix TripDocumentsTile silent null on error/forbidden

### DIFF
--- a/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
@@ -34,7 +34,7 @@ function ImageIcon() {
 }
 
 export function TripDocumentsTile({ tripId }: { tripId: string }) {
-  const { data: attachments, isLoading } = useQuery<Attachment[]>({
+  const { data: attachments, isLoading, isError } = useQuery<Attachment[]>({
     queryKey: ['trip-attachments', tripId],
     queryFn: () =>
       fetch(`/api/trips/${tripId}/attachments`).then(async r => {
@@ -43,7 +43,30 @@ export function TripDocumentsTile({ tripId }: { tripId: string }) {
       }),
   })
 
-  if (isLoading || !attachments || attachments.length === 0) return null
+  if (isLoading) return null
+
+  if (isError) {
+    return (
+      <div
+        className="rounded-2xl overflow-hidden"
+        style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+      >
+        <div className="px-6 py-5">
+          <p
+            className="text-xs font-semibold tracking-widest uppercase mb-2"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            Trip Documents
+          </p>
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            Documents could not be loaded.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!attachments || attachments.length === 0) return null
 
   return (
     <div


### PR DESCRIPTION
## Problem
`TripDocumentsTile` returned `null` on both `isError` and empty array — identical render path. A 403 (non-approved member) or any network failure was silently swallowed, indistinguishable from "no documents uploaded."

RLS on `trip_attachments` is correct (both policies use Pattern A helpers). This was a pure frontend rendering bug.

## Fix
Split `isLoading` / `isError` / empty / populated into four distinct branches:

- `isLoading` → `null` (no flash)
- `isError` → renders the tile card with a muted "Documents could not be loaded." message
- `attachments.length === 0 && !isError` → `null` (correct — no documents exist)
- `attachments.length > 0` → full list (unchanged)

## Files changed
- `app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx`