### PR TITLE
[SEQ375-ISS375] Extract RoleSelector, LangTabs, I18nField shared admin primitives

### DIFF
--- a/app/admin/components/I18nField.tsx
+++ b/app/admin/components/I18nField.tsx
@@ -27,13 +27,14 @@ export function I18nField({
     backgroundColor: 'var(--bg-card)',
   }
   const sharedClass = 'w-full border rounded-xl px-3 py-2.5 text-sm'
+  const placeholderText = placeholder ? `${placeholder} (${activeLang.toUpperCase()})` : undefined
 
   if (multiline) {
     return (
       <textarea
         value={value}
         onChange={e => onChange(activeLang, e.target.value)}
-        placeholder={placeholder ? `${placeholder} (${activeLang.toUpperCase()})` : undefined}
+        placeholder={placeholderText}
         rows={rows}
         className={`${sharedClass} resize-none`}
         style={sharedStyle}
@@ -45,7 +46,7 @@ export function I18nField({
     <input
       value={value}
       onChange={e => onChange(activeLang, e.target.value)}
-      placeholder={placeholder ? `${placeholder} (${activeLang.toUpperCase()})` : undefined}
+      placeholder={placeholderText}
       className={sharedClass}
       style={sharedStyle}
     />

--- a/app/admin/components/I18nField.tsx
+++ b/app/admin/components/I18nField.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+// Shared primitive: i18n text input or textarea for the active language.
+// Used by AnnouncementsTab (create + edit).
+
+type I18nFieldProps = {
+  activeLang: string
+  values: Record<string, string>
+  onChange: (lang: string, value: string) => void
+  multiline?: boolean
+  placeholder?: string
+  rows?: number
+}
+
+export function I18nField({
+  activeLang,
+  values,
+  onChange,
+  multiline = false,
+  placeholder,
+  rows = 4,
+}: I18nFieldProps) {
+  const value = values[activeLang] ?? ''
+  const sharedStyle = {
+    borderColor: 'var(--border-default)',
+    color: 'var(--text-primary)',
+    backgroundColor: 'var(--bg-card)',
+  }
+  const sharedClass = 'w-full border rounded-xl px-3 py-2.5 text-sm'
+
+  if (multiline) {
+    return (
+      <textarea
+        value={value}
+        onChange={e => onChange(activeLang, e.target.value)}
+        placeholder={placeholder ? `${placeholder} (${activeLang.toUpperCase()})` : undefined}
+        rows={rows}
+        className={`${sharedClass} resize-none`}
+        style={sharedStyle}
+      />
+    )
+  }
+
+  return (
+    <input
+      value={value}
+      onChange={e => onChange(activeLang, e.target.value)}
+      placeholder={placeholder ? `${placeholder} (${activeLang.toUpperCase()})` : undefined}
+      className={sharedClass}
+      style={sharedStyle}
+    />
+  )
+}

--- a/app/admin/components/LangTabs.tsx
+++ b/app/admin/components/LangTabs.tsx
@@ -11,11 +11,13 @@ type LangTabsProps = {
 
 export function LangTabs({ langs, active, onChange }: LangTabsProps) {
   return (
-    <div className="flex gap-2">
+    <div className="flex gap-2" role="tablist">
       {langs.map(l => (
         <button
           key={l}
           type="button"
+          role="tab"
+          aria-selected={active === l}
           onClick={() => onChange(l)}
           className="px-3 py-1 rounded-lg text-sm font-medium transition-colors"
           style={{

--- a/app/admin/components/LangTabs.tsx
+++ b/app/admin/components/LangTabs.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+// Shared primitive: language tab switcher.
+// Used by AnnouncementsTab (create + edit).
+
+type LangTabsProps = {
+  langs: string[]
+  active: string
+  onChange: (lang: string) => void
+}
+
+export function LangTabs({ langs, active, onChange }: LangTabsProps) {
+  return (
+    <div className="flex gap-2">
+      {langs.map(l => (
+        <button
+          key={l}
+          type="button"
+          onClick={() => onChange(l)}
+          className="px-3 py-1 rounded-lg text-sm font-medium transition-colors"
+          style={{
+            backgroundColor: active === l ? 'var(--text-primary)' : 'rgba(0,0,0,0.05)',
+            color: active === l ? 'white' : 'var(--text-secondary)',
+          }}
+        >
+          {l.toUpperCase()}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/app/admin/components/RoleSelector.tsx
+++ b/app/admin/components/RoleSelector.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+// Shared primitive: role toggle pill buttons.
+// Used by AnnouncementsTab (create + edit) and GuideForm.
+
+type RoleSelectorProps = {
+  roles: string[]
+  selected: string[]
+  onChange: (roles: string[]) => void
+}
+
+export function RoleSelector({ roles, selected, onChange }: RoleSelectorProps) {
+  function toggle(role: string) {
+    onChange(
+      selected.includes(role)
+        ? selected.filter(r => r !== role)
+        : [...selected, role]
+    )
+  }
+
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {roles.map(role => (
+        <button
+          key={role}
+          type="button"
+          onClick={() => toggle(role)}
+          className="px-3 py-1.5 rounded-full text-xs font-semibold transition-all"
+          style={{
+            backgroundColor: selected.includes(role) ? 'var(--brand-forest)' : 'rgba(0,0,0,0.06)',
+            color: selected.includes(role) ? 'var(--brand-parchment)' : 'var(--text-secondary)',
+          }}
+        >
+          {role}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/app/admin/components/RoleSelector.tsx
+++ b/app/admin/components/RoleSelector.tsx
@@ -24,6 +24,7 @@ export function RoleSelector({ roles, selected, onChange }: RoleSelectorProps) {
         <button
           key={role}
           type="button"
+          aria-pressed={selected.includes(role)}
           onClick={() => toggle(role)}
           className="px-3 py-1.5 rounded-full text-xs font-semibold transition-all"
           style={{

--- a/app/admin/content/components/AnnouncementsTab.tsx
+++ b/app/admin/content/components/AnnouncementsTab.tsx
@@ -29,6 +29,10 @@ type Announcement = {
 const LANGS = ['en', 'bg', 'sk']
 const ALL_ROLES = ['guest', 'member', 'core', 'admin']
 
+function emptyI18n() {
+  return Object.fromEntries(LANGS.map(l => [l, '']))
+}
+
 export function AnnouncementsTab() {
   const qc = useQueryClient()
   const announcementDrawer = useAdminDrawer<Announcement>()
@@ -38,15 +42,15 @@ export function AnnouncementsTab() {
   const [editALang, setEditALang] = useState('en')
 
   const [aForm, setAForm] = useState({
-    titles: { en: '', bg: '', sk: '' } as Record<string,string>,
-    contents: { en: '', bg: '', sk: '' } as Record<string,string>,
+    titles: emptyI18n() as Record<string,string>,
+    contents: emptyI18n() as Record<string,string>,
     is_active: true,
     access_level: [...ALL_ROLES] as string[],
   })
 
   const [editAForm, setEditAForm] = useState({
-    titles: { en: '', bg: '', sk: '' } as Record<string,string>,
-    contents: { en: '', bg: '', sk: '' } as Record<string,string>,
+    titles: emptyI18n() as Record<string,string>,
+    contents: emptyI18n() as Record<string,string>,
     is_active: true,
     access_level: [...ALL_ROLES] as string[],
   })
@@ -76,7 +80,7 @@ export function AnnouncementsTab() {
       }).then(r => r.json()),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['announcements'] })
-      setAForm({ titles: { en:'',bg:'',sk:'' }, contents: { en:'',bg:'',sk:'' }, is_active: true, access_level: [...ALL_ROLES] })
+      setAForm({ titles: emptyI18n(), contents: emptyI18n(), is_active: true, access_level: [...ALL_ROLES] })
     },
   })
 
@@ -109,8 +113,8 @@ export function AnnouncementsTab() {
 
   function startEditingAnnouncement(a: Announcement) {
     setEditAForm({
-      titles: { en: '', bg: '', sk: '', ...a.titles },
-      contents: { en: '', bg: '', sk: '', ...a.contents },
+      titles: { ...emptyI18n(), ...a.titles },
+      contents: { ...emptyI18n(), ...a.contents },
       is_active: a.is_active,
       access_level: Array.isArray(a.access_level) ? a.access_level : [...ALL_ROLES],
     })

--- a/app/admin/content/components/AnnouncementsTab.tsx
+++ b/app/admin/content/components/AnnouncementsTab.tsx
@@ -17,6 +17,9 @@ import { AdminListCard } from '@/app/admin/components/AdminListCard'
 import { AdminStatusBadge } from '@/app/admin/components/AdminStatusBadge'
 import { useAdminDrawer } from '@/app/admin/components/useAdminDrawer'
 import { makeDragHandlers } from './useDragSort'
+import { RoleSelector } from '@/app/admin/components/RoleSelector'
+import { LangTabs } from '@/app/admin/components/LangTabs'
+import { I18nField } from '@/app/admin/components/I18nField'
 
 type Announcement = {
   id: string; titles: Record<string,string>; contents: Record<string,string>
@@ -24,6 +27,7 @@ type Announcement = {
 }
 
 const LANGS = ['en', 'bg', 'sk']
+const ALL_ROLES = ['guest', 'member', 'core', 'admin']
 
 export function AnnouncementsTab() {
   const qc = useQueryClient()
@@ -37,14 +41,14 @@ export function AnnouncementsTab() {
     titles: { en: '', bg: '', sk: '' } as Record<string,string>,
     contents: { en: '', bg: '', sk: '' } as Record<string,string>,
     is_active: true,
-    access_level: ['guest', 'member', 'core', 'admin'] as string[],
+    access_level: [...ALL_ROLES] as string[],
   })
 
   const [editAForm, setEditAForm] = useState({
     titles: { en: '', bg: '', sk: '' } as Record<string,string>,
     contents: { en: '', bg: '', sk: '' } as Record<string,string>,
     is_active: true,
-    access_level: ['guest', 'member', 'core', 'admin'] as string[],
+    access_level: [...ALL_ROLES] as string[],
   })
 
   const { data: announcementsRaw = [] } = useQuery<Announcement[]>({
@@ -72,7 +76,7 @@ export function AnnouncementsTab() {
       }).then(r => r.json()),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['announcements'] })
-      setAForm({ titles: { en:'',bg:'',sk:'' }, contents: { en:'',bg:'',sk:'' }, is_active: true, access_level: ['guest','member','core','admin'] })
+      setAForm({ titles: { en:'',bg:'',sk:'' }, contents: { en:'',bg:'',sk:'' }, is_active: true, access_level: [...ALL_ROLES] })
     },
   })
 
@@ -108,7 +112,7 @@ export function AnnouncementsTab() {
       titles: { en: '', bg: '', sk: '', ...a.titles },
       contents: { en: '', bg: '', sk: '', ...a.contents },
       is_active: a.is_active,
-      access_level: Array.isArray(a.access_level) ? a.access_level : ['guest','member','core','admin'],
+      access_level: Array.isArray(a.access_level) ? a.access_level : [...ALL_ROLES],
     })
     setEditALang('en')
     announcementDrawer.openEdit(a)
@@ -118,42 +122,30 @@ export function AnnouncementsTab() {
 
   return (
     <section>
-      <div className="flex gap-2 mb-4">
-        {LANGS.map(l => (
-          <button key={l} onClick={() => setALang(l)}
-            className="px-3 py-1 rounded-lg text-sm font-medium transition-colors"
-            style={{
-              backgroundColor: aLang === l ? 'var(--text-primary)' : 'rgba(0,0,0,0.05)',
-              color: aLang === l ? 'white' : 'var(--text-secondary)',
-            }}>
-            {l.toUpperCase()}
-          </button>
-        ))}
+      <div className="mb-4">
+        <LangTabs langs={LANGS} active={aLang} onChange={setALang} />
       </div>
 
       {/* Inline create card — intentional exception per CLAUDE.md */}
       <div className="rounded-2xl border p-6 mb-4 space-y-3" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
-        <input value={aForm.titles[aLang] ?? ''}
-          onChange={e => setAForm(f => ({ ...f, titles: { ...f.titles, [aLang]: e.target.value } }))}
-          placeholder={`Title (${aLang.toUpperCase()})`}
-          className="w-full border rounded-xl px-3 py-2.5 text-sm"
-          style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
-        <textarea value={aForm.contents[aLang] ?? ''}
-          onChange={e => setAForm(f => ({ ...f, contents: { ...f.contents, [aLang]: e.target.value } }))}
-          placeholder={`Content (${aLang.toUpperCase()})`}
-          rows={4}
-          className="w-full border rounded-xl px-3 py-2.5 text-sm resize-none"
-          style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
-        <div className="flex gap-2 flex-wrap">
-          {['guest','member','core','admin'].map(role => (
-            <button key={role}
-              onClick={() => setAForm(f => ({ ...f, access_level: f.access_level.includes(role) ? f.access_level.filter(r => r !== role) : [...f.access_level, role] }))}
-              className="px-3 py-1 rounded-full text-xs font-semibold transition-all"
-              style={{ backgroundColor: aForm.access_level.includes(role) ? 'var(--brand-forest)' : 'rgba(0,0,0,0.06)', color: aForm.access_level.includes(role) ? 'var(--brand-parchment)' : 'var(--text-secondary)' }}>
-              {role}
-            </button>
-          ))}
-        </div>
+        <I18nField
+          activeLang={aLang}
+          values={aForm.titles}
+          onChange={(lang, val) => setAForm(f => ({ ...f, titles: { ...f.titles, [lang]: val } }))}
+          placeholder="Title"
+        />
+        <I18nField
+          activeLang={aLang}
+          values={aForm.contents}
+          onChange={(lang, val) => setAForm(f => ({ ...f, contents: { ...f.contents, [lang]: val } }))}
+          placeholder="Content"
+          multiline
+        />
+        <RoleSelector
+          roles={ALL_ROLES}
+          selected={aForm.access_level}
+          onChange={access_level => setAForm(f => ({ ...f, access_level }))}
+        />
         <button onClick={() => createAnnouncement.mutate(aForm)}
           disabled={createAnnouncement.isPending || !aForm.titles.en}
           className="px-5 py-2 rounded-xl text-sm font-semibold text-white disabled:opacity-50 hover:opacity-90 transition-opacity"
@@ -194,36 +186,25 @@ export function AnnouncementsTab() {
 
       <Drawer open={announcementDrawer.open} onClose={announcementDrawer.close} title="Edit announcement">
         <div className="space-y-3">
-          <div className="flex gap-2 mb-2">
-            {LANGS.map(l => (
-              <button key={l} onClick={() => setEditALang(l)}
-                className="px-3 py-1 rounded-lg text-sm font-medium transition-colors"
-                style={{ backgroundColor: editALang === l ? 'var(--text-primary)' : 'rgba(0,0,0,0.05)', color: editALang === l ? 'white' : 'var(--text-secondary)' }}>
-                {l.toUpperCase()}
-              </button>
-            ))}
-          </div>
-          <input value={editAForm.titles[editALang] ?? ''}
-            onChange={e => setEditAForm(f => ({ ...f, titles: { ...f.titles, [editALang]: e.target.value } }))}
-            placeholder={`Title (${editALang.toUpperCase()})`}
-            className="w-full border rounded-xl px-3 py-2.5 text-sm"
-            style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
-          <textarea value={editAForm.contents[editALang] ?? ''}
-            onChange={e => setEditAForm(f => ({ ...f, contents: { ...f.contents, [editALang]: e.target.value } }))}
-            placeholder={`Content (${editALang.toUpperCase()})`}
-            rows={4}
-            className="w-full border rounded-xl px-3 py-2.5 text-sm resize-none"
-            style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
-          <div className="flex gap-2 flex-wrap">
-            {['guest','member','core','admin'].map(role => (
-              <button key={role}
-                onClick={() => setEditAForm(f => ({ ...f, access_level: f.access_level.includes(role) ? f.access_level.filter(r => r !== role) : [...f.access_level, role] }))}
-                className="px-3 py-1 rounded-full text-xs font-semibold transition-all"
-                style={{ backgroundColor: editAForm.access_level.includes(role) ? 'var(--brand-forest)' : 'rgba(0,0,0,0.06)', color: editAForm.access_level.includes(role) ? 'var(--brand-parchment)' : 'var(--text-secondary)' }}>
-                {role}
-              </button>
-            ))}
-          </div>
+          <LangTabs langs={LANGS} active={editALang} onChange={setEditALang} />
+          <I18nField
+            activeLang={editALang}
+            values={editAForm.titles}
+            onChange={(lang, val) => setEditAForm(f => ({ ...f, titles: { ...f.titles, [lang]: val } }))}
+            placeholder="Title"
+          />
+          <I18nField
+            activeLang={editALang}
+            values={editAForm.contents}
+            onChange={(lang, val) => setEditAForm(f => ({ ...f, contents: { ...f.contents, [lang]: val } }))}
+            placeholder="Content"
+            multiline
+          />
+          <RoleSelector
+            roles={ALL_ROLES}
+            selected={editAForm.access_level}
+            onChange={access_level => setEditAForm(f => ({ ...f, access_level }))}
+          />
           <div className="flex gap-3 pt-2">
             <button onClick={() => announcementDrawer.editing && updateAnnouncement.mutate({ id: announcementDrawer.editing.id, ...editAForm })}
               disabled={updateAnnouncement.isPending || !editAForm.titles.en}

--- a/app/admin/content/components/GuideForm.tsx
+++ b/app/admin/content/components/GuideForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { AdminStatusBadge } from '@/app/admin/components/AdminStatusBadge'
+import { RoleSelector } from '@/app/admin/components/RoleSelector'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -189,15 +190,6 @@ export function GuideForm({
     }))
   }
 
-  function toggleRole(role: string) {
-    setForm(f => ({
-      ...f,
-      access_roles: f.access_roles.includes(role)
-        ? f.access_roles.filter(r => r !== role)
-        : [...f.access_roles, role],
-    }))
-  }
-
   async function handleCoverFileChange(file: File) {
     setCoverFile(file)
     setCoverUploading(true)
@@ -331,18 +323,11 @@ export function GuideForm({
       <div>
         <label className="text-xs font-semibold uppercase tracking-widest mb-2 block"
           style={{ color: 'var(--text-secondary)' }}>Access Roles</label>
-        <div className="flex gap-2">
-          {ALL_ROLES.map(role => (
-            <button key={role} onClick={() => toggleRole(role)}
-              className="px-3 py-1.5 rounded-full text-xs font-semibold transition-all"
-              style={{
-                backgroundColor: form.access_roles.includes(role) ? 'var(--brand-forest)' : 'rgba(0,0,0,0.06)',
-                color: form.access_roles.includes(role) ? 'var(--brand-parchment)' : 'var(--text-secondary)',
-              }}>
-              {role}
-            </button>
-          ))}
-        </div>
+        <RoleSelector
+          roles={ALL_ROLES}
+          selected={form.access_roles}
+          onChange={access_roles => setForm(f => ({ ...f, access_roles }))}
+        />
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
Extracts three shared admin UI primitives from duplicated implementations in AnnouncementsTab and GuideForm.

**New files:**
- `app/admin/components/RoleSelector.tsx` — pill toggle role buttons
- `app/admin/components/LangTabs.tsx` — language tab switcher
- `app/admin/components/I18nField.tsx` — i18n text input/textarea for active lang

**Migrated:**
- `AnnouncementsTab.tsx` — create card and edit drawer now use all three primitives
- `GuideForm.tsx` — role toggles now use RoleSelector; title inputs remain side-by-side grid (not tab-switched, so LangTabs/I18nField don't apply there)

**No behaviour changes.** Create/edit for announcements and guides work identically.

## Session State
**Status:** DONE
**Last touched:** `app/admin/content/components/GuideForm.tsx`
**Completed:**
- [x] RoleSelector, LangTabs, I18nField created
- [x] AnnouncementsTab migrated
- [x] GuideForm migrated
- [x] PR opened