### PR TITLE
[SEQ379] Add org-chart view to LOS page

### DIFF
--- a/app/(dashboard)/los/components/OrgChartCanvas.tsx
+++ b/app/(dashboard)/los/components/OrgChartCanvas.tsx
@@ -1,37 +1,10 @@
 'use client'
 
-import { useRef, useState, useCallback, useEffect, useMemo } from 'react'
+import { useRef, useState, useEffect, useMemo } from 'react'
+import { displayName, roleColors } from '../lib/los-utils'
+import type { LOSNode } from '../lib/los-utils'
 
-// ── Types ─────────────────────────────────────────────────────────────────────
-
-type VitalSign = {
-  event_key: string
-  event_label: string
-  has_ticket: boolean
-  updated_at: string
-}
-
-export type LOSNode = {
-  profile_id: string | null
-  abo_number: string | null
-  sponsor_abo_number: string | null
-  abo_level: string | null
-  name: string | null
-  first_name: string | null
-  last_name: string | null
-  role: string | null
-  depth: number | null
-  country: string | null
-  gpv: number | null
-  ppv: number | null
-  bonus_percent: number | null
-  group_size: number | null
-  qualified_legs: number | null
-  annual_ppv: number | null
-  renewal_date: string | null
-  vital_signs: VitalSign[]
-  children?: LOSNode[]
-}
+export type { LOSNode }
 
 // ── Layout types ──────────────────────────────────────────────────────────────
 
@@ -51,25 +24,9 @@ const GAP_Y  = 56
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function displayName(node: LOSNode): string {
-  if (node.first_name && node.last_name) return `${node.last_name}, ${node.first_name}`
-  return node.name ?? node.abo_number ?? '—'
-}
-
 function fmt(v: number | null): string {
   if (v == null) return '—'
   return v.toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-}
-
-const ROLE_COLORS: Record<string, { border: string; labelBg: string; labelColor: string }> = {
-  admin:  { border: '#2d332a',             labelBg: '#2d332a',               labelColor: '#FAF8F3' },
-  core:   { border: '#3E7785',             labelBg: '#3E7785',               labelColor: '#FAF8F3' },
-  member: { border: 'rgba(45,51,42,0.2)',  labelBg: 'rgba(62,119,133,0.12)', labelColor: '#3E7785' },
-  guest:  { border: 'rgba(45,51,42,0.1)',  labelBg: 'rgba(0,0,0,0.05)',      labelColor: '#8A8577' },
-}
-
-function rc(role: string | null) {
-  return ROLE_COLORS[role ?? 'guest'] ?? ROLE_COLORS.guest
 }
 
 // ── Depth cap ─────────────────────────────────────────────────────────────────
@@ -82,26 +39,36 @@ function capDepth(node: LOSNode, maxDepth: number, current = 0): LOSNode {
   }
 }
 
-// ── Layout algorithm ──────────────────────────────────────────────────────────
+// ── Layout algorithm (single bottom-up pass, O(N)) ────────────────────────────
+// widthMap memoizes subtree widths so each node is measured exactly once.
 
-function subtreeWidth(node: LOSNode): number {
+function buildWidthMap(node: LOSNode, map: Map<LOSNode, number>): number {
   const children = node.children ?? []
-  if (children.length === 0) return CARD_W
-  const childrenWidth = children.reduce((sum, c) => sum + subtreeWidth(c), 0)
-  return Math.max(CARD_W, childrenWidth + GAP_X * (children.length - 1))
+  if (children.length === 0) {
+    map.set(node, CARD_W)
+    return CARD_W
+  }
+  const childrenWidth = children.reduce((sum, c) => sum + buildWidthMap(c, map), 0)
+  const w = Math.max(CARD_W, childrenWidth + GAP_X * (children.length - 1))
+  map.set(node, w)
+  return w
 }
 
-function layoutNode(node: LOSNode, cx: number, y: number): LayoutNode {
+function layoutNode(node: LOSNode, cx: number, y: number, widthMap: Map<LOSNode, number>): LayoutNode {
   const children = node.children ?? []
   if (children.length === 0) return { node, x: cx, y, children: [] }
-  const widths = children.map(subtreeWidth)
-  const totalWidth = widths.reduce((s, w) => s + w, 0) + GAP_X * (children.length - 1)
+  const totalWidth = (widthMap.get(node) ?? CARD_W)
   let cursor = cx - totalWidth / 2
+  // Recompute cursor offset: totalWidth already accounts for GAP_X between siblings,
+  // but cursor starts at the left edge of the first child's subtree.
+  const childWidths = children.map(c => widthMap.get(c) ?? CARD_W)
+  const innerWidth = childWidths.reduce((s, w) => s + w, 0) + GAP_X * (children.length - 1)
+  cursor = cx - innerWidth / 2
   const layoutChildren = children.map((child, i) => {
-    const w = widths[i]
+    const w = childWidths[i]
     const childCx = cursor + w / 2
     cursor += w + GAP_X
-    return layoutNode(child, childCx, y + CARD_H + GAP_Y)
+    return layoutNode(child, childCx, y + CARD_H + GAP_Y, widthMap)
   })
   return { node, x: cx, y, children: layoutChildren }
 }
@@ -124,23 +91,21 @@ function collectEdges(root: LayoutNode): Array<{ x1: number; y1: number; x2: num
   return edges
 }
 
-function canvasBounds(nodes: LayoutNode[]): { minX: number; maxX: number; maxY: number } {
-  let minX = Infinity, maxX = -Infinity, maxY = -Infinity
+function canvasBounds(nodes: LayoutNode[]): { maxX: number; maxY: number } {
+  let maxX = -Infinity, maxY = -Infinity
   for (const n of nodes) {
-    minX = Math.min(minX, n.x - CARD_W / 2)
     maxX = Math.max(maxX, n.x + CARD_W / 2)
     maxY = Math.max(maxY, n.y + CARD_H)
   }
-  return { minX, maxX, maxY }
+  return { maxX, maxY }
 }
 
 // ── OrgChartNode card ─────────────────────────────────────────────────────────
 
 function OrgChartNode({ ln }: { ln: LayoutNode }) {
   const { node, x, y } = ln
-  const colors = rc(node.role)
+  const colors = roleColors(node.role)
   const name = displayName(node)
-  const roleLabel = node.role ?? 'guest'
 
   return (
     <foreignObject x={x - CARD_W / 2} y={y} width={CARD_W} height={CARD_H} style={{ overflow: 'visible' }}>
@@ -190,7 +155,7 @@ function OrgChartNode({ ln }: { ln: LayoutNode }) {
               letterSpacing: '0.04em',
             }}
           >
-            {roleLabel}
+            {node.role ?? 'guest'}
           </span>
         </div>
 
@@ -239,17 +204,24 @@ export function OrgChartCanvas({ roots, maxDepth }: { roots: LOSNode[]; maxDepth
   const [transform, setTransform] = useState({ x: 0, y: 0, scale: 1 })
   const dragging = useRef(false)
   const lastPos = useRef({ x: 0, y: 0 })
+  const containerRef = useRef<HTMLDivElement>(null)
 
   const { nodes, edges, svgW, svgH } = useMemo(() => {
     const PADDING = 40
     const cappedRoots = roots.map(r => capDepth(r, maxDepth))
+
+    // Single bottom-up pass: build width map for all nodes before layout
+    const widthMap = new Map<LOSNode, number>()
+    cappedRoots.forEach(r => buildWidthMap(r, widthMap))
+
     const rootLayouts: LayoutNode[] = []
     let cursor = PADDING
     for (const root of cappedRoots) {
-      const w = subtreeWidth(root)
-      rootLayouts.push(layoutNode(root, cursor + w / 2, PADDING))
+      const w = widthMap.get(root) ?? CARD_W
+      rootLayouts.push(layoutNode(root, cursor + w / 2, PADDING, widthMap))
       cursor += w + GAP_X * 2
     }
+
     const allNodes = rootLayouts.flatMap(flattenLayout)
     const allEdges = rootLayouts.flatMap(collectEdges)
     const bounds = canvasBounds(allNodes)
@@ -263,26 +235,39 @@ export function OrgChartCanvas({ roots, maxDepth }: { roots: LOSNode[]; maxDepth
 
   useEffect(() => { setTransform({ x: 0, y: 0, scale: 1 }) }, [roots, maxDepth])
 
-  const onPointerDown = useCallback((e: React.PointerEvent) => {
+  // ── Pointer drag ─────────────────────────────────────────────────────────────
+
+  const onPointerDown = (e: React.PointerEvent) => {
     dragging.current = true
     lastPos.current = { x: e.clientX, y: e.clientY }
     ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
-  }, [])
+  }
 
-  const onPointerMove = useCallback((e: React.PointerEvent) => {
+  const onPointerMove = (e: React.PointerEvent) => {
     if (!dragging.current) return
     const dx = e.clientX - lastPos.current.x
     const dy = e.clientY - lastPos.current.y
     lastPos.current = { x: e.clientX, y: e.clientY }
     setTransform(t => ({ ...t, x: t.x + dx, y: t.y + dy }))
-  }, [])
+  }
 
-  const onPointerUp = useCallback(() => { dragging.current = false }, [])
+  const onPointerUp = () => { dragging.current = false }
 
-  const onWheel = useCallback((e: React.WheelEvent) => {
-    e.preventDefault()
-    const delta = e.deltaY > 0 ? 0.9 : 1.1
-    setTransform(t => ({ ...t, scale: Math.max(0.3, Math.min(2.5, t.scale * delta)) }))
+  // ── Wheel zoom — non-passive native listener ───────────────────────────────
+  // React's synthetic onWheel is passive in Chrome/Safari; preventDefault() is
+  // silently ignored, causing the page to scroll instead of zooming.
+  // Attaching a native listener with { passive: false } is the only correct fix.
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const handler = (e: WheelEvent) => {
+      e.preventDefault()
+      const delta = e.deltaY > 0 ? 0.9 : 1.1
+      setTransform(t => ({ ...t, scale: Math.max(0.3, Math.min(2.5, t.scale * delta)) }))
+    }
+    el.addEventListener('wheel', handler, { passive: false })
+    return () => el.removeEventListener('wheel', handler)
   }, [])
 
   return (
@@ -299,11 +284,11 @@ export function OrgChartCanvas({ roots, maxDepth }: { roots: LOSNode[]; maxDepth
         Reset
       </button>
       <div
+        ref={containerRef}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerLeave={onPointerUp}
-        onWheel={onWheel}
         style={{
           width: '100%', overflowX: 'auto', overflowY: 'hidden',
           cursor: 'grab', borderRadius: 16,

--- a/app/(dashboard)/los/components/OrgChartCanvas.tsx
+++ b/app/(dashboard)/los/components/OrgChartCanvas.tsx
@@ -1,0 +1,329 @@
+'use client'
+
+import { useRef, useState, useCallback, useEffect, useMemo } from 'react'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type VitalSign = {
+  event_key: string
+  event_label: string
+  has_ticket: boolean
+  updated_at: string
+}
+
+export type LOSNode = {
+  profile_id: string | null
+  abo_number: string | null
+  sponsor_abo_number: string | null
+  abo_level: string | null
+  name: string | null
+  first_name: string | null
+  last_name: string | null
+  role: string | null
+  depth: number | null
+  country: string | null
+  gpv: number | null
+  ppv: number | null
+  bonus_percent: number | null
+  group_size: number | null
+  qualified_legs: number | null
+  annual_ppv: number | null
+  renewal_date: string | null
+  vital_signs: VitalSign[]
+  children?: LOSNode[]
+}
+
+// ── Layout types ──────────────────────────────────────────────────────────────
+
+type LayoutNode = {
+  node: LOSNode
+  x: number   // center x
+  y: number   // top y
+  children: LayoutNode[]
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const CARD_W = 160
+const CARD_H = 108
+const GAP_X  = 24
+const GAP_Y  = 56
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function displayName(node: LOSNode): string {
+  if (node.first_name && node.last_name) return `${node.last_name}, ${node.first_name}`
+  return node.name ?? node.abo_number ?? '—'
+}
+
+function fmt(v: number | null): string {
+  if (v == null) return '—'
+  return v.toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+const ROLE_COLORS: Record<string, { border: string; labelBg: string; labelColor: string }> = {
+  admin:  { border: '#2d332a',             labelBg: '#2d332a',               labelColor: '#FAF8F3' },
+  core:   { border: '#3E7785',             labelBg: '#3E7785',               labelColor: '#FAF8F3' },
+  member: { border: 'rgba(45,51,42,0.2)',  labelBg: 'rgba(62,119,133,0.12)', labelColor: '#3E7785' },
+  guest:  { border: 'rgba(45,51,42,0.1)',  labelBg: 'rgba(0,0,0,0.05)',      labelColor: '#8A8577' },
+}
+
+function rc(role: string | null) {
+  return ROLE_COLORS[role ?? 'guest'] ?? ROLE_COLORS.guest
+}
+
+// ── Depth cap ─────────────────────────────────────────────────────────────────
+
+function capDepth(node: LOSNode, maxDepth: number, current = 0): LOSNode {
+  if (current >= maxDepth) return { ...node, children: [] }
+  return {
+    ...node,
+    children: (node.children ?? []).map(c => capDepth(c, maxDepth, current + 1)),
+  }
+}
+
+// ── Layout algorithm ──────────────────────────────────────────────────────────
+
+function subtreeWidth(node: LOSNode): number {
+  const children = node.children ?? []
+  if (children.length === 0) return CARD_W
+  const childrenWidth = children.reduce((sum, c) => sum + subtreeWidth(c), 0)
+  return Math.max(CARD_W, childrenWidth + GAP_X * (children.length - 1))
+}
+
+function layoutNode(node: LOSNode, cx: number, y: number): LayoutNode {
+  const children = node.children ?? []
+  if (children.length === 0) return { node, x: cx, y, children: [] }
+  const widths = children.map(subtreeWidth)
+  const totalWidth = widths.reduce((s, w) => s + w, 0) + GAP_X * (children.length - 1)
+  let cursor = cx - totalWidth / 2
+  const layoutChildren = children.map((child, i) => {
+    const w = widths[i]
+    const childCx = cursor + w / 2
+    cursor += w + GAP_X
+    return layoutNode(child, childCx, y + CARD_H + GAP_Y)
+  })
+  return { node, x: cx, y, children: layoutChildren }
+}
+
+function flattenLayout(root: LayoutNode): LayoutNode[] {
+  const result: LayoutNode[] = [root]
+  for (const c of root.children) result.push(...flattenLayout(c))
+  return result
+}
+
+function collectEdges(root: LayoutNode): Array<{ x1: number; y1: number; x2: number; y2: number }> {
+  const edges: Array<{ x1: number; y1: number; x2: number; y2: number }> = []
+  function walk(n: LayoutNode) {
+    for (const child of n.children) {
+      edges.push({ x1: n.x, y1: n.y + CARD_H, x2: child.x, y2: child.y })
+      walk(child)
+    }
+  }
+  walk(root)
+  return edges
+}
+
+function canvasBounds(nodes: LayoutNode[]): { minX: number; maxX: number; maxY: number } {
+  let minX = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (const n of nodes) {
+    minX = Math.min(minX, n.x - CARD_W / 2)
+    maxX = Math.max(maxX, n.x + CARD_W / 2)
+    maxY = Math.max(maxY, n.y + CARD_H)
+  }
+  return { minX, maxX, maxY }
+}
+
+// ── OrgChartNode card ─────────────────────────────────────────────────────────
+
+function OrgChartNode({ ln }: { ln: LayoutNode }) {
+  const { node, x, y } = ln
+  const colors = rc(node.role)
+  const name = displayName(node)
+  const roleLabel = node.role ?? 'guest'
+
+  return (
+    <foreignObject x={x - CARD_W / 2} y={y} width={CARD_W} height={CARD_H} style={{ overflow: 'visible' }}>
+      <div
+        style={{
+          width: CARD_W,
+          height: CARD_H,
+          borderRadius: 12,
+          border: `1px solid ${colors.border}`,
+          backgroundColor: 'var(--bg-card)',
+          padding: '8px 10px',
+          boxSizing: 'border-box',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+          userSelect: 'none',
+        }}
+      >
+        {/* Name + badge */}
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4, marginBottom: 2 }}>
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              color: 'var(--text-primary)',
+              flex: 1,
+              lineHeight: 1.25,
+              overflow: 'hidden',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+            }}
+          >
+            {name}
+          </span>
+          <span
+            style={{
+              fontSize: 9,
+              fontWeight: 700,
+              padding: '1px 5px',
+              borderRadius: 99,
+              backgroundColor: colors.labelBg,
+              color: colors.labelColor,
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+            }}
+          >
+            {roleLabel}
+          </span>
+        </div>
+
+        {/* Bonus % */}
+        {node.bonus_percent != null && (
+          <span style={{ fontSize: 10, color: 'var(--text-secondary)' }}>
+            {node.bonus_percent}%
+          </span>
+        )}
+
+        {/* ЛТС (PPV) */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 9, color: 'var(--text-tertiary)', letterSpacing: '0.02em' }}>ЛТС</span>
+          <span style={{ fontSize: 10, fontWeight: 500, color: 'var(--text-primary)' }}>{fmt(node.ppv)}</span>
+        </div>
+
+        {/* ГТС (GPV) */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 9, color: 'var(--text-tertiary)', letterSpacing: '0.02em' }}>ГТС</span>
+          <span style={{ fontSize: 10, fontWeight: 500, color: 'var(--text-primary)' }}>{fmt(node.gpv)}</span>
+        </div>
+
+        {/* Group size */}
+        {node.group_size != null && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 'auto' }}>
+            <span style={{ fontSize: 9, color: 'var(--text-tertiary)' }}>👥</span>
+            <span style={{ fontSize: 10, color: 'var(--text-secondary)' }}>{node.group_size}</span>
+          </div>
+        )}
+      </div>
+    </foreignObject>
+  )
+}
+
+// ── Bezier edge ───────────────────────────────────────────────────────────────
+
+function OrgChartEdge({ x1, y1, x2, y2 }: { x1: number; y1: number; x2: number; y2: number }) {
+  const midY = (y1 + y2) / 2
+  const d = `M ${x1} ${y1} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${y2}`
+  return <path d={d} fill="none" stroke="var(--border-default)" strokeWidth={1.5} />
+}
+
+// ── Main canvas ───────────────────────────────────────────────────────────────
+
+export function OrgChartCanvas({ roots, maxDepth }: { roots: LOSNode[]; maxDepth: number }) {
+  const [transform, setTransform] = useState({ x: 0, y: 0, scale: 1 })
+  const dragging = useRef(false)
+  const lastPos = useRef({ x: 0, y: 0 })
+
+  const { nodes, edges, svgW, svgH } = useMemo(() => {
+    const PADDING = 40
+    const cappedRoots = roots.map(r => capDepth(r, maxDepth))
+    const rootLayouts: LayoutNode[] = []
+    let cursor = PADDING
+    for (const root of cappedRoots) {
+      const w = subtreeWidth(root)
+      rootLayouts.push(layoutNode(root, cursor + w / 2, PADDING))
+      cursor += w + GAP_X * 2
+    }
+    const allNodes = rootLayouts.flatMap(flattenLayout)
+    const allEdges = rootLayouts.flatMap(collectEdges)
+    const bounds = canvasBounds(allNodes)
+    return {
+      nodes: allNodes,
+      edges: allEdges,
+      svgW: Math.max(bounds.maxX + PADDING, 320),
+      svgH: bounds.maxY + PADDING,
+    }
+  }, [roots, maxDepth])
+
+  useEffect(() => { setTransform({ x: 0, y: 0, scale: 1 }) }, [roots, maxDepth])
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    dragging.current = true
+    lastPos.current = { x: e.clientX, y: e.clientY }
+    ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+  }, [])
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!dragging.current) return
+    const dx = e.clientX - lastPos.current.x
+    const dy = e.clientY - lastPos.current.y
+    lastPos.current = { x: e.clientX, y: e.clientY }
+    setTransform(t => ({ ...t, x: t.x + dx, y: t.y + dy }))
+  }, [])
+
+  const onPointerUp = useCallback(() => { dragging.current = false }, [])
+
+  const onWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault()
+    const delta = e.deltaY > 0 ? 0.9 : 1.1
+    setTransform(t => ({ ...t, scale: Math.max(0.3, Math.min(2.5, t.scale * delta)) }))
+  }, [])
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        onClick={() => setTransform({ x: 0, y: 0, scale: 1 })}
+        style={{
+          position: 'absolute', top: 8, right: 8, zIndex: 10,
+          fontSize: 11, fontWeight: 600, padding: '4px 10px',
+          borderRadius: 8, border: '1px solid var(--border-default)',
+          backgroundColor: 'var(--bg-card)', color: 'var(--text-secondary)', cursor: 'pointer',
+        }}
+      >
+        Reset
+      </button>
+      <div
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerLeave={onPointerUp}
+        onWheel={onWheel}
+        style={{
+          width: '100%', overflowX: 'auto', overflowY: 'hidden',
+          cursor: 'grab', borderRadius: 16,
+          border: '1px solid var(--border-default)',
+          backgroundColor: 'var(--bg-global)', minHeight: 200,
+        }}
+      >
+        <svg
+          width={svgW}
+          height={svgH}
+          style={{
+            display: 'block',
+            transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
+            transformOrigin: 'top center',
+          }}
+        >
+          <g>{edges.map((e, i) => <OrgChartEdge key={i} x1={e.x1} y1={e.y1} x2={e.x2} y2={e.y2} />)}</g>
+          <g>{nodes.map((ln, i) => <OrgChartNode key={ln.node.abo_number ?? ln.node.profile_id ?? i} ln={ln} />)}</g>
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/app/(dashboard)/los/lib/los-utils.ts
+++ b/app/(dashboard)/los/lib/los-utils.ts
@@ -1,0 +1,65 @@
+// ── Shared types & utilities for the LOS route ───────────────────────────────
+// Co-located here per CLAUDE.md: promote to /components only when 2+ unrelated
+// routes consume this.
+
+export type VitalSign = {
+  event_key: string
+  event_label: string
+  has_ticket: boolean
+  updated_at: string
+}
+
+export type LOSNode = {
+  profile_id: string | null
+  abo_number: string | null
+  sponsor_abo_number: string | null
+  abo_level: string | null
+  name: string | null
+  first_name: string | null
+  last_name: string | null
+  role: string | null
+  depth: number | null
+  country: string | null
+  gpv: number | null
+  ppv: number | null
+  bonus_percent: number | null
+  group_size: number | null
+  qualified_legs: number | null
+  annual_ppv: number | null
+  renewal_date: string | null
+  vital_signs: VitalSign[]
+  children?: LOSNode[]
+}
+
+export type TreeResponse = {
+  scope: 'full' | 'subtree' | 'guest'
+  nodes: LOSNode[]
+  caller_abo: string | null
+}
+
+// ── Name formatting ───────────────────────────────────────────────────────────
+// Single canonical format: First Last. Used in both list and chart views.
+export function displayName(node: Pick<LOSNode, 'first_name' | 'last_name' | 'name' | 'abo_number'>): string {
+  if (node.first_name && node.last_name) return `${node.first_name} ${node.last_name}`
+  return node.name ?? node.abo_number ?? '—'
+}
+
+// ── Role colors ───────────────────────────────────────────────────────────────
+
+export type RoleColors = {
+  border: string
+  labelBg: string
+  labelColor: string
+  opacity: number
+}
+
+const ROLE_COLORS: Record<string, RoleColors> = {
+  admin:  { border: '#2d332a',             labelBg: '#2d332a',               labelColor: '#FAF8F3', opacity: 1   },
+  core:   { border: '#3E7785',             labelBg: '#3E7785',               labelColor: '#FAF8F3', opacity: 1   },
+  member: { border: 'rgba(45,51,42,0.15)', labelBg: 'rgba(62,119,133,0.12)', labelColor: '#3E7785', opacity: 1   },
+  guest:  { border: 'rgba(45,51,42,0.08)', labelBg: 'rgba(0,0,0,0.05)',      labelColor: '#8A8577', opacity: 0.6 },
+}
+
+export function roleColors(role: string | null): RoleColors {
+  return ROLE_COLORS[role ?? 'guest'] ?? ROLE_COLORS.guest
+}

--- a/app/(dashboard)/los/page.tsx
+++ b/app/(dashboard)/los/page.tsx
@@ -1,8 +1,11 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, Suspense } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { formatDate } from '@/lib/format'
+import { OrgChartCanvas } from './components/OrgChartCanvas'
+import type { LOSNode } from './components/OrgChartCanvas'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -13,42 +16,22 @@ type VitalSign = {
   updated_at: string
 }
 
-type LOSNode = {
-  profile_id: string | null
-  abo_number: string | null
-  sponsor_abo_number: string | null
-  abo_level: string | null
-  name: string | null
-  first_name: string | null
-  last_name: string | null
-  role: string | null
-  depth: number | null
-  country: string | null
-  gpv: number | null
-  ppv: number | null
-  bonus_percent: number | null
-  group_size: number | null
-  qualified_legs: number | null
-  annual_ppv: number | null
-  renewal_date: string | null
-  vital_signs: VitalSign[]
-  children?: LOSNode[]
-}
+type LOSNodeInternal = LOSNode
 
 type TreeResponse = {
   scope: 'full' | 'subtree' | 'guest'
-  nodes: LOSNode[]
+  nodes: LOSNodeInternal[]
   caller_abo: string | null
 }
 
 // ── Tree builder ──────────────────────────────────────────────────────────────
 
-function buildTree(nodes: LOSNode[], rootAbo: string | null): LOSNode[] {
-  const byAbo: Record<string, LOSNode> = {}
+function buildTree(nodes: LOSNodeInternal[], rootAbo: string | null): LOSNodeInternal[] {
+  const byAbo: Record<string, LOSNodeInternal> = {}
   for (const n of nodes) {
     if (n.abo_number) byAbo[n.abo_number] = { ...n, children: [] }
   }
-  const roots: LOSNode[] = []
+  const roots: LOSNodeInternal[] = []
   for (const n of Object.values(byAbo)) {
     const parent = n.sponsor_abo_number ? byAbo[n.sponsor_abo_number] : null
     if (parent) parent.children!.push(n)
@@ -58,7 +41,7 @@ function buildTree(nodes: LOSNode[], rootAbo: string | null): LOSNode[] {
   return roots
 }
 
-function displayName(node: LOSNode): string {
+function displayName(node: LOSNodeInternal): string {
   if (node.first_name && node.last_name) return `${node.first_name} ${node.last_name}`
   return node.name ?? node.abo_number ?? '—'
 }
@@ -90,7 +73,7 @@ function Stat({ label, value }: { label: string; value: string }) {
 // ── MemberCard ────────────────────────────────────────────────────────────────
 
 function MemberCard({ node, isExpanded, onToggle }: {
-  node: LOSNode
+  node: LOSNodeInternal
   isExpanded: boolean
   onToggle: () => void
 }) {
@@ -116,30 +99,25 @@ function MemberCard({ node, isExpanded, onToggle }: {
         >
           <polyline points="9 18 15 12 9 6" />
         </svg>
-
         <span className="text-sm font-semibold flex-1 min-w-0 truncate" style={{ color: 'var(--text-primary)' }}>
           {name}
         </span>
-
         {node.abo_number && (
           <span className="text-xs font-mono flex-shrink-0" style={{ color: 'var(--text-tertiary)' }}>
             {node.abo_number}
           </span>
         )}
-
         <span
           className="text-[10px] font-bold px-2 py-0.5 rounded-full flex-shrink-0 uppercase tracking-wide"
           style={{ backgroundColor: rc.labelBg, color: rc.labelColor }}
         >
           {node.role ?? 'guest'}
         </span>
-
         {node.abo_level && (
           <span className="text-[10px] flex-shrink-0" style={{ color: 'var(--text-secondary)' }}>
             {node.abo_level}%
           </span>
         )}
-
         {!isExpanded && hasVitals && (
           <div className="flex gap-1 flex-shrink-0">
             {node.vital_signs.map(vs => (
@@ -159,8 +137,8 @@ function MemberCard({ node, isExpanded, onToggle }: {
           {hasStats && (
             <div className="grid grid-cols-2 gap-x-6 gap-y-2">
               {node.abo_level && <Stat label="ABO Level" value={`${node.abo_level}%`} />}
-              {node.gpv != null && <Stat label="GPV" value={node.gpv.toLocaleString('de-DE', { maximumFractionDigits: 0 })} />}
-              {node.ppv != null && <Stat label="PPV" value={node.ppv.toLocaleString('de-DE', { maximumFractionDigits: 0 })} />}
+              {node.gpv != null && <Stat label="ГТС" value={node.gpv.toLocaleString('de-DE', { maximumFractionDigits: 0 })} />}
+              {node.ppv != null && <Stat label="ЛТС" value={node.ppv.toLocaleString('de-DE', { maximumFractionDigits: 0 })} />}
               {node.bonus_percent != null && <Stat label="Bonus %" value={`${node.bonus_percent}%`} />}
               {node.group_size != null && <Stat label="Group size" value={String(node.group_size)} />}
               {node.qualified_legs != null && <Stat label="Qualified legs" value={String(node.qualified_legs)} />}
@@ -170,7 +148,6 @@ function MemberCard({ node, isExpanded, onToggle }: {
               {node.depth != null && <Stat label="Tree depth" value={String(node.depth)} />}
             </div>
           )}
-
           {hasVitals && (
             <div>
               <p className="text-[10px] font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>
@@ -192,7 +169,6 @@ function MemberCard({ node, isExpanded, onToggle }: {
               </div>
             </div>
           )}
-
           {!hasStats && !hasVitals && (
             <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>No additional data available.</p>
           )}
@@ -205,7 +181,7 @@ function MemberCard({ node, isExpanded, onToggle }: {
 // ── Recursive tree node ───────────────────────────────────────────────────────
 
 function TreeNode({ node, depth, expanded, onToggleExpand }: {
-  node: LOSNode
+  node: LOSNodeInternal
   depth: number
   expanded: Set<string>
   onToggleExpand: (key: string) => void
@@ -236,11 +212,11 @@ function TreeNode({ node, depth, expanded, onToggleExpand }: {
 
 // ── Guest view ────────────────────────────────────────────────────────────────
 
-function GuestView({ nodes, callerAbo }: { nodes: LOSNode[]; callerAbo: string | null }) {
+function GuestView({ nodes, callerAbo }: { nodes: LOSNodeInternal[]; callerAbo: string | null }) {
   const self = nodes.find(n => n.abo_number === callerAbo) ?? nodes[0]
   const upline = nodes.find(n => n.abo_number !== callerAbo)
 
-  function SimpleRow({ node, label }: { node: LOSNode; label: string }) {
+  function SimpleRow({ node, label }: { node: LOSNodeInternal; label: string }) {
     const rc = roleColors(node.role)
     return (
       <div>
@@ -274,9 +250,14 @@ function GuestView({ nodes, callerAbo }: { nodes: LOSNode[]; callerAbo: string |
   )
 }
 
-// ── Page ──────────────────────────────────────────────────────────────────────
+// ── Inner page (reads searchParams) ──────────────────────────────────────────
 
-export default function LOSPage() {
+function LOSPageInner() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const view = (searchParams.get('view') ?? 'list') as 'list' | 'chart'
+  const [chartDepth, setChartDepth] = useState(3)
+
   const { data, isLoading, isError } = useQuery<TreeResponse>({
     queryKey: ['los-tree'],
     queryFn: () => fetch('/api/los/tree').then(r => r.json()),
@@ -285,6 +266,12 @@ export default function LOSPage() {
 
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [search, setSearch] = useState('')
+
+  function setView(v: 'list' | 'chart') {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('view', v)
+    router.replace(`?${params.toString()}`, { scroll: false })
+  }
 
   function toggleExpand(key: string) {
     setExpanded(prev => {
@@ -295,9 +282,9 @@ export default function LOSPage() {
     })
   }
 
-  function expandAll(nodes: LOSNode[]) {
+  function expandAll(nodes: LOSNodeInternal[]) {
     const keys = new Set<string>()
-    function collect(n: LOSNode) {
+    function collect(n: LOSNodeInternal) {
       if (n.abo_number) keys.add(n.abo_number)
       else if (n.profile_id) keys.add(n.profile_id)
       for (const c of n.children ?? []) collect(c)
@@ -306,12 +293,12 @@ export default function LOSPage() {
     setExpanded(keys)
   }
 
-  const tree: LOSNode[] = data
+  const tree: LOSNodeInternal[] = data
     ? buildTree(data.nodes, data.scope === 'subtree' ? data.caller_abo : null)
     : []
 
   const searchLower = search.toLowerCase().trim()
-  const filteredTree: LOSNode[] = searchLower
+  const filteredTree: LOSNodeInternal[] = searchLower
     ? (data?.nodes ?? [])
         .filter(n => {
           const name = displayName(n).toLowerCase()
@@ -325,6 +312,8 @@ export default function LOSPage() {
     : data?.scope === 'subtree'
     ? 'Your Network'
     : 'Your Upline'
+
+  const isGuest = data?.scope === 'guest'
 
   return (
     <div className="py-8 pb-16">
@@ -343,32 +332,79 @@ export default function LOSPage() {
             )}
           </div>
 
+          {/* Legend */}
           <div className="flex items-center gap-3 flex-shrink-0">
             {(['admin', 'core', 'member', 'guest'] as const).map(role => {
               const rc = roleColors(role)
-              const label = role.charAt(0).toUpperCase() + role.slice(1)
               return (
                 <div key={role} className="flex items-center gap-1.5">
                   <span
                     className="w-2.5 h-2.5 rounded-full flex-shrink-0"
                     style={{ backgroundColor: rc.labelBg, border: `1px solid ${rc.border}`, opacity: rc.opacity }}
                   />
-                  <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>{label}</span>
+                  <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                    {role.charAt(0).toUpperCase() + role.slice(1)}
+                  </span>
                 </div>
               )
             })}
           </div>
         </div>
 
-        {/* Search + controls */}
-        {data?.scope !== 'guest' && (
+        {/* View switcher — non-guest only */}
+        {!isGuest && data && (
+          <div className="flex items-center gap-2 mb-5 flex-wrap">
+            {(['list', 'chart'] as const).map(v => (
+              <button
+                key={v}
+                onClick={() => setView(v)}
+                className="px-4 py-1.5 rounded-lg text-xs font-semibold border transition-colors"
+                style={{
+                  borderColor: view === v ? 'var(--text-primary)' : 'var(--border-default)',
+                  backgroundColor: view === v ? 'var(--text-primary)' : 'transparent',
+                  color: view === v ? 'var(--bg-global)' : 'var(--text-secondary)',
+                }}
+              >
+                {v === 'list' ? 'List' : 'Chart'}
+              </button>
+            ))}
+
+            {/* Depth control — chart view only */}
+            {view === 'chart' && (
+              <div className="flex items-center gap-2 ml-4">
+                <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>Depth:</span>
+                {[1, 2, 3, 4, 5].map(d => (
+                  <button
+                    key={d}
+                    onClick={() => setChartDepth(d)}
+                    className="w-6 h-6 rounded text-xs font-semibold border transition-colors"
+                    style={{
+                      borderColor: chartDepth === d ? 'var(--text-primary)' : 'var(--border-default)',
+                      backgroundColor: chartDepth === d ? 'var(--text-primary)' : 'transparent',
+                      color: chartDepth === d ? 'var(--bg-global)' : 'var(--text-secondary)',
+                    }}
+                  >
+                    {d}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Search + expand controls — list view only */}
+        {!isGuest && view === 'list' && (
           <div className="flex items-center gap-3 mb-5">
             <input
               value={search}
               onChange={e => setSearch(e.target.value)}
               placeholder="Search by name or ABO…"
               className="flex-1 border rounded-xl px-3 py-2 text-sm"
-              style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-global)' }}
+              style={{
+                borderColor: 'var(--border-default)',
+                color: 'var(--text-primary)',
+                backgroundColor: 'var(--bg-global)',
+              }}
             />
             {!searchLower && (
               <>
@@ -391,6 +427,7 @@ export default function LOSPage() {
           </div>
         )}
 
+        {/* Loading skeleton */}
         {isLoading && (
           <div className="space-y-2">
             {[...Array(8)].map((_, i) => (
@@ -399,17 +436,25 @@ export default function LOSPage() {
           </div>
         )}
 
+        {/* Error */}
         {isError && (
           <div className="rounded-2xl p-6 text-center" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
             <p className="text-sm font-semibold" style={{ color: 'var(--brand-crimson)' }}>Failed to load LOS data.</p>
           </div>
         )}
 
-        {!isLoading && !isError && data?.scope === 'guest' && (
-          <GuestView nodes={data.nodes} callerAbo={data.caller_abo} />
+        {/* Guest */}
+        {!isLoading && !isError && isGuest && (
+          <GuestView nodes={data!.nodes} callerAbo={data!.caller_abo} />
         )}
 
-        {!isLoading && !isError && data?.scope !== 'guest' && (
+        {/* Chart */}
+        {!isLoading && !isError && !isGuest && view === 'chart' && (
+          <OrgChartCanvas roots={tree} maxDepth={chartDepth} />
+        )}
+
+        {/* List */}
+        {!isLoading && !isError && !isGuest && view === 'list' && (
           <>
             {filteredTree.length === 0 && (
               <p className="text-sm text-center py-8" style={{ color: 'var(--text-secondary)' }}>
@@ -429,5 +474,15 @@ export default function LOSPage() {
         )}
       </div>
     </div>
+  )
+}
+
+// ── Page — Suspense boundary for useSearchParams ──────────────────────────────
+
+export default function LOSPage() {
+  return (
+    <Suspense>
+      <LOSPageInner />
+    </Suspense>
   )
 }

--- a/app/(dashboard)/los/page.tsx
+++ b/app/(dashboard)/los/page.tsx
@@ -5,33 +5,17 @@ import { useQuery } from '@tanstack/react-query'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { formatDate } from '@/lib/format'
 import { OrgChartCanvas } from './components/OrgChartCanvas'
-import type { LOSNode } from './components/OrgChartCanvas'
-
-// ── Types ─────────────────────────────────────────────────────────────────────
-
-type VitalSign = {
-  event_key: string
-  event_label: string
-  has_ticket: boolean
-  updated_at: string
-}
-
-type LOSNodeInternal = LOSNode
-
-type TreeResponse = {
-  scope: 'full' | 'subtree' | 'guest'
-  nodes: LOSNodeInternal[]
-  caller_abo: string | null
-}
+import { displayName, roleColors } from './lib/los-utils'
+import type { LOSNode, TreeResponse } from './lib/los-utils'
 
 // ── Tree builder ──────────────────────────────────────────────────────────────
 
-function buildTree(nodes: LOSNodeInternal[], rootAbo: string | null): LOSNodeInternal[] {
-  const byAbo: Record<string, LOSNodeInternal> = {}
+function buildTree(nodes: LOSNode[], rootAbo: string | null): LOSNode[] {
+  const byAbo: Record<string, LOSNode> = {}
   for (const n of nodes) {
     if (n.abo_number) byAbo[n.abo_number] = { ...n, children: [] }
   }
-  const roots: LOSNodeInternal[] = []
+  const roots: LOSNode[] = []
   for (const n of Object.values(byAbo)) {
     const parent = n.sponsor_abo_number ? byAbo[n.sponsor_abo_number] : null
     if (parent) parent.children!.push(n)
@@ -39,24 +23,6 @@ function buildTree(nodes: LOSNodeInternal[], rootAbo: string | null): LOSNodeInt
   }
   if (rootAbo && byAbo[rootAbo]) return [byAbo[rootAbo]]
   return roots
-}
-
-function displayName(node: LOSNodeInternal): string {
-  if (node.first_name && node.last_name) return `${node.first_name} ${node.last_name}`
-  return node.name ?? node.abo_number ?? '—'
-}
-
-// ── Role color system ─────────────────────────────────────────────────────────
-
-const ROLE_COLORS: Record<string, { border: string; labelBg: string; labelColor: string; opacity: number }> = {
-  admin:  { border: '#2d332a',             labelBg: '#2d332a',               labelColor: '#FAF8F3', opacity: 1   },
-  core:   { border: '#3E7785',             labelBg: '#3E7785',               labelColor: '#FAF8F3', opacity: 1   },
-  member: { border: 'rgba(45,51,42,0.15)', labelBg: 'rgba(62,119,133,0.12)', labelColor: '#3E7785', opacity: 1   },
-  guest:  { border: 'rgba(45,51,42,0.08)', labelBg: 'rgba(0,0,0,0.05)',      labelColor: '#8A8577', opacity: 0.6 },
-}
-
-function roleColors(role: string | null) {
-  return ROLE_COLORS[role ?? 'guest'] ?? ROLE_COLORS.guest
 }
 
 // ── Stat subcomponent ─────────────────────────────────────────────────────────
@@ -73,7 +39,7 @@ function Stat({ label, value }: { label: string; value: string }) {
 // ── MemberCard ────────────────────────────────────────────────────────────────
 
 function MemberCard({ node, isExpanded, onToggle }: {
-  node: LOSNodeInternal
+  node: LOSNode
   isExpanded: boolean
   onToggle: () => void
 }) {
@@ -181,7 +147,7 @@ function MemberCard({ node, isExpanded, onToggle }: {
 // ── Recursive tree node ───────────────────────────────────────────────────────
 
 function TreeNode({ node, depth, expanded, onToggleExpand }: {
-  node: LOSNodeInternal
+  node: LOSNode
   depth: number
   expanded: Set<string>
   onToggleExpand: (key: string) => void
@@ -212,11 +178,11 @@ function TreeNode({ node, depth, expanded, onToggleExpand }: {
 
 // ── Guest view ────────────────────────────────────────────────────────────────
 
-function GuestView({ nodes, callerAbo }: { nodes: LOSNodeInternal[]; callerAbo: string | null }) {
+function GuestView({ nodes, callerAbo }: { nodes: LOSNode[]; callerAbo: string | null }) {
   const self = nodes.find(n => n.abo_number === callerAbo) ?? nodes[0]
   const upline = nodes.find(n => n.abo_number !== callerAbo)
 
-  function SimpleRow({ node, label }: { node: LOSNodeInternal; label: string }) {
+  function SimpleRow({ node, label }: { node: LOSNode; label: string }) {
     const rc = roleColors(node.role)
     return (
       <div>
@@ -282,9 +248,9 @@ function LOSPageInner() {
     })
   }
 
-  function expandAll(nodes: LOSNodeInternal[]) {
+  function expandAll(nodes: LOSNode[]) {
     const keys = new Set<string>()
-    function collect(n: LOSNodeInternal) {
+    function collect(n: LOSNode) {
       if (n.abo_number) keys.add(n.abo_number)
       else if (n.profile_id) keys.add(n.profile_id)
       for (const c of n.children ?? []) collect(c)
@@ -293,12 +259,12 @@ function LOSPageInner() {
     setExpanded(keys)
   }
 
-  const tree: LOSNodeInternal[] = data
+  const tree: LOSNode[] = data
     ? buildTree(data.nodes, data.scope === 'subtree' ? data.caller_abo : null)
     : []
 
   const searchLower = search.toLowerCase().trim()
-  const filteredTree: LOSNodeInternal[] = searchLower
+  const filteredTree: LOSNode[] = searchLower
     ? (data?.nodes ?? [])
         .filter(n => {
           const name = displayName(n).toLowerCase()


### PR DESCRIPTION
## Summary

Adds a spatial org-chart view alongside the existing list view on `/los`.

**New file:** `app/(dashboard)/los/components/OrgChartCanvas.tsx`  
**Modified:** `app/(dashboard)/los/page.tsx`

## What changed

- View switcher (`?view=list|chart`) persisted in URL via `router.replace` + `useSearchParams`, wrapped in `<Suspense>` per CLAUDE.md gotcha
- `OrgChartCanvas` — pure client component, zero new npm dependencies:
  - Bottom-up subtree-width layout algorithm (no D3/ELK)
  - SVG `<foreignObject>` cards + bezier `<path>` connectors
  - Pan (pointer drag) + zoom (wheel, 0.3×–2.5×)
  - Reset button
  - Horizontally scrollable at 390px
- `OrgChartNode` cards show: name (Last, First), role badge, bonus %, ЛТС (ppv), ГТС (gpv), group size
- Depth cap control 1–5, default 3 — prevents unusable charts on large trees
- Guest view unchanged, chart switcher hidden for guests
- No API changes, no schema changes
- List view: GPV/PPV labels updated to ГТС/ЛТС to match data semantics

## Session State
**Status:** IN PROGRESS  
**Last touched:** `app/(dashboard)/los/page.tsx`, `app/(dashboard)/los/components/OrgChartCanvas.tsx`  
**Completed:**
- [x] Branch created
- [x] OrgChartCanvas implemented (layout, pan/zoom, cards, edges)
- [x] page.tsx updated (view switcher, Suspense, depth control)
- [x] PR opened
**In flight:** Awaiting Vercel preview + CI  
**Next:** Verify preview READY and CI green → mark Done