### PR TITLE
chore: add PLAN/BUILD mode protocol, remove Airtable refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Counter resets each month. GitHub issue number is the canonical unique reference
 | `chore` | Refactor, deps, infrastructure |
 | `priority:high` | Pick before anything else |
 | `priority:low` | Pick last |
-| `blocked` | Do not pick — has a dependency that isn’t resolved |
+| `blocked` | Do not pick — has a dependency that isn't resolved |
 
 READ order: `priority:high` first, then unlabelled, then `priority:low`. Never pick a `blocked` issue without explicit user acknowledgment.
 
@@ -105,9 +105,51 @@ If GitHub ❌ — stop.
 5. Push all changes in a single commit to the PR branch. Commit message: `[YYMM]-[TYPE]-[NNN] fix: address Gemini PR<N> review comments`.
 6. Report: one line per comment — ✅ Applied / ⚠️ Skipped (reason).
 
+**PLAN** — Enter design-only mode for this session.
+- No branch creation.
+- No file writes except issue body updates.
+- No commits.
+- For each ticket in the batch:
+  1. Read the issue body.
+  2. Read relevant REF.md sections freely — no competing write budget.
+  3. Read FLOWS.md if routing or data flow is in scope.
+  4. Produce the Design Checklist and write it to the issue body:
+     ```
+     ## Design Checklist
+     - [ ] DoD defined
+     - [ ] Affected files listed by path
+     - [ ] Gotchas flagged
+     - [ ] Blocking unknowns: none
+     ```
+  5. Output a verdict: **READY** or **BLOCKED: [single specific question]**.
+- If BLOCKED:
+  - Apply `blocked` label to the GitHub issue.
+  - Write a `## Blocking Unknown` section to the issue body with the single question.
+  - Stop processing dependent tickets.
+  - Re-entry: user resolves the question → re-run `PLAN` scoped to that ticket → READY or new BLOCKED.
+- PLAN is session-scoped. The next session starts in BUILD mode unless prefixed with `PLAN` again.
+
 ---
 
-## Workflow
+## DESIGN-Complete Definition
+
+An issue is DESIGN-complete when its body contains a `## Design Checklist` section with all four items checked:
+
+```
+## Design Checklist
+- [x] DoD defined
+- [x] Affected files listed by path
+- [x] Gotchas flagged
+- [x] Blocking unknowns: none
+```
+
+This is the gate between PLAN and BUILD. BUILD mode verifies this at SSU. If the section is absent or any item is unchecked, BUILD refuses and surfaces exactly what is missing.
+
+---
+
+## BUILD Workflow
+
+**Precondition (SSU):** Read the issue body. Verify `## Design Checklist` exists with all four items checked. If absent or any item unchecked — stop, state exactly what is missing, do not proceed.
 
 **READ** → Check open GitHub Issues. Resume any in-progress issue (open PR exists). Otherwise pick the highest `priority:high` open issue without the `blocked` label. If none, pick the next unlabelled issue by creation order.
 

--- a/docs/ai/system-prompt.xml
+++ b/docs/ai/system-prompt.xml
@@ -14,14 +14,20 @@
 
   <instructions>
     At the start of every session, read CLAUDE.md from the repo root via GitHub MCP.
-    It contains the workflow loop, hard constraints, Airtable field IDs, code style,
-    gotchas, and the Supabase MCP workflow. Do not proceed with any task without
-    reading it first.
+    It contains the workflow loop, hard constraints, code style, gotchas, and the
+    Supabase MCP workflow. Do not proceed with any task without reading it first.
+
+    Sessions operate in one of two modes:
+    - PLAN: design-only. No branch creation, no file writes, no commits. Produces
+      DESIGN-complete issue bodies with a verified Design Checklist.
+    - BUILD: execution-only. Requires all four Design Checklist items checked in the
+      issue body before proceeding. Refuse and surface what is missing if not.
+    Default mode is BUILD unless the session is prefixed with PLAN.
 
     docs/ai/CONTEXT.md contains reference material (schema, directory tree, design
     system, navigation, CI detail). It is NEVER read at session start. Read only the
     sections relevant to the current ticket during GATHER, using the section map
-    in CLAUDE.md §9.
+    in CLAUDE.md §9. In PLAN mode, read freely — there is no competing write budget.
   </instructions>
 
   <optimal_mode>


### PR DESCRIPTION
## What

Formalises the two-mode workflow discussed in session.

### CLAUDE.md
- Added `PLAN` command definition with full protocol (no-write constraint, Design Checklist output, BLOCKED handling with `blocked` label + re-entry path)
- Added `## DESIGN-Complete Definition` section — the machine-checkable gate between PLAN and BUILD
- Renamed `## Workflow` → `## BUILD Workflow` with precondition check at SSU (refuses if Design Checklist absent or any item unchecked)

### docs/ai/system-prompt.xml
- Removed "Airtable field IDs" from CLAUDE.md description in `<instructions>` (Airtable removed from workflow)
- Added two-mode protocol paragraph to `<instructions>`
- Added PLAN mode note to CONTEXT.md guidance (read freely — no competing write budget)

## What's unchanged
- `<identity>` block — untouched
- `<optimal_mode>` — untouched
- All Hard Constraints, Gotchas, SSU/PIU/GCR commands — untouched