### PR TITLE
[2604-CHORE-006] i18n: suppress no-literal-string in email templates

### DIFF
--- a/lib/email/templates/AboVerificationEmail.tsx
+++ b/lib/email/templates/AboVerificationEmail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/AboVerificationEmail.tsx
+++ b/lib/email/templates/AboVerificationEmail.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no lang context available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/DocumentExpiryEmail.tsx
+++ b/lib/email/templates/DocumentExpiryEmail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/DocumentExpiryEmail.tsx
+++ b/lib/email/templates/DocumentExpiryEmail.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no lang context available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/EventRoleRequestEmail.tsx
+++ b/lib/email/templates/EventRoleRequestEmail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/EventRoleRequestEmail.tsx
+++ b/lib/email/templates/EventRoleRequestEmail.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no lang context available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/GuestEventMagicLinkEmail.tsx
+++ b/lib/email/templates/GuestEventMagicLinkEmail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
 import { Button, Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding, labelStyle } from './_shell'

--- a/lib/email/templates/GuestEventMagicLinkEmail.tsx
+++ b/lib/email/templates/GuestEventMagicLinkEmail.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no lang context available */
 import { Button, Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding, labelStyle } from './_shell'

--- a/lib/email/templates/PaymentStatusEmail.tsx
+++ b/lib/email/templates/PaymentStatusEmail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/PaymentStatusEmail.tsx
+++ b/lib/email/templates/PaymentStatusEmail.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no lang context available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/PaymentSubmittedEmail.tsx
+++ b/lib/email/templates/PaymentSubmittedEmail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/PaymentSubmittedEmail.tsx
+++ b/lib/email/templates/PaymentSubmittedEmail.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no lang context available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/TripRegistrationEmail.tsx
+++ b/lib/email/templates/TripRegistrationEmail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/TripRegistrationEmail.tsx
+++ b/lib/email/templates/TripRegistrationEmail.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no lang context available */
 import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/WelcomeEmail.tsx
+++ b/lib/email/templates/WelcomeEmail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
 import { Section, Text, Button } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/WelcomeEmail.tsx
+++ b/lib/email/templates/WelcomeEmail.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no lang context available */
 import { Section, Text, Button } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'

--- a/lib/email/templates/_shell.tsx
+++ b/lib/email/templates/_shell.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no lang context available */
 import {
   Body, Container, Head, Heading, Html, Preview, Section, Text, Hr,
 } from '@react-email/components'

--- a/lib/email/templates/_shell.tsx
+++ b/lib/email/templates/_shell.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */
 import {
   Body, Container, Head, Heading, Html, Preview, Section, Text, Hr,
 } from '@react-email/components'


### PR DESCRIPTION
# [2604-CHORE-006] i18n: suppress no-literal-string in email templates\n\n## DoD\n`npm run lint` produces zero `i18next/no-literal-string` warnings across all files in `lib/email/templates/`.\n\n## Approach decision: Option 1 (suppress)\n\nEmail templates are static, server-rendered copy delivered via Resend. The `useTranslation` hook is unavailable in this context. No email i18n architecture exists in the project — introducing one would require:\n- A new `lib/i18n/domains/email.ts` domain file\n- A `lang` parameter threaded through `sendNotificationEmail` and `sendTransactionalEmail`\n- Updates to all call sites listed in CLAUDE.md gotcha\n\nThat scope is not justified to unblock a lint gate. Option 2 remains the correct long-term direction; these suppressions are explicit and `grep`-able via `TODO: email i18n`.\n\n## Changes\n\nAdded a single file-level disable comment to each of the 9 affected templates:\n\n```\n/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no t() available */\n```\n\nFiles changed (9):\n- `lib/email/templates/_shell.tsx`\n- `lib/email/templates/WelcomeEmail.tsx`\n- `lib/email/templates/PaymentStatusEmail.tsx`\n- `lib/email/templates/AboVerificationEmail.tsx`\n- `lib/email/templates/EventRoleRequestEmail.tsx`\n- `lib/email/templates/DocumentExpiryEmail.tsx`\n- `lib/email/templates/TripRegistrationEmail.tsx`\n- `lib/email/templates/PaymentSubmittedEmail.tsx`\n- `lib/email/templates/GuestEventMagicLinkEmail.tsx`\n\nNo functional changes. Zero diff to runtime behaviour.\n\nCloses #40\n\n---\n\n## Session State\n**Status:** DONE\n**Last touched:** `lib/email/templates/GuestEventMagicLinkEmail.tsx`\n**Completed:**\n- [x] Read all 9 template files\n- [x] Added file-level eslint-disable to all 9 files (2 push_files commits)\n- [x] PR opened\n**In flight:** None\n**Next:** Merge via GitHub UI, then confirm Vercel production deployment READY. After this ticket + CHORE-004 + CHORE-005 are done, flip `no-literal-string` from `warn` to `error` in `eslint.config.mjs`."