### PR TITLE
[SEQ351] Calendar sync meeting_url from conferenceData; SVG favicon

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#1a3c2e"/>
+  <text
+    x="16"
+    y="23"
+    font-family="Georgia, 'Times New Roman', serif"
+    font-size="20"
+    font-weight="400"
+    fill="#f4f1eb"
+    text-anchor="middle"
+    letter-spacing="-0.5"
+  >V</text>
+</svg>

--- a/supabase/functions/sync-google-calendar/index.ts
+++ b/supabase/functions/sync-google-calendar/index.ts
@@ -7,10 +7,26 @@ const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
 async function getGoogleAccessToken(sa: Record<string,string>): Promise<string> {
   const now = Math.floor(Date.now() / 1000)
   const b64u = (o: unknown) => btoa(JSON.stringify(o)).replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_')
-  const input = `${b64u({alg:'RS256',typ:'JWT'})}.${b64u({iss:sa.client_email,scope:'https://www.googleapis.com/auth/calendar.readonly',aud:'https://oauth2.googleapis.com/token',exp:now+3600,iat:now})}`
-  const key = await crypto.subtle.importKey('pkcs8',Uint8Array.from(atob(sa.private_key.replace(/-----[^-]+-----|\\n/g,'')),c=>c.charCodeAt(0)),{name:'RSASSA-PKCS1-v1_5',hash:'SHA-256'},false,['sign'])
-  const sig = btoa(String.fromCharCode(...new Uint8Array(await crypto.subtle.sign('RSASSA-PKCS1-v1_5',key,new TextEncoder().encode(input))))).replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_')
-  const r = await fetch('https://oauth2.googleapis.com/token',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({grant_type:'urn:ietf:params:oauth:grant-type:jwt-bearer',assertion:`${input}.${sig}`})})
+  const header  = b64u({alg:'RS256',typ:'JWT'})
+  const payload = b64u({iss:sa.client_email,scope:'https://www.googleapis.com/auth/calendar.readonly',aud:'https://oauth2.googleapis.com/token',exp:now+3600,iat:now})
+  const input   = header + '.' + payload
+  const key = await crypto.subtle.importKey(
+    'pkcs8',
+    Uint8Array.from(atob(sa.private_key.replace(/-----[^-]+-----|\\n/g,'')),c=>c.charCodeAt(0)),
+    {name:'RSASSA-PKCS1-v1_5',hash:'SHA-256'},
+    false,
+    ['sign'],
+  )
+  const sigBytes = new Uint8Array(await crypto.subtle.sign('RSASSA-PKCS1-v1_5',key,new TextEncoder().encode(input)))
+  const sig = btoa(String.fromCharCode(...sigBytes)).replace(/=/g,'').replace(/\+/g,'-').replace(/\//g,'_')
+  const r = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {'Content-Type':'application/x-www-form-urlencoded'},
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: input + '.' + sig,
+    }),
+  })
   const d = await r.json()
   if (!r.ok) throw new Error(JSON.stringify(d))
   return d.access_token
@@ -24,10 +40,31 @@ function isoWeek(date: Date): number {
   return 1+Math.round(((d.getTime()-w1.getTime())/86400000-3+((w1.getDay()+6)%7))/7)
 }
 
-/** Extract the first href from an HTML string, or return null. */
-function extractFirstHref(html: string): string | null {
-  const m = html.match(/href=["']([^"']+)["']/i)
-  return m ? m[1] : null
+/**
+ * Extract meeting URL from a GCal event item.
+ * Priority: conferenceData.entryPoints (video type) > fallback to first href in description HTML.
+ * conferenceDataVersion=1 must be set on the API request for this field to be present.
+ */
+function extractMeetingUrl(
+  item: Record<string, unknown>,
+  rawDesc: string | null,
+): string | null {
+  // 1. conferenceData.entryPoints — Google Meet, Zoom via GCal, etc.
+  const conferenceData = item.conferenceData as Record<string, unknown> | undefined
+  if (conferenceData) {
+    const entryPoints = conferenceData.entryPoints as Array<Record<string, unknown>> | undefined
+    if (Array.isArray(entryPoints)) {
+      const video = entryPoints.find(e => e.entryPointType === 'video')
+      const uri = video?.uri ?? entryPoints[0]?.uri
+      if (typeof uri === 'string') return uri
+    }
+  }
+  // 2. Fallback: first href in description HTML (for manually-pasted links)
+  if (rawDesc) {
+    const m = rawDesc.match(/href=["']([^"']+)["']/i)
+    if (m) return m[1]
+  }
+  return null
 }
 
 /** Strip all HTML tags and decode common HTML entities. */
@@ -49,9 +86,8 @@ Deno.serve(async (req: Request) => {
     return new Response(JSON.stringify({error:'Unauthorized'}), {status:401})
   }
 
-  const sa = Deno.env.get('GOOGLE_SERVICE_ACCOUNT')
+  const sa    = Deno.env.get('GOOGLE_SERVICE_ACCOUNT')
   const calId = Deno.env.get('GOOGLE_CALENDAR_ID')
-
   if (!sa || !calId) {
     return new Response(JSON.stringify({error:'Missing env secrets'}), {status:500})
   }
@@ -60,48 +96,50 @@ Deno.serve(async (req: Request) => {
   try { token = await getGoogleAccessToken(JSON.parse(sa)) }
   catch(e) { return new Response(JSON.stringify({error:'auth_failed',detail:String(e)}),{status:500}) }
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+  const sb   = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
   const tMin = new Date().toISOString()
   const tMax = new Date(Date.now()+180*864e5).toISOString()
-  const url = new URL(`https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calId)}/events`)
-  url.searchParams.set('timeMin',tMin)
-  url.searchParams.set('timeMax',tMax)
-  url.searchParams.set('singleEvents','true')
-  url.searchParams.set('orderBy','startTime')
-  url.searchParams.set('maxResults','100')
+  const url  = new URL('https://www.googleapis.com/calendar/v3/calendars/' + encodeURIComponent(calId) + '/events')
+  url.searchParams.set('timeMin', tMin)
+  url.searchParams.set('timeMax', tMax)
+  url.searchParams.set('singleEvents', 'true')
+  url.searchParams.set('orderBy', 'startTime')
+  url.searchParams.set('maxResults', '100')
+  // Required to receive conferenceData (Google Meet links) in the response
+  url.searchParams.set('conferenceDataVersion', '1')
 
-  const calRes = await fetch(url.toString(),{headers:{Authorization:`Bearer ${token}`}})
+  const calRes = await fetch(url.toString(), {headers: {Authorization: 'Bearer ' + token}})
   if (!calRes.ok) return new Response(JSON.stringify({error:'calendar_api_failed',detail:await calRes.text()}),{status:500})
 
   const items: Record<string,unknown>[] = (await calRes.json()).items ?? []
-  let upserted=0, newEvents=0
+  let upserted = 0, newEvents = 0
   const errors: string[] = []
 
   for (const item of items) {
-    if (item.status==='cancelled') continue
+    if (item.status === 'cancelled') continue
     const startRaw = (item.start as Record<string,string>)?.dateTime ?? (item.start as Record<string,string>)?.date
     const endRaw   = (item.end   as Record<string,string>)?.dateTime ?? (item.end   as Record<string,string>)?.date
-    if (!startRaw||!endRaw) continue
+    if (!startRaw || !endRaw) continue
     const st = new Date(startRaw), et = new Date(endRaw)
-    const personal = String(item.summary??'').includes('[Personal]')||String(item.description??'').includes('[Personal]')
+    const personal = String(item.summary??'').includes('[Personal]') || String(item.description??'').includes('[Personal]')
 
-    // Extract meeting_url from description HTML before stripping tags
-    const rawDesc = item.description ? String(item.description) : null
-    const meetingUrl = rawDesc ? extractFirstHref(rawDesc) : null
-    const cleanDesc = rawDesc ? (stripHtml(rawDesc) || null) : null
+    const rawDesc    = item.description ? String(item.description) : null
+    const meetingUrl = extractMeetingUrl(item, rawDesc)
+    const cleanDesc  = rawDesc ? (stripHtml(rawDesc) || null) : null
 
-    const {data:ex} = await sb.from('calendar_events').select('id').eq('google_event_id',item.id).maybeSingle()
+    const {data:ex} = await sb.from('calendar_events').select('id').eq('google_event_id', item.id).maybeSingle()
     const {error:ue} = await sb.from('calendar_events').upsert({
-      google_event_id: item.id,
-      title: String(item.summary??'Untitled'),
-      description: cleanDesc,
-      meeting_url: meetingUrl,
-      start_time: st.toISOString(), end_time: et.toISOString(),
-      category: personal?'Personal':'N21',
-      visibility_roles: personal?['member','core','admin']:['admin','core','member','guest'],
-      week_number: isoWeek(st)
-    },{onConflict:'google_event_id'})
-    if (ue) errors.push(`${item.id}: ${ue.message}`)
+      google_event_id:  item.id,
+      title:            String(item.summary ?? 'Untitled'),
+      description:      cleanDesc,
+      meeting_url:      meetingUrl,
+      start_time:       st.toISOString(),
+      end_time:         et.toISOString(),
+      category:         personal ? 'Personal' : 'N21',
+      visibility_roles: personal ? ['member','core','admin'] : ['admin','core','member','guest'],
+      week_number:      isoWeek(st),
+    }, {onConflict: 'google_event_id'})
+    if (ue) errors.push(String(item.id) + ': ' + ue.message)
     else { upserted++; if (!ex) newEvents++ }
   }
 
@@ -109,10 +147,18 @@ Deno.serve(async (req: Request) => {
     const {data:profiles} = await sb.from('profiles').select('id').in('role',['member','core','admin'])
     if (profiles?.length) {
       await sb.from('notifications').insert(
-        profiles.map((p:{id:string}) => ({profile_id:p.id,type:'event_fetched',title:'New events added',message:`${newEvents} new event${newEvents>1?'s':''} added to the calendar.`,action_url:'/calendar'}))
+        profiles.map((p:{id:string}) => ({
+          profile_id: p.id,
+          type:       'event_fetched',
+          title:      'New events added',
+          message:    newEvents + ' new event' + (newEvents > 1 ? 's' : '') + ' added to the calendar.',
+          action_url: '/calendar',
+        }))
       )
     }
   }
 
-  return new Response(JSON.stringify({upserted,new_events:newEvents,errors}),{headers:{'Content-Type':'application/json'}})
+  return new Response(JSON.stringify({upserted, new_events: newEvents, errors}), {
+    headers: {'Content-Type': 'application/json'},
+  })
 })


### PR DESCRIPTION
## SEQ351 — Calendar sync meeting_url fix + SVG favicon

### 1. Calendar sync: `conferenceData` priority for `meeting_url`

**Problem:** `extractFirstHref` pulled the first `href` from the description HTML. Google Meet links are not in the description — they live in `conferenceData.entryPoints`. So every sync was writing `null` (or a random description link) to `meeting_url`, overwriting any manually-set value.

**Fix:**
- Added `conferenceDataVersion=1` to the GCal API request (required to receive `conferenceData` in the response)
- New `extractMeetingUrl()` function: checks `conferenceData.entryPoints` first, prefers `entryPointType === 'video'`, falls back to first href in description HTML for manually-pasted links
- Old `extractFirstHref` helper removed

**Result:** Events with a Google Meet will have `meeting_url` populated automatically on every sync. Manually-set URLs on events without GCal conference data are still handled by the description fallback.

### 2. Favicon: SVG monogram

Added `app/icon.svg` — Next.js serves this as the browser tab icon automatically (takes priority over `favicon.ico` in modern browsers). Dark green `#1a3c2e` rounded square, serif "V" in `#f4f1eb`. No build step required.

---

## Session State
**Status:** IN PROGRESS
**Last touched:** `supabase/functions/sync-google-calendar/index.ts`, `app/icon.svg`
**Completed:**
- [x] `conferenceDataVersion=1` added to GCal API request
- [x] `extractMeetingUrl` reads `conferenceData.entryPoints` first
- [x] `app/icon.svg` committed
**In flight:** Awaiting Vercel preview
**Next:** Verify preview READY → merge → redeploy edge function via Supabase MCP