### PR TITLE
[2604-CHORE-004c] i18n: create admin.ts domain + wrap shared admin primitives

### DIFF
--- a/app/admin/components/AdminNav.tsx
+++ b/app/admin/components/AdminNav.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ADMIN_NAV } from '@/lib/nav'
 import { useLanguage } from '@/lib/hooks/useLanguage'
-import { t } from '@/lib/i18n'
 import {
   Sheet,
   SheetContent,
@@ -17,7 +16,7 @@ import {
 export default function AdminNav() {
   const pathname = usePathname()
   const [open, setOpen] = useState(false)
-  const { lang } = useLanguage()
+  const { lang, t } = useLanguage()
 
   const isActive = (href: string) => pathname?.startsWith(href) ?? false
 
@@ -25,14 +24,14 @@ export default function AdminNav() {
     <div style={{ backgroundColor: 'var(--brand-forest)' }}>
       <div className="max-w-[1440px] mx-auto px-4 md:px-6 lg:px-8 h-14 flex items-center">
 
-        {/* ── DESKTOP (lg+) ──────────────────────────────────────────────── */}
+        {/* ── DESKTOP (lg+) ──────────────────────────────────────────── */}
         <div className="hidden lg:flex items-center gap-1 w-full justify-center">
           {/* ADMIN label */}
           <span
             className="text-xs font-bold tracking-widest uppercase px-2 flex-shrink-0"
             style={{ color: 'rgba(255,255,255,0.35)' }}
           >
-            {t('nav.admin', lang)}
+            {t('nav.admin')}
           </span>
 
           {/* Pipe */}
@@ -51,7 +50,7 @@ export default function AdminNav() {
                 backgroundColor: isActive(href) ? 'rgba(255,255,255,0.10)' : 'transparent',
               }}
             >
-              {labels.en}
+              {labels[lang]}
             </Link>
           ))}
 
@@ -66,7 +65,7 @@ export default function AdminNav() {
             className="flex items-center gap-1.5 px-2 text-xs font-semibold tracking-widest uppercase transition-colors hover:text-white flex-shrink-0"
             style={{ color: 'rgba(255,255,255,0.7)' }}
           >
-            {t('admin.nav.portal', lang)}
+            {t('admin.nav.portal')}
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
               stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="9 18 15 12 9 6"/>
@@ -74,19 +73,19 @@ export default function AdminNav() {
           </Link>
         </div>
 
-        {/* ── MOBILE (<lg) ───────────────────────────────────────────────── */}
+        {/* ── MOBILE (<lg) ───────────────────────────────────────────── */}
         <div className="flex lg:hidden items-center justify-between w-full">
           <span
             className="text-xs font-bold tracking-widest uppercase"
             style={{ color: 'rgba(255,255,255,0.35)' }}
           >
-            {t('nav.admin', lang)}
+            {t('nav.admin')}
           </span>
 
           <Sheet open={open} onOpenChange={setOpen}>
             <SheetTrigger asChild>
               <button
-                aria-label={t('admin.nav.openMenu', lang)}
+                aria-label={t('admin.nav.openMenu')}
                 className="flex items-center justify-center w-9 h-9 rounded-lg transition-colors"
                 style={{ color: 'rgba(255,255,255,0.7)' }}
               >
@@ -105,7 +104,7 @@ export default function AdminNav() {
                   className="text-xs font-bold tracking-widest uppercase"
                   style={{ color: 'rgba(255,255,255,0.35)' }}
                 >
-                  {t('nav.admin', lang)}
+                  {t('nav.admin')}
                 </SheetTitle>
               </SheetHeader>
 
@@ -121,7 +120,7 @@ export default function AdminNav() {
                       backgroundColor: isActive(href) ? 'rgba(255,255,255,0.10)' : 'transparent',
                     }}
                   >
-                    {labels.en}
+                    {labels[lang]}
                   </Link>
                 ))}
 
@@ -133,7 +132,7 @@ export default function AdminNav() {
                   className="flex items-center gap-1.5 px-3 py-2.5 rounded-lg text-xs font-semibold tracking-widest uppercase transition-colors"
                   style={{ color: 'rgba(255,255,255,0.7)' }}
                 >
-                  {t('admin.nav.portal', lang)}
+                  {t('admin.nav.portal')}
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                     stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <polyline points="9 18 15 12 9 6"/>

--- a/app/admin/components/AdminNav.tsx
+++ b/app/admin/components/AdminNav.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ADMIN_NAV } from '@/lib/nav'
+import { useLanguage } from '@/lib/hooks/useLanguage'
+import { t } from '@/lib/i18n'
 import {
   Sheet,
   SheetContent,
@@ -15,6 +17,7 @@ import {
 export default function AdminNav() {
   const pathname = usePathname()
   const [open, setOpen] = useState(false)
+  const { lang } = useLanguage()
 
   const isActive = (href: string) => pathname?.startsWith(href) ?? false
 
@@ -29,10 +32,12 @@ export default function AdminNav() {
             className="text-xs font-bold tracking-widest uppercase px-2 flex-shrink-0"
             style={{ color: 'rgba(255,255,255,0.35)' }}
           >
-            Admin
+            {t('nav.admin', lang)}
           </span>
 
           {/* Pipe */}
+          {/* eslint-disable-next-line i18next/no-literal-string */}
+          {/* reason: decorative punctuation, not UI copy */}
           <span className="text-xs px-1 flex-shrink-0" style={{ color: 'rgba(255,255,255,0.2)' }}>|</span>
 
           {/* Nav items */}
@@ -51,6 +56,8 @@ export default function AdminNav() {
           ))}
 
           {/* Pipe */}
+          {/* eslint-disable-next-line i18next/no-literal-string */}
+          {/* reason: decorative punctuation, not UI copy */}
           <span className="text-xs px-1 flex-shrink-0" style={{ color: 'rgba(255,255,255,0.2)' }}>|</span>
 
           {/* Portal link */}
@@ -59,7 +66,7 @@ export default function AdminNav() {
             className="flex items-center gap-1.5 px-2 text-xs font-semibold tracking-widest uppercase transition-colors hover:text-white flex-shrink-0"
             style={{ color: 'rgba(255,255,255,0.7)' }}
           >
-            Portal
+            {t('admin.nav.portal', lang)}
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
               stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="9 18 15 12 9 6"/>
@@ -73,13 +80,13 @@ export default function AdminNav() {
             className="text-xs font-bold tracking-widest uppercase"
             style={{ color: 'rgba(255,255,255,0.35)' }}
           >
-            Admin
+            {t('nav.admin', lang)}
           </span>
 
           <Sheet open={open} onOpenChange={setOpen}>
             <SheetTrigger asChild>
               <button
-                aria-label="Open admin navigation"
+                aria-label={t('admin.nav.openMenu', lang)}
                 className="flex items-center justify-center w-9 h-9 rounded-lg transition-colors"
                 style={{ color: 'rgba(255,255,255,0.7)' }}
               >
@@ -98,7 +105,7 @@ export default function AdminNav() {
                   className="text-xs font-bold tracking-widest uppercase"
                   style={{ color: 'rgba(255,255,255,0.35)' }}
                 >
-                  Admin
+                  {t('nav.admin', lang)}
                 </SheetTitle>
               </SheetHeader>
 
@@ -126,7 +133,7 @@ export default function AdminNav() {
                   className="flex items-center gap-1.5 px-3 py-2.5 rounded-lg text-xs font-semibold tracking-widest uppercase transition-colors"
                   style={{ color: 'rgba(255,255,255,0.7)' }}
                 >
-                  Portal
+                  {t('admin.nav.portal', lang)}
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                     stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <polyline points="9 18 15 12 9 6"/>

--- a/app/admin/components/I18nField.tsx
+++ b/app/admin/components/I18nField.tsx
@@ -27,6 +27,8 @@ export function I18nField({
     backgroundColor: 'var(--bg-card)',
   }
   const sharedClass = 'w-full border rounded-xl px-3 py-2.5 text-sm'
+  // eslint-disable-next-line i18next/no-literal-string
+  // reason: admin-internal format string, not UI copy for translation
   const placeholderText = placeholder ? `${placeholder} (${activeLang.toUpperCase()})` : undefined
 
   if (multiline) {

--- a/lib/i18n/domains/admin.ts
+++ b/lib/i18n/domains/admin.ts
@@ -1,0 +1,4 @@
+export const admin = {
+  'admin.nav.portal':   { en: 'Portal',               bg: 'Портал'              },
+  'admin.nav.openMenu': { en: 'Open admin navigation', bg: 'Отвори навигацията'  },
+} as const

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -9,6 +9,7 @@ import { trips }         from './domains/trips'
 import { calendar }      from './domains/calendar'
 import { events }        from './domains/events'
 import { los }           from './domains/los'
+import { admin }         from './domains/admin'
 
 export type Lang = 'en' | 'bg'
 
@@ -39,7 +40,7 @@ function assertNoDuplicateKeys(
 
 assertNoDuplicateKeys([
   nav, roles, announcements, time, guides,
-  notifications, profile, trips, calendar, events, los,
+  notifications, profile, trips, calendar, events, los, admin,
 ])
 
 export const translations = {
@@ -54,6 +55,7 @@ export const translations = {
   ...calendar,
   ...events,
   ...los,
+  ...admin,
 } as const
 
 export type TranslationKey = keyof typeof translations


### PR DESCRIPTION
## Session State
**Status:** IN PROGRESS
**Last touched:** `lib/i18n/domains/admin.ts`, `lib/i18n/index.ts`, `app/admin/components/AdminNav.tsx`, `app/admin/components/I18nField.tsx`
**Completed:**
- [x] Created `lib/i18n/domains/admin.ts` with 2 keys: `admin.nav.portal`, `admin.nav.openMenu`
- [x] Wired into `lib/i18n/index.ts` (import + assertNoDuplicateKeys + translations spread)
- [x] `AdminNav.tsx` — replaced `"Admin"` (×3) with `t('nav.admin', lang)`, `"Portal"` (×2) with `t('admin.nav.portal', lang)`, aria-label with `t('admin.nav.openMenu', lang)`, pipe separators inline-suppressed
- [x] `I18nField.tsx` — format string inline-suppressed with reason comment
**In flight:** Awaiting Vercel preview build
**Next:** Verify preview READY + CI green, then mark Done

---

## Summary

Creates `lib/i18n/domains/admin.ts` as the foundational domain file for the entire admin i18n chain. Unblocks #46, #47, #48.

## Key decisions

**`"Admin"` reuses `nav.admin`** — that key already existed in `nav.ts`. No duplication needed; `useLanguage()` is added to `AdminNav` to resolve it at runtime.

**`"|"` pipe separators** — decorative punctuation, not UI copy. Inline-suppressed with reason comment.

**`I18nField` template literal** — `placeholder (${activeLang.toUpperCase()})` is an admin-internal format string shown only to admins building content. Inline-suppressed; extracting this into a translation key would be semantically wrong (the lang code itself is the data).

**`AdminListCard`, `AdminStatusBadge`, `AdminTabs`, `LangTabs`, `RoleSelector`, `layout.tsx`** — zero literals after inspection. No changes needed.

## Files changed

| File | Change |
|---|---|
| `lib/i18n/domains/admin.ts` | Created; 2 keys |
| `lib/i18n/index.ts` | Import + collision guard + spread wired in |
| `app/admin/components/AdminNav.tsx` | `useLanguage()` added; literals → `t()` or suppressed |
| `app/admin/components/I18nField.tsx` | Format string suppressed with reason |

## DoD

`npm run lint` produces zero `i18next/no-literal-string` warnings across all files in `app/admin/components/`, `app/admin/layout.tsx`, and stub `page.tsx` files.

Closes #45