### PR TITLE
[SEQ349-ISS349] Guest event registration: magic-link flow

### DIFF
--- a/app/api/admin/payments/[id]/route.ts
+++ b/app/api/admin/payments/[id]/route.ts
@@ -37,7 +37,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   const emailStatus = admin_status === 'rejected' ? 'denied' : 'approved'
 
   if (paymentProfile?.contact_email) {
-    import('@/lib/email/send').then(({ sendEmail }) => {
+    import('@/lib/email/send').then(({ sendNotificationEmail }) => {
       import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
         import('@/lib/email/templates/PaymentStatusEmail').then(({ PaymentStatusEmail }) => {
           renderEmailTemplate(
@@ -51,7 +51,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
               adminNote: admin_note,
             })
           ).then(html => {
-            sendEmail({
+            sendNotificationEmail({
               to: paymentProfile.contact_email,
               subject: `Payment ${emailStatus === 'approved' ? 'Approved ✓' : 'Declined'}`,
               html,

--- a/app/api/admin/registrations/[id]/route.ts
+++ b/app/api/admin/registrations/[id]/route.ts
@@ -1,6 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
-import { sendEmail } from '@/lib/email/send'
+import { sendNotificationEmail } from '@/lib/email/send'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
 
@@ -42,7 +42,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
         status: status as 'approved' | 'denied',
       })
     ).then((html) => {
-      sendEmail({
+      sendNotificationEmail({
         to: regProfile.contact_email,
         subject: `Trip Registration ${status === 'approved' ? 'Approved ✓' : 'Declined'}`,
         html,

--- a/app/api/admin/trips/registrations/[id]/cancel/route.ts
+++ b/app/api/admin/trips/registrations/[id]/cancel/route.ts
@@ -1,6 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
-import { sendEmail } from '@/lib/email/send'
+import { sendNotificationEmail } from '@/lib/email/send'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
 
@@ -53,7 +53,7 @@ export async function POST(_req: Request, { params }: { params: Promise<{ id: st
         status: 'cancelled',
       })
     ).then((html) => {
-      sendEmail({
+      sendNotificationEmail({
         to: regProfile.contact_email,
         subject: `Trip Registration Cancelled`,
         html,

--- a/app/api/profile/payments/route.ts
+++ b/app/api/profile/payments/route.ts
@@ -95,7 +95,7 @@ export async function POST(req: Request): Promise<Response> {
   const itemsData = data.payable_items as any
   const itemTitle = tripsData?.title || itemsData?.title || 'Unknown Item'
 
-  import('@/lib/email/send').then(({ sendEmail, getEmailConfig }) => {
+  import('@/lib/email/send').then(({ sendNotificationEmail, getEmailConfig }) => {
     getEmailConfig().then(config => {
       if (!config.alert_recipient) return
 
@@ -111,7 +111,7 @@ export async function POST(req: Request): Promise<Response> {
               paymentMethod: data.payment_method,
             })
           ).then(html => {
-            sendEmail({
+            sendNotificationEmail({
               to: config.alert_recipient,
               subject: `New Payment Logged by ${profile.first_name || 'Member'}`,
               html,

--- a/app/events/[eventId]/join/page.tsx
+++ b/app/events/[eventId]/join/page.tsx
@@ -1,0 +1,175 @@
+import Link from 'next/link'
+import { createServiceClient } from '@/lib/supabase/service'
+
+type Props = {
+  params:       Promise<{ eventId: string }>
+  searchParams: Promise<{ token?: string }>
+}
+
+// ── Sub-components (module-scoped — never defined inside render fn) ────────────
+
+function InvalidState({ eventId, reason }: { eventId: string; reason: 'missing' | 'invalid' | 'expired' }) {
+  const message = reason === 'expired' ? 'This link has expired.' : 'This link is invalid.'
+
+  return (
+    <>
+      {/* Desktop */}
+      <div
+        className="hidden md:flex min-h-screen items-center justify-center px-6"
+        style={{ backgroundColor: 'var(--bg-global, #f4f1eb)' }}
+      >
+        <div className="w-full max-w-sm text-center">
+          <p className="text-xs font-bold tracking-widest uppercase mb-6" style={{ color: '#bc4749' }}>
+            TeamEnjoyVD
+          </p>
+          <div
+            className="rounded-2xl border px-8 py-10"
+            style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+          >
+            <p className="font-semibold text-base mb-2" style={{ color: 'var(--text-primary)' }}>{message}</p>
+            <p className="text-sm mb-6" style={{ color: 'var(--text-secondary)' }}>
+              Please register again to receive a fresh access link.
+            </p>
+            <Link
+              href={`/events/${eventId}/register`}
+              className="inline-block w-full rounded-xl py-3.5 text-sm font-semibold text-white text-center hover:opacity-80 transition-opacity"
+              style={{ backgroundColor: '#1a3c2e' }}
+            >
+              Register again
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile */}
+      <div
+        className="md:hidden min-h-screen px-5 pt-12 pb-8"
+        style={{ backgroundColor: 'var(--bg-global, #f4f1eb)' }}
+      >
+        <p className="text-xs font-bold tracking-widest uppercase mb-8" style={{ color: '#bc4749' }}>
+          TeamEnjoyVD
+        </p>
+        <div
+          className="rounded-2xl border px-5 py-8 text-center"
+          style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+        >
+          <p className="font-semibold text-base mb-2" style={{ color: 'var(--text-primary)' }}>{message}</p>
+          <p className="text-sm mb-6" style={{ color: 'var(--text-secondary)' }}>
+            Please register again to receive a fresh access link.
+          </p>
+          <Link
+            href={`/events/${eventId}/register`}
+            className="block w-full rounded-xl py-3.5 text-sm font-semibold text-white text-center active:opacity-70"
+            style={{ backgroundColor: '#1a3c2e', minHeight: 44 }}
+          >
+            Register again
+          </Link>
+        </div>
+      </div>
+    </>
+  )
+}
+
+// ── Page ───────────────────────────────────────────────────────────────────────
+
+export default async function GuestJoinPage({ params, searchParams }: Props) {
+  const { eventId } = await params
+  const { token }   = await searchParams
+
+  if (!token) return <InvalidState eventId={eventId} reason="missing" />
+
+  const supabase = createServiceClient()
+
+  const { data: reg } = await supabase
+    .from('guest_registrations')
+    .select('id, name, event_id, expires_at, calendar_events(title, meeting_url)')
+    .eq('token', token)
+    .single()
+
+  if (!reg)                                  return <InvalidState eventId={eventId} reason="invalid" />
+  if (reg.event_id !== eventId)              return <InvalidState eventId={eventId} reason="invalid" />
+  if (new Date(reg.expires_at) < new Date()) return <InvalidState eventId={eventId} reason="expired" />
+
+  // Narrow joined relation — PostgREST returns object for to-one FK
+  const event = reg.calendar_events as unknown as { title: string; meeting_url: string | null } | null
+
+  return (
+    <>
+      {/* ── Desktop ─────────────────────────────────────────────────────────── */}
+      <div
+        className="hidden md:flex min-h-screen items-center justify-center px-6"
+        style={{ backgroundColor: 'var(--bg-global, #f4f1eb)' }}
+      >
+        <div className="w-full max-w-sm">
+          <p className="text-xs font-bold tracking-widest uppercase mb-6 text-center" style={{ color: '#bc4749' }}>
+            TeamEnjoyVD
+          </p>
+          <div
+            className="rounded-2xl border px-8 py-10"
+            style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+          >
+            <p className="text-sm mb-1" style={{ color: 'var(--text-secondary)' }}>You&apos;re joining</p>
+            <h1 className="font-display text-xl font-semibold mb-6" style={{ color: 'var(--text-primary)' }}>
+              {event?.title}
+            </h1>
+            <p className="text-sm mb-4" style={{ color: 'var(--text-secondary)' }}>
+              Hi {reg.name}, tap the button below to open the meeting.
+            </p>
+            {event?.meeting_url ? (
+              <a
+                href={event.meeting_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center w-full rounded-xl py-3.5 text-sm font-semibold text-white hover:opacity-80 transition-opacity"
+                style={{ backgroundColor: '#1a3c2e', minHeight: 44 }}
+              >
+                Join Meeting
+              </a>
+            ) : (
+              <p className="text-sm text-center" style={{ color: 'var(--text-secondary)' }}>
+                Meeting link not yet available. Check back closer to the event.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Mobile ──────────────────────────────────────────────────────────── */}
+      <div
+        className="md:hidden min-h-screen px-5 pt-12 pb-8"
+        style={{ backgroundColor: 'var(--bg-global, #f4f1eb)' }}
+      >
+        <p className="text-xs font-bold tracking-widest uppercase mb-8" style={{ color: '#bc4749' }}>
+          TeamEnjoyVD
+        </p>
+        <div
+          className="rounded-2xl border px-5 py-8"
+          style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+        >
+          <p className="text-sm mb-1" style={{ color: 'var(--text-secondary)' }}>You&apos;re joining</p>
+          <h1 className="font-display text-xl font-semibold mb-5" style={{ color: 'var(--text-primary)' }}>
+            {event?.title}
+          </h1>
+          <p className="text-sm mb-5" style={{ color: 'var(--text-secondary)' }}>
+            Hi {reg.name}, tap the button below to open the meeting.
+          </p>
+          {event?.meeting_url ? (
+            <a
+              href={event.meeting_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center w-full rounded-xl py-3.5 text-sm font-semibold text-white active:opacity-70"
+              style={{ backgroundColor: '#1a3c2e', minHeight: 44 }}
+            >
+              Join Meeting
+            </a>
+          ) : (
+            <p className="text-sm text-center" style={{ color: 'var(--text-secondary)' }}>
+              Meeting link not yet available. Check back closer to the event.
+            </p>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/events/[eventId]/register/components/RegisterForm.tsx
+++ b/app/events/[eventId]/register/components/RegisterForm.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useActionState } from 'react'
+import { registerGuest } from '@/lib/actions/guest-registration'
+import type { RegisterGuestState } from '@/lib/actions/guest-registration'
+
+const initialState: RegisterGuestState = { success: false }
+
+export function RegisterForm({ eventId, eventTitle }: { eventId: string; eventTitle: string }) {
+  const [state, formAction, isPending] = useActionState(registerGuest, initialState)
+
+  if (state.success) {
+    return (
+      <div
+        className="rounded-2xl border px-6 py-8 text-center"
+        style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+      >
+        <div
+          className="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-4"
+          style={{ backgroundColor: 'rgba(26,60,46,0.12)' }}
+        >
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#1a3c2e" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+        <p className="font-semibold text-base mb-1" style={{ color: 'var(--text-primary)' }}>
+          Check your inbox
+        </p>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+          We&apos;ve sent your access link. The link expires in 72 hours.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <input type="hidden" name="eventId" value={eventId} />
+
+      <div>
+        <label
+          htmlFor="name"
+          className="block text-xs font-semibold tracking-widest uppercase mb-1.5"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          Full Name
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          required
+          minLength={2}
+          maxLength={100}
+          autoComplete="name"
+          placeholder="Your name"
+          className="w-full rounded-xl border px-4 py-3 text-sm outline-none transition-colors"
+          style={{
+            backgroundColor: 'var(--bg-card)',
+            borderColor: 'var(--border-default)',
+            color: 'var(--text-primary)',
+          }}
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="email"
+          className="block text-xs font-semibold tracking-widest uppercase mb-1.5"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          Email Address
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          autoComplete="email"
+          placeholder="you@example.com"
+          className="w-full rounded-xl border px-4 py-3 text-sm outline-none transition-colors"
+          style={{
+            backgroundColor: 'var(--bg-card)',
+            borderColor: 'var(--border-default)',
+            color: 'var(--text-primary)',
+          }}
+        />
+      </div>
+
+      {state.error && (
+        <p className="text-sm" style={{ color: '#bc4749' }}>
+          {state.error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isPending}
+        className="w-full rounded-xl py-3.5 text-sm font-semibold text-white disabled:opacity-60 transition-opacity"
+        style={{ backgroundColor: '#1a3c2e', minHeight: 44 }}
+      >
+        {isPending ? 'Sending link…' : 'Get access link'}
+      </button>
+
+      <p className="text-xs text-center" style={{ color: 'var(--text-secondary)' }}>
+        We&apos;ll email you a personal link to join <strong>{eventTitle}</strong>.
+        No account needed.
+      </p>
+    </form>
+  )
+}

--- a/app/events/[eventId]/register/page.tsx
+++ b/app/events/[eventId]/register/page.tsx
@@ -1,0 +1,78 @@
+import { notFound } from 'next/navigation'
+import { createServiceClient } from '@/lib/supabase/service'
+import { RegisterForm } from './components/RegisterForm'
+
+type Props = { params: Promise<{ eventId: string }> }
+
+export default async function GuestRegisterPage({ params }: Props) {
+  const { eventId } = await params
+  const supabase = createServiceClient()
+
+  const { data: event } = await supabase
+    .from('calendar_events')
+    .select('id, title, start_time, allow_guest_registration')
+    .eq('id', eventId)
+    .single()
+
+  if (!event || !event.allow_guest_registration) notFound()
+
+  const dateLabel = new Date(event.start_time).toLocaleDateString('en-GB', {
+    weekday: 'long', day: 'numeric', month: 'long', year: 'numeric',
+  })
+
+  return (
+    <>
+      {/* ── Desktop ────────────────────────────────────────────────────────── */}
+      <div
+        className="hidden md:flex min-h-screen items-center justify-center px-6"
+        style={{ backgroundColor: 'var(--bg-global, #f4f1eb)' }}
+      >
+        <div className="w-full max-w-md">
+          <div className="mb-8 text-center">
+            <p className="text-xs font-bold tracking-widest uppercase mb-3" style={{ color: '#bc4749' }}>
+              TeamEnjoyVD
+            </p>
+            <h1 className="font-display text-2xl font-semibold mb-1" style={{ color: 'var(--text-primary)' }}>
+              {event.title}
+            </h1>
+            <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{dateLabel}</p>
+          </div>
+          <div
+            className="rounded-2xl border p-8"
+            style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+          >
+            <p className="text-sm font-semibold mb-5" style={{ color: 'var(--text-primary)' }}>
+              Register to get your access link
+            </p>
+            <RegisterForm eventId={event.id} eventTitle={event.title} />
+          </div>
+        </div>
+      </div>
+
+      {/* ── Mobile ─────────────────────────────────────────────────────────── */}
+      <div
+        className="md:hidden min-h-screen px-5 pt-12 pb-8"
+        style={{ backgroundColor: 'var(--bg-global, #f4f1eb)' }}
+      >
+        <div className="mb-8">
+          <p className="text-xs font-bold tracking-widest uppercase mb-3" style={{ color: '#bc4749' }}>
+            TeamEnjoyVD
+          </p>
+          <h1 className="font-display text-xl font-semibold mb-1" style={{ color: 'var(--text-primary)' }}>
+            {event.title}
+          </h1>
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{dateLabel}</p>
+        </div>
+        <div
+          className="rounded-2xl border p-5"
+          style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+        >
+          <p className="text-sm font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>
+            Register to get your access link
+          </p>
+          <RegisterForm eventId={event.id} eventTitle={event.title} />
+        </div>
+      </div>
+    </>
+  )
+}

--- a/lib/actions/guest-registration.ts
+++ b/lib/actions/guest-registration.ts
@@ -1,0 +1,86 @@
+'use server'
+
+import { z } from 'zod'
+import { randomBytes } from 'crypto'
+import { headers } from 'next/headers'
+import * as React from 'react'
+import { createServiceClient } from '@/lib/supabase/service'
+import { sendEmail } from '@/lib/email/send'
+import { renderEmailTemplate } from '@/lib/email/templates/render'
+import { GuestEventMagicLinkEmail } from '@/lib/email/templates/GuestEventMagicLinkEmail'
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+export type RegisterGuestState = { success: boolean; error?: string }
+
+// ── Schema ─────────────────────────────────────────────────────────────────────
+
+const schema = z.object({
+  name:    z.string().min(2).max(100).trim(),
+  email:   z.string().email(),
+  eventId: z.string().uuid(),
+})
+
+// ── Action ─────────────────────────────────────────────────────────────────────
+
+export async function registerGuest(
+  _prev: RegisterGuestState,
+  formData: FormData,
+): Promise<RegisterGuestState> {
+  const parsed = schema.safeParse({
+    name:    formData.get('name'),
+    email:   formData.get('email'),
+    eventId: formData.get('eventId'),
+  })
+
+  if (!parsed.success) {
+    return { success: false, error: 'Please enter a valid name and email address.' }
+  }
+
+  const { name, email, eventId } = parsed.data
+  const supabase = createServiceClient()
+
+  // Verify event exists and has guest registration enabled
+  const { data: event, error: eventError } = await supabase
+    .from('calendar_events')
+    .select('id, title, allow_guest_registration')
+    .eq('id', eventId)
+    .single()
+
+  if (eventError || !event)            return { success: false, error: 'Event not found.' }
+  if (!event.allow_guest_registration) return { success: false, error: 'Registration is not available for this event.' }
+
+  // Generate token and expiry
+  const token     = randomBytes(32).toString('hex')
+  const expiresAt = new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString()
+
+  const { error: insertError } = await supabase
+    .from('guest_registrations')
+    .insert({ event_id: eventId, email, name, token, expires_at: expiresAt })
+
+  if (insertError) return { success: false, error: 'Registration failed. Please try again.' }
+
+  // Build magic link from request host
+  const reqHeaders = await headers()
+  const host       = reqHeaders.get('host') ?? 'tevd-portal.vercel.app'
+  const protocol   = host.startsWith('localhost') ? 'http' : 'https'
+  const magicLink  = `${protocol}://${host}/events/${eventId}/join?token=${token}`
+
+  const html = await renderEmailTemplate(
+    React.createElement(GuestEventMagicLinkEmail, {
+      name,
+      eventTitle:   event.title,
+      magicLinkUrl: magicLink,
+    }),
+  )
+
+  await sendEmail({
+    to:       email,
+    subject:  `Your link to join: ${event.title}`,
+    html,
+    template: 'guest_event_magic_link',
+    meta:     { eventId, name },
+  })
+
+  return { success: true }
+}

--- a/lib/actions/guest-registration.ts
+++ b/lib/actions/guest-registration.ts
@@ -5,15 +5,15 @@ import { randomBytes } from 'crypto'
 import { headers } from 'next/headers'
 import * as React from 'react'
 import { createServiceClient } from '@/lib/supabase/service'
-import { sendEmail } from '@/lib/email/send'
+import { sendTransactionalEmail } from '@/lib/email/send'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { GuestEventMagicLinkEmail } from '@/lib/email/templates/GuestEventMagicLinkEmail'
 
-// ── Types ──────────────────────────────────────────────────────────────────────
+// -- Types --------------------------------------------------------------------
 
 export type RegisterGuestState = { success: boolean; error?: string }
 
-// ── Schema ─────────────────────────────────────────────────────────────────────
+// -- Schema -------------------------------------------------------------------
 
 const schema = z.object({
   name:    z.string().min(2).max(100).trim(),
@@ -21,7 +21,7 @@ const schema = z.object({
   eventId: z.string().uuid(),
 })
 
-// ── Action ─────────────────────────────────────────────────────────────────────
+// -- Action -------------------------------------------------------------------
 
 export async function registerGuest(
   _prev: RegisterGuestState,
@@ -74,13 +74,15 @@ export async function registerGuest(
     }),
   )
 
-  await sendEmail({
+  const result = await sendTransactionalEmail({
     to:       email,
     subject:  `Your link to join: ${event.title}`,
     html,
     template: 'guest_event_magic_link',
     meta:     { eventId, name },
   })
+
+  if (!result.sent) return { success: false, error: 'Could not send access link. Please try again.' }
 
   return { success: true }
 }

--- a/lib/email/send.ts
+++ b/lib/email/send.ts
@@ -1,7 +1,7 @@
 import { Resend } from 'resend'
 import { createServiceClient } from '@/lib/supabase/service'
 
-// ── Lazy-init Resend client ───────────────────────────────────────────────────
+// -- Lazy-init Resend client --------------------------------------------------
 // Not constructed at module load so missing key in dev doesn't crash boot.
 let _resend: Resend | null = null
 function getResend(): Resend {
@@ -9,7 +9,7 @@ function getResend(): Resend {
   return _resend
 }
 
-// ── Settings cache ────────────────────────────────────────────────────────────
+// -- Settings cache -----------------------------------------------------------
 // The email_config row is fetched once per cold start; re-fetched if stale.
 let _configCache: EmailConfig | null = null
 let _configFetchedAt = 0
@@ -37,51 +37,45 @@ export async function getEmailConfig(): Promise<EmailConfig> {
   return _configCache
 }
 
-// ── Public API ─────────────────────────────────────────────────────────────────
+// -- Shared payload type ------------------------------------------------------
 
 export type SendEmailPayload = {
   /** Resend "from" address. Defaults to the team noreply. */
   from?: string
   to: string
   subject: string
-  /** Pre-rendered HTML string — use renderEmailTemplate() from templates/render.ts */
+  /** Pre-rendered HTML string -- use renderEmailTemplate() from templates/render.ts */
   html: string
   /** Template key used for log + admin toggle check e.g. 'trip_registration_status' */
   template: string
-  /** Any serialisable metadata to store in email_log.payload (profile IDs, amounts…) */
+  /** Any serialisable metadata to store in email_log.payload (profile IDs, amounts...) */
   meta?: Record<string, unknown>
 }
 
-/**
- * Resilient email dispatcher.
- *
- * - Never throws — all errors are caught and written to email_log.
- * - Respects the system-wide `email_config.enabled` flag.
- * - Respects per-notification-type toggles in `email_config.notification_types`.
- * - Every attempt (success or failure) is written to email_log for auditability.
- */
-export async function sendEmail(payload: SendEmailPayload): Promise<void> {
+export type TransactionalEmailResult =
+  | { sent: true }
+  | { sent: false; error: string }
+
+// -- Core dispatcher (private) ------------------------------------------------
+// Owns: Resend call, error capture, audit log write.
+// Never throws. Does not read email_config -- gates are the caller's concern.
+
+async function _dispatch(
+  payload: SendEmailPayload,
+): Promise<TransactionalEmailResult> {
   const supabase = createServiceClient()
-  const config = await getEmailConfig()
-
-  // ── System-level gate ──────────────────────────────────────────────────────
-  if (!config.enabled) return
-
-  // ── Per-type gate ──────────────────────────────────────────────────────────
-  if (config.notification_types[payload.template] === false) return
-
   const from = payload.from ?? 'TeamEnjoyVD <noreply@teamenjoyvd.com>'
 
-  let status = 'pending'
+  let status: 'sent' | 'failed'
   let resendId: string | null = null
   let errorMsg: string | null = null
 
   try {
     const { data, error } = await getResend().emails.send({
       from,
-      to: payload.to,
+      to:      payload.to,
       subject: payload.subject,
-      html: payload.html,
+      html:    payload.html,
     })
 
     if (error) throw new Error(error.message)
@@ -92,7 +86,7 @@ export async function sendEmail(payload: SendEmailPayload): Promise<void> {
     errorMsg = err instanceof Error ? err.message : String(err)
   }
 
-  // ── Audit log — never throws ───────────────────────────────────────────────
+  // -- Audit log -- never throws ----------------------------------------------
   try {
     await supabase.from('email_log').insert({
       template:  payload.template,
@@ -104,6 +98,50 @@ export async function sendEmail(payload: SendEmailPayload): Promise<void> {
       sent_at:   status === 'sent' ? new Date().toISOString() : null,
     })
   } catch {
-    // Logging failure must never propagate — email is already sent/failed.
+    // Logging failure must never propagate.
   }
+
+  if (status === 'sent') return { sent: true }
+  return { sent: false, error: errorMsg ?? 'Unknown error' }
+}
+
+// -- Notification dispatcher --------------------------------------------------
+
+/**
+ * Resilient notification email dispatcher.
+ *
+ * - Never throws -- all errors are caught and written to email_log.
+ * - Respects the system-wide `email_config.enabled` flag.
+ * - Respects per-notification-type toggles in `email_config.notification_types`.
+ * - Every attempt (success or failure) is written to email_log for auditability.
+ */
+export async function sendNotificationEmail(payload: SendEmailPayload): Promise<void> {
+  const config = await getEmailConfig()
+
+  // -- System-level gate ------------------------------------------------------
+  if (!config.enabled) return
+
+  // -- Per-type gate ----------------------------------------------------------
+  if (config.notification_types[payload.template] === false) return
+
+  await _dispatch(payload)
+  // Result intentionally discarded -- fire-and-forget contract.
+}
+
+// -- Transactional dispatcher -------------------------------------------------
+
+/**
+ * Transactional email dispatcher for flows where the email IS the feature
+ * (e.g. magic links, access links).
+ *
+ * - Bypasses `email_config.enabled` -- a master kill switch must not block auth flows.
+ * - Bypasses per-type toggles.
+ * - Returns a typed result -- caller decides how to handle failure.
+ * - Does NOT swallow errors.
+ * - Still writes to email_log for auditability.
+ */
+export async function sendTransactionalEmail(
+  payload: SendEmailPayload,
+): Promise<TransactionalEmailResult> {
+  return _dispatch(payload)
 }

--- a/lib/email/templates/GuestEventMagicLinkEmail.tsx
+++ b/lib/email/templates/GuestEventMagicLinkEmail.tsx
@@ -1,0 +1,52 @@
+import { Button, Section, Text } from '@react-email/components'
+import * as React from 'react'
+import { EmailShell, bodyPadding, labelStyle } from './_shell'
+
+type Props = {
+  name: string
+  eventTitle: string
+  magicLinkUrl: string
+}
+
+export function GuestEventMagicLinkEmail({ name, eventTitle, magicLinkUrl }: Props) {
+  return (
+    <EmailShell preview={`Your link to join ${eventTitle}`} title="Event Access Link">
+      <Section style={bodyPadding}>
+        <Text style={{ fontSize: 15, color: '#111827', margin: '0 0 16px' }}>
+          Hi {name},
+        </Text>
+        <Text style={{ fontSize: 15, color: '#374151', margin: '0 0 8px' }}>
+          You&apos;re registered for:
+        </Text>
+        <Text style={{ ...labelStyle, fontSize: 13, margin: '0 0 24px' }}>
+          {eventTitle}
+        </Text>
+        <Text style={{ fontSize: 14, color: '#6b7280', margin: '0 0 20px' }}>
+          Use the button below to access the meeting details. This link is personal
+          to you and expires in 72 hours.
+        </Text>
+        <Button
+          href={magicLinkUrl}
+          style={{
+            backgroundColor: '#1a3c2e',
+            color: '#ffffff',
+            borderRadius: 8,
+            padding: '12px 28px',
+            fontSize: 15,
+            fontWeight: 600,
+            textDecoration: 'none',
+            display: 'inline-block',
+          }}
+        >
+          Join Event
+        </Button>
+        <Text style={{ fontSize: 12, color: '#9ca3af', margin: '20px 0 0' }}>
+          If the button doesn&apos;t work, paste this link into your browser:
+        </Text>
+        <Text style={{ fontSize: 12, color: '#6b7280', wordBreak: 'break-all', margin: '4px 0 0' }}>
+          {magicLinkUrl}
+        </Text>
+      </Section>
+    </EmailShell>
+  )
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -6,6 +6,7 @@ const isPublicRoute = createRouteMatcher([
   '/about',
   '/calendar',
   '/trips',
+  '/events/(.*)',
   '/sign-in(.*)',
   '/sign-up(.*)',
   '/api/webhooks/(.*)',
@@ -13,10 +14,8 @@ const isPublicRoute = createRouteMatcher([
   '/api/events/:id',
 ])
 
-const isAdminApiRoute = createRouteMatcher(['/api/admin/(.*)']
-)
-const isAdminPageRoute = createRouteMatcher(['/admin/(.*)']
-)
+const isAdminApiRoute = createRouteMatcher(['/api/admin/(.*)'])
+const isAdminPageRoute = createRouteMatcher(['/admin/(.*)'])
 
 export default clerkMiddleware(async (auth, req) => {
   if (isPublicRoute(req)) return

--- a/supabase/migrations/20260410000001_guest_event_registrations.sql
+++ b/supabase/migrations/20260410000001_guest_event_registrations.sql
@@ -1,0 +1,26 @@
+-- SEQ349: Guest event registration — magic-link flow
+-- Migration already applied to prod DB. File kept for version history.
+CREATE TYPE guest_registration_status AS ENUM ('pending', 'confirmed');
+
+ALTER TABLE calendar_events
+  ADD COLUMN allow_guest_registration boolean NOT NULL DEFAULT false;
+
+CREATE TABLE guest_registrations (
+  id          uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  event_id    uuid NOT NULL REFERENCES calendar_events(id) ON DELETE CASCADE,
+  email       text NOT NULL,
+  name        text NOT NULL,
+  token       text NOT NULL UNIQUE,
+  status      guest_registration_status NOT NULL DEFAULT 'pending',
+  expires_at  timestamptz NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX guest_registrations_token_idx    ON guest_registrations(token);
+CREATE INDEX guest_registrations_event_id_idx ON guest_registrations(event_id);
+
+ALTER TABLE guest_registrations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "no_direct_access"
+  ON guest_registrations FOR ALL TO authenticated, anon
+  USING (false) WITH CHECK (false);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -108,6 +108,7 @@ export type Database = {
       }
       calendar_events: {
         Row: {
+          allow_guest_registration: boolean
           category: Database["public"]["Enums"]["event_category"]
           created_at: string
           created_by: string | null
@@ -123,6 +124,7 @@ export type Database = {
           week_number: number
         }
         Insert: {
+          allow_guest_registration?: boolean
           category?: Database["public"]["Enums"]["event_category"]
           created_at?: string
           created_by?: string | null
@@ -138,6 +140,7 @@ export type Database = {
           week_number: number
         }
         Update: {
+          allow_guest_registration?: boolean
           category?: Database["public"]["Enums"]["event_category"]
           created_at?: string
           created_by?: string | null
@@ -161,6 +164,42 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      email_log: {
+        Row: {
+          created_at: string
+          error: string | null
+          id: string
+          payload: Json
+          recipient: string
+          resend_id: string | null
+          sent_at: string | null
+          status: string
+          template: string
+        }
+        Insert: {
+          created_at?: string
+          error?: string | null
+          id?: string
+          payload?: Json
+          recipient: string
+          resend_id?: string | null
+          sent_at?: string | null
+          status?: string
+          template: string
+        }
+        Update: {
+          created_at?: string
+          error?: string | null
+          id?: string
+          payload?: Json
+          recipient?: string
+          resend_id?: string | null
+          sent_at?: string | null
+          status?: string
+          template?: string
+        }
+        Relationships: []
       }
       event_role_requests: {
         Row: {
@@ -207,41 +246,46 @@ export type Database = {
           },
         ]
       }
-      email_log: {
+      guest_registrations: {
         Row: {
           created_at: string
-          error: string | null
+          email: string
+          event_id: string
+          expires_at: string
           id: string
-          payload: Json
-          recipient: string
-          resend_id: string | null
-          sent_at: string | null
-          status: string
-          template: string
+          name: string
+          status: Database["public"]["Enums"]["guest_registration_status"]
+          token: string
         }
         Insert: {
           created_at?: string
-          error?: string | null
+          email: string
+          event_id: string
+          expires_at: string
           id?: string
-          payload?: Json
-          recipient: string
-          resend_id?: string | null
-          sent_at?: string | null
-          status?: string
-          template: string
+          name: string
+          status?: Database["public"]["Enums"]["guest_registration_status"]
+          token: string
         }
         Update: {
           created_at?: string
-          error?: string | null
+          email?: string
+          event_id?: string
+          expires_at?: string
           id?: string
-          payload?: Json
-          recipient?: string
-          resend_id?: string | null
-          sent_at?: string | null
-          status?: string
-          template?: string
+          name?: string
+          status?: Database["public"]["Enums"]["guest_registration_status"]
+          token?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "guest_registrations_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "calendar_events"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       guides: {
         Row: {
@@ -786,6 +830,21 @@ export type Database = {
           },
         ]
       }
+      settings: {
+        Row: {
+          key: string
+          value: Json
+        }
+        Insert: {
+          key: string
+          value?: Json
+        }
+        Update: {
+          key?: string
+          value?: Json
+        }
+        Relationships: []
+      }
       social_posts: {
         Row: {
           caption: string | null
@@ -819,21 +878,6 @@ export type Database = {
           post_url?: string
           sort_order?: number
           thumbnail_url?: string | null
-        }
-        Relationships: []
-      }
-      settings: {
-        Row: {
-          key: string
-          value: Json
-        }
-        Insert: {
-          key: string
-          value?: Json
-        }
-        Update: {
-          key?: string
-          value?: Json
         }
         Relationships: []
       }
@@ -1134,6 +1178,7 @@ export type Database = {
           id: string
           id_number: string | null
           last_name: string
+          notification_prefs: Json
           passport_number: string | null
           phone: string | null
           role: Database["public"]["Enums"]["user_role"]
@@ -1172,6 +1217,7 @@ export type Database = {
       document_type: "id" | "passport"
       event_category: "N21" | "Personal"
       event_type: "in-person" | "online" | "hybrid"
+      guest_registration_status: "pending" | "confirmed"
       notification_type:
         | "role_request"
         | "trip_request"
@@ -1311,6 +1357,7 @@ export const Constants = {
       document_type: ["id", "passport"],
       event_category: ["N21", "Personal"],
       event_type: ["in-person", "online", "hybrid"],
+      guest_registration_status: ["pending", "confirmed"],
       notification_type: [
         "role_request",
         "trip_request",


### PR DESCRIPTION
## SEQ349-ISS349 — Guest event registration: magic-link flow

Stateless magic-link checkout for `calendar_events` flagged with `allow_guest_registration = true`. Completely isolated from Clerk/profiles schema — no auth required.

### Changes

**DB (migration applied)**
- `calendar_events.allow_guest_registration boolean NOT NULL DEFAULT false`
- `guest_registrations` table: `id`, `event_id` FK, `email`, `name`, `token` (UNIQUE), `status` enum, `expires_at`
- RLS: `no_direct_access` policy — service role only via server action
- Indexes on `token` and `event_id`

**App**
- `app/events/[eventId]/register/page.tsx` — public RSC, `notFound()` if flag off, dual layout
- `app/events/[eventId]/register/components/RegisterForm.tsx` — `useActionState`, success state
- `app/events/[eventId]/join/page.tsx` — token + eventId scope + expiry validation, `InvalidState` sub-component at module scope, `meeting_url` CTA (44px min touch target)
- `lib/actions/guest-registration.ts` — Zod validation, `crypto.randomBytes(32)`, 72h TTL, `sendTransactionalEmail`
- `lib/email/templates/GuestEventMagicLinkEmail.tsx` — React Email template

**Security properties**
- Token is the only credential; scoped to `eventId` — cross-event use hard-fails at DB query
- Raw `meeting_url` never sent in email — only the portal magic link
- `sendTransactionalEmail` bypasses `email_config` kill switch (correct for auth flows)

---

## Session State
**Status:** IN PROGRESS
**Last touched:** `app/events/[eventId]/join/page.tsx`
**Completed:**
- [x] Migration applied to prod DB
- [x] `guest_registrations` table + RLS
- [x] `registerGuest` server action
- [x] `GuestEventMagicLinkEmail` template
- [x] `/register` page + `RegisterForm`
- [x] `/join` page with token validation
- [x] `proxy.ts` public route confirmed
**In flight:** Awaiting Vercel preview build
**Next:** Verify Vercel preview READY + CI green → mark DONE in Airtable