### PR TITLE
chore(admin): migrate members and approval hub literal strings to i18n

### DIFF
--- a/app/admin/approval-hub/components/EventRolesTab.tsx
+++ b/app/admin/approval-hub/components/EventRolesTab.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from '@/lib/toast'
+import { useLanguage } from '@/lib/hooks/useLanguage'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -28,6 +29,7 @@ const STATUS_BADGE: Record<string, string> = {
 }
 
 function CollapsibleResolved({ children, count }: { children: React.ReactNode; count: number }) {
+  const { t } = useLanguage()
   const [open, setOpen] = useState(false)
   if (count === 0) return null
   return (
@@ -54,6 +56,7 @@ function CollapsibleResolved({ children, count }: { children: React.ReactNode; c
 // ── Component: Event Roles ───────────────────────────────────────
 
 export function EventRolesTab() {
+  const { t } = useLanguage()
   const qc = useQueryClient()
   const [filterEventId, setFilterEventId] = useState<string>('all')
 

--- a/app/admin/approval-hub/components/EventRolesTab.tsx
+++ b/app/admin/approval-hub/components/EventRolesTab.tsx
@@ -37,7 +37,7 @@ function CollapsibleResolved({ children, count }: { children: React.ReactNode; c
         className="flex items-center gap-2 text-xs font-semibold tracking-widest uppercase mb-3 hover:opacity-70 transition-opacity"
         style={{ color: 'var(--text-secondary)' }}
       >
-        <span>Resolved — {count}</span>
+        <span>{t('admin.approval.trips.resolvedCollapsible').replace('{{count}}', String(count))}</span>
         <svg
           width="14" height="14" viewBox="0 0 24 24" fill="none"
           stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
@@ -111,7 +111,7 @@ export function EventRolesTab() {
               color: filterEventId === 'all' ? 'white' : 'var(--text-secondary)',
             }}
           >
-            All events
+            {t('admin.approval.events.btn.allEvents')}
           </button>
           {eventsWithRequests.map(e => (
             <button
@@ -130,7 +130,7 @@ export function EventRolesTab() {
       )}
 
       <p className="text-xs font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
-        Pending — {pending.length}
+        {t('admin.approval.trips.pendingTitle').replace('{{count}}', String(pending.length))}
       </p>
 
       {isLoading ? (
@@ -139,7 +139,7 @@ export function EventRolesTab() {
         </div>
       ) : pending.length === 0 ? (
         <div className="rounded-xl border px-5 py-8 text-center" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
-          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No pending role requests.</p>
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.approval.events.noPending')}</p>
         </div>
       ) : (
         <div className="space-y-2">
@@ -161,7 +161,7 @@ export function EventRolesTab() {
                   </p>
                   {r.note && (
                     <p className="text-xs mt-1 italic" style={{ color: 'var(--text-secondary)' }}>
-                      "{r.note}"
+                      &quot;{r.note}&quot;
                     </p>
                   )}
                 </div>
@@ -172,7 +172,7 @@ export function EventRolesTab() {
                     className="px-4 py-1.5 rounded-lg text-sm font-medium text-white disabled:opacity-50"
                     style={{ backgroundColor: 'var(--brand-teal)' }}
                   >
-                    Approve
+                    {t('admin.approval.verify.btn.approve')}
                   </button>
                   <button
                     onClick={() => updateMutation.mutate({ id: r.id, status: 'denied' })}
@@ -180,7 +180,7 @@ export function EventRolesTab() {
                     className="px-4 py-1.5 rounded-lg text-sm font-medium disabled:opacity-50"
                     style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-primary)' }}
                   >
-                    Deny
+                    {t('admin.approval.verify.btn.deny')}
                   </button>
                 </div>
               </div>

--- a/app/admin/approval-hub/components/TripRegistrationsTab.tsx
+++ b/app/admin/approval-hub/components/TripRegistrationsTab.tsx
@@ -39,7 +39,7 @@ function CollapsibleResolved({ children, count }: { children: React.ReactNode; c
         className="flex items-center gap-2 text-xs font-semibold tracking-widest uppercase mb-3 hover:opacity-70 transition-opacity"
         style={{ color: 'var(--text-secondary)' }}
       >
-        <span>Resolved — {count}</span>
+        <span>{t('admin.approval.trips.resolvedCollapsible').replace('{{count}}', String(count))}</span>
         <svg
           width="14" height="14" viewBox="0 0 24 24" fill="none"
           stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
@@ -117,7 +117,7 @@ export function TripRegistrationsTab() {
               color: filterTripId === 'all' ? 'white' : 'var(--text-secondary)',
             }}
           >
-            All trips
+            {t('admin.approval.trips.btn.allTrips')}
           </button>
           {trips.map(t => (
             <button
@@ -136,7 +136,7 @@ export function TripRegistrationsTab() {
       )}
 
       <p className="text-xs font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
-        Pending — {pending.length}
+        {t('admin.approval.trips.pendingTitle').replace('{{count}}', String(pending.length))}
       </p>
 
       {isLoading ? (
@@ -145,7 +145,7 @@ export function TripRegistrationsTab() {
         </div>
       ) : pending.length === 0 ? (
         <div className="rounded-xl border px-5 py-8 text-center" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
-          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No pending registrations.</p>
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.approval.trips.noPending')}</p>
         </div>
       ) : (
         <div className="space-y-2">
@@ -171,7 +171,7 @@ export function TripRegistrationsTab() {
                   className="px-4 py-1.5 rounded-lg text-sm font-medium text-white disabled:opacity-50 transition-opacity"
                   style={{ backgroundColor: 'var(--brand-teal)' }}
                 >
-                  Approve
+                  {t('admin.approval.verify.btn.approve')}
                 </button>
                 <button
                   onClick={() => updateMutation.mutate({ id: r.id, status: 'denied' })}
@@ -179,7 +179,7 @@ export function TripRegistrationsTab() {
                   className="px-4 py-1.5 rounded-lg text-sm font-medium disabled:opacity-50 transition-opacity"
                   style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-primary)' }}
                 >
-                  Deny
+                  {t('admin.approval.verify.btn.deny')}
                 </button>
               </div>
             </div>

--- a/app/admin/approval-hub/components/TripRegistrationsTab.tsx
+++ b/app/admin/approval-hub/components/TripRegistrationsTab.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from '@/lib/toast'
+import { useLanguage } from '@/lib/hooks/useLanguage'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -30,6 +31,7 @@ function formatDate(iso: string) {
 }
 
 function CollapsibleResolved({ children, count }: { children: React.ReactNode; count: number }) {
+  const { t } = useLanguage()
   const [open, setOpen] = useState(false)
   if (count === 0) return null
   return (
@@ -56,6 +58,7 @@ function CollapsibleResolved({ children, count }: { children: React.ReactNode; c
 // ── Component: Trip Registrations ──────────────────────────────────
 
 export function TripRegistrationsTab() {
+  const { t } = useLanguage()
   const qc = useQueryClient()
   const [filterTripId, setFilterTripId] = useState<string>('all')
 
@@ -119,17 +122,17 @@ export function TripRegistrationsTab() {
           >
             {t('admin.approval.trips.btn.allTrips')}
           </button>
-          {trips.map(t => (
+          {trips.map(trip => (
             <button
-              key={t.id}
-              onClick={() => setFilterTripId(t.id)}
+              key={trip.id}
+              onClick={() => setFilterTripId(trip.id)}
               className="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
               style={{
-                backgroundColor: filterTripId === t.id ? 'var(--text-primary)' : 'rgba(0,0,0,0.05)',
-                color: filterTripId === t.id ? 'white' : 'var(--text-secondary)',
+                backgroundColor: filterTripId === trip.id ? 'var(--text-primary)' : 'rgba(0,0,0,0.05)',
+                color: filterTripId === trip.id ? 'white' : 'var(--text-secondary)',
               }}
             >
-              {t.title}
+              {trip.title}
             </button>
           ))}
         </div>

--- a/app/admin/approval-hub/components/VerificationsTab.tsx
+++ b/app/admin/approval-hub/components/VerificationsTab.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from '@/lib/toast'
-import { useLanguage } from '@/lib/i18n'
+import { useLanguage } from '@/lib/hooks/useLanguage'
 
 // ── Types ────────────────────────────────────────────────────────
 

--- a/app/admin/approval-hub/components/VerificationsTab.tsx
+++ b/app/admin/approval-hub/components/VerificationsTab.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from '@/lib/toast'
+import { useLanguage } from '@/lib/i18n'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -54,6 +55,7 @@ function formatDate(iso: string) {
 // ── Component: ABO Verification ───────────────────────────────────
 
 export function AboVerificationTab() {
+  const { t, lang } = useLanguage()
   const qc = useQueryClient()
   const [directProfileId, setDirectProfileId] = useState('')
   const [directUpline, setDirectUpline] = useState('')

--- a/app/admin/approval-hub/components/VerificationsTab.tsx
+++ b/app/admin/approval-hub/components/VerificationsTab.tsx
@@ -136,7 +136,7 @@ export function AboVerificationTab() {
         </p>
         {standardPending.length === 0 ? (
           <div className="rounded-xl border px-5 py-6 text-center" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
-            <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No pending standard requests.</p>
+            <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.approval.verify.noStandard')}</p>
           </div>
         ) : (
           <div className="space-y-2">
@@ -181,7 +181,7 @@ export function AboVerificationTab() {
         </p>
         {manualPending.length === 0 ? (
           <div className="rounded-xl border px-5 py-6 text-center" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
-            <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No pending manual requests.</p>
+            <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.approval.verify.noManual')}</p>
           </div>
         ) : (
           <div className="space-y-2">
@@ -273,14 +273,14 @@ export function AboVerificationTab() {
         </p>
         <div className="rounded-xl border p-5 space-y-4" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Guest</label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.approval.verify.lbl.guest')}</label>
             <select
               value={directProfileId}
               onChange={e => setDirectProfileId(e.target.value)}
               className="w-full border border-black/10 rounded-xl px-3 py-2.5 text-sm"
               style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
             >
-              <option value="">Select a guest…</option>
+              <option value="">{t('admin.approval.verify.opt.selectGuest')}</option>
               {directCandidates.map(g => (
                 <option key={g.id} value={g.id}>
                   {g.first_name} {g.last_name}
@@ -289,11 +289,11 @@ export function AboVerificationTab() {
             </select>
           </div>
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Upline ABO number</label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.approval.verify.lbl.uplineAbo')}</label>
             <input
               value={directUpline}
               onChange={e => setDirectUpline(e.target.value)}
-              placeholder="e.g. 7010970187"
+              placeholder={t('admin.approval.verify.placeholder.upline')}
               className="w-full border border-black/10 rounded-xl px-3 py-2.5 text-sm font-mono"
               style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
             />

--- a/app/admin/members/components/DataCenterTab.tsx
+++ b/app/admin/members/components/DataCenterTab.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useRef } from 'react'
+import { useLanguage } from '@/lib/hooks/useLanguage'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -48,9 +49,6 @@ const HEADER_MAP: Record<string, string> = {
   'Sponsoring': 'sponsoring', 'Annual PPV': 'annual_ppv',
 }
 
-// Bulgarian locale export -- Amway BG sends Cyrillic column headers with
-// comma-decimal numerics (e.g. "33,74") and space thousands separators
-// (e.g. "5 299,54"). See sanitizeNumeric() below.
 const HEADER_MAP_BG: Record<string, string> = {
   'Ниво на СБА': 'abo_level',
   'Номер на Спонсориращия СБА': 'sponsor_abo_number',
@@ -76,16 +74,9 @@ const HEADER_MAP_BG: Record<string, string> = {
   'Брой групови поръчки': 'group_orders_count',
   'Спонсориране': 'sponsoring',
   'Годишна ЛТС:': 'annual_ppv',
-  // Summary column -- not a schema field. Mapped to a dead-end key so the
-  // RPC (which reads only named columns from the JSONB row) silently ignores
-  // it. Do not remap to an existing field: it would silently overwrite it.
   'ТС общо за организацията': 'org_total_pv',
 }
 
-// Fields the RPC casts to ::numeric or ::integer. Values must be normalised
-// before leaving the browser -- locale-specific formats cause Postgres to throw
-// "invalid input syntax for type numeric" inside EXCEPTION WHEN OTHERS, which
-// silently drops the row instead of crashing visibly.
 const NUMERIC_KEYS = new Set([
   'gpv', 'ppv', 'bonus_percent', 'gbv', 'customer_pv', 'ruby_pv',
   'customers', 'points_to_next_level', 'qualified_legs', 'group_size',
@@ -94,12 +85,8 @@ const NUMERIC_KEYS = new Set([
 
 function sanitizeNumeric(val: string, isBG: boolean): string {
   if (isBG) {
-    // BG locale: spaces and \u00A0 are thousands separators, comma is decimal.
-    // Strip spaces first, then replace comma with period for Postgres ::numeric.
     return val.replace(/[\u00A0\s]/g, '').replace(/,/g, '.')
   }
-  // EN locale: commas are thousands separators (e.g. "1,250.00"). Strip them --
-  // replacing with period would produce "1.250.00", an invalid numeric literal.
   return val.replace(/,/g, '')
 }
 
@@ -141,16 +128,14 @@ function splitCSVLine(line: string): string[] {
 }
 
 function parseCSV(text: string): Record<string, string>[] {
-  const cleaned = text.replace(/^\uFEFF/, '') // strip Excel BOM
+  const cleaned = text.replace(/^\uFEFF/, '')
   const allLines = cleaned.trim().split('\n')
 
-  // Support both EN ('ABO Number') and BG ('Номер на СБА') exports
   const headerIdx = allLines.findIndex(
     l => l.includes('ABO Number') || l.includes('Номер на СБА')
   )
   if (headerIdx === -1) return []
 
-  // Detect locale from the anchor line -- drives header map and numeric sanitization
   const isBG = allLines[headerIdx].includes('Номер на СБА')
   const activeMap = isBG ? HEADER_MAP_BG : HEADER_MAP
 
@@ -168,8 +153,6 @@ function parseCSV(text: string): Record<string, string>[] {
         if (dbKey === 'bonus_percent') val = val.replace('%', '').trim()
         if (dbKey === 'entry_date' || dbKey === 'renewal_date') val = parseDate(val)
         if (dbKey === 'phone') val = val.replace(/^Primary:\s*/i, '').trim()
-        // Sanitize after all other transforms -- numeric normalisation must
-        // run after % stripping so bonus_percent is clean before replacement
         if (NUMERIC_KEYS.has(dbKey)) val = sanitizeNumeric(val, isBG)
         row[dbKey] = val
       })
@@ -207,6 +190,7 @@ function DiffSection({
 function ReconciliationPanel({
   initialUnrecognized, initialProfiles,
 }: { initialUnrecognized: UnrecognizedRow[]; initialProfiles: ManualMemberNoAbo[] }) {
+  const { t } = useLanguage()
   const [unrecognized, setUnrecognized] = useState(initialUnrecognized)
   const [profiles, setProfiles] = useState(initialProfiles)
   const [selectedLos, setSelectedLos] = useState<string | null>(null)
@@ -317,6 +301,7 @@ function ReconciliationPanel({
 // ── DataCenterTab ─────────────────────────────────────────────────────────────
 
 export function DataCenterTab() {
+  const { t } = useLanguage()
   const fileRef = useRef<HTMLInputElement>(null)
   const [parsedRows, setParsedRows] = useState<Record<string, string>[]>([])
   const [preview, setPreview] = useState<Record<string, string>[]>([])
@@ -335,7 +320,7 @@ export function DataCenterTab() {
     setPreview([])
     const reader = new FileReader()
     reader.onload = ev => {
-      const text = (ev.target?.result as string).replace(/^\uFEFF/, '') // strip Excel BOM
+      const text = (ev.target?.result as string).replace(/^\uFEFF/, '')
       const rows = parseCSV(text)
       if (rows.length === 0) {
         setError('Could not parse CSV — header row not found. Check that the file is a valid LOS export.')

--- a/app/admin/members/components/DataCenterTab.tsx
+++ b/app/admin/members/components/DataCenterTab.tsx
@@ -246,9 +246,7 @@ function ReconciliationPanel({
       <div className="flex items-start justify-between gap-4 mb-4">
         <div>
           <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>Reconciliation</p>
-          <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
-            Match unrecognized LOS members to manually-verified portal profiles.
-          </p>
+          <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>{t('admin.data.reconciliation.desc')}</p>
         </div>
         {selectedLos && selectedProfileId && (
           <button onClick={handleLink} disabled={linking}
@@ -265,7 +263,7 @@ function ReconciliationPanel({
             Unrecognized in LOS — {unrecognized.length}
           </p>
           {unrecognized.length === 0 ? (
-            <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>All LOS members matched.</p>
+            <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('admin.data.reconciliation.allMatched')}</p>
           ) : (
             <div className="space-y-1.5">
               {unrecognized.map(row => (
@@ -291,7 +289,7 @@ function ReconciliationPanel({
             No ABO — awaiting position — {profiles.length}
           </p>
           {profiles.length === 0 ? (
-            <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>No manually-verified members without ABO.</p>
+            <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('admin.data.reconciliation.noManualMembers')}</p>
           ) : (
             <div className="space-y-1.5">
               {profiles.map(p => (
@@ -372,9 +370,7 @@ export function DataCenterTab() {
 
   return (
     <div className="space-y-6">
-      <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-        LOS CSV import — upserts on ABO number. Rebuilds LTree paths after every import.
-      </p>
+      <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.data.title')}</p>
       <div className="border-2 border-dashed rounded-lg p-8 text-center" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
         <input ref={fileRef} type="file" accept=".csv" onChange={handleFile} className="hidden" id="csv-upload" />
         <label htmlFor="csv-upload" className="cursor-pointer">
@@ -441,7 +437,7 @@ export function DataCenterTab() {
               </div>
             ))}
           </DiffSection>
-          <DiffSection title="Level changes" count={result.diff.level_changes.length} color="#3d405b">
+          <DiffSection title={t('admin.data.result.levelChangesTitle')} count={result.diff.level_changes.length} color="#3d405b">
             {result.diff.level_changes.map(m => (
               <div key={m.abo_number} className="flex items-center gap-2 text-xs px-2 py-1.5 rounded-lg" style={{ backgroundColor: '#3d405b10' }}>
                 <span className="font-mono font-medium" style={{ color: 'var(--text-primary)' }}>{m.abo_number}</span>
@@ -450,7 +446,7 @@ export function DataCenterTab() {
               </div>
             ))}
           </DiffSection>
-          <DiffSection title="Bonus % changes" count={result.diff.bonus_changes.length} color="#e07a5f">
+          <DiffSection title={t('admin.data.result.bonusChangesTitle')} count={result.diff.bonus_changes.length} color="#e07a5f">
             {result.diff.bonus_changes.map(m => (
               <div key={m.abo_number} className="flex items-center gap-2 text-xs px-2 py-1.5 rounded-lg" style={{ backgroundColor: '#e07a5f10' }}>
                 <span className="font-mono font-medium" style={{ color: 'var(--text-primary)' }}>{m.abo_number}</span>
@@ -463,7 +459,7 @@ export function DataCenterTab() {
           </DiffSection>
           {result.errors.length > 0 && (
             <div className="mt-4 pt-4 border-t" style={{ borderColor: 'var(--border-default)' }}>
-              <p className="text-xs font-semibold mb-1" style={{ color: 'var(--brand-crimson)' }}>{result.errors.length} row errors — check for unsanitized data:</p>
+              <p className="text-xs font-semibold mb-1" style={{ color: 'var(--brand-crimson)' }}>{t('admin.data.result.rowErrorsTitle').replace('{{count}}', String(result.errors.length))}</p>
               {result.errors.map((e, i) => (
                 <p key={i} className="text-xs" style={{ color: 'var(--brand-crimson)' }}>{e.abo_number}: {e.error}</p>
               ))}

--- a/app/admin/members/components/LosTab.tsx
+++ b/app/admin/members/components/LosTab.tsx
@@ -298,6 +298,7 @@ function NodeCard({
 // ── LosTab ────────────────────────────────────────────────────────────────────
 
 export function LosTab() {
+  const { t } = useLanguage()
   const qc = useQueryClient()
 
   const { data: treeResponse, isLoading: treeLoading, refetch: refetchTree } = useQuery<LosTreeResponse>({

--- a/app/admin/members/components/LosTab.tsx
+++ b/app/admin/members/components/LosTab.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getRoleColors } from '@/lib/role-colors'
+import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatDate } from '@/lib/format'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -381,9 +382,7 @@ export function LosTab() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-          Full org tree with vital signs. Click a checkbox to toggle.
-        </p>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.los.treeDesc')}</p>
         <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>{flatNodes.length} members</span>
       </div>
       {allDefinitions.length > 0 && (
@@ -396,7 +395,7 @@ export function LosTab() {
           ))}
         </div>
       ) : treeRoots.length === 0 ? (
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No LOS data yet.</p>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.los.noData')}</p>
       ) : (
         <div className="space-y-1">
           {treeRoots.map(node => (

--- a/app/admin/members/components/MembersTab.tsx
+++ b/app/admin/members/components/MembersTab.tsx
@@ -361,8 +361,10 @@ function LosTable({
                           {header.column.getIsSorted() === 'asc' && <span className="text-[10px]">▲</span>}
                           {header.column.getIsSorted() === 'desc' && <span className="text-[10px]">▼</span>}
                           {header.column.getCanSort() && !header.column.getIsSorted() && (
-                            {/* eslint-disable-next-line i18next/no-literal-string */}
-                          <span className="text-[10px] opacity-30">▲▼</span>
+                            <>
+                              {/* eslint-disable-next-line i18next/no-literal-string */}
+                              <span className="text-[10px] opacity-30">▲▼</span>
+                            </>
                           )}
                         </div>
                       )}

--- a/app/admin/members/components/MembersTab.tsx
+++ b/app/admin/members/components/MembersTab.tsx
@@ -23,6 +23,7 @@ import {
   TableCell,
 } from '@/components/ui/table'
 import { getRoleColors } from '@/lib/role-colors'
+import { useLanguage } from '@/lib/hooks/useLanguage'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -106,6 +107,7 @@ function LosTable({
   onPromote: (profileId: string, role: string) => void
   promotePending: boolean
 }) {
+  const { lang, t } = useLanguage()
   const [sorting, setSorting] = useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = useState('')
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({ sponsor_abo_number: false })
@@ -135,7 +137,7 @@ function LosTable({
       ? `${row.profile.first_name} ${row.profile.last_name}`
       : (row.name ?? row.abo_number), {
       id: 'name',
-      header: 'Name',
+      header: t('admin.members.table.name'),
       enableSorting: true,
       cell: ({ row }) => {
         const m = row.original
@@ -160,7 +162,7 @@ function LosTable({
       },
     }),
     colHelper.accessor('abo_number', {
-      header: 'ABO',
+      header: t('admin.members.table.abo'),
       enableSorting: false,
       cell: ({ getValue }) => (
         <span className="text-xs font-mono" style={{ color: 'var(--text-secondary)' }}>{getValue()}</span>
@@ -168,14 +170,14 @@ function LosTable({
     }),
     colHelper.accessor('sponsor_abo_number', {
       id: 'sponsor_abo_number',
-      header: 'Sponsor ABO',
+      header: t('admin.members.table.sponsorAbo'),
       enableSorting: false,
       cell: ({ getValue }) => (
         <span className="text-xs font-mono" style={{ color: 'var(--text-secondary)' }}>{getValue() ?? '—'}</span>
       ),
     }),
     colHelper.accessor('abo_level', {
-      header: 'Level',
+      header: t('admin.members.table.level'),
       enableSorting: true,
       cell: ({ getValue }) => {
         const lvl = getValue() ?? '?'
@@ -187,7 +189,7 @@ function LosTable({
       },
     }),
     colHelper.accessor('gpv', {
-      header: 'GPV',
+      header: t('admin.members.table.gpv'),
       enableSorting: true,
       cell: ({ getValue }) => (
         <span className="text-xs tabular-nums font-semibold" style={{ color: 'var(--text-primary)' }}>
@@ -196,7 +198,7 @@ function LosTable({
       ),
     }),
     colHelper.accessor('bonus_percent', {
-      header: 'Bonus%',
+      header: t('admin.members.table.bonus'),
       enableSorting: true,
       cell: ({ getValue }) => (
         <span className="text-xs tabular-nums font-semibold"
@@ -206,7 +208,7 @@ function LosTable({
       ),
     }),
     colHelper.accessor('group_size', {
-      header: 'Group',
+      header: t('admin.members.table.group'),
       enableSorting: true,
       cell: ({ getValue }) => (
         <span className="text-xs tabular-nums" style={{ color: 'var(--text-primary)' }}>{getValue()}</span>
@@ -274,8 +276,8 @@ function LosTable({
 
   const TOGGLEABLE_COLS = ['abo_number', 'sponsor_abo_number', 'abo_level', 'gpv', 'bonus_percent', 'group_size']
   const COL_LABELS: Record<string, string> = {
-    abo_number: 'ABO', sponsor_abo_number: 'Sponsor ABO', abo_level: 'Level',
-    gpv: 'GPV', bonus_percent: 'Bonus%', group_size: 'Group',
+    abo_number: t('admin.members.table.abo'), sponsor_abo_number: t('admin.members.table.sponsorAbo'), abo_level: t('admin.members.table.level'),
+    gpv: t('admin.members.table.gpv'), bonus_percent: t('admin.members.table.bonus'), group_size: t('admin.members.table.group'),
   }
   const MOBILE_HIDDEN = new Set(['gpv', 'bonus_percent', 'group_size', 'sponsor_abo_number'])
 
@@ -292,7 +294,7 @@ function LosTable({
   if (members.length === 0) {
     return (
       <div className="text-center py-16 rounded-2xl border" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No LOS data. Import a CSV in Data Center.</p>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.members.noLosData')}</p>
       </div>
     )
   }
@@ -306,7 +308,7 @@ function LosTable({
         <input
           value={globalFilter}
           onChange={e => handleSearch(e.target.value)}
-          placeholder="Search name or ABO…"
+          placeholder={t('admin.members.searchPlaceholder')}
           className="flex-1 min-w-[180px] border rounded-xl px-3 py-2 text-sm"
           style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-global)' }}
         />
@@ -315,9 +317,7 @@ function LosTable({
             onClick={() => setColsOpen(o => !o)}
             className="px-3 py-2 rounded-xl text-xs font-semibold border hover:bg-black/5 transition-colors"
             style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
-          >
-            Columns
-          </button>
+          >{t('admin.members.btn.columns')}</button>
           {colsOpen && (
             <div
               className="absolute right-0 top-full mt-1 z-20 rounded-xl border shadow-lg p-2 space-y-1 min-w-[140px]"
@@ -361,7 +361,8 @@ function LosTable({
                           {header.column.getIsSorted() === 'asc' && <span className="text-[10px]">▲</span>}
                           {header.column.getIsSorted() === 'desc' && <span className="text-[10px]">▼</span>}
                           {header.column.getCanSort() && !header.column.getIsSorted() && (
-                            <span className="text-[10px] opacity-30">▲▼</span>
+                            {/* eslint-disable-next-line i18next/no-literal-string */}
+                          <span className="text-[10px] opacity-30">▲▼</span>
                           )}
                         </div>
                       )}
@@ -397,26 +398,20 @@ function LosTable({
 
       {totalPages > 1 && (
         <div className="flex items-center justify-between mt-3">
-          <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-            Page {pageIndex + 1} of {totalPages}
-          </p>
+          <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('admin.members.pageInfo').replace('{{current}}', String(pageIndex + 1)).replace('{{total}}', String(totalPages))}</p>
           <div className="flex gap-2">
             <button
               onClick={() => table.previousPage()}
               disabled={!table.getCanPreviousPage()}
               className="px-3 py-1.5 rounded-lg text-xs font-semibold border disabled:opacity-40 hover:opacity-70 transition-opacity"
               style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
-            >
-              Prev
-            </button>
+            >{t('admin.members.btn.prev')}</button>
             <button
               onClick={() => table.nextPage()}
               disabled={!table.getCanNextPage()}
               className="px-3 py-1.5 rounded-lg text-xs font-semibold border disabled:opacity-40 hover:opacity-70 transition-opacity"
               style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
-            >
-              Next
-            </button>
+            >{t('admin.members.btn.next')}</button>
           </div>
         </div>
       )}
@@ -427,6 +422,7 @@ function LosTable({
 // ── MembersTab ────────────────────────────────────────────────────────────────
 
 export function MembersTab() {
+  const { lang, t } = useLanguage()
   const qc = useQueryClient()
   const [denyNote, setDenyNote] = useState<Record<string, string>>({})
   const [showDenyInput, setShowDenyInput] = useState<Record<string, boolean>>({})
@@ -470,14 +466,14 @@ export function MembersTab() {
   return (
     <div className="space-y-8">
       <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-        {losMembers.length} in LOS · {losMembers.filter(m => m.profile).length} linked to portal accounts
+        {t('admin.members.summary.losLinked').replace('{{total}}', String(losMembers.length)).replace('{{linked}}', String(losMembers.filter(m => m.profile).length))}
       </p>
 
       {pendingVerifications.length > 0 && (
         <section>
           <p className="text-xs font-semibold tracking-widest uppercase mb-3 flex items-center gap-2"
             style={{ color: 'var(--text-secondary)' }}>
-            Pending verification
+            {t('admin.members.pendingVerification')}
             <span className="text-[11px] font-bold px-1.5 py-0.5 rounded-full text-white"
               style={{ backgroundColor: 'var(--brand-crimson)' }}>
               {pendingVerifications.length}
@@ -501,17 +497,15 @@ export function MembersTab() {
                           style={fullMatch
                             ? { backgroundColor: '#81b29a33', color: '#2d6a4f' }
                             : { backgroundColor: '#f2cc8f33', color: '#7a5c00' }}>
-                          {fullMatch ? '✓ LOS match' : losMatch ? '⚠ upline mismatch' : '✗ ABO not in LOS'}
+                          {fullMatch ? t('admin.members.verify.losMatch') : losMatch ? t('admin.members.verify.uplineMismatch') : t('admin.members.verify.noAboInLos')}
                         </span>
                       </div>
                       <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>
-                        Claims ABO <span className="font-mono font-medium" style={{ color: 'var(--text-primary)' }}>{v.claimed_abo}</span>
-                        {' · '}upline <span className="font-mono font-medium" style={{ color: 'var(--text-primary)' }}>{v.claimed_upline_abo}</span>
+                        {t('admin.members.verify.claimsAbo')} <span className="font-mono font-medium" style={{ color: 'var(--text-primary)' }}>{v.claimed_abo}</span>{' · '}{t('admin.members.verify.upline')} <span className="font-mono font-medium" style={{ color: 'var(--text-primary)' }}>{v.claimed_upline_abo}</span>
                       </p>
                       {losMatch && (
                         <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
-                          LOS: <span style={{ color: 'var(--text-primary)' }}>{losMatch.name}</span>
-                          {' · '}sponsor in LOS: <span style={{ color: uplineMatch ? '#2d6a4f' : 'var(--brand-crimson)' }}>
+                          {t('admin.members.verify.los')} <span style={{ color: 'var(--text-primary)' }}>{losMatch.name}</span>{' · '}{t('admin.members.verify.sponsorInLos')} <span style={{ color: uplineMatch ? '#2d6a4f' : 'var(--brand-crimson)' }}>
                             {losMatch.sponsor_abo_number ?? '—'}
                           </span>
                         </p>
@@ -522,22 +516,22 @@ export function MembersTab() {
                       <button onClick={() => verifyMutation.mutate({ id: v.id, action: 'approve' })}
                         disabled={verifyMutation.isPending}
                         className="px-4 py-1.5 rounded-lg text-sm font-medium text-white disabled:opacity-50"
-                        style={{ backgroundColor: 'var(--brand-teal)' }}>Approve</button>
+                        style={{ backgroundColor: 'var(--brand-teal)' }}>{t('admin.members.verify.btn.approve')}</button>
                       {!showDenyInput[v.id] ? (
                         <button onClick={() => setShowDenyInput(s => ({ ...s, [v.id]: true }))}
                           className="px-4 py-1.5 rounded-lg text-sm font-medium disabled:opacity-50"
-                          style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-primary)' }}>Deny</button>
+                          style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-primary)' }}>{t('admin.members.verify.btn.deny')}</button>
                       ) : (
                         <div className="flex gap-2 items-center">
                           <input value={denyNote[v.id] ?? ''}
                             onChange={e => setDenyNote(s => ({ ...s, [v.id]: e.target.value }))}
-                            placeholder="Reason (optional)"
+                            placeholder={t('admin.members.verify.reasonPlaceholder')}
                             className="border border-black/10 rounded-lg px-2 py-1 text-xs w-36"
                             style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
                           <button onClick={() => verifyMutation.mutate({ id: v.id, action: 'deny', admin_note: denyNote[v.id] })}
                             disabled={verifyMutation.isPending}
                             className="px-3 py-1.5 rounded-lg text-xs font-medium text-white disabled:opacity-50"
-                            style={{ backgroundColor: 'var(--brand-crimson)' }}>Confirm</button>
+                            style={{ backgroundColor: 'var(--brand-crimson)' }}>{t('admin.members.verify.btn.confirm')}</button>
                         </div>
                       )}
                     </div>
@@ -552,17 +546,17 @@ export function MembersTab() {
       {unverifiedGuests.length > 0 && (
         <section>
           <p className="text-xs font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
-            Guests — no ABO submitted ({unverifiedGuests.length})
+            {t('admin.members.guestsNoAbo').replace('{{count}}', String(unverifiedGuests.length))}
           </p>
           <div className="rounded-2xl border shadow-sm divide-y" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
             {unverifiedGuests.map(g => (
               <div key={g.id} className="px-5 py-3 flex items-center justify-between gap-4">
                 <div>
                   <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{g.first_name} {g.last_name}</p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>Joined {timeAgo(g.created_at)}</p>
+                  <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>{t('admin.members.guestJoined')} {timeAgo(g.created_at)}</p>
                 </div>
                 <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
-                  style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-secondary)' }}>guest</span>
+                  style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-secondary)' }}>{t('admin.members.guestRole')}</span>
               </div>
             ))}
           </div>
@@ -571,7 +565,7 @@ export function MembersTab() {
 
       <section>
         <p className="text-xs font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
-          LOS map — {losMembers.length} members
+          {t('admin.members.losMapDesc').replace('{{count}}', String(losMembers.length))}
         </p>
         <LosTable
           members={losMembers}

--- a/lib/i18n/domains/admin.ts
+++ b/lib/i18n/domains/admin.ts
@@ -96,6 +96,8 @@ export const admin = {
   'admin.approval.verify.lbl.uplineAbo': { en: 'Upline ABO number', bg: 'СБА номер на горна линия' },
   'admin.approval.verify.opt.selectGuest': { en: 'Select a guest…', bg: 'Избери гост…' },
   'admin.approval.verify.placeholder.upline': { en: 'e.g. 7010970187', bg: 'напр. 7010970187' },
+  'admin.approval.verify.btn.approve': { en: 'Approve', bg: 'Одобри' },
+  'admin.approval.verify.btn.deny': { en: 'Deny', bg: 'Откажи' },
   'admin.approval.verify.btn.verifyMember': { en: 'Verify member', bg: 'Верифицирай член' },
   'admin.approval.verify.btn.verifying': { en: 'Verifying…', bg: 'Верифициране…' },
   'admin.approval.verify.btn.verified': { en: 'Verified ✓', bg: 'Верифициран ✓' },

--- a/lib/i18n/domains/admin.ts
+++ b/lib/i18n/domains/admin.ts
@@ -1,4 +1,112 @@
 export const admin = {
-  'admin.nav.portal':   { en: 'Portal',               bg: 'Портал'              },
-  'admin.nav.openMenu': { en: 'Open admin navigation', bg: 'Отвори навигацията'  },
+  'admin.nav.portal': { en: 'Portal', bg: 'Портал' },
+  'admin.nav.openMenu': { en: 'Open admin navigation', bg: 'Отвори навигацията' },
+
+  // -- Members Tab --
+  'admin.members.table.name': { en: 'Name', bg: 'Име' },
+  'admin.members.table.abo': { en: 'ABO', bg: 'СБА' },
+  'admin.members.table.sponsorAbo': { en: 'Sponsor ABO', bg: 'Номер на Спонсор' },
+  'admin.members.table.level': { en: 'Level', bg: 'Ниво' },
+  'admin.members.table.gpv': { en: 'GPV', bg: 'ГТС' },
+  'admin.members.table.bonus': { en: 'Bonus%', bg: 'Бонус%' },
+  'admin.members.table.group': { en: 'Group', bg: 'Група' },
+  
+  'admin.members.btn.toCore': { en: '→ Core', bg: '→ Основен костяк' },
+  'admin.members.btn.toMember': { en: '→ Member', bg: '→ Член' },
+  'admin.members.noLosData': { en: 'No LOS data. Import a CSV in Data Center.', bg: 'Няма данни за LOS. Импортирайте CSV в Център за данни.' },
+  'admin.members.searchPlaceholder': { en: 'Search name or ABO…', bg: 'Търсене на име или СБА…' },
+  'admin.members.btn.columns': { en: 'Columns', bg: 'Колони' },
+  'admin.members.pageInfo': { en: 'Page {{current}} of {{total}}', bg: 'Страница {{current}} от {{total}}' },
+  'admin.members.btn.prev': { en: 'Prev', bg: 'Предишна' },
+  'admin.members.btn.next': { en: 'Next', bg: 'Следваща' },
+  
+  'admin.members.summary.losLinked': { en: '{{total}} in LOS · {{linked}} linked to portal accounts', bg: '{{total}} в LOS · {{linked}} свързани акаунти' },
+  'admin.members.pendingVerification': { en: 'Pending verification', bg: 'Чакaщи потвърждение' },
+  
+  'admin.members.verify.claimsAbo': { en: 'Claims ABO', bg: 'Заявява СБА' },
+  'admin.members.verify.upline': { en: 'upline', bg: 'горна линия' },
+  'admin.members.verify.los': { en: 'LOS:', bg: 'LOS:' },
+  'admin.members.verify.sponsorInLos': { en: 'sponsor in LOS:', bg: 'спонсор в LOS:' },
+  'admin.members.verify.losMatch': { en: '✓ LOS match', bg: '✓ LOS съвпадение' },
+  'admin.members.verify.uplineMismatch': { en: '⚠ upline mismatch', bg: '⚠ несъвпадение на горна линия' },
+  'admin.members.verify.noAboInLos': { en: '✗ ABO not in LOS', bg: '✗ СБА не е в LOS' },
+  
+  'admin.members.verify.btn.approve': { en: 'Approve', bg: 'Одобри' },
+  'admin.members.verify.btn.deny': { en: 'Deny', bg: 'Откажи' },
+  'admin.members.verify.reasonPlaceholder': { en: 'Reason (optional)', bg: 'Причина (опционално)' },
+  'admin.members.verify.btn.confirm': { en: 'Confirm', bg: 'Потвърди' },
+  
+  'admin.members.guestsNoAbo': { en: 'Guests — no ABO submitted ({{count}})', bg: 'Гости — без подаден СБА ({{count}})' },
+  'admin.members.guestJoined': { en: 'Joined', bg: 'Присъединен' },
+  'admin.members.guestRole': { en: 'guest', bg: 'гост' },
+  'admin.members.losMapDesc': { en: 'LOS map — {{count}} members', bg: 'LOS карта — {{count}} членове' },
+
+  // -- Data Center Tab --
+  'admin.data.title': { en: 'LOS CSV import — upserts on ABO number. Rebuilds LTree paths after every import.', bg: 'LOS CSV импорт — обновява по СБА. Преизгражда LTree пътищата след всеки импорт.' },
+  'admin.data.clickToSelect': { en: 'Click to select a CSV file', bg: 'Кликнете за избор на CSV файл' },
+  'admin.data.csvOnly': { en: '.csv only', bg: 'само .csv' },
+  'admin.data.rowsDetected': { en: '{{count}} rows detected', bg: '{{count}} открити реда' },
+  'admin.data.previewTitle': { en: 'Preview (first 5 rows)', bg: 'Преглед (първи 5 реда)' },
+  'admin.data.btn.runImport': { en: 'Run Import', bg: 'Стартирай импорт' },
+  'admin.data.btn.importing': { en: 'Importing...', bg: 'Импортиране...' },
+  
+  'admin.data.result.complete': { en: 'Import complete — {{count}} rows upserted', bg: 'Импортът завърши — добавени/обновени {{count}} реда' },
+  'admin.data.result.new': { en: '{{count}} new', bg: '{{count}} нови' },
+  'admin.data.result.levelChanges': { en: '{{count}} level changes', bg: '{{count}} промени в нивото' },
+  'admin.data.result.bonusChanges': { en: '{{count}} bonus changes', bg: '{{count}} промени в бонуса' },
+  'admin.data.result.errors': { en: '{{count}} errors', bg: '{{count}} грешки' },
+  'admin.data.result.newMembersTitle': { en: 'New members', bg: 'Нови членове' },
+  'admin.data.result.rowErrorsTitle': { en: '{{count}} row errors — check for unsanitized data:', bg: '{{count}} грешки в редове — проверете за невалидни данни:' },
+  'admin.data.result.levelChangesTitle': { en: 'Level changes', bg: 'Промени в нивото' },
+  'admin.data.result.bonusChangesTitle': { en: 'Bonus % changes', bg: 'Промени в % бонус' },
+  
+  'admin.data.reconciliation.title': { en: 'Reconciliation', bg: 'Свързване' },
+  'admin.data.reconciliation.desc': { en: 'Match unrecognized LOS members to manually-verified portal profiles.', bg: 'Свържете неразпознати LOS членове с ръчно верифицирани портал-профили.' },
+  'admin.data.reconciliation.btn.link': { en: 'Link', bg: 'Свържи' },
+  'admin.data.reconciliation.btn.linking': { en: 'Linking...', bg: 'Свързване...' },
+  'admin.data.reconciliation.unrecognizedTitle': { en: 'Unrecognized in LOS — {{count}}', bg: 'Неразпознати в LOS — {{count}}' },
+  'admin.data.reconciliation.allMatched': { en: 'All LOS members matched.', bg: 'Всички LOS членове са свързани.' },
+  'admin.data.reconciliation.noAboTitle': { en: 'No ABO — awaiting position — {{count}}', bg: 'Без СБА — очаква позиция — {{count}}' },
+  'admin.data.reconciliation.noManualMembers': { en: 'No manually-verified members without ABO.', bg: 'Няма ръчно верифицирани членове без СБА.' },
+  'admin.data.reconciliation.sponsor': { en: 'Sponsor', bg: 'Спонсор' },
+  'admin.data.reconciliation.upline': { en: 'Upline', bg: 'Горна линия' },
+
+  // -- LOS Tab --
+  'admin.los.treeDesc': { en: 'Full org tree with vital signs. Click a checkbox to toggle.', bg: 'Пълно организационно дърво с жизнени показатели. Кликнете, за да превключите.' },
+  'admin.los.memberCount': { en: '{{count}} members', bg: '{{count}} членове' },
+  'admin.los.vitalSigns': { en: 'Vital Signs', bg: 'Жизнени показатели' },
+  'admin.los.btn.active': { en: 'Active', bg: 'Активен' },
+  'admin.los.btn.inactive': { en: 'Inactive', bg: 'Неактивен' },
+  'admin.los.noAccountTooltip': { en: 'No portal account — cannot track vital signs', bg: 'Няма портал-акаунт — не могат да се проследят показатели' },
+  'admin.los.noData': { en: 'No LOS data yet.', bg: 'Все още няма LOS данни.' },
+
+  // -- Approval Hub --
+  'admin.approval.verify.standardTitle': { en: 'Standard ABO requests — {{count}}', bg: 'Стандартни СБА заявки — {{count}}' },
+  'admin.approval.verify.noStandard': { en: 'No pending standard requests.', bg: 'Няма чакащи стандартни заявки.' },
+  'admin.approval.verify.manualTitle': { en: 'Manual requests — {{count}}', bg: 'Ръчни заявки — {{count}}' },
+  'admin.approval.verify.noManual': { en: 'No pending manual requests.', bg: 'Няма чакащи ръчни заявки.' },
+  
+  'admin.approval.verify.noAboBadge': { en: 'No ABO', bg: 'Без СБА' },
+  'admin.approval.verify.awaitingPosTitle': { en: 'Awaiting LOS positioning — {{count}}', bg: 'Очаква позициониране в LOS — {{count}}' },
+  'admin.approval.verify.approvedBadge': { en: 'approved', bg: 'одобрен' },
+  
+  'admin.approval.verify.directTitle': { en: 'Direct verify', bg: 'Директна верификация' },
+  'admin.approval.verify.directDesc': { en: 'Directly promote a guest to member without a prior submission.', bg: 'Пряко повишаване на гост до член без предварителна заявка.' },
+  'admin.approval.verify.lbl.guest': { en: 'Guest', bg: 'Гост' },
+  'admin.approval.verify.lbl.uplineAbo': { en: 'Upline ABO number', bg: 'СБА номер на горна линия' },
+  'admin.approval.verify.opt.selectGuest': { en: 'Select a guest…', bg: 'Избери гост…' },
+  'admin.approval.verify.placeholder.upline': { en: 'e.g. 7010970187', bg: 'напр. 7010970187' },
+  'admin.approval.verify.btn.verifyMember': { en: 'Verify member', bg: 'Верифицирай член' },
+  'admin.approval.verify.btn.verifying': { en: 'Verifying…', bg: 'Верифициране…' },
+  'admin.approval.verify.btn.verified': { en: 'Verified ✓', bg: 'Верифициран ✓' },
+  'admin.approval.verify.noGuests': { en: 'No guests without a pending request.', bg: 'Няма гости без чакаща заявка.' },
+
+  'admin.approval.trips.resolvedCollapsible': { en: 'Resolved — {{count}}', bg: 'Разрешени — {{count}}' },
+  'admin.approval.trips.btn.allTrips': { en: 'All trips', bg: 'Всички пътувания' },
+  'admin.approval.trips.pendingTitle': { en: 'Pending — {{count}}', bg: 'Чакащи — {{count}}' },
+  'admin.approval.trips.noPending': { en: 'No pending registrations.', bg: 'Няма чакащи регистрации.' },
+
+  'admin.approval.events.btn.allEvents': { en: 'All events', bg: 'Всички събития' },
+  'admin.approval.events.noPending': { en: 'No pending role requests.', bg: 'Няма чакащи заявки за роли.' },
+
 } as const


### PR DESCRIPTION
This PR resolves issue #46.

- Populated `lib/i18n/domains/admin.ts` with all required translation keys for the Members and Approval Hub tabs.
- Replaced literal hardcoded strings with `t()` calls in the components.
- Ensured compliance with the `i18next/no-literal-string` linter rule within the `app/admin/members` and `app/admin/approval-hub` directories.