### PR TITLE
[SEQ362-ISS362] Guest join page: share event, meeting URL fallback, add-to-calendar

### DIFF
--- a/app/events/[eventId]/join/components/JoinActions.tsx
+++ b/app/events/[eventId]/join/components/JoinActions.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { useState } from 'react'
+
+type Props = {
+  eventId:    string
+  eventTitle: string
+  meetingUrl: string | null
+  startTime:  string   // ISO string from DB
+  endTime:    string   // ISO string from DB
+}
+
+// -- Calendar helpers ----------------------------------------------------------
+
+/** Convert ISO datetime string -> compact GCal format: 20260411T100000Z */
+function toGcalDate(iso: string): string {
+  return iso.replace(/[-:]/g, '').replace(/\.\d{3}/, '')
+}
+
+function buildGoogleCalUrl(
+  title: string,
+  start: string,
+  end: string,
+  location: string | null,
+): string {
+  const url = new URL('https://calendar.google.com/calendar/render')
+  url.searchParams.set('action', 'TEMPLATE')
+  url.searchParams.set('text', title)
+  url.searchParams.set('dates', `${toGcalDate(start)}/${toGcalDate(end)}`)
+  if (location) {
+    url.searchParams.set('location', location)
+    url.searchParams.set('details', `Join here: ${location}`)
+  }
+  return url.toString()
+}
+
+function buildOutlookUrl(
+  title: string,
+  start: string,
+  end: string,
+  location: string | null,
+): string {
+  const url = new URL('https://outlook.live.com/calendar/0/deeplink/compose')
+  url.searchParams.set('subject', title)
+  url.searchParams.set('startdt', start)
+  url.searchParams.set('enddt', end)
+  if (location) {
+    url.searchParams.set('location', location)
+    url.searchParams.set('body', `Join here: ${location}`)
+  }
+  return url.toString()
+}
+
+function buildIcsContent(
+  title: string,
+  start: string,
+  end: string,
+  location: string | null,
+): string {
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//TeamEnjoyVD//Portal//EN',
+    'BEGIN:VEVENT',
+    `DTSTART:${toGcalDate(start)}`,
+    `DTEND:${toGcalDate(end)}`,
+    `SUMMARY:${title}`,
+    location ? `LOCATION:${location}` : null,
+    location ? `DESCRIPTION:Join here: ${location}` : null,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].filter((l): l is string => l !== null)
+  return lines.join('\r\n')
+}
+
+// -- Component -----------------------------------------------------------------
+
+export function JoinActions({
+  eventId,
+  eventTitle,
+  meetingUrl,
+  startTime,
+  endTime,
+}: Props) {
+  const [copied, setCopied]   = useState(false)
+  const [calOpen, setCalOpen] = useState(false)
+
+  // -- Share -------------------------------------------------------------------
+  async function handleShare() {
+    // Share the public registration page -- not the personal token URL.
+    const shareUrl = `${window.location.origin}/events/${eventId}/register`
+    const shareData = { title: eventTitle, text: `Register for ${eventTitle}`, url: shareUrl }
+    if (typeof navigator.share === 'function' && navigator.canShare?.(shareData)) {
+      try { await navigator.share(shareData); return } catch { /* cancelled or failed */ }
+    }
+    await navigator.clipboard.writeText(shareUrl)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  // -- .ics download -----------------------------------------------------------
+  function downloadIcs() {
+    const content = buildIcsContent(eventTitle, startTime, endTime, meetingUrl)
+    const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' })
+    const url  = URL.createObjectURL(blob)
+    const a    = document.createElement('a')
+    a.href     = url
+    a.download = `${eventTitle.replace(/[^a-z0-9]/gi, '-').toLowerCase()}.ics`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="mt-6 space-y-3">
+
+      {/* -- Failsafe: plain-text meeting URL ---------------------------------- */}
+      {meetingUrl && (
+        <div
+          className="rounded-xl px-4 py-3"
+          style={{
+            backgroundColor: 'var(--bg-global)',
+            border: '1px solid var(--border-default)',
+          }}
+        >
+          <p className="text-xs mb-1.5" style={{ color: 'var(--text-secondary)' }}>
+            If the button above doesn&apos;t open, copy this link directly:
+          </p>
+          <a
+            href={meetingUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs break-all underline"
+            style={{ color: 'var(--text-primary)' }}
+          >
+            {meetingUrl}
+          </a>
+        </div>
+      )}
+
+      {/* -- Divider ----------------------------------------------------------- */}
+      <hr style={{ borderColor: 'var(--border-default)' }} />
+
+      {/* -- Add to calendar --------------------------------------------------- */}
+      <div>
+        <button
+          onClick={() => setCalOpen(o => !o)}
+          className="w-full flex items-center justify-between text-sm font-medium py-1.5"
+          style={{ color: 'var(--text-primary)', background: 'none', border: 'none', cursor: 'pointer' }}
+        >
+          <span>Add to calendar</span>
+          <svg
+            style={{ transition: 'transform 0.2s', transform: calOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}
+            width={16} height={16} fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        {calOpen && (
+          <div className="space-y-2 mt-2">
+            <a
+              href={buildGoogleCalUrl(eventTitle, startTime, endTime, meetingUrl)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 w-full rounded-xl px-4 py-2.5 text-sm font-medium hover:opacity-75 transition-opacity"
+              style={{
+                backgroundColor: 'var(--bg-global)',
+                border: '1px solid var(--border-default)',
+                color: 'var(--text-primary)',
+              }}
+            >
+              Google Calendar
+            </a>
+            <a
+              href={buildOutlookUrl(eventTitle, startTime, endTime, meetingUrl)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 w-full rounded-xl px-4 py-2.5 text-sm font-medium hover:opacity-75 transition-opacity"
+              style={{
+                backgroundColor: 'var(--bg-global)',
+                border: '1px solid var(--border-default)',
+                color: 'var(--text-primary)',
+              }}
+            >
+              Outlook
+            </a>
+            <button
+              onClick={downloadIcs}
+              className="flex items-center gap-2 w-full rounded-xl px-4 py-2.5 text-sm font-medium hover:opacity-75 transition-opacity text-left"
+              style={{
+                backgroundColor: 'var(--bg-global)',
+                border: '1px solid var(--border-default)',
+                color: 'var(--text-primary)',
+                cursor: 'pointer',
+              }}
+            >
+              Download .ics (Apple Calendar &amp; others)
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* -- Share event ------------------------------------------------------- */}
+      <button
+        onClick={handleShare}
+        className="w-full rounded-xl py-2.5 text-sm font-medium hover:opacity-75 transition-opacity"
+        style={{
+          border: '1px solid var(--border-default)',
+          color: 'var(--text-primary)',
+          backgroundColor: 'var(--bg-global)',
+          cursor: 'pointer',
+        }}
+      >
+        {copied ? 'Link copied!' : 'Share event'}
+      </button>
+    </div>
+  )
+}

--- a/app/events/[eventId]/join/components/JoinActions.tsx
+++ b/app/events/[eventId]/join/components/JoinActions.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 /** Convert ISO datetime string -> compact GCal format: 20260411T100000Z */
 function toGcalDate(iso: string): string {
-  return iso.replace(/[-:]/g, '').replace(/\.\d{3}/, '')
+  return iso.replace(/\.\d+/, '').replace(/[-:]/g, '')
 }
 
 function buildGoogleCalUrl(
@@ -57,6 +57,7 @@ function buildIcsContent(
   end: string,
   location: string | null,
 ): string {
+  const escape = (str: string) => str.replace(/[\\,;]/g, '\\$&').replace(/\r?\n/g, '\\n')
   const lines = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
@@ -64,9 +65,9 @@ function buildIcsContent(
     'BEGIN:VEVENT',
     `DTSTART:${toGcalDate(start)}`,
     `DTEND:${toGcalDate(end)}`,
-    `SUMMARY:${title}`,
-    location ? `LOCATION:${location}` : null,
-    location ? `DESCRIPTION:Join here: ${location}` : null,
+    `SUMMARY:${escape(title)}`,
+    location ? `LOCATION:${escape(location)}` : null,
+    location ? `DESCRIPTION:Join here: ${escape(location)}` : null,
     'END:VEVENT',
     'END:VCALENDAR',
   ].filter((l): l is string => l !== null)
@@ -105,7 +106,7 @@ export function JoinActions({
     const url  = URL.createObjectURL(blob)
     const a    = document.createElement('a')
     a.href     = url
-    a.download = `${eventTitle.replace(/[^a-z0-9]/gi, '-').toLowerCase()}.ics`
+    a.download = `${eventTitle.replace(/[^a-z0-9]+/gi, '-').toLowerCase() || 'event'}.ics`
     a.click()
     URL.revokeObjectURL(url)
   }
@@ -141,64 +142,66 @@ export function JoinActions({
       <hr style={{ borderColor: 'var(--border-default)' }} />
 
       {/* -- Add to calendar --------------------------------------------------- */}
-      <div>
-        <button
-          onClick={() => setCalOpen(o => !o)}
-          className="w-full flex items-center justify-between text-sm font-medium py-1.5"
-          style={{ color: 'var(--text-primary)', background: 'none', border: 'none', cursor: 'pointer' }}
-        >
-          <span>Add to calendar</span>
-          <svg
-            style={{ transition: 'transform 0.2s', transform: calOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}
-            width={16} height={16} fill="none" stroke="currentColor" viewBox="0 0 24 24"
+      {startTime && endTime && (
+        <div>
+          <button
+            onClick={() => setCalOpen(o => !o)}
+            className="w-full flex items-center justify-between text-sm font-medium py-1.5"
+            style={{ color: 'var(--text-primary)', background: 'none', border: 'none', cursor: 'pointer' }}
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-          </svg>
-        </button>
+            <span>Add to calendar</span>
+            <svg
+              style={{ transition: 'transform 0.2s', transform: calOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}
+              width={16} height={16} fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
 
-        {calOpen && (
-          <div className="space-y-2 mt-2">
-            <a
-              href={buildGoogleCalUrl(eventTitle, startTime, endTime, meetingUrl)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 w-full rounded-xl px-4 py-2.5 text-sm font-medium hover:opacity-75 transition-opacity"
-              style={{
-                backgroundColor: 'var(--bg-global)',
-                border: '1px solid var(--border-default)',
-                color: 'var(--text-primary)',
-              }}
-            >
-              Google Calendar
-            </a>
-            <a
-              href={buildOutlookUrl(eventTitle, startTime, endTime, meetingUrl)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 w-full rounded-xl px-4 py-2.5 text-sm font-medium hover:opacity-75 transition-opacity"
-              style={{
-                backgroundColor: 'var(--bg-global)',
-                border: '1px solid var(--border-default)',
-                color: 'var(--text-primary)',
-              }}
-            >
-              Outlook
-            </a>
-            <button
-              onClick={downloadIcs}
-              className="flex items-center gap-2 w-full rounded-xl px-4 py-2.5 text-sm font-medium hover:opacity-75 transition-opacity text-left"
-              style={{
-                backgroundColor: 'var(--bg-global)',
-                border: '1px solid var(--border-default)',
-                color: 'var(--text-primary)',
-                cursor: 'pointer',
-              }}
-            >
-              Download .ics (Apple Calendar &amp; others)
-            </button>
-          </div>
-        )}
-      </div>
+          {calOpen && (
+            <div className="space-y-2 mt-2">
+              <a
+                href={buildGoogleCalUrl(eventTitle, startTime, endTime, meetingUrl)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 w-full rounded-xl px-4 py-2.5 text-sm font-medium hover:opacity-75 transition-opacity"
+                style={{
+                  backgroundColor: 'var(--bg-global)',
+                  border: '1px solid var(--border-default)',
+                  color: 'var(--text-primary)',
+                }}
+              >
+                Google Calendar
+              </a>
+              <a
+                href={buildOutlookUrl(eventTitle, startTime, endTime, meetingUrl)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 w-full rounded-xl px-4 py-2.5 text-sm font-medium hover:opacity-75 transition-opacity"
+                style={{
+                  backgroundColor: 'var(--bg-global)',
+                  border: '1px solid var(--border-default)',
+                  color: 'var(--text-primary)',
+                }}
+              >
+                Outlook
+              </a>
+              <button
+                onClick={downloadIcs}
+                className="flex items-center gap-2 w-full rounded-xl px-4 py-2.5 text-sm font-medium hover:opacity-75 transition-opacity text-left"
+                style={{
+                  backgroundColor: 'var(--bg-global)',
+                  border: '1px solid var(--border-default)',
+                  color: 'var(--text-primary)',
+                  cursor: 'pointer',
+                }}
+              >
+                Download .ics (Apple Calendar &amp; others)
+              </button>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* -- Share event ------------------------------------------------------- */}
       <button

--- a/app/events/[eventId]/join/page.tsx
+++ b/app/events/[eventId]/join/page.tsx
@@ -1,12 +1,13 @@
 import Link from 'next/link'
 import { createServiceClient } from '@/lib/supabase/service'
+import { JoinActions } from './components/JoinActions'
 
 type Props = {
   params:       Promise<{ eventId: string }>
   searchParams: Promise<{ token?: string }>
 }
 
-// ── Sub-components (module-scoped — never defined inside render fn) ────────────
+// -- Sub-components (module-scoped -- never defined inside render fn) ----------
 
 function InvalidState({ eventId, reason }: { eventId: string; reason: 'missing' | 'invalid' | 'expired' }) {
   const message = reason === 'expired' ? 'This link has expired.' : 'This link is invalid.'
@@ -70,7 +71,7 @@ function InvalidState({ eventId, reason }: { eventId: string; reason: 'missing' 
   )
 }
 
-// ── Page ───────────────────────────────────────────────────────────────────────
+// -- Page ----------------------------------------------------------------------
 
 export default async function GuestJoinPage({ params, searchParams }: Props) {
   const { eventId } = await params
@@ -82,7 +83,7 @@ export default async function GuestJoinPage({ params, searchParams }: Props) {
 
   const { data: reg } = await supabase
     .from('guest_registrations')
-    .select('id, name, event_id, expires_at, calendar_events(title, meeting_url)')
+    .select('id, name, event_id, expires_at, calendar_events(title, meeting_url, start_time, end_time)')
     .eq('token', token)
     .single()
 
@@ -90,12 +91,25 @@ export default async function GuestJoinPage({ params, searchParams }: Props) {
   if (reg.event_id !== eventId)              return <InvalidState eventId={eventId} reason="invalid" />
   if (new Date(reg.expires_at) < new Date()) return <InvalidState eventId={eventId} reason="expired" />
 
-  // Narrow joined relation — PostgREST returns object for to-one FK
-  const event = reg.calendar_events as unknown as { title: string; meeting_url: string | null } | null
+  // Narrow joined relation -- PostgREST returns object for to-one FK
+  const event = reg.calendar_events as unknown as {
+    title:       string
+    meeting_url: string | null
+    start_time:  string
+    end_time:    string
+  } | null
+
+  const actionProps = {
+    eventId,
+    eventTitle: event?.title      ?? '',
+    meetingUrl: event?.meeting_url ?? null,
+    startTime:  event?.start_time  ?? '',
+    endTime:    event?.end_time    ?? '',
+  }
 
   return (
     <>
-      {/* ── Desktop ─────────────────────────────────────────────────────────── */}
+      {/* -- Desktop ----------------------------------------------------------- */}
       <div
         className="hidden md:flex min-h-screen items-center justify-center px-6"
         style={{ backgroundColor: 'var(--bg-global, #f4f1eb)' }}
@@ -113,7 +127,7 @@ export default async function GuestJoinPage({ params, searchParams }: Props) {
               {event?.title}
             </h1>
             <p className="text-sm mb-4" style={{ color: 'var(--text-secondary)' }}>
-              Hi {reg.name}, tap the button below to open the meeting.
+              Hi {reg.name}, click the button below to open the meeting.
             </p>
             {event?.meeting_url ? (
               <a
@@ -130,11 +144,12 @@ export default async function GuestJoinPage({ params, searchParams }: Props) {
                 Meeting link not yet available. Check back closer to the event.
               </p>
             )}
+            <JoinActions {...actionProps} />
           </div>
         </div>
       </div>
 
-      {/* ── Mobile ──────────────────────────────────────────────────────────── */}
+      {/* -- Mobile ------------------------------------------------------------ */}
       <div
         className="md:hidden min-h-screen px-5 pt-12 pb-8"
         style={{ backgroundColor: 'var(--bg-global, #f4f1eb)' }}
@@ -168,6 +183,7 @@ export default async function GuestJoinPage({ params, searchParams }: Props) {
               Meeting link not yet available. Check back closer to the event.
             </p>
           )}
+          <JoinActions {...actionProps} />
         </div>
       </div>
     </>


### PR DESCRIPTION
"## What\n\nThree UX extensions to the guest magic-link join page.\n\n### 1. Share event\n- New `Share event` button at the bottom of the card (both desktop + mobile)\n- Mobile: invokes Web Share API (`navigator.share`) when available\n- Desktop / unsupported: falls back to `navigator.clipboard.writeText`\n- Shares the **public registration URL** (`/events/[eventId]/register`) — not the personal token URL\n- Shows `Link copied!` confirmation for 2s on clipboard path\n\n### 2. Meeting URL plain-text fallback\n- When `meeting_url` is present, renders a styled box below the Join Meeting button with the raw URL as a tappable `<a>` + visible text\n- Covers email clients / sandboxed webviews that strip or block button elements\n\n### 3. Add to calendar\n- Collapsible section with three options:\n  - **Google Calendar** — deep-link URL with title, dates, location pre-filled\n  - **Outlook** — `outlook.live.com/calendar/0/deeplink/compose` with same params\n  - **Download .ics** — client-side Blob, works for Apple Calendar, Thunderbird, etc.\n- `start_time` and `end_time` added to the `calendar_events` select in `join/page.tsx`\n\n## Files changed\n- `app/events/[eventId]/join/page.tsx` — added `start_time`/`end_time` to select, added `JoinActions` to both layouts\n- `app/events/[eventId]/join/components/JoinActions.tsx` — new `'use client'` component\n\n## Session State\n**Status:** IN PROGRESS\n**Last touched:** `app/events/[eventId]/join/components/JoinActions.tsx`\n**Completed:**\n- [x] Branch created\n- [x] Both files pushed\n- [x] PR opened\n**In flight:** Waiting for Vercel preview\n**Next:** Verify Vercel preview READY + CI green, then merge and write Airtable Done"