### PR TITLE
[2604-CHORE-003] Promote VitalSign type and isVitalRecorded predicate to lib/vitals.ts

### DIFF
--- a/app/(dashboard)/los/lib/los-utils.ts
+++ b/app/(dashboard)/los/lib/los-utils.ts
@@ -23,7 +23,7 @@ export type LOSNode = {
   qualified_legs: number | null
   annual_ppv: number | null
   renewal_date: string | null
-  vital_signs: import('@/lib/vitals').VitalSign[]
+  vital_signs: VitalSign[]
   children?: LOSNode[]
 }
 

--- a/app/(dashboard)/los/lib/los-utils.ts
+++ b/app/(dashboard)/los/lib/los-utils.ts
@@ -2,12 +2,8 @@
 // Co-located here per CLAUDE.md: promote to /components only when 2+ unrelated
 // routes consume this.
 
-export type VitalSign = {
-  definition_id: string
-  label: string        // mapped from vital_sign_definitions.category
-  recorded_at: string | null  // null = definition exists but not recorded for this member
-  note: string | null
-}
+export type { VitalSign } from '@/lib/vitals'
+export { isVitalRecorded } from '@/lib/vitals'
 
 export type LOSNode = {
   profile_id: string | null
@@ -27,7 +23,7 @@ export type LOSNode = {
   qualified_legs: number | null
   annual_ppv: number | null
   renewal_date: string | null
-  vital_signs: VitalSign[]
+  vital_signs: import('@/lib/vitals').VitalSign[]
   children?: LOSNode[]
 }
 

--- a/app/(dashboard)/los/lib/los-utils.ts
+++ b/app/(dashboard)/los/lib/los-utils.ts
@@ -2,6 +2,7 @@
 // Co-located here per CLAUDE.md: promote to /components only when 2+ unrelated
 // routes consume this.
 
+import type { VitalSign } from '@/lib/vitals'
 export type { VitalSign } from '@/lib/vitals'
 export { isVitalRecorded } from '@/lib/vitals'
 

--- a/app/(dashboard)/los/page.tsx
+++ b/app/(dashboard)/los/page.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { formatDate } from '@/lib/format'
 import { OrgChartCanvas } from './components/OrgChartCanvas'
-import { displayName, roleColors } from './lib/los-utils'
+import { displayName, roleColors, isVitalRecorded } from './lib/los-utils'
 import type { LOSNode, TreeResponse } from './lib/los-utils'
 
 // ── Tree builder ──────────────────────────────────────────────────────────────
@@ -89,9 +89,9 @@ function MemberCard({ node, isExpanded, onToggle }: {
             {node.vital_signs.map(vs => (
               <span
                 key={vs.definition_id}
-                title={`${vs.label}: ${vs.recorded_at ? 'recorded' : 'not recorded'}`}
+                title={`${vs.label}: ${isVitalRecorded(vs) ? 'recorded' : 'not recorded'}`}
                 className="w-2 h-2 rounded-full flex-shrink-0"
-                style={{ backgroundColor: vs.recorded_at ? 'var(--brand-crimson)' : 'rgba(0,0,0,0.12)' }}
+                style={{ backgroundColor: isVitalRecorded(vs) ? 'var(--brand-crimson)' : 'rgba(0,0,0,0.12)' }}
               />
             ))}
           </div>
@@ -124,11 +124,11 @@ function MemberCard({ node, isExpanded, onToggle }: {
                     key={vs.definition_id}
                     className="text-xs font-semibold px-2.5 py-1 rounded-full"
                     style={{
-                      backgroundColor: vs.recorded_at ? 'rgba(188,71,73,0.12)' : 'rgba(0,0,0,0.05)',
-                      color: vs.recorded_at ? 'var(--brand-crimson)' : 'var(--text-secondary)',
+                      backgroundColor: isVitalRecorded(vs) ? 'rgba(188,71,73,0.12)' : 'rgba(0,0,0,0.05)',
+                      color: isVitalRecorded(vs) ? 'var(--brand-crimson)' : 'var(--text-secondary)',
                     }}
                   >
-                    {vs.recorded_at ? '✓' : '○'} {vs.label}
+                    {isVitalRecorded(vs) ? '✓' : '○'} {vs.label}
                   </span>
                 ))}
               </div>

--- a/app/(dashboard)/profile/components/VitalsSection.tsx
+++ b/app/(dashboard)/profile/components/VitalsSection.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Drawer } from '@/components/ui/Drawer'
-import { type VitalSign, VARIABLE_CAP } from '../types'
+import { isVitalRecorded } from '@/lib/vitals'
+import { type ProfileVitalSign, VARIABLE_CAP } from '../types'
 import { ShowMoreButton } from './shared'
 
 export const VITALS_MIN_HEIGHT = 280
@@ -11,7 +12,7 @@ export const VITALS_MIN_HEIGHT = 280
 export function VitalsSection({ profileId, role }: { profileId: string; role: string }) {
   const [drawerOpen, setDrawerOpen] = useState(false)
 
-  const { data: vitalsData, isLoading } = useQuery<VitalSign[]>({
+  const { data: vitalsData, isLoading } = useQuery<ProfileVitalSign[]>({
     queryKey: ['profile-vitals'],
     queryFn: () => fetch('/api/profile/vital-signs').then(r => r.json()),
     enabled: !!profileId && role !== 'guest',
@@ -26,10 +27,10 @@ export function VitalsSection({ profileId, role }: { profileId: string; role: st
   const visible = vitals.slice(0, VARIABLE_CAP)
   const overflow = vitals.length - VARIABLE_CAP
 
-  const VitalRow = ({ vs }: { vs: VitalSign }) => {
+  const VitalRow = ({ vs }: { vs: ProfileVitalSign }) => {
     const label = vs.vital_sign_definitions?.label ?? vs.definition_id
     const category = vs.vital_sign_definitions?.category
-    const recorded = vs.is_recorded && vs.is_active
+    const recorded = isVitalRecorded(vs)
     return (
       <div className="flex items-center justify-between gap-3 text-xs py-1.5">
         <div className="min-w-0">

--- a/app/(dashboard)/profile/types.ts
+++ b/app/(dashboard)/profile/types.ts
@@ -114,7 +114,7 @@ export { isVitalRecorded } from '@/lib/vitals'
 
 // Profile API response extends the base VitalSign with the nested definition shape
 // returned by /api/profile/vital-signs.
-export type ProfileVitalSign = import('@/lib/vitals').VitalSign & {
+export type ProfileVitalSign = VitalSign & {
   id: string
   is_recorded: boolean
   created_at: string | null

--- a/app/(dashboard)/profile/types.ts
+++ b/app/(dashboard)/profile/types.ts
@@ -107,14 +107,16 @@ export type GenericPayment = {
   } | null
 }
 
-export type VitalSign = {
+// VitalSign canonical type and predicate live in lib/vitals.ts.
+// Re-exported here so profile components can import from a single local barrel.
+export type { VitalSign } from '@/lib/vitals'
+export { isVitalRecorded } from '@/lib/vitals'
+
+// Profile API response extends the base VitalSign with the nested definition shape
+// returned by /api/profile/vital-signs.
+export type ProfileVitalSign = import('@/lib/vitals').VitalSign & {
   id: string
-  definition_id: string
-  /** Present in all API responses after 2604-BUG-002. True = row exists AND is_active=true. */
   is_recorded: boolean
-  is_active: boolean
-  recorded_at: string | null
-  note: string | null
   created_at: string | null
   vital_sign_definitions: {
     category: string

--- a/app/(dashboard)/profile/types.ts
+++ b/app/(dashboard)/profile/types.ts
@@ -109,6 +109,7 @@ export type GenericPayment = {
 
 // VitalSign canonical type and predicate live in lib/vitals.ts.
 // Re-exported here so profile components can import from a single local barrel.
+import type { VitalSign } from '@/lib/vitals'
 export type { VitalSign } from '@/lib/vitals'
 export { isVitalRecorded } from '@/lib/vitals'
 

--- a/app/api/admin/members/[id]/vital-signs/route.ts
+++ b/app/api/admin/members/[id]/vital-signs/route.ts
@@ -39,7 +39,7 @@ export async function GET(
     return {
       ...def,
       is_recorded: !!entry,
-      is_active_record: entry?.is_active ?? false,
+      is_active: entry?.is_active ?? false,
       recorded_at: entry?.recorded_at ?? null,
       note: entry?.note ?? null,
     }

--- a/app/api/los/tree/route.ts
+++ b/app/api/los/tree/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import type { VitalSign } from '@/lib/vitals'
 
 type LOSRow = {
   abo_number: string
@@ -20,14 +21,6 @@ type LOSRow = {
   last_name: string | null
   role: string | null
   depth: number | null
-}
-
-type VitalSign = {
-  definition_id: string
-  label: string
-  is_active: boolean
-  recorded_at: string | null
-  note: string | null
 }
 
 type LOSNodeWithVitals = LOSRow & { vital_signs: VitalSign[] }

--- a/lib/vitals.ts
+++ b/lib/vitals.ts
@@ -7,13 +7,17 @@
 /**
  * Represents one vital sign entry as returned by any /vital-signs API endpoint.
  * Covers both surfaces: profile member view and LOS tree admin view.
+ *
+ * Note: `label` is optional because the profile API nests it inside
+ * `vital_sign_definitions` rather than at the top level. LOS and admin routes
+ * do include it top-level. Use ProfileVitalSign for the profile surface.
  */
 export type VitalSign = {
   definition_id: string
-  label: string
+  label?: string
   /** true = row exists with is_active=true. false = row absent or deactivated. */
   is_active: boolean
-  /** recorded_at from member_vital_signs; null when no row exists or row is inactive. */
+  /** recorded_at from member_vital_signs; null only when no row exists at all. */
   recorded_at: string | null
   note: string | null
 }

--- a/lib/vitals.ts
+++ b/lib/vitals.ts
@@ -1,0 +1,29 @@
+// ── Canonical VitalSign type and recorded predicate ──────────────────────────
+// Single source of truth for vital sign shape and "recorded" semantics.
+// All consumers — API routes, LOS tree, profile bento — import from here.
+// No consumer should inspect is_active or recorded_at directly for the
+// recorded decision; call isVitalRecorded(vs) instead.
+
+/**
+ * Represents one vital sign entry as returned by any /vital-signs API endpoint.
+ * Covers both surfaces: profile member view and LOS tree admin view.
+ */
+export type VitalSign = {
+  definition_id: string
+  label: string
+  /** true = row exists with is_active=true. false = row absent or deactivated. */
+  is_active: boolean
+  /** recorded_at from member_vital_signs; null when no row exists or row is inactive. */
+  recorded_at: string | null
+  note: string | null
+}
+
+/**
+ * The canonical "recorded" predicate.
+ * A vital sign is recorded if and only if a row exists AND is_active=true.
+ * recorded_at is preserved on deactivation (no deletes), so it cannot be
+ * used as the sole signal — a deactivated row has a non-null recorded_at.
+ */
+export function isVitalRecorded(vs: Pick<VitalSign, 'is_active'>): boolean {
+  return vs.is_active
+}


### PR DESCRIPTION
# [2604-CHORE-001] VitalSign canonical type + recorded predicate

## DoD
Single `VitalSign` type and `isVitalRecorded(vs)` predicate exported from `lib/vitals.ts`; all consumers import from there; no consumer inspects `is_active` or `recorded_at` directly for the recorded decision; admin GET route field name normalized to `is_active`; profile bento and LOS list agree on recorded state for all three states (never recorded / active / deactivated).

---

## What changed

### `lib/vitals.ts` — **created**
Canonical `VitalSign` type and `isVitalRecorded` predicate. Single source of truth.

Key design decision documented in JSDoc: `recorded_at` is preserved on deactivation (no deletes), so it **cannot** be used as the sole signal. `isVitalRecorded` gates on `is_active` only.

### `app/(dashboard)/los/lib/los-utils.ts`
Removed local `VitalSign` type definition. Now re-exports `VitalSign` and `isVitalRecorded` from `lib/vitals.ts`. `LOSNode.vital_signs` typed against the canonical type.

### `app/api/los/tree/route.ts`
Removed inline `VitalSign` type. Imports `VitalSign` from `lib/vitals.ts`. Logic unchanged.

### `app/(dashboard)/profile/types.ts`
Removed local `VitalSign` type. Re-exports `VitalSign` and `isVitalRecorded` from `lib/vitals.ts`. Introduced `ProfileVitalSign` which extends the base type with the nested `vital_sign_definitions` shape and `is_recorded`/`created_at` fields specific to the profile API response shape.

### `app/(dashboard)/profile/components/VitalsSection.tsx`
- Now typed against `ProfileVitalSign` (the richer profile-specific shape)
- `const recorded = vs.is_recorded && vs.is_active` → `const recorded = isVitalRecorded(vs)`
- Import of `VitalSign` replaced by `ProfileVitalSign` + `isVitalRecorded`

### `app/(dashboard)/los/page.tsx` — **bug fix**
Three occurrences of `vs.recorded_at ?` replaced with `isVitalRecorded(vs)`:
- Collapsed dot indicator background
- Expanded pill badge background + color
- Expanded pill checkmark character

This fixes the visible divergence: a deactivated vital sign has a non-null `recorded_at` (history preserved by design), so LOS was showing it as crimson/recorded while the profile bento correctly showed it as not recorded.

### `app/api/admin/members/[id]/vital-signs/route.ts` — **field name fix**
GET response: `is_active_record` → `is_active`. Normalized to match every other surface.

---

## State machine invariant this enforces

| State | `is_active` | `recorded_at` | `isVitalRecorded` |
|---|---|---|---|
| Never recorded | false | null | false |
| Active | true | non-null | **true** |
| Deactivated | false | non-null | **false** |

The old LOS code conflated "deactivated" with "active" because both have non-null `recorded_at`. Fixed.

---

## Session State
**Status:** DONE
**Last touched:** `lib/vitals.ts`
**Completed:**
- [x] lib/vitals.ts created with canonical type + predicate
- [x] los-utils.ts re-exports from lib/vitals.ts
- [x] api/los/tree/route.ts imports VitalSign from lib/vitals.ts
- [x] profile/types.ts re-exports + ProfileVitalSign introduced
- [x] VitalsSection.tsx uses isVitalRecorded
- [x] los/page.tsx uses isVitalRecorded (3 occurrences fixed)
- [x] admin vital-signs GET normalizes is_active_record → is_active
**In flight:** —
**Next:** Verify Vercel preview, merge

Closes #34