### PR TITLE
[2604-CHORE-004a] i18n: suppress no-literal-string in app/api/ route handlers

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,15 @@ const eslintConfig = defineConfig([
       ],
     },
   },
+  // API route handlers are server-only. Literal strings here are error messages
+  // and log output — never rendered as UI copy. Translation is not appropriate.
+  // reason: server-only
+  {
+    files: ["app/api/**/*.ts", "app/api/**/*.tsx"],
+    rules: {
+      "i18next/no-literal-string": "off",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,9 +49,11 @@ const eslintConfig = defineConfig([
   },
   // API route handlers are server-only. Literal strings here are error messages
   // and log output — never rendered as UI copy. Translation is not appropriate.
+  // .tsx is intentionally excluded: OG image handlers and similar UI-generating
+  // routes under app/api/ should remain covered by i18n checks.
   // reason: server-only
   {
-    files: ["app/api/**/*.ts", "app/api/**/*.tsx"],
+    files: ["app/api/**/*.ts"],
     rules: {
       "i18next/no-literal-string": "off",
     },


### PR DESCRIPTION
## Session State
**Status:** IN PROGRESS
**Last touched:** `eslint.config.mjs`
**Completed:**
- [x] Added `app/api/**` override block disabling `i18next/no-literal-string`
**In flight:** Awaiting Vercel preview build
**Next:** Verify preview READY + CI green, then mark Done

---

## Summary

Suppresses `i18next/no-literal-string` for all files under `app/api/`. Route handlers are permanently server-side — their literal strings are error messages and log output, never rendered as UI copy. Translation is not applicable.

## Approach

Rather than adding `// eslint-disable-next-line` to each of the ~40 route files (fragile, easy to miss on new files), a dedicated config block in `eslint.config.mjs` targets `app/api/**/*.ts` and `app/api/**/*.tsx` with `"i18next/no-literal-string": "off"`. New route files added under `app/api/` are suppressed automatically.

The override block includes a `// reason: server-only` comment making the intent searchable.

## Change

**`eslint.config.mjs`** — added one new config object at the end of the array:
```js
{
  files: ["app/api/**/*.ts", "app/api/**/*.tsx"],
  rules: { "i18next/no-literal-string": "off" },
}
```

## DoD

`npm run lint` produces zero `i18next/no-literal-string` warnings across all files in `app/api/`.

Closes #43