### PR TITLE
[SEQ363–368] Payment UX, PaymentForm component, docs 403 fix, calendar deep-link, share buttons

### DIFF
--- a/app/(dashboard)/calendar/components/CalendarClient.tsx
+++ b/app/(dashboard)/calendar/components/CalendarClient.tsx
@@ -367,7 +367,9 @@ export default function CalendarClient({
     const [y, m] = initialMonth.split('-').map(Number)
     return new Date(y, m - 1, 1)
   })
-  const [selectedEventId, setSelectedEventId]     = useState<string | null>(initialEventId)
+  // Deep-link: highlight the agenda row, but do NOT auto-open the popup.
+  // selectedEventId is only set from user interaction (click), not from initialEventId.
+  const [selectedEventId, setSelectedEventId]     = useState<string | null>(null)
   const [anchorEl, setAnchorEl]                   = useState<HTMLElement | null>(null)
   const [showN21, setShowN21]                     = useState(true)
   const [showPersonal, setShowPersonal]           = useState(true)

--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useMemo  } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
@@ -73,6 +74,7 @@ export default function EventPopup({
 }: Props) {
   const qc = useQueryClient()
   const { t } = useLanguage()
+  const [shareCopied, setShareCopied] = useState(false)
   const isBottomSheet = (anchorEl !== null) && (typeof window !== 'undefined') && window.innerWidth < 768
   const anchorElRef = useMemo(() => ({
     current: anchorEl ?? { getBoundingClientRect: () => new DOMRect(0, 0, 0, 0) },
@@ -113,6 +115,17 @@ export default function EventPopup({
       }).then(r => r.json()),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['event', eventId] }),
   })
+
+  async function handleShare() {
+    const shareUrl = `${window.location.origin}/events/${eventId}/register`
+    const shareData = { title: event?.title ?? '', text: `Register for ${event?.title ?? ''}`, url: shareUrl }
+    if (typeof navigator.share === 'function' && navigator.canShare?.(shareData)) {
+      try { await navigator.share(shareData); return } catch { /* cancelled */ }
+    }
+    await navigator.clipboard.writeText(shareUrl)
+    setShareCopied(true)
+    setTimeout(() => setShareCopied(false), 2000)
+  }
 
   const eventTypeStyle = event?.event_type ? EVENT_TYPE_STYLES[event.event_type] : null
   const visibleRoleRequests = isAdmin
@@ -207,6 +220,22 @@ export default function EventPopup({
                   </a>
                 </div>
               )}
+              {/* Share button */}
+              <button
+                onClick={handleShare}
+                className="mt-3 flex items-center gap-1.5 text-xs font-medium hover:opacity-70 transition-opacity"
+                style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="18" cy="5" r="3"/>
+                  <circle cx="6" cy="12" r="3"/>
+                  <circle cx="18" cy="19" r="3"/>
+                  <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+                  <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+                </svg>
+                {shareCopied ? 'Link copied!' : 'Share event'}
+              </button>
             </div>
             {event.description && event.description !== event.meeting_url && (
               <div className="px-4 py-3 border-b border-black/5">

--- a/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useState } from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { formatDate, formatCurrency } from '@/lib/format'
 import { getRoleColors } from '@/lib/role-colors'
 import { Drawer } from '@/components/ui/Drawer'
+import { PaymentForm } from '@/components/payment/PaymentForm'
 import { TripDocumentsTile } from './TripDocumentsTile'
 import { BackButton, TripHero } from './shared'
 import type { Tables } from '@/types/supabase'
@@ -22,147 +22,9 @@ function SubmitPaymentDrawer({
   open: boolean
   onClose: () => void
 }) {
-  const qc = useQueryClient()
-  const [amount, setAmount] = useState('')
-  const [date, setDate] = useState('')
-  const [method, setMethod] = useState<'cash' | 'bank_transfer'>('cash')
-  const [file, setFile] = useState<File | null>(null)
-  const [note, setNote] = useState('')
-
-  const submitMutation = useMutation({
-    mutationFn: async () => {
-      let proof_url: string | null = null
-
-      if (file) {
-        const fd = new FormData()
-        fd.append('file', file)
-        const uploadRes = await fetch('/api/profile/payments/upload', { method: 'POST', body: fd })
-        if (!uploadRes.ok) throw new Error((await uploadRes.json()).error ?? 'Upload failed')
-        const { url } = await uploadRes.json()
-        proof_url = url
-      }
-
-      const res = await fetch('/api/payments', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          trip_id: tripId,
-          amount: parseFloat(amount),
-          currency: 'EUR',
-          transaction_date: date,
-          payment_method: method,
-          proof_url,
-          note: note || null,
-        }),
-      })
-      if (!res.ok) throw new Error((await res.json()).error ?? 'Submission failed')
-      return res.json()
-    },
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['trip-payments', tripId] })
-      onClose()
-      setAmount(''); setDate(''); setMethod('cash'); setFile(null); setNote('')
-    },
-  })
-
-  const inputStyle = {
-    backgroundColor: 'var(--bg-global)',
-    border: '1px solid var(--border-default)',
-    color: 'var(--text-primary)',
-    borderRadius: '0.75rem',
-    padding: '0.625rem 0.875rem',
-    fontSize: '0.875rem',
-    width: '100%',
-    outline: 'none',
-  } as const
-
-  const labelStyle = {
-    display: 'block',
-    fontSize: '0.75rem',
-    fontWeight: 600,
-    marginBottom: '0.375rem',
-    color: 'var(--text-secondary)',
-  } as const
-
-  const pillBase: React.CSSProperties = {
-    flex: 1,
-    padding: '0.5rem 0',
-    borderRadius: '0.625rem',
-    fontSize: '0.875rem',
-    fontWeight: 600,
-    cursor: 'pointer',
-    transition: 'background-color 0.15s, color 0.15s',
-    border: 'none',
-  }
-
   return (
     <Drawer open={open} onClose={onClose} title="Submit Payment">
-      <div className="space-y-5">
-        <div>
-          <label style={labelStyle}>Amount (EUR) *</label>
-          <input type="number" min="0" step="0.01" placeholder="0.00"
-            value={amount} onChange={e => setAmount(e.target.value)} style={inputStyle} />
-        </div>
-        <div>
-          <label style={labelStyle}>Payment Date *</label>
-          <input type="date" value={date} onChange={e => setDate(e.target.value)} style={inputStyle} />
-        </div>
-        <div>
-          <label style={labelStyle}>Payment Method</label>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => setMethod('cash')}
-              style={{
-                ...pillBase,
-                backgroundColor: method === 'cash' ? '#bc4749' : 'transparent',
-                color: method === 'cash' ? '#ffffff' : 'var(--text-secondary)',
-                border: method === 'cash' ? 'none' : '1px solid var(--border-default)',
-              }}
-            >
-              Cash
-            </button>
-            <button
-              type="button"
-              onClick={() => setMethod('bank_transfer')}
-              style={{
-                ...pillBase,
-                backgroundColor: method === 'bank_transfer' ? '#bc4749' : 'transparent',
-                color: method === 'bank_transfer' ? '#ffffff' : 'var(--text-secondary)',
-                border: method === 'bank_transfer' ? 'none' : '1px solid var(--border-default)',
-              }}
-            >
-              Bank Transfer
-            </button>
-          </div>
-        </div>
-        <div>
-          <label style={labelStyle}>Note</label>
-          <input type="text" placeholder="Optional note"
-            value={note} onChange={e => setNote(e.target.value)} style={inputStyle} />
-        </div>
-        <div>
-          <label style={labelStyle}>Proof of Payment</label>
-          <input type="file" accept="image/*,.pdf"
-            onChange={e => setFile(e.target.files?.[0] ?? null)}
-            style={{ ...inputStyle, padding: '0.5rem' }} />
-        </div>
-
-        {submitMutation.isError && (
-          <p className="text-xs" style={{ color: '#bc4749' }}>
-            {(submitMutation.error as Error).message}
-          </p>
-        )}
-
-        <button
-          onClick={() => submitMutation.mutate()}
-          disabled={submitMutation.isPending || !amount || !date}
-          className="w-full py-3 rounded-xl text-sm font-semibold text-white disabled:opacity-50 transition-opacity hover:opacity-90"
-          style={{ backgroundColor: 'var(--brand-forest)' }}
-        >
-          {submitMutation.isPending ? 'Submitting…' : 'Submit Payment'}
-        </button>
-      </div>
+      <PaymentForm tripId={tripId} onSuccess={onClose} onCancel={onClose} />
     </Drawer>
   )
 }
@@ -389,7 +251,7 @@ export function AttendeeView({
         {/* Who's Going */}
         <WhosGoingTile attendees={teamAttendees} />
 
-        {/* Trip Documents (SEQ313) */}
+        {/* Trip Documents */}
         <TripDocumentsTile tripId={trip.id} />
 
         {/* Trip info (read-only) */}

--- a/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 interface Attachment {
@@ -7,6 +8,11 @@ interface Attachment {
   file_url: string
   file_name: string
   file_type: 'pdf' | 'image'
+}
+
+interface ApiError {
+  status?: number
+  message: string
 }
 
 function PdfIcon() {
@@ -34,33 +40,47 @@ function ImageIcon() {
 }
 
 export function TripDocumentsTile({ tripId }: { tripId: string }) {
-  const { data: attachments, isLoading, isError } = useQuery<Attachment[]>({
+  const [retrying, setRetrying] = useState(false)
+
+  const { data: attachments, isLoading, isError, error, refetch } = useQuery<Attachment[], ApiError>({
     queryKey: ['trip-attachments', tripId],
     queryFn: () =>
       fetch(`/api/trips/${tripId}/attachments`).then(async r => {
-        if (!r.ok) throw new Error((await r.json()).error ?? 'Failed')
+        if (!r.ok) {
+          const body = await r.json().catch(() => ({}))
+          const err: ApiError = { status: r.status, message: body.error ?? 'Failed' }
+          throw err
+        }
         return r.json()
       }),
+    retry: false,
   })
 
   if (isLoading) return null
 
+  // 403 = no approved registration — expected, render nothing
+  if (isError && (error as ApiError)?.status === 403) return null
+
+  // 5xx or network error — show discreet retry, no alarming message
   if (isError) {
     return (
       <div
         className="rounded-2xl overflow-hidden"
         style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
       >
-        <div className="px-6 py-5">
-          <p
-            className="text-xs font-semibold tracking-widest uppercase mb-2"
-            style={{ color: 'var(--text-secondary)' }}
-          >
+        <div className="px-6 py-4 flex items-center justify-between">
+          <p className="text-xs font-semibold tracking-widest uppercase"
+            style={{ color: 'var(--text-secondary)' }}>
             Trip Documents
           </p>
-          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-            Documents could not be loaded.
-          </p>
+          <button
+            onClick={async () => { setRetrying(true); await refetch(); setRetrying(false) }}
+            disabled={retrying}
+            className="text-xs hover:opacity-70 transition-opacity disabled:opacity-40"
+            style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer' }}
+          >
+            {retrying ? 'Retrying…' : '↺ Retry'}
+          </button>
         </div>
       </div>
     )

--- a/app/events/[eventId]/join/components/JoinActions.tsx
+++ b/app/events/[eventId]/join/components/JoinActions.tsx
@@ -83,21 +83,7 @@ export function JoinActions({
   startTime,
   endTime,
 }: Props) {
-  const [copied, setCopied]   = useState(false)
   const [calOpen, setCalOpen] = useState(false)
-
-  // -- Share -------------------------------------------------------------------
-  async function handleShare() {
-    // Share the public registration page -- not the personal token URL.
-    const shareUrl = `${window.location.origin}/events/${eventId}/register`
-    const shareData = { title: eventTitle, text: `Register for ${eventTitle}`, url: shareUrl }
-    if (typeof navigator.share === 'function' && navigator.canShare?.(shareData)) {
-      try { await navigator.share(shareData); return } catch { /* cancelled or failed */ }
-    }
-    await navigator.clipboard.writeText(shareUrl)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
 
   // -- .ics download -----------------------------------------------------------
   function downloadIcs() {
@@ -202,20 +188,6 @@ export function JoinActions({
           )}
         </div>
       )}
-
-      {/* -- Share event ------------------------------------------------------- */}
-      <button
-        onClick={handleShare}
-        className="w-full rounded-xl py-2.5 text-sm font-medium hover:opacity-75 transition-opacity"
-        style={{
-          border: '1px solid var(--border-default)',
-          color: 'var(--text-primary)',
-          backgroundColor: 'var(--bg-global)',
-          cursor: 'pointer',
-        }}
-      >
-        {copied ? 'Link copied!' : 'Share event'}
-      </button>
     </div>
   )
 }

--- a/components/payment/PaymentForm.tsx
+++ b/components/payment/PaymentForm.tsx
@@ -1,0 +1,254 @@
+'use client'
+
+import { useState, useRef } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+type Props = {
+  tripId: string
+  onSuccess?: () => void
+  onCancel?: () => void
+}
+
+/**
+ * Unified payment submission form.
+ * Used in AttendeeView (trip detail) and any future payment surfaces.
+ * Applies the SEQ363 UX: segmented control for method, forest-green CTA,
+ * styled upload zone, required-field legend.
+ */
+export function PaymentForm({ tripId, onSuccess, onCancel }: Props) {
+  const qc = useQueryClient()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [amount, setAmount]   = useState('')
+  const [date, setDate]       = useState('')
+  const [method, setMethod]   = useState<'cash' | 'bank_transfer'>('cash')
+  const [file, setFile]       = useState<File | null>(null)
+  const [note, setNote]       = useState('')
+
+  const submitMutation = useMutation({
+    mutationFn: async () => {
+      let proof_url: string | null = null
+
+      if (file) {
+        const fd = new FormData()
+        fd.append('file', file)
+        const uploadRes = await fetch('/api/profile/payments/upload', { method: 'POST', body: fd })
+        if (!uploadRes.ok) throw new Error((await uploadRes.json()).error ?? 'Upload failed')
+        const { url } = await uploadRes.json()
+        proof_url = url
+      }
+
+      const res = await fetch('/api/payments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          trip_id: tripId,
+          amount: parseFloat(amount),
+          currency: 'EUR',
+          transaction_date: date,
+          payment_method: method,
+          proof_url,
+          note: note || null,
+        }),
+      })
+      if (!res.ok) throw new Error((await res.json()).error ?? 'Submission failed')
+      return res.json()
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['trip-payments', tripId] })
+      setAmount(''); setDate(''); setMethod('cash'); setFile(null); setNote('')
+      onSuccess?.()
+    },
+  })
+
+  const canSubmit = !!amount && !!date && !submitMutation.isPending
+
+  const inputStyle = {
+    backgroundColor: 'var(--bg-global)',
+    border: '1px solid var(--border-default)',
+    color: 'var(--text-primary)',
+    borderRadius: '0.75rem',
+    padding: '0.625rem 0.875rem',
+    fontSize: '0.875rem',
+    width: '100%',
+    outline: 'none',
+  } as const
+
+  const labelStyle = {
+    display: 'block',
+    fontSize: '0.75rem',
+    fontWeight: 600,
+    marginBottom: '0.375rem',
+    color: 'var(--text-secondary)',
+  } as const
+
+  return (
+    <div className="space-y-5">
+      {/* Required field legend */}
+      <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+        Fields marked <span style={{ color: 'var(--brand-crimson)' }}>*</span> are required.
+      </p>
+
+      {/* Amount */}
+      <div>
+        <label style={labelStyle}>
+          Amount (EUR) <span style={{ color: 'var(--brand-crimson)' }}>*</span>
+        </label>
+        <input
+          type="number" min="0" step="0.01" placeholder="0.00"
+          value={amount} onChange={e => setAmount(e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      {/* Date */}
+      <div>
+        <label style={labelStyle}>
+          Payment Date <span style={{ color: 'var(--brand-crimson)' }}>*</span>
+        </label>
+        <input
+          type="date" value={date} onChange={e => setDate(e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      {/* Payment Method — segmented control */}
+      <div>
+        <label style={labelStyle}>Payment Method</label>
+        <div
+          className="flex p-1 gap-1 rounded-xl"
+          style={{ backgroundColor: 'rgba(0,0,0,0.05)' }}
+        >
+          {(['cash', 'bank_transfer'] as const).map(m => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMethod(m)}
+              className="flex-1 py-2 rounded-lg text-xs font-semibold transition-all"
+              style={{
+                backgroundColor: method === m ? 'var(--bg-card)' : 'transparent',
+                color: method === m ? 'var(--text-primary)' : 'var(--text-secondary)',
+                boxShadow: method === m ? '0 1px 3px rgba(0,0,0,0.1)' : 'none',
+                border: 'none',
+                cursor: 'pointer',
+              }}
+            >
+              {m === 'cash' ? 'Cash' : 'Bank Transfer'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Note */}
+      <div>
+        <label style={labelStyle}>Note</label>
+        <input
+          type="text" placeholder="Optional note"
+          value={note} onChange={e => setNote(e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      {/* Proof of Payment — styled upload zone */}
+      <div>
+        <label style={labelStyle}>Proof of Payment</label>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*,.pdf"
+          className="hidden"
+          onChange={e => setFile(e.target.files?.[0] ?? null)}
+        />
+        {file ? (
+          <div
+            className="flex items-center justify-between gap-3 rounded-xl px-4 py-3"
+            style={{
+              border: '1px solid var(--border-default)',
+              backgroundColor: 'var(--bg-global)',
+            }}
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                <polyline points="14 2 14 8 20 8"/>
+              </svg>
+              <span className="text-sm truncate" style={{ color: 'var(--text-primary)' }}>
+                {file.name}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={() => { setFile(null); if (fileInputRef.current) fileInputRef.current.value = '' }}
+              className="text-xs flex-shrink-0 hover:opacity-70 transition-opacity"
+              style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer' }}
+            >
+              Remove
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="w-full flex flex-col items-center justify-center gap-2 rounded-xl py-6 transition-colors hover:bg-black/[0.02]"
+            style={{
+              border: '1.5px dashed var(--border-default)',
+              backgroundColor: 'transparent',
+              cursor: 'pointer',
+            }}
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
+              stroke="var(--text-secondary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+              <polyline points="17 8 12 3 7 8"/>
+              <line x1="12" y1="3" x2="12" y2="15"/>
+            </svg>
+            <span className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
+              Upload proof (PDF or image)
+            </span>
+          </button>
+        )}
+      </div>
+
+      {/* Error */}
+      {submitMutation.isError && (
+        <p className="text-xs" style={{ color: '#bc4749' }}>
+          {(submitMutation.error as Error).message}
+        </p>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-3 pt-1">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 py-3 rounded-xl text-sm font-semibold transition-opacity hover:opacity-70"
+            style={{
+              backgroundColor: 'transparent',
+              border: '1px solid var(--border-default)',
+              color: 'var(--text-secondary)',
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => submitMutation.mutate()}
+          disabled={!canSubmit}
+          className="flex-1 py-3 rounded-xl text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          style={{
+            backgroundColor: canSubmit ? 'var(--brand-forest)' : 'rgba(0,0,0,0.12)',
+            color: canSubmit ? '#ffffff' : 'var(--text-secondary)',
+            cursor: canSubmit ? 'pointer' : 'not-allowed',
+            border: 'none',
+          }}
+        >
+          {submitMutation.isPending ? 'Submitting…' : 'Submit Payment'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/payment/PaymentForm.tsx
+++ b/components/payment/PaymentForm.tsx
@@ -33,9 +33,9 @@ export function PaymentForm({ tripId, onSuccess, onCancel }: Props) {
         const fd = new FormData()
         fd.append('file', file)
         const uploadRes = await fetch('/api/profile/payments/upload', { method: 'POST', body: fd })
-        if (!uploadRes.ok) throw new Error((await uploadRes.json()).error ?? 'Upload failed')
-        const { url } = await uploadRes.json()
-        proof_url = url
+        const uploadBody = await uploadRes.json().catch(() => ({}))
+        if (!uploadRes.ok) throw new Error(uploadBody.error ?? 'Upload failed')
+        proof_url = uploadBody.url
       }
 
       const res = await fetch('/api/payments', {
@@ -51,8 +51,9 @@ export function PaymentForm({ tripId, onSuccess, onCancel }: Props) {
           note: note || null,
         }),
       })
-      if (!res.ok) throw new Error((await res.json()).error ?? 'Submission failed')
-      return res.json()
+      const body = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(body.error ?? 'Submission failed')
+      return body
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['trip-payments', tripId] })
@@ -61,7 +62,8 @@ export function PaymentForm({ tripId, onSuccess, onCancel }: Props) {
     },
   })
 
-  const canSubmit = !!amount && !!date && !submitMutation.isPending
+  const parsedAmount = parseFloat(amount)
+  const canSubmit = !isNaN(parsedAmount) && parsedAmount > 0 && !!date && !submitMutation.isPending
 
   const inputStyle = {
     backgroundColor: 'var(--bg-global)',


### PR DESCRIPTION
"## Session State\n**Status:** IN PROGRESS\n**Last touched:** `components/payment/PaymentForm.tsx`, `app/(dashboard)/trips/[id]/components/AttendeeView.tsx`, `app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx`, `app/(dashboard)/calendar/components/CalendarClient.tsx`, `app/events/[eventId]/join/components/JoinActions.tsx`, `app/(dashboard)/calendar/components/EventPopup.tsx`\n\n**Completed:**\n- [x] SEQ368 — `components/payment/PaymentForm.tsx` created (unified, reusable)\n- [x] SEQ363 — `AttendeeView.tsx` uses `PaymentForm`; UX applied (segmented control, forest CTA, upload zone, required legend)\n- [x] SEQ364 — `TripDocumentsTile.tsx` returns null on 403, discreet retry on 5xx\n- [x] SEQ365 — `CalendarClient.tsx` `selectedEventId` no longer initialised from `initialEventId`; deep-link only highlights agenda row\n- [x] SEQ366 — `JoinActions.tsx` Share button removed\n- [x] SEQ367 — `EventPopup.tsx` Share button added (navigator.share + clipboard fallback)\n\n**In flight:** Awaiting Vercel preview build\n**Next:** Verify Vercel preview READY + CI green, then mark all 6 tickets Done\n\n---\n\n## Tickets\n| SEQ | Title | Type |\n|-----|-------|------|\n| SEQ363 | Payment flyover: segmented control, primary CTA, styled upload zone, required legend | Feature |\n| SEQ364 | TripDocumentsTile: suppress error display on 403, return null | Bug |\n| SEQ365 | Calendar deep-link: popup displaced to top-left on page load | Bug |\n| SEQ366 | Join token page: remove Share event button | Bug |\n| SEQ367 | EventPopup: add Share button for public registration URL | Feature |\n| SEQ368 | Create unified PaymentForm component | Feature |\n\n## Changes\n\n### `components/payment/PaymentForm.tsx` (new)\nShared payment form component. Props: `tripId`, `onSuccess`, `onCancel`. Implements all SEQ363 UX: segmented method control, conditional forest-green CTA, dashed upload zone with filename+remove, required-field legend. Replaces the inline `SubmitPaymentDrawer` form in `AttendeeView`.\n\n### `AttendeeView.tsx`\n`SubmitPaymentDrawer` body replaced with `<PaymentForm>`. All payment state and mutation logic removed from this file.\n\n### `TripDocumentsTile.tsx`\nQuery throws typed error with `.status`. 403 → `return null` (no registration = no docs, expected). Non-403 error → discreet header-level retry button, no alarming message text. Real 500s are still surfaced as actionable.\n\n### `CalendarClient.tsx`\n`selectedEventId` initial state changed from `initialEventId` to `null`. Deep-link popups no longer auto-open at mount with `anchorEl=null`. `deepLinkId` still initialises from `initialEventId` for agenda row highlight + scroll.\n\n### `JoinActions.tsx`\nRemoved Share button and `copied`/`handleShare` state entirely. Calendar section and meeting URL fallback unaffected.\n\n### `EventPopup.tsx`\nAdded `handleShare` function (navigator.share → clipboard fallback, same pattern as original JoinActions). Share button rendered inline in the date/time section of `Body`, visible on both Popover (desktop) and Dialog (mobile)."