### PR TITLE
[2604-CHORE-004e] i18n: wrap literal strings in t() — admin/operations/ + notifications/ + settings/

### DIFF
--- a/app/admin/notifications/page.tsx
+++ b/app/admin/notifications/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { redirect } from 'next/navigation'
 import { formatDateTime } from '@/lib/format'
+import { t } from '@/lib/i18n'
 
 const PAGE_SIZE = 50
 
@@ -32,8 +33,8 @@ export default async function AdminNotificationsPage({
   if (error) {
     return (
       <div>
-        <h1 className="text-xl font-bold mb-4" style={{ color: 'var(--text-primary)' }}>Notification Audit Log</h1>
-        <p className="text-sm" style={{ color: 'var(--brand-crimson)' }}>Error loading notifications: {error.message}</p>
+        <h1 className="text-xl font-bold mb-4" style={{ color: 'var(--text-primary)' }}>{t('admin.notifications.pageTitle', 'en')}</h1>
+        <p className="text-sm" style={{ color: 'var(--brand-crimson)' }}>{t('admin.notifications.errorLoading', 'en')} {error.message}</p>
       </div>
     )
   }
@@ -45,9 +46,9 @@ export default async function AdminNotificationsPage({
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-2xl font-display font-bold" style={{ color: 'var(--text-primary)' }}>Notification Audit Log</h1>
+        <h1 className="text-2xl font-display font-bold" style={{ color: 'var(--text-primary)' }}>{t('admin.notifications.pageTitle', 'en')}</h1>
         <p className="text-sm mt-1" style={{ color: 'var(--text-secondary)' }}>
-          All system notifications ever fired — including soft-deleted. Read-only.
+          {t('admin.notifications.pageDesc', 'en')}
         </p>
       </div>
 
@@ -56,12 +57,12 @@ export default async function AdminNotificationsPage({
           <table className="w-full text-sm">
             <thead>
               <tr style={{ backgroundColor: 'var(--bg-card)', borderBottom: '1px solid var(--border-default)' }}>
-                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>Created</th>
-                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>Type</th>
-                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>Title</th>
-                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>Member</th>
-                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>Read</th>
-                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>Deleted</th>
+                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>{t('admin.notifications.col.created', 'en')}</th>
+                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>{t('admin.notifications.col.type', 'en')}</th>
+                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>{t('admin.notifications.col.title', 'en')}</th>
+                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>{t('admin.notifications.col.member', 'en')}</th>
+                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>{t('admin.notifications.col.read', 'en')}</th>
+                <th className="text-left px-4 py-3 font-semibold text-xs tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>{t('admin.notifications.col.deleted', 'en')}</th>
               </tr>
             </thead>
             <tbody>
@@ -87,10 +88,10 @@ export default async function AdminNotificationsPage({
                     <td className="px-4 py-3">
                       {row.is_read ? (
                         <span className="text-xs font-medium px-2 py-0.5 rounded-full"
-                          style={{ backgroundColor: 'rgba(45,51,42,0.08)', color: 'var(--brand-forest)' }}>Read</span>
+                          style={{ backgroundColor: 'rgba(45,51,42,0.08)', color: 'var(--brand-forest)' }}>{t('admin.notifications.badge.read', 'en')}</span>
                       ) : (
                         <span className="text-xs font-medium px-2 py-0.5 rounded-full"
-                          style={{ backgroundColor: 'rgba(188,71,73,0.10)', color: 'var(--brand-crimson)' }}>Unread</span>
+                          style={{ backgroundColor: 'rgba(188,71,73,0.10)', color: 'var(--brand-crimson)' }}>{t('admin.notifications.badge.unread', 'en')}</span>
                       )}
                     </td>
                     <td className="px-4 py-3 whitespace-nowrap" style={{ color: 'var(--text-secondary)' }}>
@@ -100,7 +101,7 @@ export default async function AdminNotificationsPage({
                 )
               })}
               {(rows ?? []).length === 0 && (
-                <tr><td colSpan={6} className="px-4 py-12 text-center text-sm" style={{ color: 'var(--text-secondary)' }}>No notifications found.</td></tr>
+                <tr><td colSpan={6} className="px-4 py-12 text-center text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.notifications.empty', 'en')}</td></tr>
               )}
             </tbody>
           </table>
@@ -109,17 +110,22 @@ export default async function AdminNotificationsPage({
 
       {totalPages > 1 && (
         <div className="flex items-center justify-between mt-6">
-          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>Page {page} of {totalPages} — {count ?? 0} total</p>
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            {t('admin.notifications.pagination.info', 'en')
+              .replace('{{page}}', String(page))
+              .replace('{{total}}', String(totalPages))
+              .replace('{{count}}', String(count ?? 0))}
+          </p>
           <div className="flex items-center gap-2">
             {page > 1 && (
               <a href={buildUrl(page - 1)}
                 className="px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors hover:bg-black/5"
-                style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}>← Prev</a>
+                style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}>{t('admin.notifications.pagination.prev', 'en')}</a>
             )}
             {page < totalPages && (
               <a href={buildUrl(page + 1)}
                 className="px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors hover:bg-black/5"
-                style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}>Next →</a>
+                style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}>{t('admin.notifications.pagination.next', 'en')}</a>
             )}
           </div>
         </div>

--- a/app/admin/operations/components/ItemsTab.tsx
+++ b/app/admin/operations/components/ItemsTab.tsx
@@ -12,7 +12,7 @@ import {
   SelectItem,
 } from '@/components/ui/select'
 import type { Trip } from './TripsTab'
-import { useTranslation } from '@/lib/i18n/useTranslation'
+import { t } from '@/lib/i18n'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -49,7 +49,6 @@ const emptyItem = (): ItemForm => ({
 // ── Component ────────────────────────────────────────────────────
 
 export function ItemsTab({ trips }: { trips: Trip[] }) {
-  const { t } = useTranslation()
   const qc = useQueryClient()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [editing, setEditing] = useState<PayableItem | null>(null)
@@ -135,7 +134,7 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
           className="px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
           style={{ backgroundColor: 'var(--brand-crimson)' }}
         >
-          {t('admin.operations.items.btn.new')}
+          {t('admin.operations.items.btn.new', 'en')}
         </button>
       </div>
 
@@ -144,7 +143,7 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
           {[...Array(3)].map((_, i) => <div key={i} className="h-16 rounded-xl animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }} />)}
         </div>
       ) : items.length === 0 ? (
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.empty')}</p>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.empty', 'en')}</p>
       ) : (
         <div className="rounded-2xl border overflow-hidden" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
           {items.map((item, i) => (
@@ -155,7 +154,7 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
                   <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{item.title}</p>
                   <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
                     style={{ backgroundColor: item.is_active ? '#81b29a33' : 'rgba(0,0,0,0.06)', color: item.is_active ? '#2d6a4f' : 'var(--text-secondary)' }}>
-                    {item.is_active ? t('admin.operations.items.badge.active') : t('admin.operations.items.badge.inactive')}
+                    {item.is_active ? t('admin.operations.items.badge.active', 'en') : t('admin.operations.items.badge.inactive', 'en')}
                   </span>
                   <span className="text-[10px] font-medium px-2 py-0.5 rounded-full" style={{ backgroundColor: 'rgba(0,0,0,0.05)', color: 'var(--text-secondary)' }}>
                     {item.item_type}
@@ -168,14 +167,14 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
                 </p>
               </div>
               <div className="flex items-center gap-3 flex-shrink-0">
-                <button onClick={() => openEdit(item)} className="text-xs hover:opacity-70 transition-opacity" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.btn.edit')}</button>
+                <button onClick={() => openEdit(item)} className="text-xs hover:opacity-70 transition-opacity" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.btn.edit', 'en')}</button>
                 {item.is_active && (
                   <button
                     onClick={() => deactivateMutation.mutate(item.id)}
                     disabled={deactivateMutation.isPending}
                     className="text-xs hover:opacity-70 transition-opacity disabled:opacity-40"
                     style={{ color: 'var(--brand-crimson)' }}
-                  >{t('admin.operations.items.btn.deactivate')}</button>
+                  >{t('admin.operations.items.btn.deactivate', 'en')}</button>
                 )}
               </div>
             </div>
@@ -183,43 +182,43 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
         </div>
       )}
 
-      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? t('admin.operations.items.title.edit').replace('{{title}}', editing.title) : t('admin.operations.items.btn.create')}>
+      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? t('admin.operations.items.title.edit', 'en').replace('{{title}}', editing.title) : t('admin.operations.items.btn.create', 'en')}>
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.title')}</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.title', 'en')}</label>
               <input value={form.title} onChange={e => setForm(f => ({ ...f, title: e.target.value }))}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
             </div>
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.type')}</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.type', 'en')}</label>
               <Select
                 value={form.item_type}
                 onValueChange={val => setForm(f => ({ ...f, item_type: val as ItemForm['item_type'] }))}
               >
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  {ITEM_TYPES.map(tp => <SelectItem key={tp} value={tp}>{t(`admin.operations.items.type.${tp}`)}</SelectItem>)}
+                  {ITEM_TYPES.map(tp => <SelectItem key={tp} value={tp}>{t(`admin.operations.items.type.${tp}` as Parameters<typeof t>[0], 'en')}</SelectItem>)}
                 </SelectContent>
               </Select>
             </div>
           </div>
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.description')}</label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.description', 'en')}</label>
             <textarea value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
               rows={2} className="w-full border rounded-xl px-3 py-2.5 text-sm resize-none"
               style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.amount')}</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.amount', 'en')}</label>
               <input type="number" step="0.01" min="0" value={form.amount} onChange={e => setForm(f => ({ ...f, amount: e.target.value }))}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
             </div>
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.currency')}</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.currency', 'en')}</label>
               <input value={form.currency} onChange={e => setForm(f => ({ ...f, currency: e.target.value }))}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
@@ -229,7 +228,7 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
             <button onClick={() => setForm(f => ({ ...f, is_active: !f.is_active }))}
               className="text-xs font-semibold px-3 py-1.5 rounded-full transition-all"
               style={{ backgroundColor: form.is_active ? 'var(--brand-forest)' : 'rgba(0,0,0,0.06)', color: form.is_active ? 'var(--brand-parchment)' : 'var(--text-secondary)' }}>
-              {form.is_active ? t('admin.operations.items.toggle.active') : t('admin.operations.items.toggle.inactive')}
+              {form.is_active ? t('admin.operations.items.toggle.active', 'en') : t('admin.operations.items.toggle.inactive', 'en')}
             </button>
           </div>
           {error && <p className="text-sm" style={{ color: 'var(--brand-crimson)' }}>{error}</p>}
@@ -237,11 +236,11 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
             <button onClick={handleSave} disabled={isPending || !isValid}
               className="px-6 py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
               style={{ backgroundColor: 'var(--brand-crimson)' }}>
-              {isPending ? t('admin.operations.items.btn.saving') : editing ? t('admin.operations.items.btn.saveChanges') : t('admin.operations.items.btn.create')}
+              {isPending ? t('admin.operations.items.btn.saving', 'en') : editing ? t('admin.operations.items.btn.saveChanges', 'en') : t('admin.operations.items.btn.create', 'en')}
             </button>
             <button onClick={() => setDrawerOpen(false)}
               className="px-6 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
-              style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>{t('admin.operations.items.btn.cancel')}</button>
+              style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>{t('admin.operations.items.btn.cancel', 'en')}</button>
           </div>
         </div>
       </Drawer>

--- a/app/admin/operations/components/ItemsTab.tsx
+++ b/app/admin/operations/components/ItemsTab.tsx
@@ -12,6 +12,7 @@ import {
   SelectItem,
 } from '@/components/ui/select'
 import type { Trip } from './TripsTab'
+import { useTranslation } from '@/lib/i18n/useTranslation'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -48,6 +49,7 @@ const emptyItem = (): ItemForm => ({
 // ── Component ────────────────────────────────────────────────────
 
 export function ItemsTab({ trips }: { trips: Trip[] }) {
+  const { t } = useTranslation()
   const qc = useQueryClient()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [editing, setEditing] = useState<PayableItem | null>(null)
@@ -133,7 +135,7 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
           className="px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
           style={{ backgroundColor: 'var(--brand-crimson)' }}
         >
-          + New item
+          {t('admin.operations.items.btn.new')}
         </button>
       </div>
 
@@ -142,7 +144,7 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
           {[...Array(3)].map((_, i) => <div key={i} className="h-16 rounded-xl animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }} />)}
         </div>
       ) : items.length === 0 ? (
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No payable items yet.</p>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.empty')}</p>
       ) : (
         <div className="rounded-2xl border overflow-hidden" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
           {items.map((item, i) => (
@@ -153,7 +155,7 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
                   <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{item.title}</p>
                   <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
                     style={{ backgroundColor: item.is_active ? '#81b29a33' : 'rgba(0,0,0,0.06)', color: item.is_active ? '#2d6a4f' : 'var(--text-secondary)' }}>
-                    {item.is_active ? 'active' : 'inactive'}
+                    {item.is_active ? t('admin.operations.items.badge.active') : t('admin.operations.items.badge.inactive')}
                   </span>
                   <span className="text-[10px] font-medium px-2 py-0.5 rounded-full" style={{ backgroundColor: 'rgba(0,0,0,0.05)', color: 'var(--text-secondary)' }}>
                     {item.item_type}
@@ -166,14 +168,14 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
                 </p>
               </div>
               <div className="flex items-center gap-3 flex-shrink-0">
-                <button onClick={() => openEdit(item)} className="text-xs hover:opacity-70 transition-opacity" style={{ color: 'var(--text-secondary)' }}>Edit</button>
+                <button onClick={() => openEdit(item)} className="text-xs hover:opacity-70 transition-opacity" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.btn.edit')}</button>
                 {item.is_active && (
                   <button
                     onClick={() => deactivateMutation.mutate(item.id)}
                     disabled={deactivateMutation.isPending}
                     className="text-xs hover:opacity-70 transition-opacity disabled:opacity-40"
                     style={{ color: 'var(--brand-crimson)' }}
-                  >Deactivate</button>
+                  >{t('admin.operations.items.btn.deactivate')}</button>
                 )}
               </div>
             </div>
@@ -181,43 +183,43 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
         </div>
       )}
 
-      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? `Edit: ${editing.title}` : 'New payable item'}>
+      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? `Edit: ${editing.title}` : t('admin.operations.items.btn.create')}>
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Title *</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.title')}</label>
               <input value={form.title} onChange={e => setForm(f => ({ ...f, title: e.target.value }))}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
             </div>
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Type *</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.type')}</label>
               <Select
                 value={form.item_type}
                 onValueChange={val => setForm(f => ({ ...f, item_type: val as ItemForm['item_type'] }))}
               >
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  {ITEM_TYPES.map(t => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+                  {ITEM_TYPES.map(tp => <SelectItem key={tp} value={tp}>{tp}</SelectItem>)}
                 </SelectContent>
               </Select>
             </div>
           </div>
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Description</label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.description')}</label>
             <textarea value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
               rows={2} className="w-full border rounded-xl px-3 py-2.5 text-sm resize-none"
               style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Amount *</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.amount')}</label>
               <input type="number" step="0.01" min="0" value={form.amount} onChange={e => setForm(f => ({ ...f, amount: e.target.value }))}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
             </div>
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Currency</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.items.lbl.currency')}</label>
               <input value={form.currency} onChange={e => setForm(f => ({ ...f, currency: e.target.value }))}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
@@ -227,7 +229,7 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
             <button onClick={() => setForm(f => ({ ...f, is_active: !f.is_active }))}
               className="text-xs font-semibold px-3 py-1.5 rounded-full transition-all"
               style={{ backgroundColor: form.is_active ? 'var(--brand-forest)' : 'rgba(0,0,0,0.06)', color: form.is_active ? 'var(--brand-parchment)' : 'var(--text-secondary)' }}>
-              {form.is_active ? 'Active' : 'Inactive'}
+              {form.is_active ? t('admin.operations.items.toggle.active') : t('admin.operations.items.toggle.inactive')}
             </button>
           </div>
           {error && <p className="text-sm" style={{ color: 'var(--brand-crimson)' }}>{error}</p>}
@@ -235,11 +237,11 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
             <button onClick={handleSave} disabled={isPending || !isValid}
               className="px-6 py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
               style={{ backgroundColor: 'var(--brand-crimson)' }}>
-              {isPending ? 'Saving…' : editing ? 'Save changes' : 'Create item'}
+              {isPending ? t('admin.operations.items.btn.saving') : editing ? t('admin.operations.items.btn.saveChanges') : t('admin.operations.items.btn.create')}
             </button>
             <button onClick={() => setDrawerOpen(false)}
               className="px-6 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
-              style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>Cancel</button>
+              style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>{t('admin.operations.items.btn.cancel')}</button>
           </div>
         </div>
       </Drawer>

--- a/app/admin/operations/components/ItemsTab.tsx
+++ b/app/admin/operations/components/ItemsTab.tsx
@@ -183,7 +183,7 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
         </div>
       )}
 
-      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? `Edit: ${editing.title}` : t('admin.operations.items.btn.create')}>
+      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? t('admin.operations.items.title.edit').replace('{{title}}', editing.title) : t('admin.operations.items.btn.create')}>
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div>
@@ -200,7 +200,7 @@ export function ItemsTab({ trips }: { trips: Trip[] }) {
               >
                 <SelectTrigger><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  {ITEM_TYPES.map(tp => <SelectItem key={tp} value={tp}>{tp}</SelectItem>)}
+                  {ITEM_TYPES.map(tp => <SelectItem key={tp} value={tp}>{t(`admin.operations.items.type.${tp}`)}</SelectItem>)}
                 </SelectContent>
               </Select>
             </div>

--- a/app/admin/operations/components/PaymentsTab.tsx
+++ b/app/admin/operations/components/PaymentsTab.tsx
@@ -17,7 +17,7 @@ import {
 import type { Trip } from './TripsTab'
 import type { PayableItem } from './ItemsTab'
 import { useQuery } from '@tanstack/react-query'
-import { useTranslation } from '@/lib/i18n/useTranslation'
+import { t } from '@/lib/i18n'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -61,7 +61,6 @@ function statusPill(status: string) {
 // ── Component ────────────────────────────────────────────────────
 
 export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData: MembersResponse | undefined }) {
-  const { t } = useTranslation()
   const qc = useQueryClient()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [statusFilter, setStatusFilter] = useState<'all' | 'pending' | 'approved' | 'rejected'>('all')
@@ -182,14 +181,14 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
           className="px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
           style={{ backgroundColor: 'var(--brand-crimson)' }}
         >
-          {t('admin.operations.payments.btn.log')}
+          {t('admin.operations.payments.btn.log', 'en')}
         </button>
       </div>
 
       {pendingSubmissions.length > 0 && (
         <div>
           <p className="text-xs font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
-            {t('admin.operations.payments.pendingTitle').replace('{{count}}', String(pendingSubmissions.length))}
+            {t('admin.operations.payments.pendingTitle', 'en').replace('{{count}}', String(pendingSubmissions.length))}
           </p>
           <div className="rounded-2xl border overflow-hidden" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
             {pendingSubmissions.map((p, i) => (
@@ -208,15 +207,15 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
                       {p.payment_method && ` · ${p.payment_method}`}
                     </p>
                     {p.note && <p className="text-xs mt-0.5 italic" style={{ color: 'var(--text-secondary)' }}>{p.note}</p>}
-                    {p.proof_url && <a href={p.proof_url} target="_blank" rel="noopener noreferrer" className="text-xs hover:underline" style={{ color: 'var(--brand-teal)' }}>{t('admin.operations.payments.viewProof')}</a>}
+                    {p.proof_url && <a href={p.proof_url} target="_blank" rel="noopener noreferrer" className="text-xs hover:underline" style={{ color: 'var(--brand-teal)' }}>{t('admin.operations.payments.viewProof', 'en')}</a>}
                   </div>
-                  <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0" style={{ backgroundColor: '#f2cc8f33', color: '#7a5c00' }}>{t('admin.operations.payments.badge.pending')}</span>
+                  <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0" style={{ backgroundColor: '#f2cc8f33', color: '#7a5c00' }}>{t('admin.operations.payments.badge.pending', 'en')}</span>
                 </div>
                 <div className="flex items-center gap-3">
                   <input
                     value={reviewNotes[p.id] ?? ''}
                     onChange={e => setReviewNotes(n => ({ ...n, [p.id]: e.target.value }))}
-                    placeholder={t('admin.operations.payments.placeholder.adminNote')}
+                    placeholder={t('admin.operations.payments.placeholder.adminNote', 'en')}
                     className="flex-1 border rounded-xl px-3 py-2 text-xs"
                     style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
                   />
@@ -224,12 +223,12 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
                     onClick={() => reviewMutation.mutate({ id: p.id, admin_status: 'approved', admin_note: reviewNotes[p.id] || null })}
                     disabled={reviewMutation.isPending}
                     className="px-4 py-2 rounded-xl text-xs font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity flex-shrink-0"
-                    style={{ backgroundColor: '#2d6a4f' }}>{t('admin.operations.payments.btn.approve')}</button>
+                    style={{ backgroundColor: '#2d6a4f' }}>{t('admin.operations.payments.btn.approve', 'en')}</button>
                   <button
                     onClick={() => reviewMutation.mutate({ id: p.id, admin_status: 'rejected', admin_note: reviewNotes[p.id] || null })}
                     disabled={reviewMutation.isPending}
                     className="px-4 py-2 rounded-xl text-xs font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity flex-shrink-0"
-                    style={{ backgroundColor: 'var(--brand-crimson)' }}>{t('admin.operations.payments.btn.deny')}</button>
+                    style={{ backgroundColor: 'var(--brand-crimson)' }}>{t('admin.operations.payments.btn.deny', 'en')}</button>
                 </div>
               </div>
             ))}
@@ -245,7 +244,7 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
               backgroundColor: statusFilter === f.key ? 'var(--text-primary)' : 'rgba(0,0,0,0.06)',
               color: statusFilter === f.key ? 'var(--bg-card)' : 'var(--text-secondary)',
             }}>
-            {t(f.labelKey)}
+            {t(f.labelKey, 'en')}
           </button>
         ))}
       </div>
@@ -255,7 +254,7 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
           {[...Array(4)].map((_, i) => <div key={i} className="h-14 rounded-xl animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }} />)}
         </div>
       ) : payments.length === 0 ? (
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.empty')}</p>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.empty', 'en')}</p>
       ) : (
         <div className="rounded-2xl border overflow-hidden" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
           {payments.map((p, i) => {
@@ -284,23 +283,23 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
         </div>
       )}
 
-      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={t('admin.operations.payments.drawer.title')}>
+      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={t('admin.operations.payments.drawer.title', 'en')}>
         <div className="space-y-4">
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.entity')}</label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.entity', 'en')}</label>
             <Select value={entity} onValueChange={setEntity}>
-              <SelectTrigger><SelectValue placeholder={t('admin.operations.payments.placeholder.entity')} /></SelectTrigger>
+              <SelectTrigger><SelectValue placeholder={t('admin.operations.payments.placeholder.entity', 'en')} /></SelectTrigger>
               <SelectContent>
                 {trips.length > 0 && (
                   <SelectGroup>
-                    <SelectLabel>{t('admin.operations.payments.group.trips')}</SelectLabel>
+                    <SelectLabel>{t('admin.operations.payments.group.trips', 'en')}</SelectLabel>
                     {trips.map(t2 => <SelectItem key={t2.id} value={`trip::${t2.id}`}>{t2.title}</SelectItem>)}
                   </SelectGroup>
                 )}
                 {trips.length > 0 && activeItems.length > 0 && <SelectSeparator />}
                 {activeItems.length > 0 && (
                   <SelectGroup>
-                    <SelectLabel>{t('admin.operations.payments.group.items')}</SelectLabel>
+                    <SelectLabel>{t('admin.operations.payments.group.items', 'en')}</SelectLabel>
                     {activeItems.map(it => <SelectItem key={it.id} value={`item::${it.id}`}>{it.title}</SelectItem>)}
                   </SelectGroup>
                 )}
@@ -308,9 +307,9 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
             </Select>
           </div>
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.member')}</label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.member', 'en')}</label>
             <Select value={profileId} onValueChange={setProfileId}>
-              <SelectTrigger><SelectValue placeholder={t('admin.operations.payments.placeholder.member')} /></SelectTrigger>
+              <SelectTrigger><SelectValue placeholder={t('admin.operations.payments.placeholder.member', 'en')} /></SelectTrigger>
               <SelectContent>
                 {allMembers.map(m => (
                   <SelectItem key={m.id} value={m.id}>
@@ -322,13 +321,13 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.amount')}</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.amount', 'en')}</label>
               <input type="number" step="0.01" min="0" value={amount} onChange={e => setAmount(e.target.value)}
                 placeholder="0.00" className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
             </div>
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.currency')}</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.currency', 'en')}</label>
               <input value={currency} onChange={e => setCurrency(e.target.value)}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
@@ -336,35 +335,35 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.date')}</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.date', 'en')}</label>
               <input type="date" value={txDate} onChange={e => setTxDate(e.target.value)}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
             </div>
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.method')}</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.method', 'en')}</label>
               <input value={method} onChange={e => setMethod(e.target.value)}
-                placeholder={t('admin.operations.payments.placeholder.method')}
+                placeholder={t('admin.operations.payments.placeholder.method', 'en')}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
             </div>
           </div>
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.status')}</label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.status', 'en')}</label>
             <Select value={payStatus} onValueChange={val => setPayStatus(val as 'approved' | 'pending')}>
               <SelectTrigger><SelectValue /></SelectTrigger>
               <SelectContent>
-                <SelectItem value="approved">{t('admin.operations.payments.status.approved')}</SelectItem>
-                <SelectItem value="pending">{t('admin.operations.payments.status.pending')}</SelectItem>
+                <SelectItem value="approved">{t('admin.operations.payments.status.approved', 'en')}</SelectItem>
+                <SelectItem value="pending">{t('admin.operations.payments.status.pending', 'en')}</SelectItem>
               </SelectContent>
             </Select>
           </div>
           <div>
             <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>
-              {t('admin.operations.payments.lbl.note')} <span className="opacity-60 font-normal">{t('admin.operations.payments.lbl.noteOptional')}</span>
+              {t('admin.operations.payments.lbl.note', 'en')} <span className="opacity-60 font-normal">{t('admin.operations.payments.lbl.noteOptional', 'en')}</span>
             </label>
             <input value={note} onChange={e => setNote(e.target.value)}
-              placeholder={t('admin.operations.payments.placeholder.note')}
+              placeholder={t('admin.operations.payments.placeholder.note', 'en')}
               className="w-full border rounded-xl px-3 py-2.5 text-sm"
               style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
           </div>
@@ -374,11 +373,11 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
               disabled={logMutation.isPending || !entity || !profileId || !amount || Number(amount) <= 0}
               className="px-6 py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
               style={{ backgroundColor: 'var(--brand-crimson)' }}>
-              {logMutation.isPending ? t('admin.operations.payments.btn.saving') : t('admin.operations.payments.btn.log2')}
+              {logMutation.isPending ? t('admin.operations.payments.btn.saving', 'en') : t('admin.operations.payments.btn.log2', 'en')}
             </button>
             <button onClick={() => setDrawerOpen(false)}
               className="px-6 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
-              style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>{t('admin.operations.payments.btn.cancel')}</button>
+              style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>{t('admin.operations.payments.btn.cancel', 'en')}</button>
           </div>
         </div>
       </Drawer>

--- a/app/admin/operations/components/PaymentsTab.tsx
+++ b/app/admin/operations/components/PaymentsTab.tsx
@@ -17,6 +17,7 @@ import {
 import type { Trip } from './TripsTab'
 import type { PayableItem } from './ItemsTab'
 import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from '@/lib/i18n/useTranslation'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -60,6 +61,7 @@ function statusPill(status: string) {
 // ── Component ────────────────────────────────────────────────────
 
 export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData: MembersResponse | undefined }) {
+  const { t } = useTranslation()
   const qc = useQueryClient()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [statusFilter, setStatusFilter] = useState<'all' | 'pending' | 'approved' | 'rejected'>('all')
@@ -164,11 +166,11 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
   }
 
   const STATUS_FILTERS = [
-    { key: 'all', label: 'All' },
-    { key: 'pending', label: 'Pending' },
-    { key: 'approved', label: 'Approved' },
-    { key: 'rejected', label: 'Rejected' },
-  ] as const
+    { key: 'all' as const, labelKey: 'admin.operations.payments.filter.all' as const },
+    { key: 'pending' as const, labelKey: 'admin.operations.payments.filter.pending' as const },
+    { key: 'approved' as const, labelKey: 'admin.operations.payments.filter.approved' as const },
+    { key: 'rejected' as const, labelKey: 'admin.operations.payments.filter.rejected' as const },
+  ]
 
   const activeItems = items.filter(i => i.is_active)
 
@@ -180,14 +182,14 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
           className="px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
           style={{ backgroundColor: 'var(--brand-crimson)' }}
         >
-          Log Payment
+          {t('admin.operations.payments.btn.log')}
         </button>
       </div>
 
       {pendingSubmissions.length > 0 && (
         <div>
           <p className="text-xs font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
-            Pending submissions ({pendingSubmissions.length})
+            {t('admin.operations.payments.pendingTitle').replace('{{count}}', String(pendingSubmissions.length))}
           </p>
           <div className="rounded-2xl border overflow-hidden" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
             {pendingSubmissions.map((p, i) => (
@@ -206,15 +208,15 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
                       {p.payment_method && ` · ${p.payment_method}`}
                     </p>
                     {p.note && <p className="text-xs mt-0.5 italic" style={{ color: 'var(--text-secondary)' }}>{p.note}</p>}
-                    {p.proof_url && <a href={p.proof_url} target="_blank" rel="noopener noreferrer" className="text-xs hover:underline" style={{ color: 'var(--brand-teal)' }}>View proof ↗</a>}
+                    {p.proof_url && <a href={p.proof_url} target="_blank" rel="noopener noreferrer" className="text-xs hover:underline" style={{ color: 'var(--brand-teal)' }}>{t('admin.operations.payments.viewProof')}</a>}
                   </div>
-                  <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0" style={{ backgroundColor: '#f2cc8f33', color: '#7a5c00' }}>pending</span>
+                  <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0" style={{ backgroundColor: '#f2cc8f33', color: '#7a5c00' }}>{t('admin.operations.payments.badge.pending')}</span>
                 </div>
                 <div className="flex items-center gap-3">
                   <input
                     value={reviewNotes[p.id] ?? ''}
                     onChange={e => setReviewNotes(n => ({ ...n, [p.id]: e.target.value }))}
-                    placeholder="Admin note (optional)"
+                    placeholder={t('admin.operations.payments.placeholder.adminNote')}
                     className="flex-1 border rounded-xl px-3 py-2 text-xs"
                     style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
                   />
@@ -222,12 +224,12 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
                     onClick={() => reviewMutation.mutate({ id: p.id, admin_status: 'approved', admin_note: reviewNotes[p.id] || null })}
                     disabled={reviewMutation.isPending}
                     className="px-4 py-2 rounded-xl text-xs font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity flex-shrink-0"
-                    style={{ backgroundColor: '#2d6a4f' }}>Approve</button>
+                    style={{ backgroundColor: '#2d6a4f' }}>{t('admin.operations.payments.btn.approve')}</button>
                   <button
                     onClick={() => reviewMutation.mutate({ id: p.id, admin_status: 'rejected', admin_note: reviewNotes[p.id] || null })}
                     disabled={reviewMutation.isPending}
                     className="px-4 py-2 rounded-xl text-xs font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity flex-shrink-0"
-                    style={{ backgroundColor: 'var(--brand-crimson)' }}>Deny</button>
+                    style={{ backgroundColor: 'var(--brand-crimson)' }}>{t('admin.operations.payments.btn.deny')}</button>
                 </div>
               </div>
             ))}
@@ -243,7 +245,7 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
               backgroundColor: statusFilter === f.key ? 'var(--text-primary)' : 'rgba(0,0,0,0.06)',
               color: statusFilter === f.key ? 'var(--bg-card)' : 'var(--text-secondary)',
             }}>
-            {f.label}
+            {t(f.labelKey)}
           </button>
         ))}
       </div>
@@ -253,7 +255,7 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
           {[...Array(4)].map((_, i) => <div key={i} className="h-14 rounded-xl animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }} />)}
         </div>
       ) : payments.length === 0 ? (
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No payments found.</p>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.empty')}</p>
       ) : (
         <div className="rounded-2xl border overflow-hidden" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
           {payments.map((p, i) => {
@@ -282,23 +284,23 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
         </div>
       )}
 
-      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title="Log Payment">
+      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={t('admin.operations.payments.drawer.title')}>
         <div className="space-y-4">
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Entity *</label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.entity')}</label>
             <Select value={entity} onValueChange={setEntity}>
-              <SelectTrigger><SelectValue placeholder="Select entity…" /></SelectTrigger>
+              <SelectTrigger><SelectValue placeholder={t('admin.operations.payments.placeholder.entity')} /></SelectTrigger>
               <SelectContent>
                 {trips.length > 0 && (
                   <SelectGroup>
-                    <SelectLabel>Trips</SelectLabel>
-                    {trips.map(t => <SelectItem key={t.id} value={`trip::${t.id}`}>{t.title}</SelectItem>)}
+                    <SelectLabel>{t('admin.operations.payments.group.trips')}</SelectLabel>
+                    {trips.map(t2 => <SelectItem key={t2.id} value={`trip::${t2.id}`}>{t2.title}</SelectItem>)}
                   </SelectGroup>
                 )}
                 {trips.length > 0 && activeItems.length > 0 && <SelectSeparator />}
                 {activeItems.length > 0 && (
                   <SelectGroup>
-                    <SelectLabel>Items</SelectLabel>
+                    <SelectLabel>{t('admin.operations.payments.group.items')}</SelectLabel>
                     {activeItems.map(it => <SelectItem key={it.id} value={`item::${it.id}`}>{it.title}</SelectItem>)}
                   </SelectGroup>
                 )}
@@ -306,9 +308,9 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
             </Select>
           </div>
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Member *</label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.member')}</label>
             <Select value={profileId} onValueChange={setProfileId}>
-              <SelectTrigger><SelectValue placeholder="Select member…" /></SelectTrigger>
+              <SelectTrigger><SelectValue placeholder={t('admin.operations.payments.placeholder.member')} /></SelectTrigger>
               <SelectContent>
                 {allMembers.map(m => (
                   <SelectItem key={m.id} value={m.id}>
@@ -320,13 +322,13 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Amount *</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.amount')}</label>
               <input type="number" step="0.01" min="0" value={amount} onChange={e => setAmount(e.target.value)}
                 placeholder="0.00" className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
             </div>
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Currency</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.currency')}</label>
               <input value={currency} onChange={e => setCurrency(e.target.value)}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
@@ -334,33 +336,35 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Date</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.date')}</label>
               <input type="date" value={txDate} onChange={e => setTxDate(e.target.value)}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
             </div>
             <div>
-              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Payment method</label>
+              <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.method')}</label>
               <input value={method} onChange={e => setMethod(e.target.value)}
-                placeholder="e.g. bank transfer, cash"
+                placeholder={t('admin.operations.payments.placeholder.method')}
                 className="w-full border rounded-xl px-3 py-2.5 text-sm"
                 style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
             </div>
           </div>
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Status</label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.payments.lbl.status')}</label>
             <Select value={payStatus} onValueChange={val => setPayStatus(val as 'approved' | 'pending')}>
               <SelectTrigger><SelectValue /></SelectTrigger>
               <SelectContent>
-                <SelectItem value="approved">Approved</SelectItem>
-                <SelectItem value="pending">Pending</SelectItem>
+                <SelectItem value="approved">{t('admin.operations.payments.status.approved')}</SelectItem>
+                <SelectItem value="pending">{t('admin.operations.payments.status.pending')}</SelectItem>
               </SelectContent>
             </Select>
           </div>
           <div>
-            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Note <span className="opacity-60 font-normal">(optional)</span></label>
+            <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>
+              {t('admin.operations.payments.lbl.note')} <span className="opacity-60 font-normal">{t('admin.operations.payments.lbl.noteOptional')}</span>
+            </label>
             <input value={note} onChange={e => setNote(e.target.value)}
-              placeholder="e.g. Cash payment, ref #123"
+              placeholder={t('admin.operations.payments.placeholder.note')}
               className="w-full border rounded-xl px-3 py-2.5 text-sm"
               style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
           </div>
@@ -370,11 +374,11 @@ export function PaymentsTab({ trips, membersData }: { trips: Trip[]; membersData
               disabled={logMutation.isPending || !entity || !profileId || !amount || Number(amount) <= 0}
               className="px-6 py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
               style={{ backgroundColor: 'var(--brand-crimson)' }}>
-              {logMutation.isPending ? 'Saving…' : 'Log payment'}
+              {logMutation.isPending ? t('admin.operations.payments.btn.saving') : t('admin.operations.payments.btn.log2')}
             </button>
             <button onClick={() => setDrawerOpen(false)}
               className="px-6 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
-              style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>Cancel</button>
+              style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>{t('admin.operations.payments.btn.cancel')}</button>
           </div>
         </div>
       </Drawer>

--- a/app/admin/operations/components/TripForm.tsx
+++ b/app/admin/operations/components/TripForm.tsx
@@ -14,7 +14,7 @@ import {
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog'
 import { ALL_ROLES, type Milestone, type Trip } from './TripsTab'
-import { useTranslation } from '@/lib/i18n/useTranslation'
+import { t } from '@/lib/i18n'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -34,7 +34,6 @@ export type MilestoneInputState = { label: string; amount: string; due_date: str
 // ── AttachmentsSection ───────────────────────────────────────────
 
 function AttachmentsSection({ tripId }: { tripId: string }) {
-  const { t } = useTranslation()
   const qc = useQueryClient()
   const [uploading, setUploading] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
@@ -85,11 +84,11 @@ function AttachmentsSection({ tripId }: { tripId: string }) {
   return (
     <div>
       <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>
-        {t('admin.operations.form.documents')}
+        {t('admin.operations.form.documents', 'en')}
       </p>
 
       {isLoading ? (
-        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.loading')}</p>
+        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.loading', 'en')}</p>
       ) : attachments.length > 0 ? (
         <div className="rounded-xl border mb-3 overflow-hidden" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
           {attachments.map((a, i) => (
@@ -123,13 +122,13 @@ function AttachmentsSection({ tripId }: { tripId: string }) {
                 className="text-xs flex-shrink-0 hover:opacity-70 transition-opacity"
                 style={{ color: 'var(--brand-crimson)' }}
               >
-                {t('admin.operations.form.btn.remove')}
+                {t('admin.operations.form.btn.remove', 'en')}
               </button>
             </div>
           ))}
         </div>
       ) : (
-        <p className="text-xs mb-3" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.noDocuments')}</p>
+        <p className="text-xs mb-3" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.noDocuments', 'en')}</p>
       )}
 
       <label className="flex items-center gap-2 cursor-pointer">
@@ -137,9 +136,9 @@ function AttachmentsSection({ tripId }: { tripId: string }) {
           className="px-3 py-1.5 rounded-xl text-xs font-semibold border transition-colors hover:bg-black/5 flex-shrink-0"
           style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
         >
-          {uploading ? t('admin.operations.form.btn.uploading') : t('admin.operations.form.btn.upload')}
+          {uploading ? t('admin.operations.form.btn.uploading', 'en') : t('admin.operations.form.btn.upload', 'en')}
         </span>
-        <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.uploadHint')}</span>
+        <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.uploadHint', 'en')}</span>
         <input
           type="file"
           accept="image/*,application/pdf"
@@ -156,17 +155,17 @@ function AttachmentsSection({ tripId }: { tripId: string }) {
       <AlertDialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{t('admin.operations.form.dialog.title')}</AlertDialogTitle>
+            <AlertDialogTitle>{t('admin.operations.form.dialog.title', 'en')}</AlertDialogTitle>
             <AlertDialogDescription>
-              {t('admin.operations.form.dialog.removeConfirm').replace('{{name}}', deleteTarget?.file_name ?? '')} {t('admin.operations.form.dialog.body')}
+              {t('admin.operations.form.dialog.removeConfirm', 'en').replace('{{name}}', deleteTarget?.file_name ?? '')} {t('admin.operations.form.dialog.body', 'en')}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>{t('admin.operations.form.dialog.cancel')}</AlertDialogCancel>
+            <AlertDialogCancel>{t('admin.operations.form.dialog.cancel', 'en')}</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => { if (deleteTarget) deleteMutation.mutate(deleteTarget) }}
             >
-              {t('admin.operations.form.dialog.confirm')}
+              {t('admin.operations.form.dialog.confirm', 'en')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -200,8 +199,6 @@ export function TripForm({
   onSave: () => void
   onClose: () => void
 }): React.JSX.Element {
-  const { t } = useTranslation()
-
   function addMilestone() {
     if (!milestoneInput.label || !milestoneInput.amount || !milestoneInput.due_date) return
     setForm(f => ({
@@ -231,7 +228,7 @@ export function TripForm({
         ))}
       </div>
       <div>
-        <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.description')}</label>
+        <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.description', 'en')}</label>
         <textarea
           value={form.description}
           onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
@@ -242,74 +239,74 @@ export function TripForm({
       </div>
       <div className="grid grid-cols-3 gap-4">
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.startDate')}</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.startDate', 'en')}</label>
           <input type="date" value={form.start_date} onChange={e => setForm(f => ({ ...f, start_date: e.target.value }))}
             className="w-full border rounded-xl px-3 py-2.5 text-sm" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.endDate')}</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.endDate', 'en')}</label>
           <input type="date" value={form.end_date} onChange={e => setForm(f => ({ ...f, end_date: e.target.value }))}
             className="w-full border rounded-xl px-3 py-2.5 text-sm" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.cost')}</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.cost', 'en')}</label>
           <input type="number" value={form.total_cost} onChange={e => setForm(f => ({ ...f, total_cost: Number(e.target.value) }))}
             className="w-full border rounded-xl px-3 py-2.5 text-sm" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
       </div>
       <div>
-        <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.milestones')}</p>
+        <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.milestones', 'en')}</p>
         {form.milestones.map((m, i) => (
           <div key={i} className="flex items-center gap-3 text-sm mb-2 py-2 border-b" style={{ borderColor: 'var(--border-default)' }}>
             <span className="flex-1 font-medium" style={{ color: 'var(--text-primary)' }}>{m.label}</span>
             <span style={{ color: 'var(--text-secondary)' }}>{formatCurrency(m.amount, 'EUR')}</span>
             <span style={{ color: 'var(--text-secondary)' }}>{m.due_date}</span>
             <button onClick={() => setForm(f => ({ ...f, milestones: f.milestones.filter((_, idx) => idx !== i) }))}
-              className="text-xs" style={{ color: 'var(--brand-crimson)' }}>{t('admin.operations.form.btn.remove')}</button>
+              className="text-xs" style={{ color: 'var(--brand-crimson)' }}>{t('admin.operations.form.btn.remove', 'en')}</button>
           </div>
         ))}
         <div className="grid grid-cols-4 gap-2 mt-2">
-          <input placeholder={t('admin.operations.form.placeholder.label')} value={milestoneInput.label}
+          <input placeholder={t('admin.operations.form.placeholder.label', 'en')} value={milestoneInput.label}
             onChange={e => setMilestoneInput(m => ({ ...m, label: e.target.value }))}
             className="border rounded-xl px-3 py-2 text-sm col-span-1" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
-          <input placeholder={t('admin.operations.form.placeholder.amount')} type="number" value={milestoneInput.amount}
+          <input placeholder={t('admin.operations.form.placeholder.amount', 'en')} type="number" value={milestoneInput.amount}
             onChange={e => setMilestoneInput(m => ({ ...m, amount: e.target.value }))}
             className="border rounded-xl px-3 py-2 text-sm" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
           <input type="date" value={milestoneInput.due_date}
             onChange={e => setMilestoneInput(m => ({ ...m, due_date: e.target.value }))}
             className="border rounded-xl px-3 py-2 text-sm" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
           <button onClick={addMilestone}
-            className="border rounded-xl text-sm hover:bg-black/5 transition-colors" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}>{t('admin.operations.form.btn.addMilestone')}</button>
+            className="border rounded-xl text-sm hover:bg-black/5 transition-colors" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}>{t('admin.operations.form.btn.addMilestone', 'en')}</button>
         </div>
       </div>
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.location')}</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.location', 'en')}</label>
           <input value={form.location ?? ''} onChange={e => setForm(f => ({ ...f, location: e.target.value || null }))}
             placeholder="e.g. Oradea, Romania" className="w-full border rounded-xl px-3 py-2.5 text-sm"
             style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.tripType')}</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.tripType', 'en')}</label>
           <input value={form.trip_type ?? ''} onChange={e => setForm(f => ({ ...f, trip_type: e.target.value || null }))}
             placeholder="e.g. leisure, training" className="w-full border rounded-xl px-3 py-2.5 text-sm"
             style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.accommodation')}</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.accommodation', 'en')}</label>
           <input value={form.accommodation_type ?? ''} onChange={e => setForm(f => ({ ...f, accommodation_type: e.target.value || null }))}
             placeholder="e.g. hotel, hostel" className="w-full border rounded-xl px-3 py-2.5 text-sm"
             style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.inclusions')}</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.inclusions', 'en')}</label>
           <input value={form.inclusions.join(', ')} onChange={e => setForm(f => ({ ...f, inclusions: e.target.value.split(',').map(s => s.trim()).filter(Boolean) }))}
             placeholder="e.g. flights, hotel" className="w-full border rounded-xl px-3 py-2.5 text-sm"
             style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
       </div>
       <div>
-        <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.visibleTo')}</p>
+        <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.visibleTo', 'en')}</p>
         <div className="flex gap-2 flex-wrap">
           {ALL_ROLES.map(role => (
             <button key={role} onClick={() => setForm(f => ({
@@ -340,11 +337,11 @@ export function TripForm({
         <button onClick={onSave} disabled={isPending || !isValid}
           className="px-6 py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
           style={{ backgroundColor: 'var(--brand-crimson)' }}>
-          {isPending ? t('admin.operations.form.btn.saving') : editing ? t('admin.operations.form.btn.saveChanges') : t('admin.operations.form.btn.createTrip')}
+          {isPending ? t('admin.operations.form.btn.saving', 'en') : editing ? t('admin.operations.form.btn.saveChanges', 'en') : t('admin.operations.form.btn.createTrip', 'en')}
         </button>
         <button onClick={onClose}
           className="px-6 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
-          style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>{t('admin.operations.form.btn.cancel')}</button>
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>{t('admin.operations.form.btn.cancel', 'en')}</button>
       </div>
     </div>
   )

--- a/app/admin/operations/components/TripForm.tsx
+++ b/app/admin/operations/components/TripForm.tsx
@@ -14,6 +14,7 @@ import {
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog'
 import { ALL_ROLES, type Milestone, type Trip } from './TripsTab'
+import { useTranslation } from '@/lib/i18n/useTranslation'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -33,6 +34,7 @@ export type MilestoneInputState = { label: string; amount: string; due_date: str
 // ── AttachmentsSection ───────────────────────────────────────────
 
 function AttachmentsSection({ tripId }: { tripId: string }) {
+  const { t } = useTranslation()
   const qc = useQueryClient()
   const [uploading, setUploading] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
@@ -83,11 +85,11 @@ function AttachmentsSection({ tripId }: { tripId: string }) {
   return (
     <div>
       <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>
-        Trip documents
+        {t('admin.operations.form.documents')}
       </p>
 
       {isLoading ? (
-        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>Loading…</p>
+        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.loading')}</p>
       ) : attachments.length > 0 ? (
         <div className="rounded-xl border mb-3 overflow-hidden" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
           {attachments.map((a, i) => (
@@ -121,13 +123,13 @@ function AttachmentsSection({ tripId }: { tripId: string }) {
                 className="text-xs flex-shrink-0 hover:opacity-70 transition-opacity"
                 style={{ color: 'var(--brand-crimson)' }}
               >
-                Remove
+                {t('admin.operations.form.btn.remove')}
               </button>
             </div>
           ))}
         </div>
       ) : (
-        <p className="text-xs mb-3" style={{ color: 'var(--text-secondary)' }}>No documents uploaded yet.</p>
+        <p className="text-xs mb-3" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.noDocuments')}</p>
       )}
 
       <label className="flex items-center gap-2 cursor-pointer">
@@ -135,9 +137,9 @@ function AttachmentsSection({ tripId }: { tripId: string }) {
           className="px-3 py-1.5 rounded-xl text-xs font-semibold border transition-colors hover:bg-black/5 flex-shrink-0"
           style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
         >
-          {uploading ? 'Uploading…' : '+ Upload file'}
+          {uploading ? t('admin.operations.form.btn.uploading') : t('admin.operations.form.btn.upload')}
         </span>
-        <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>PDF or image, max 10 MB</span>
+        <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.uploadHint')}</span>
         <input
           type="file"
           accept="image/*,application/pdf"
@@ -154,17 +156,17 @@ function AttachmentsSection({ tripId }: { tripId: string }) {
       <AlertDialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Remove document</AlertDialogTitle>
+            <AlertDialogTitle>{t('admin.operations.form.dialog.title')}</AlertDialogTitle>
             <AlertDialogDescription>
-              Remove &ldquo;{deleteTarget?.file_name}&rdquo;? This cannot be undone.
+              Remove &ldquo;{deleteTarget?.file_name}&rdquo;? {t('admin.operations.form.dialog.body')}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t('admin.operations.form.dialog.cancel')}</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => { if (deleteTarget) deleteMutation.mutate(deleteTarget) }}
             >
-              Remove
+              {t('admin.operations.form.dialog.confirm')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -198,6 +200,8 @@ export function TripForm({
   onSave: () => void
   onClose: () => void
 }): React.JSX.Element {
+  const { t } = useTranslation()
+
   function addMilestone() {
     if (!milestoneInput.label || !milestoneInput.amount || !milestoneInput.due_date) return
     setForm(f => ({
@@ -227,7 +231,7 @@ export function TripForm({
         ))}
       </div>
       <div>
-        <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Description</label>
+        <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.description')}</label>
         <textarea
           value={form.description}
           onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
@@ -238,74 +242,74 @@ export function TripForm({
       </div>
       <div className="grid grid-cols-3 gap-4">
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Start date</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.startDate')}</label>
           <input type="date" value={form.start_date} onChange={e => setForm(f => ({ ...f, start_date: e.target.value }))}
             className="w-full border rounded-xl px-3 py-2.5 text-sm" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>End date</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.endDate')}</label>
           <input type="date" value={form.end_date} onChange={e => setForm(f => ({ ...f, end_date: e.target.value }))}
             className="w-full border rounded-xl px-3 py-2.5 text-sm" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Cost (EUR)</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.cost')}</label>
           <input type="number" value={form.total_cost} onChange={e => setForm(f => ({ ...f, total_cost: Number(e.target.value) }))}
             className="w-full border rounded-xl px-3 py-2.5 text-sm" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
       </div>
       <div>
-        <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>Payment milestones</p>
+        <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.milestones')}</p>
         {form.milestones.map((m, i) => (
           <div key={i} className="flex items-center gap-3 text-sm mb-2 py-2 border-b" style={{ borderColor: 'var(--border-default)' }}>
             <span className="flex-1 font-medium" style={{ color: 'var(--text-primary)' }}>{m.label}</span>
             <span style={{ color: 'var(--text-secondary)' }}>{formatCurrency(m.amount, 'EUR')}</span>
             <span style={{ color: 'var(--text-secondary)' }}>{m.due_date}</span>
             <button onClick={() => setForm(f => ({ ...f, milestones: f.milestones.filter((_, idx) => idx !== i) }))}
-              className="text-xs" style={{ color: 'var(--brand-crimson)' }}>Remove</button>
+              className="text-xs" style={{ color: 'var(--brand-crimson)' }}>{t('admin.operations.form.btn.remove')}</button>
           </div>
         ))}
         <div className="grid grid-cols-4 gap-2 mt-2">
-          <input placeholder="Label" value={milestoneInput.label}
+          <input placeholder={t('admin.operations.form.placeholder.label')} value={milestoneInput.label}
             onChange={e => setMilestoneInput(m => ({ ...m, label: e.target.value }))}
             className="border rounded-xl px-3 py-2 text-sm col-span-1" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
-          <input placeholder="Amount" type="number" value={milestoneInput.amount}
+          <input placeholder={t('admin.operations.form.placeholder.amount')} type="number" value={milestoneInput.amount}
             onChange={e => setMilestoneInput(m => ({ ...m, amount: e.target.value }))}
             className="border rounded-xl px-3 py-2 text-sm" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
           <input type="date" value={milestoneInput.due_date}
             onChange={e => setMilestoneInput(m => ({ ...m, due_date: e.target.value }))}
             className="border rounded-xl px-3 py-2 text-sm" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
           <button onClick={addMilestone}
-            className="border rounded-xl text-sm hover:bg-black/5 transition-colors" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}>+ Add</button>
+            className="border rounded-xl text-sm hover:bg-black/5 transition-colors" style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}>{t('admin.operations.form.btn.addMilestone')}</button>
         </div>
       </div>
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Location</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.location')}</label>
           <input value={form.location ?? ''} onChange={e => setForm(f => ({ ...f, location: e.target.value || null }))}
             placeholder="e.g. Oradea, Romania" className="w-full border rounded-xl px-3 py-2.5 text-sm"
             style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Trip type</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.tripType')}</label>
           <input value={form.trip_type ?? ''} onChange={e => setForm(f => ({ ...f, trip_type: e.target.value || null }))}
             placeholder="e.g. leisure, training" className="w-full border rounded-xl px-3 py-2.5 text-sm"
             style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Accommodation</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.accommodation')}</label>
           <input value={form.accommodation_type ?? ''} onChange={e => setForm(f => ({ ...f, accommodation_type: e.target.value || null }))}
             placeholder="e.g. hotel, hostel" className="w-full border rounded-xl px-3 py-2.5 text-sm"
             style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
         <div>
-          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>Inclusions (comma-sep)</label>
+          <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.inclusions')}</label>
           <input value={form.inclusions.join(', ')} onChange={e => setForm(f => ({ ...f, inclusions: e.target.value.split(',').map(s => s.trim()).filter(Boolean) }))}
             placeholder="e.g. flights, hotel" className="w-full border rounded-xl px-3 py-2.5 text-sm"
             style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }} />
         </div>
       </div>
       <div>
-        <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>Visible to</p>
+        <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.form.lbl.visibleTo')}</p>
         <div className="flex gap-2 flex-wrap">
           {ALL_ROLES.map(role => (
             <button key={role} onClick={() => setForm(f => ({
@@ -336,11 +340,11 @@ export function TripForm({
         <button onClick={onSave} disabled={isPending || !isValid}
           className="px-6 py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
           style={{ backgroundColor: 'var(--brand-crimson)' }}>
-          {isPending ? 'Saving…' : editing ? 'Save changes' : 'Create trip'}
+          {isPending ? t('admin.operations.form.btn.saving') : editing ? t('admin.operations.form.btn.saveChanges') : t('admin.operations.form.btn.createTrip')}
         </button>
         <button onClick={onClose}
           className="px-6 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
-          style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>Cancel</button>
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>{t('admin.operations.form.btn.cancel')}</button>
       </div>
     </div>
   )

--- a/app/admin/operations/components/TripForm.tsx
+++ b/app/admin/operations/components/TripForm.tsx
@@ -158,7 +158,7 @@ function AttachmentsSection({ tripId }: { tripId: string }) {
           <AlertDialogHeader>
             <AlertDialogTitle>{t('admin.operations.form.dialog.title')}</AlertDialogTitle>
             <AlertDialogDescription>
-              Remove &ldquo;{deleteTarget?.file_name}&rdquo;? {t('admin.operations.form.dialog.body')}
+              {t('admin.operations.form.dialog.removeConfirm').replace('{{name}}', deleteTarget?.file_name ?? '')} {t('admin.operations.form.dialog.body')}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/app/admin/operations/components/TripsTab.tsx
+++ b/app/admin/operations/components/TripsTab.tsx
@@ -15,7 +15,7 @@ import {
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog'
 import { TripForm, type TripFormState, type MilestoneInputState } from './TripForm'
-import { useTranslation } from '@/lib/i18n/useTranslation'
+import { t } from '@/lib/i18n'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -48,7 +48,6 @@ const emptyTrip = (): TripFormState => ({
 // ── Component ────────────────────────────────────────────────────
 
 export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boolean }) {
-  const { t } = useTranslation()
   const qc = useQueryClient()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [editing, setEditing] = useState<Trip | null>(null)
@@ -129,7 +128,7 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
           className="px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
           style={{ backgroundColor: 'var(--brand-crimson)' }}
         >
-          {t('admin.operations.trips.btn.new')}
+          {t('admin.operations.trips.btn.new', 'en')}
         </button>
       </div>
 
@@ -138,7 +137,7 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
           {[...Array(2)].map((_, i) => <div key={i} className="h-16 rounded-xl animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }} />)}
         </div>
       ) : trips.length === 0 ? (
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.trips.empty')}</p>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.trips.empty', 'en')}</p>
       ) : (
         <div className="rounded-2xl border overflow-hidden" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
           {trips.map((trip, i) => (
@@ -149,23 +148,23 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
                 <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
                   {trip.destination} · {formatDate(trip.start_date)} → {formatDate(trip.end_date)}
                   {' · '}{formatCurrency(trip.total_cost, 'EUR')}
-                  {' · '}{trip.milestones?.length ?? 0} {t('admin.operations.trips.milestones').replace('{{count}} ', '')}
+                  {' · '}{trip.milestones?.length ?? 0} {t('admin.operations.trips.milestones', 'en').replace('{{count}} ', '')}
                 </p>
               </div>
               <div className="flex items-center gap-3 flex-shrink-0">
-                <button onClick={() => openEdit(trip)} className="text-xs hover:opacity-70 transition-opacity" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.trips.btn.edit')}</button>
+                <button onClick={() => openEdit(trip)} className="text-xs hover:opacity-70 transition-opacity" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.trips.btn.edit', 'en')}</button>
                 <button
                   onClick={() => setAlertTarget({ id: trip.id, name: trip.title })}
                   className="text-xs hover:opacity-70 transition-opacity"
                   style={{ color: 'var(--brand-crimson)' }}
-                >{t('admin.operations.trips.btn.delete')}</button>
+                >{t('admin.operations.trips.btn.delete', 'en')}</button>
               </div>
             </div>
           ))}
         </div>
       )}
 
-      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? t('admin.operations.trips.title.edit').replace('{{title}}', editing.title) : t('admin.operations.form.btn.createTrip')}>
+      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? t('admin.operations.trips.title.edit', 'en').replace('{{title}}', editing.title) : t('admin.operations.form.btn.createTrip', 'en')}>
         <TripForm
           form={form}
           setForm={setForm}
@@ -183,20 +182,20 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
       <AlertDialog open={!!alertTarget} onOpenChange={open => { if (!open) setAlertTarget(null) }}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{t('admin.operations.trips.dialog.title')}</AlertDialogTitle>
+            <AlertDialogTitle>{t('admin.operations.trips.dialog.title', 'en')}</AlertDialogTitle>
             <AlertDialogDescription>
-              Delete &ldquo;{alertTarget?.name}&rdquo;? {t('admin.operations.trips.dialog.body')}
+              Delete &ldquo;{alertTarget?.name}&rdquo;? {t('admin.operations.trips.dialog.body', 'en')}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>{t('admin.operations.trips.dialog.cancel')}</AlertDialogCancel>
+            <AlertDialogCancel>{t('admin.operations.trips.dialog.cancel', 'en')}</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
                 if (alertTarget) deleteMutation.mutate(alertTarget.id)
                 setAlertTarget(null)
               }}
             >
-              {t('admin.operations.trips.dialog.confirm')}
+              {t('admin.operations.trips.dialog.confirm', 'en')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/app/admin/operations/components/TripsTab.tsx
+++ b/app/admin/operations/components/TripsTab.tsx
@@ -165,7 +165,7 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
         </div>
       )}
 
-      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? `Edit: ${editing.title}` : t('admin.operations.form.btn.createTrip')}>
+      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? t('admin.operations.trips.title.edit').replace('{{title}}', editing.title) : t('admin.operations.form.btn.createTrip')}>
         <TripForm
           form={form}
           setForm={setForm}

--- a/app/admin/operations/components/TripsTab.tsx
+++ b/app/admin/operations/components/TripsTab.tsx
@@ -15,6 +15,7 @@ import {
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog'
 import { TripForm, type TripFormState, type MilestoneInputState } from './TripForm'
+import { useTranslation } from '@/lib/i18n/useTranslation'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -47,6 +48,7 @@ const emptyTrip = (): TripFormState => ({
 // ── Component ────────────────────────────────────────────────────
 
 export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boolean }) {
+  const { t } = useTranslation()
   const qc = useQueryClient()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [editing, setEditing] = useState<Trip | null>(null)
@@ -127,7 +129,7 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
           className="px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
           style={{ backgroundColor: 'var(--brand-crimson)' }}
         >
-          + New trip
+          {t('admin.operations.trips.btn.new')}
         </button>
       </div>
 
@@ -136,7 +138,7 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
           {[...Array(2)].map((_, i) => <div key={i} className="h-16 rounded-xl animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }} />)}
         </div>
       ) : trips.length === 0 ? (
-        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No trips yet.</p>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.trips.empty')}</p>
       ) : (
         <div className="rounded-2xl border overflow-hidden" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
           {trips.map((trip, i) => (
@@ -147,23 +149,23 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
                 <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
                   {trip.destination} · {formatDate(trip.start_date)} → {formatDate(trip.end_date)}
                   {' · '}{formatCurrency(trip.total_cost, 'EUR')}
-                  {' · '}{trip.milestones?.length ?? 0} milestones
+                  {' · '}{trip.milestones?.length ?? 0} {t('admin.operations.trips.milestones').replace('{{count}} ', '')}
                 </p>
               </div>
               <div className="flex items-center gap-3 flex-shrink-0">
-                <button onClick={() => openEdit(trip)} className="text-xs hover:opacity-70 transition-opacity" style={{ color: 'var(--text-secondary)' }}>Edit</button>
+                <button onClick={() => openEdit(trip)} className="text-xs hover:opacity-70 transition-opacity" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.trips.btn.edit')}</button>
                 <button
                   onClick={() => setAlertTarget({ id: trip.id, name: trip.title })}
                   className="text-xs hover:opacity-70 transition-opacity"
                   style={{ color: 'var(--brand-crimson)' }}
-                >Delete</button>
+                >{t('admin.operations.trips.btn.delete')}</button>
               </div>
             </div>
           ))}
         </div>
       )}
 
-      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? `Edit: ${editing.title}` : 'New trip'}>
+      <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={editing ? `Edit: ${editing.title}` : t('admin.operations.form.btn.createTrip')}>
         <TripForm
           form={form}
           setForm={setForm}
@@ -181,20 +183,20 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
       <AlertDialog open={!!alertTarget} onOpenChange={open => { if (!open) setAlertTarget(null) }}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete trip</AlertDialogTitle>
+            <AlertDialogTitle>{t('admin.operations.trips.dialog.title')}</AlertDialogTitle>
             <AlertDialogDescription>
-              Delete &ldquo;{alertTarget?.name}&rdquo;? This cannot be undone.
+              Delete &ldquo;{alertTarget?.name}&rdquo;? {t('admin.operations.trips.dialog.body')}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t('admin.operations.trips.dialog.cancel')}</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
                 if (alertTarget) deleteMutation.mutate(alertTarget.id)
                 setAlertTarget(null)
               }}
             >
-              Delete
+              {t('admin.operations.trips.dialog.confirm')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/app/admin/settings/components/EmailLogTable.tsx
+++ b/app/admin/settings/components/EmailLogTable.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useTranslation } from '@/lib/i18n/useTranslation'
+import { t } from '@/lib/i18n'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -57,7 +57,6 @@ const TEMPLATE_LABELS: Record<string, string> = {
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function EmailLogTable() {
-  const { t } = useTranslation()
   const qc = useQueryClient()
   const [statusFilter, setStatusFilter] = useState<'all' | 'sent' | 'failed' | 'pending'>('all')
   const [templateFilter, setTemplateFilter] = useState('all')
@@ -105,10 +104,10 @@ export function EmailLogTable() {
     <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5 w-full shadow-sm flex flex-col gap-5">
       <div className="flex flex-col gap-1">
         <h2 className="text-lg font-semibold text-[var(--semantic-fg-primary)] tracking-tight">
-          {t('admin.settings.emailLog.title')}
+          {t('admin.settings.emailLog.title', 'en')}
         </h2>
         <p className="text-xs text-[var(--semantic-fg-secondary)]">
-          {t('admin.settings.emailLog.desc')}
+          {t('admin.settings.emailLog.desc', 'en')}
         </p>
       </div>
 
@@ -124,7 +123,7 @@ export function EmailLogTable() {
                 color: statusFilter === s.key ? 'var(--bg-card)' : 'var(--semantic-fg-secondary)',
               }}
             >
-              {t(s.labelKey)}
+              {t(s.labelKey, 'en')}
             </button>
           ))}
         </div>
@@ -139,7 +138,7 @@ export function EmailLogTable() {
             color: 'var(--semantic-fg-primary)',
           }}
         >
-          <option value="all">{t('admin.settings.emailLog.allTemplates')}</option>
+          <option value="all">{t('admin.settings.emailLog.allTemplates', 'en')}</option>
           {Object.entries(TEMPLATE_LABELS).map(([id, label]) => (
             <option key={id} value={id}>{label}</option>
           ))}
@@ -148,7 +147,7 @@ export function EmailLogTable() {
 
       {retryError && (
         <p className="text-xs px-3 py-2 rounded-lg bg-red-50 text-red-700 border border-red-200">
-          {t('admin.settings.emailLog.retryError')} {retryError}
+          {t('admin.settings.emailLog.retryError', 'en')} {retryError}
         </p>
       )}
 
@@ -159,17 +158,17 @@ export function EmailLogTable() {
           ))}
         </div>
       ) : rows.length === 0 ? (
-        <p className="text-sm text-[var(--semantic-fg-secondary)] py-4 text-center">{t('admin.settings.emailLog.empty')}</p>
+        <p className="text-sm text-[var(--semantic-fg-secondary)] py-4 text-center">{t('admin.settings.emailLog.empty', 'en')}</p>
       ) : (
         <div className="rounded-xl border overflow-hidden" style={{ borderColor: 'var(--border-subtle)' }}>
           <div
             className="hidden md:grid grid-cols-[1fr_1fr_1fr_auto_auto] gap-4 px-4 py-2.5 text-[10px] font-semibold uppercase tracking-widest"
             style={{ backgroundColor: 'rgba(0,0,0,0.03)', color: 'var(--semantic-fg-tertiary)', borderBottom: '1px solid var(--border-subtle)' }}
           >
-            <span>{t('admin.settings.emailLog.col.template')}</span>
-            <span>{t('admin.settings.emailLog.col.recipient')}</span>
-            <span>{t('admin.settings.emailLog.col.sentAt')}</span>
-            <span>{t('admin.settings.emailLog.col.status')}</span>
+            <span>{t('admin.settings.emailLog.col.template', 'en')}</span>
+            <span>{t('admin.settings.emailLog.col.recipient', 'en')}</span>
+            <span>{t('admin.settings.emailLog.col.sentAt', 'en')}</span>
+            <span>{t('admin.settings.emailLog.col.status', 'en')}</span>
             <span></span>
           </div>
 
@@ -207,7 +206,7 @@ export function EmailLogTable() {
                       className="text-xs font-semibold px-3 py-1 rounded-lg border transition-colors hover:bg-black/5 disabled:opacity-40"
                       style={{ borderColor: 'var(--border-subtle)', color: 'var(--semantic-fg-primary)' }}
                     >
-                      {retryingId === row.id ? t('admin.settings.emailLog.btn.retrying') : t('admin.settings.emailLog.btn.retry')}
+                      {retryingId === row.id ? t('admin.settings.emailLog.btn.retrying', 'en') : t('admin.settings.emailLog.btn.retry', 'en')}
                     </button>
                   )}
                 </div>
@@ -229,7 +228,7 @@ export function EmailLogTable() {
               className="px-3 py-1.5 text-xs font-semibold rounded-lg border disabled:opacity-40 transition-colors hover:bg-black/5"
               style={{ borderColor: 'var(--border-subtle)', color: 'var(--semantic-fg-primary)' }}
             >
-              {t('admin.settings.emailLog.pagination.prev')}
+              {t('admin.settings.emailLog.pagination.prev', 'en')}
             </button>
             <button
               disabled={page >= totalPages - 1}
@@ -237,7 +236,7 @@ export function EmailLogTable() {
               className="px-3 py-1.5 text-xs font-semibold rounded-lg border disabled:opacity-40 transition-colors hover:bg-black/5"
               style={{ borderColor: 'var(--border-subtle)', color: 'var(--semantic-fg-primary)' }}
             >
-              {t('admin.settings.emailLog.pagination.next')}
+              {t('admin.settings.emailLog.pagination.next', 'en')}
             </button>
           </div>
         </div>

--- a/app/admin/settings/components/EmailLogTable.tsx
+++ b/app/admin/settings/components/EmailLogTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from '@/lib/i18n/useTranslation'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -56,6 +57,7 @@ const TEMPLATE_LABELS: Record<string, string> = {
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function EmailLogTable() {
+  const { t } = useTranslation()
   const qc = useQueryClient()
   const [statusFilter, setStatusFilter] = useState<'all' | 'sent' | 'failed' | 'pending'>('all')
   const [templateFilter, setTemplateFilter] = useState('all')
@@ -92,41 +94,41 @@ export function EmailLogTable() {
     onError: (e: Error) => setRetryError(e.message),
   })
 
-  // Templates from currently visible rows for filter
-  const STATUS_FILTERS = ['all', 'sent', 'failed', 'pending'] as const
+  const STATUS_FILTERS = [
+    { key: 'all' as const, labelKey: 'admin.settings.emailLog.filter.all' as const },
+    { key: 'sent' as const, labelKey: 'admin.settings.emailLog.filter.sent' as const },
+    { key: 'failed' as const, labelKey: 'admin.settings.emailLog.filter.failed' as const },
+    { key: 'pending' as const, labelKey: 'admin.settings.emailLog.filter.pending' as const },
+  ]
 
   return (
     <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-5 w-full shadow-sm flex flex-col gap-5">
-      {/* Header */}
       <div className="flex flex-col gap-1">
         <h2 className="text-lg font-semibold text-[var(--semantic-fg-primary)] tracking-tight">
-          Email Log
+          {t('admin.settings.emailLog.title')}
         </h2>
         <p className="text-xs text-[var(--semantic-fg-secondary)]">
-          Every outbound email attempt is recorded here. Use Retry on failed rows.
+          {t('admin.settings.emailLog.desc')}
         </p>
       </div>
 
-      {/* Filters */}
       <div className="flex flex-wrap items-center gap-2">
-        {/* Status chips */}
         <div className="flex gap-1.5">
           {STATUS_FILTERS.map(s => (
             <button
-              key={s}
-              onClick={() => { setStatusFilter(s); setPage(0) }}
+              key={s.key}
+              onClick={() => { setStatusFilter(s.key); setPage(0) }}
               className="px-3 py-1 rounded-full text-xs font-semibold capitalize transition-all"
               style={{
-                backgroundColor: statusFilter === s ? 'var(--semantic-fg-primary)' : 'rgba(0,0,0,0.06)',
-                color: statusFilter === s ? 'var(--bg-card)' : 'var(--semantic-fg-secondary)',
+                backgroundColor: statusFilter === s.key ? 'var(--semantic-fg-primary)' : 'rgba(0,0,0,0.06)',
+                color: statusFilter === s.key ? 'var(--bg-card)' : 'var(--semantic-fg-secondary)',
               }}
             >
-              {s === 'all' ? 'All' : s}
+              {t(s.labelKey)}
             </button>
           ))}
         </div>
 
-        {/* Template select */}
         <select
           value={templateFilter}
           onChange={e => { setTemplateFilter(e.target.value); setPage(0) }}
@@ -137,7 +139,7 @@ export function EmailLogTable() {
             color: 'var(--semantic-fg-primary)',
           }}
         >
-          <option value="all">All templates</option>
+          <option value="all">{t('admin.settings.emailLog.allTemplates')}</option>
           {Object.entries(TEMPLATE_LABELS).map(([id, label]) => (
             <option key={id} value={id}>{label}</option>
           ))}
@@ -146,11 +148,10 @@ export function EmailLogTable() {
 
       {retryError && (
         <p className="text-xs px-3 py-2 rounded-lg bg-red-50 text-red-700 border border-red-200">
-          Retry error: {retryError}
+          {t('admin.settings.emailLog.retryError')} {retryError}
         </p>
       )}
 
-      {/* Table */}
       {isLoading ? (
         <div className="space-y-2">
           {[...Array(5)].map((_, i) => (
@@ -158,18 +159,17 @@ export function EmailLogTable() {
           ))}
         </div>
       ) : rows.length === 0 ? (
-        <p className="text-sm text-[var(--semantic-fg-secondary)] py-4 text-center">No email log entries found.</p>
+        <p className="text-sm text-[var(--semantic-fg-secondary)] py-4 text-center">{t('admin.settings.emailLog.empty')}</p>
       ) : (
         <div className="rounded-xl border overflow-hidden" style={{ borderColor: 'var(--border-subtle)' }}>
-          {/* Desktop header */}
           <div
             className="hidden md:grid grid-cols-[1fr_1fr_1fr_auto_auto] gap-4 px-4 py-2.5 text-[10px] font-semibold uppercase tracking-widest"
             style={{ backgroundColor: 'rgba(0,0,0,0.03)', color: 'var(--semantic-fg-tertiary)', borderBottom: '1px solid var(--border-subtle)' }}
           >
-            <span>Template</span>
-            <span>Recipient</span>
-            <span>Sent at</span>
-            <span>Status</span>
+            <span>{t('admin.settings.emailLog.col.template')}</span>
+            <span>{t('admin.settings.emailLog.col.recipient')}</span>
+            <span>{t('admin.settings.emailLog.col.sentAt')}</span>
+            <span>{t('admin.settings.emailLog.col.status')}</span>
             <span></span>
           </div>
 
@@ -181,7 +181,6 @@ export function EmailLogTable() {
                 className="px-4 py-3 flex flex-col md:grid md:grid-cols-[1fr_1fr_1fr_auto_auto] md:items-center gap-2 md:gap-4"
                 style={{ borderTop: i > 0 ? '1px solid var(--border-subtle)' : 'none' }}
               >
-                {/* Template */}
                 <div className="flex flex-col gap-0.5">
                   <span className="text-xs font-medium text-[var(--semantic-fg-primary)]">
                     {TEMPLATE_LABELS[row.template] ?? row.template}
@@ -190,24 +189,16 @@ export function EmailLogTable() {
                     <span className="text-[10px] text-red-600 leading-tight line-clamp-2">{row.error}</span>
                   )}
                 </div>
-
-                {/* Recipient */}
                 <span className="text-xs text-[var(--semantic-fg-secondary)] truncate">{row.recipient}</span>
-
-                {/* Date */}
                 <span className="text-xs text-[var(--semantic-fg-tertiary)]">
                   {row.sent_at ? formatDate(row.sent_at) : formatDate(row.created_at)}
                 </span>
-
-                {/* Status pill */}
                 <span
                   className="text-[10px] font-semibold px-2.5 py-0.5 rounded-full whitespace-nowrap w-fit"
                   style={{ backgroundColor: pill.bg, color: pill.color }}
                 >
                   {row.status}
                 </span>
-
-                {/* Retry */}
                 <div className="flex justify-end">
                   {row.status === 'failed' && (
                     <button
@@ -216,7 +207,7 @@ export function EmailLogTable() {
                       className="text-xs font-semibold px-3 py-1 rounded-lg border transition-colors hover:bg-black/5 disabled:opacity-40"
                       style={{ borderColor: 'var(--border-subtle)', color: 'var(--semantic-fg-primary)' }}
                     >
-                      {retryingId === row.id ? 'Retrying…' : 'Retry'}
+                      {retryingId === row.id ? t('admin.settings.emailLog.btn.retrying') : t('admin.settings.emailLog.btn.retry')}
                     </button>
                   )}
                 </div>
@@ -226,7 +217,6 @@ export function EmailLogTable() {
         </div>
       )}
 
-      {/* Pagination */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between pt-2">
           <span className="text-xs text-[var(--semantic-fg-tertiary)]">
@@ -239,7 +229,7 @@ export function EmailLogTable() {
               className="px-3 py-1.5 text-xs font-semibold rounded-lg border disabled:opacity-40 transition-colors hover:bg-black/5"
               style={{ borderColor: 'var(--border-subtle)', color: 'var(--semantic-fg-primary)' }}
             >
-              ← Prev
+              {t('admin.settings.emailLog.pagination.prev')}
             </button>
             <button
               disabled={page >= totalPages - 1}
@@ -247,7 +237,7 @@ export function EmailLogTable() {
               className="px-3 py-1.5 text-xs font-semibold rounded-lg border disabled:opacity-40 transition-colors hover:bg-black/5"
               style={{ borderColor: 'var(--border-subtle)', color: 'var(--semantic-fg-primary)' }}
             >
-              Next →
+              {t('admin.settings.emailLog.pagination.next')}
             </button>
           </div>
         </div>

--- a/app/admin/settings/components/EmailSettingsPanel.tsx
+++ b/app/admin/settings/components/EmailSettingsPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { useTranslation } from '@/lib/i18n/useTranslation'
+import { t } from '@/lib/i18n'
 
 export type EmailConfig = {
   enabled: boolean
@@ -20,7 +20,6 @@ const TEMPLATES = [
 ]
 
 export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConfig }) {
-  const { t } = useTranslation()
   const [config, setConfig] = useState<EmailConfig>(initialConfig)
 
   const mutation = useMutation({
@@ -56,8 +55,8 @@ export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConf
     <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-6 w-full shadow-sm flex flex-col gap-8">
       <div className="flex items-center justify-between pb-6 border-b border-[var(--border-subtle)]">
         <div className="flex flex-col gap-1">
-          <h3 className="text-sm font-semibold text-[var(--semantic-fg-primary)]">{t('admin.settings.emailPanel.globalTitle')}</h3>
-          <p className="text-xs text-[var(--semantic-fg-secondary)]">{t('admin.settings.emailPanel.globalDesc')}</p>
+          <h3 className="text-sm font-semibold text-[var(--semantic-fg-primary)]">{t('admin.settings.emailPanel.globalTitle', 'en')}</h3>
+          <p className="text-xs text-[var(--semantic-fg-secondary)]">{t('admin.settings.emailPanel.globalDesc', 'en')}</p>
         </div>
         <button
           onClick={() => toggleAll(!config.enabled)}
@@ -69,8 +68,8 @@ export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConf
 
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-1">
-          <label className="text-sm font-semibold text-[var(--semantic-fg-primary)]">{t('admin.settings.emailPanel.recipientTitle')}</label>
-          <p className="text-xs text-[var(--semantic-fg-secondary)]">{t('admin.settings.emailPanel.recipientDesc')}</p>
+          <label className="text-sm font-semibold text-[var(--semantic-fg-primary)]">{t('admin.settings.emailPanel.recipientTitle', 'en')}</label>
+          <p className="text-xs text-[var(--semantic-fg-secondary)]">{t('admin.settings.emailPanel.recipientDesc', 'en')}</p>
         </div>
         <div className="flex gap-2">
           <input
@@ -85,17 +84,17 @@ export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConf
             disabled={mutation.isPending}
             className="px-4 py-2 bg-[var(--semantic-fg-primary)] text-[var(--bg-card)] rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
           >
-            {t('admin.settings.emailPanel.btn.save')}
+            {t('admin.settings.emailPanel.btn.save', 'en')}
           </button>
         </div>
       </div>
 
       <div className="flex flex-col gap-4">
-        <h3 className="text-sm font-semibold text-[var(--semantic-fg-primary)]">{t('admin.settings.emailPanel.automatedTitle')}</h3>
+        <h3 className="text-sm font-semibold text-[var(--semantic-fg-primary)]">{t('admin.settings.emailPanel.automatedTitle', 'en')}</h3>
         <div className="grid gap-3">
           {TEMPLATES.map(tmpl => (
             <div key={tmpl.id} className="flex items-center justify-between p-3 rounded-lg border border-[var(--border-subtle)] hover:bg-black/[0.02] transition-colors">
-              <span className="text-xs font-medium text-[var(--semantic-fg-secondary)]">{t(`admin.settings.emailPanel.template.${tmpl.id}`)}</span>
+              <span className="text-xs font-medium text-[var(--semantic-fg-secondary)]">{t(`admin.settings.emailPanel.template.${tmpl.id}` as Parameters<typeof t>[0], 'en')}</span>
               <button
                 onClick={() => toggleType(tmpl.id, !(config.notification_types?.[tmpl.id] !== false))}
                 className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${config.notification_types?.[tmpl.id] !== false ? 'bg-green-600' : 'bg-gray-200'}`}

--- a/app/admin/settings/components/EmailSettingsPanel.tsx
+++ b/app/admin/settings/components/EmailSettingsPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
+import { useTranslation } from '@/lib/i18n/useTranslation'
 
 export type EmailConfig = {
   enabled: boolean
@@ -19,6 +20,7 @@ const TEMPLATES = [
 ]
 
 export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConfig }) {
+  const { t } = useTranslation()
   const [config, setConfig] = useState<EmailConfig>(initialConfig)
 
   const mutation = useMutation({
@@ -52,11 +54,10 @@ export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConf
 
   return (
     <div className="bg-[var(--bg-card)] rounded-xl border border-[var(--border-subtle)] p-6 w-full shadow-sm flex flex-col gap-8">
-      {/* Global Toggle */}
       <div className="flex items-center justify-between pb-6 border-b border-[var(--border-subtle)]">
         <div className="flex flex-col gap-1">
-          <h3 className="text-sm font-semibold text-[var(--semantic-fg-primary)]">System-wide Email</h3>
-          <p className="text-xs text-[var(--semantic-fg-secondary)]">Enable or disable all automated outbound emails.</p>
+          <h3 className="text-sm font-semibold text-[var(--semantic-fg-primary)]">{t('admin.settings.emailPanel.globalTitle')}</h3>
+          <p className="text-xs text-[var(--semantic-fg-secondary)]">{t('admin.settings.emailPanel.globalDesc')}</p>
         </div>
         <button
           onClick={() => toggleAll(!config.enabled)}
@@ -66,11 +67,10 @@ export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConf
         </button>
       </div>
 
-      {/* Alert Recipient */}
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-1">
-          <label className="text-sm font-semibold text-[var(--semantic-fg-primary)]">Admin Alert Recipient</label>
-          <p className="text-xs text-[var(--semantic-fg-secondary)]">Receives bcc or system alerts if configured.</p>
+          <label className="text-sm font-semibold text-[var(--semantic-fg-primary)]">{t('admin.settings.emailPanel.recipientTitle')}</label>
+          <p className="text-xs text-[var(--semantic-fg-secondary)]">{t('admin.settings.emailPanel.recipientDesc')}</p>
         </div>
         <div className="flex gap-2">
           <input
@@ -85,23 +85,22 @@ export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConf
             disabled={mutation.isPending}
             className="px-4 py-2 bg-[var(--semantic-fg-primary)] text-[var(--bg-card)] rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
           >
-            Save
+            {t('admin.settings.emailPanel.btn.save')}
           </button>
         </div>
       </div>
 
-      {/* Template Toggles */}
       <div className="flex flex-col gap-4">
-        <h3 className="text-sm font-semibold text-[var(--semantic-fg-primary)]">Automated Notifications</h3>
+        <h3 className="text-sm font-semibold text-[var(--semantic-fg-primary)]">{t('admin.settings.emailPanel.automatedTitle')}</h3>
         <div className="grid gap-3">
-          {TEMPLATES.map(t => (
-            <div key={t.id} className="flex items-center justify-between p-3 rounded-lg border border-[var(--border-subtle)] hover:bg-black/[0.02] transition-colors">
-              <span className="text-xs font-medium text-[var(--semantic-fg-secondary)]">{t.label}</span>
+          {TEMPLATES.map(tmpl => (
+            <div key={tmpl.id} className="flex items-center justify-between p-3 rounded-lg border border-[var(--border-subtle)] hover:bg-black/[0.02] transition-colors">
+              <span className="text-xs font-medium text-[var(--semantic-fg-secondary)]">{tmpl.label}</span>
               <button
-                onClick={() => toggleType(t.id, !(config.notification_types?.[t.id] !== false))}
-                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${config.notification_types?.[t.id] !== false ? 'bg-green-600' : 'bg-gray-200'}`}
+                onClick={() => toggleType(tmpl.id, !(config.notification_types?.[tmpl.id] !== false))}
+                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${config.notification_types?.[tmpl.id] !== false ? 'bg-green-600' : 'bg-gray-200'}`}
               >
-                <span className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${config.notification_types?.[t.id] !== false ? 'translate-x-5' : 'translate-x-1'}`} />
+                <span className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${config.notification_types?.[tmpl.id] !== false ? 'translate-x-5' : 'translate-x-1'}`} />
               </button>
             </div>
           ))}

--- a/app/admin/settings/components/EmailSettingsPanel.tsx
+++ b/app/admin/settings/components/EmailSettingsPanel.tsx
@@ -12,11 +12,11 @@ export type EmailConfig = {
 }
 
 const TEMPLATES = [
-  { id: 'welcome', label: 'Welcome Email' },
-  { id: 'payment_status', label: 'Payment Status Updates' },
-  { id: 'doc_expiry', label: 'Document Expiry Warnings' },
-  { id: 'abo_verification_result', label: 'ABO Verification Results' },
-  { id: 'trip_registration_status', label: 'Trip Registration Updates' },
+  { id: 'welcome' },
+  { id: 'payment_status' },
+  { id: 'doc_expiry' },
+  { id: 'abo_verification_result' },
+  { id: 'trip_registration_status' },
 ]
 
 export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConfig }) {
@@ -95,7 +95,7 @@ export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConf
         <div className="grid gap-3">
           {TEMPLATES.map(tmpl => (
             <div key={tmpl.id} className="flex items-center justify-between p-3 rounded-lg border border-[var(--border-subtle)] hover:bg-black/[0.02] transition-colors">
-              <span className="text-xs font-medium text-[var(--semantic-fg-secondary)]">{tmpl.label}</span>
+              <span className="text-xs font-medium text-[var(--semantic-fg-secondary)]">{t(`admin.settings.emailPanel.template.${tmpl.id}`)}</span>
               <button
                 onClick={() => toggleType(tmpl.id, !(config.notification_types?.[tmpl.id] !== false))}
                 className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${config.notification_types?.[tmpl.id] !== false ? 'bg-green-600' : 'bg-gray-200'}`}

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -4,12 +4,12 @@ import { createServiceClient } from '@/lib/supabase/service'
 import { requireAdmin } from '@/lib/supabase/guards'
 import { EmailSettingsPanel, EmailConfig } from './components/EmailSettingsPanel'
 import { EmailLogTable } from './components/EmailLogTable'
+import { t } from '@/lib/i18n'
 
 export default async function AdminSettingsPage() {
   const { userId } = await auth()
   if (!userId) redirect('/')
 
-  // Fetch current settings
   const supabase = createServiceClient()
   const { data: settingsData } = await supabase
     .from('settings')
@@ -23,25 +23,22 @@ export default async function AdminSettingsPage() {
     notification_types: {},
   }
 
-  // Dual layout is canonical in the code base: lg:grid lg:grid-cols-12 gap-6
   return (
     <main className="max-w-[1440px] w-full mx-auto p-4 md:p-6 lg:p-8">
       <div className="mb-6">
         <h1 className="text-2xl font-bold tracking-tight text-[var(--semantic-fg-primary)]">
-          System Settings
+          {t('admin.settings.pageTitle', 'en')}
         </h1>
         <p className="text-sm text-[var(--semantic-fg-secondary)] mt-1">
-          Manage global configurations and monitor automated systems
+          {t('admin.settings.pageDesc', 'en')}
         </p>
       </div>
 
       <div className="flex flex-col lg:grid lg:grid-cols-12 gap-6 items-start">
-        {/* Left Col: Settings Form */}
         <section className="lg:col-span-4 w-full flex flex-col gap-6">
           <EmailSettingsPanel initialConfig={config} />
         </section>
 
-        {/* Right Col: Logs */}
         <section className="lg:col-span-8 w-full flex flex-col gap-6">
           <EmailLogTable />
         </section>

--- a/lib/i18n/domains/admin.ts
+++ b/lib/i18n/domains/admin.ts
@@ -117,6 +117,7 @@ export const admin = {
   'admin.operations.trips.milestones': { en: '{{count}} milestones', bg: '{{count}} вноски' },
   'admin.operations.trips.btn.edit': { en: 'Edit', bg: 'Редактирай' },
   'admin.operations.trips.btn.delete': { en: 'Delete', bg: 'Изтрий' },
+  'admin.operations.trips.title.edit': { en: 'Edit: {{title}}', bg: 'Редактиране: {{title}}' },
   'admin.operations.trips.dialog.title': { en: 'Delete trip', bg: 'Изтриване на пътуване' },
   'admin.operations.trips.dialog.body': { en: 'This cannot be undone.', bg: 'Това действие е необратимо.' },
   'admin.operations.trips.dialog.cancel': { en: 'Cancel', bg: 'Откажи' },
@@ -131,6 +132,7 @@ export const admin = {
   'admin.operations.form.uploadHint': { en: 'PDF or image, max 10 MB', bg: 'PDF или изображение, макс. 10 МБ' },
   'admin.operations.form.btn.remove': { en: 'Remove', bg: 'Премахни' },
   'admin.operations.form.dialog.title': { en: 'Remove document', bg: 'Премахване на документ' },
+  'admin.operations.form.dialog.removeConfirm': { en: 'Remove "{{name}}"?', bg: 'Премахване на "{{name}}"?' },
   'admin.operations.form.dialog.body': { en: 'This cannot be undone.', bg: 'Това действие е необратимо.' },
   'admin.operations.form.dialog.cancel': { en: 'Cancel', bg: 'Откажи' },
   'admin.operations.form.dialog.confirm': { en: 'Remove', bg: 'Премахни' },
@@ -194,6 +196,7 @@ export const admin = {
   'admin.operations.items.btn.deactivate': { en: 'Deactivate', bg: 'Деактивирай' },
   'admin.operations.items.badge.active': { en: 'active', bg: 'активен' },
   'admin.operations.items.badge.inactive': { en: 'inactive', bg: 'неактивен' },
+  'admin.operations.items.title.edit': { en: 'Edit: {{title}}', bg: 'Редактиране: {{title}}' },
   'admin.operations.items.lbl.title': { en: 'Title *', bg: 'Наименование *' },
   'admin.operations.items.lbl.type': { en: 'Type *', bg: 'Тип *' },
   'admin.operations.items.lbl.description': { en: 'Description', bg: 'Описание' },
@@ -205,6 +208,11 @@ export const admin = {
   'admin.operations.items.btn.saveChanges': { en: 'Save changes', bg: 'Запази промените' },
   'admin.operations.items.btn.create': { en: 'Create item', bg: 'Създай артикул' },
   'admin.operations.items.btn.cancel': { en: 'Cancel', bg: 'Откажи' },
+  'admin.operations.items.type.merchandise': { en: 'merchandise', bg: 'стока' },
+  'admin.operations.items.type.ticket': { en: 'ticket', bg: 'билет' },
+  'admin.operations.items.type.food': { en: 'food', bg: 'храна' },
+  'admin.operations.items.type.book': { en: 'book', bg: 'книга' },
+  'admin.operations.items.type.other': { en: 'other', bg: 'друго' },
 
   // -- Notifications audit log --
   'admin.notifications.pageTitle': { en: 'Notification Audit Log', bg: 'Одиторски журнал на известията' },
@@ -253,5 +261,10 @@ export const admin = {
   'admin.settings.emailPanel.recipientDesc': { en: 'Receives bcc or system alerts if configured.', bg: 'Получава скрито копие или системни сигнали при конфигурация.' },
   'admin.settings.emailPanel.btn.save': { en: 'Save', bg: 'Запази' },
   'admin.settings.emailPanel.automatedTitle': { en: 'Automated Notifications', bg: 'Автоматизирани известия' },
+  'admin.settings.emailPanel.template.welcome': { en: 'Welcome Email', bg: 'Приветствен имейл' },
+  'admin.settings.emailPanel.template.payment_status': { en: 'Payment Status Updates', bg: 'Обновяване на статус на плащане' },
+  'admin.settings.emailPanel.template.doc_expiry': { en: 'Document Expiry Warnings', bg: 'Предупреждения за изтичащи документи' },
+  'admin.settings.emailPanel.template.abo_verification_result': { en: 'ABO Verification Results', bg: 'Резултати от СБА верификация' },
+  'admin.settings.emailPanel.template.trip_registration_status': { en: 'Trip Registration Updates', bg: 'Обновяване на регистрация за пътуване' },
 
 } as const

--- a/lib/i18n/domains/admin.ts
+++ b/lib/i18n/domains/admin.ts
@@ -10,7 +10,7 @@ export const admin = {
   'admin.members.table.gpv': { en: 'GPV', bg: 'ГТС' },
   'admin.members.table.bonus': { en: 'Bonus%', bg: 'Бонус%' },
   'admin.members.table.group': { en: 'Group', bg: 'Група' },
-  
+
   'admin.members.btn.toCore': { en: '→ Core', bg: '→ Основен костяк' },
   'admin.members.btn.toMember': { en: '→ Member', bg: '→ Член' },
   'admin.members.noLosData': { en: 'No LOS data. Import a CSV in Data Center.', bg: 'Няма данни за LOS. Импортирайте CSV в Център за данни.' },
@@ -19,10 +19,10 @@ export const admin = {
   'admin.members.pageInfo': { en: 'Page {{current}} of {{total}}', bg: 'Страница {{current}} от {{total}}' },
   'admin.members.btn.prev': { en: 'Prev', bg: 'Предишна' },
   'admin.members.btn.next': { en: 'Next', bg: 'Следваща' },
-  
+
   'admin.members.summary.losLinked': { en: '{{total}} in LOS · {{linked}} linked to portal accounts', bg: '{{total}} в LOS · {{linked}} свързани акаунти' },
   'admin.members.pendingVerification': { en: 'Pending verification', bg: 'Чакaщи потвърждение' },
-  
+
   'admin.members.verify.claimsAbo': { en: 'Claims ABO', bg: 'Заявява СБА' },
   'admin.members.verify.upline': { en: 'upline', bg: 'горна линия' },
   'admin.members.verify.los': { en: 'LOS:', bg: 'LOS:' },
@@ -30,12 +30,12 @@ export const admin = {
   'admin.members.verify.losMatch': { en: '✓ LOS match', bg: '✓ LOS съвпадение' },
   'admin.members.verify.uplineMismatch': { en: '⚠ upline mismatch', bg: '⚠ несъвпадение на горна линия' },
   'admin.members.verify.noAboInLos': { en: '✗ ABO not in LOS', bg: '✗ СБА не е в LOS' },
-  
+
   'admin.members.verify.btn.approve': { en: 'Approve', bg: 'Одобри' },
   'admin.members.verify.btn.deny': { en: 'Deny', bg: 'Откажи' },
   'admin.members.verify.reasonPlaceholder': { en: 'Reason (optional)', bg: 'Причина (опционално)' },
   'admin.members.verify.btn.confirm': { en: 'Confirm', bg: 'Потвърди' },
-  
+
   'admin.members.guestsNoAbo': { en: 'Guests — no ABO submitted ({{count}})', bg: 'Гости — без подаден СБА ({{count}})' },
   'admin.members.guestJoined': { en: 'Joined', bg: 'Присъединен' },
   'admin.members.guestRole': { en: 'guest', bg: 'гост' },
@@ -49,7 +49,7 @@ export const admin = {
   'admin.data.previewTitle': { en: 'Preview (first 5 rows)', bg: 'Преглед (първи 5 реда)' },
   'admin.data.btn.runImport': { en: 'Run Import', bg: 'Стартирай импорт' },
   'admin.data.btn.importing': { en: 'Importing...', bg: 'Импортиране...' },
-  
+
   'admin.data.result.complete': { en: 'Import complete — {{count}} rows upserted', bg: 'Импортът завърши — добавени/обновени {{count}} реда' },
   'admin.data.result.new': { en: '{{count}} new', bg: '{{count}} нови' },
   'admin.data.result.levelChanges': { en: '{{count}} level changes', bg: '{{count}} промени в нивото' },
@@ -59,7 +59,7 @@ export const admin = {
   'admin.data.result.rowErrorsTitle': { en: '{{count}} row errors — check for unsanitized data:', bg: '{{count}} грешки в редове — проверете за невалидни данни:' },
   'admin.data.result.levelChangesTitle': { en: 'Level changes', bg: 'Промени в нивото' },
   'admin.data.result.bonusChangesTitle': { en: 'Bonus % changes', bg: 'Промени в % бонус' },
-  
+
   'admin.data.reconciliation.title': { en: 'Reconciliation', bg: 'Свързване' },
   'admin.data.reconciliation.desc': { en: 'Match unrecognized LOS members to manually-verified portal profiles.', bg: 'Свържете неразпознати LOS членове с ръчно верифицирани портал-профили.' },
   'admin.data.reconciliation.btn.link': { en: 'Link', bg: 'Свържи' },
@@ -85,11 +85,11 @@ export const admin = {
   'admin.approval.verify.noStandard': { en: 'No pending standard requests.', bg: 'Няма чакащи стандартни заявки.' },
   'admin.approval.verify.manualTitle': { en: 'Manual requests — {{count}}', bg: 'Ръчни заявки — {{count}}' },
   'admin.approval.verify.noManual': { en: 'No pending manual requests.', bg: 'Няма чакащи ръчни заявки.' },
-  
+
   'admin.approval.verify.noAboBadge': { en: 'No ABO', bg: 'Без СБА' },
   'admin.approval.verify.awaitingPosTitle': { en: 'Awaiting LOS positioning — {{count}}', bg: 'Очаква позициониране в LOS — {{count}}' },
   'admin.approval.verify.approvedBadge': { en: 'approved', bg: 'одобрен' },
-  
+
   'admin.approval.verify.directTitle': { en: 'Direct verify', bg: 'Директна верификация' },
   'admin.approval.verify.directDesc': { en: 'Directly promote a guest to member without a prior submission.', bg: 'Пряко повишаване на гост до член без предварителна заявка.' },
   'admin.approval.verify.lbl.guest': { en: 'Guest', bg: 'Гост' },
@@ -110,5 +110,148 @@ export const admin = {
 
   'admin.approval.events.btn.allEvents': { en: 'All events', bg: 'Всички събития' },
   'admin.approval.events.noPending': { en: 'No pending role requests.', bg: 'Няма чакащи заявки за роли.' },
+
+  // -- Operations: Trips --
+  'admin.operations.trips.btn.new': { en: '+ New trip', bg: '+ Ново пътуване' },
+  'admin.operations.trips.empty': { en: 'No trips yet.', bg: 'Все още няма пътувания.' },
+  'admin.operations.trips.milestones': { en: '{{count}} milestones', bg: '{{count}} вноски' },
+  'admin.operations.trips.btn.edit': { en: 'Edit', bg: 'Редактирай' },
+  'admin.operations.trips.btn.delete': { en: 'Delete', bg: 'Изтрий' },
+  'admin.operations.trips.dialog.title': { en: 'Delete trip', bg: 'Изтриване на пътуване' },
+  'admin.operations.trips.dialog.body': { en: 'This cannot be undone.', bg: 'Това действие е необратимо.' },
+  'admin.operations.trips.dialog.cancel': { en: 'Cancel', bg: 'Откажи' },
+  'admin.operations.trips.dialog.confirm': { en: 'Delete', bg: 'Изтрий' },
+
+  // -- Operations: TripForm --
+  'admin.operations.form.documents': { en: 'Trip documents', bg: 'Документи за пътуването' },
+  'admin.operations.form.loading': { en: 'Loading…', bg: 'Зареждане…' },
+  'admin.operations.form.noDocuments': { en: 'No documents uploaded yet.', bg: 'Все още няма качени документи.' },
+  'admin.operations.form.btn.uploading': { en: 'Uploading…', bg: 'Качване…' },
+  'admin.operations.form.btn.upload': { en: '+ Upload file', bg: '+ Качи файл' },
+  'admin.operations.form.uploadHint': { en: 'PDF or image, max 10 MB', bg: 'PDF или изображение, макс. 10 МБ' },
+  'admin.operations.form.btn.remove': { en: 'Remove', bg: 'Премахни' },
+  'admin.operations.form.dialog.title': { en: 'Remove document', bg: 'Премахване на документ' },
+  'admin.operations.form.dialog.body': { en: 'This cannot be undone.', bg: 'Това действие е необратимо.' },
+  'admin.operations.form.dialog.cancel': { en: 'Cancel', bg: 'Откажи' },
+  'admin.operations.form.dialog.confirm': { en: 'Remove', bg: 'Премахни' },
+  'admin.operations.form.lbl.description': { en: 'Description', bg: 'Описание' },
+  'admin.operations.form.lbl.startDate': { en: 'Start date', bg: 'Начална дата' },
+  'admin.operations.form.lbl.endDate': { en: 'End date', bg: 'Крайна дата' },
+  'admin.operations.form.lbl.cost': { en: 'Cost (EUR)', bg: 'Цена (EUR)' },
+  'admin.operations.form.lbl.milestones': { en: 'Payment milestones', bg: 'Вноски' },
+  'admin.operations.form.placeholder.label': { en: 'Label', bg: 'Наименование' },
+  'admin.operations.form.placeholder.amount': { en: 'Amount', bg: 'Сума' },
+  'admin.operations.form.btn.addMilestone': { en: '+ Add', bg: '+ Добави' },
+  'admin.operations.form.lbl.location': { en: 'Location', bg: 'Местоположение' },
+  'admin.operations.form.lbl.tripType': { en: 'Trip type', bg: 'Тип пътуване' },
+  'admin.operations.form.lbl.accommodation': { en: 'Accommodation', bg: 'Настаняване' },
+  'admin.operations.form.lbl.inclusions': { en: 'Inclusions (comma-sep)', bg: 'Включено (разделено със запетая)' },
+  'admin.operations.form.lbl.visibleTo': { en: 'Visible to', bg: 'Видимо за' },
+  'admin.operations.form.btn.saving': { en: 'Saving…', bg: 'Запазване…' },
+  'admin.operations.form.btn.saveChanges': { en: 'Save changes', bg: 'Запази промените' },
+  'admin.operations.form.btn.createTrip': { en: 'Create trip', bg: 'Създай пътуване' },
+  'admin.operations.form.btn.cancel': { en: 'Cancel', bg: 'Откажи' },
+
+  // -- Operations: Payments --
+  'admin.operations.payments.btn.log': { en: 'Log Payment', bg: 'Регистрирай плащане' },
+  'admin.operations.payments.pendingTitle': { en: 'Pending submissions ({{count}})', bg: 'Чакащи подавания ({{count}})' },
+  'admin.operations.payments.viewProof': { en: 'View proof ↗', bg: 'Виж доказателство ↗' },
+  'admin.operations.payments.badge.pending': { en: 'pending', bg: 'чакащо' },
+  'admin.operations.payments.filter.all': { en: 'All', bg: 'Всички' },
+  'admin.operations.payments.filter.pending': { en: 'Pending', bg: 'Чакащи' },
+  'admin.operations.payments.filter.approved': { en: 'Approved', bg: 'Одобрени' },
+  'admin.operations.payments.filter.rejected': { en: 'Rejected', bg: 'Отказани' },
+  'admin.operations.payments.empty': { en: 'No payments found.', bg: 'Няма намерени плащания.' },
+  'admin.operations.payments.drawer.title': { en: 'Log Payment', bg: 'Регистрирай плащане' },
+  'admin.operations.payments.lbl.entity': { en: 'Entity *', bg: 'Обект *' },
+  'admin.operations.payments.placeholder.entity': { en: 'Select entity…', bg: 'Избери обект…' },
+  'admin.operations.payments.group.trips': { en: 'Trips', bg: 'Пътувания' },
+  'admin.operations.payments.group.items': { en: 'Items', bg: 'Артикули' },
+  'admin.operations.payments.lbl.member': { en: 'Member *', bg: 'Член *' },
+  'admin.operations.payments.placeholder.member': { en: 'Select member…', bg: 'Избери член…' },
+  'admin.operations.payments.lbl.amount': { en: 'Amount *', bg: 'Сума *' },
+  'admin.operations.payments.lbl.currency': { en: 'Currency', bg: 'Валута' },
+  'admin.operations.payments.lbl.date': { en: 'Date', bg: 'Дата' },
+  'admin.operations.payments.lbl.method': { en: 'Payment method', bg: 'Начин на плащане' },
+  'admin.operations.payments.placeholder.method': { en: 'e.g. bank transfer, cash', bg: 'напр. банков превод, в брой' },
+  'admin.operations.payments.lbl.status': { en: 'Status', bg: 'Статус' },
+  'admin.operations.payments.lbl.note': { en: 'Note', bg: 'Бележка' },
+  'admin.operations.payments.lbl.noteOptional': { en: '(optional)', bg: '(незадължително)' },
+  'admin.operations.payments.placeholder.note': { en: 'e.g. Cash payment, ref #123', bg: 'напр. Плащане в брой, реф. #123' },
+  'admin.operations.payments.btn.saving': { en: 'Saving…', bg: 'Запазване…' },
+  'admin.operations.payments.btn.log2': { en: 'Log payment', bg: 'Регистрирай плащане' },
+  'admin.operations.payments.btn.cancel': { en: 'Cancel', bg: 'Откажи' },
+  'admin.operations.payments.btn.approve': { en: 'Approve', bg: 'Одобри' },
+  'admin.operations.payments.btn.deny': { en: 'Deny', bg: 'Откажи' },
+  'admin.operations.payments.placeholder.adminNote': { en: 'Admin note (optional)', bg: 'Бележка на администратор (незадължително)' },
+  'admin.operations.payments.status.approved': { en: 'Approved', bg: 'Одобрено' },
+  'admin.operations.payments.status.pending': { en: 'Pending', bg: 'Чакащо' },
+
+  // -- Operations: Items --
+  'admin.operations.items.btn.new': { en: '+ New item', bg: '+ Нов артикул' },
+  'admin.operations.items.empty': { en: 'No payable items yet.', bg: 'Все още няма артикули.' },
+  'admin.operations.items.btn.edit': { en: 'Edit', bg: 'Редактирай' },
+  'admin.operations.items.btn.deactivate': { en: 'Deactivate', bg: 'Деактивирай' },
+  'admin.operations.items.badge.active': { en: 'active', bg: 'активен' },
+  'admin.operations.items.badge.inactive': { en: 'inactive', bg: 'неактивен' },
+  'admin.operations.items.lbl.title': { en: 'Title *', bg: 'Наименование *' },
+  'admin.operations.items.lbl.type': { en: 'Type *', bg: 'Тип *' },
+  'admin.operations.items.lbl.description': { en: 'Description', bg: 'Описание' },
+  'admin.operations.items.lbl.amount': { en: 'Amount *', bg: 'Сума *' },
+  'admin.operations.items.lbl.currency': { en: 'Currency', bg: 'Валута' },
+  'admin.operations.items.toggle.active': { en: 'Active', bg: 'Активен' },
+  'admin.operations.items.toggle.inactive': { en: 'Inactive', bg: 'Неактивен' },
+  'admin.operations.items.btn.saving': { en: 'Saving…', bg: 'Запазване…' },
+  'admin.operations.items.btn.saveChanges': { en: 'Save changes', bg: 'Запази промените' },
+  'admin.operations.items.btn.create': { en: 'Create item', bg: 'Създай артикул' },
+  'admin.operations.items.btn.cancel': { en: 'Cancel', bg: 'Откажи' },
+
+  // -- Notifications audit log --
+  'admin.notifications.pageTitle': { en: 'Notification Audit Log', bg: 'Одиторски журнал на известията' },
+  'admin.notifications.pageDesc': { en: 'All system notifications ever fired — including soft-deleted. Read-only.', bg: 'Всички системни известия — включително изтритите. Само за четене.' },
+  'admin.notifications.errorLoading': { en: 'Error loading notifications:', bg: 'Грешка при зареждане на известия:' },
+  'admin.notifications.col.created': { en: 'Created', bg: 'Създадено' },
+  'admin.notifications.col.type': { en: 'Type', bg: 'Тип' },
+  'admin.notifications.col.title': { en: 'Title', bg: 'Заглавие' },
+  'admin.notifications.col.member': { en: 'Member', bg: 'Член' },
+  'admin.notifications.col.read': { en: 'Read', bg: 'Прочетено' },
+  'admin.notifications.col.deleted': { en: 'Deleted', bg: 'Изтрито' },
+  'admin.notifications.badge.read': { en: 'Read', bg: 'Прочетено' },
+  'admin.notifications.badge.unread': { en: 'Unread', bg: 'Непрочетено' },
+  'admin.notifications.empty': { en: 'No notifications found.', bg: 'Няма намерени известия.' },
+  'admin.notifications.pagination.info': { en: 'Page {{page}} of {{total}} — {{count}} total', bg: 'Страница {{page}} от {{total}} — {{count}} общо' },
+  'admin.notifications.pagination.prev': { en: '← Prev', bg: '← Предишна' },
+  'admin.notifications.pagination.next': { en: 'Next →', bg: 'Следваща →' },
+
+  // -- Settings --
+  'admin.settings.pageTitle': { en: 'System Settings', bg: 'Системни настройки' },
+  'admin.settings.pageDesc': { en: 'Manage global configurations and monitor automated systems', bg: 'Управлявайте глобалните конфигурации и наблюдавайте автоматизираните системи' },
+
+  // -- Settings: Email Log --
+  'admin.settings.emailLog.title': { en: 'Email Log', bg: 'Журнал на имейлите' },
+  'admin.settings.emailLog.desc': { en: 'Every outbound email attempt is recorded here. Use Retry on failed rows.', bg: 'Всеки опит за изпращане на имейл се записва тук. Използвайте Повторен опит за неуспешни редове.' },
+  'admin.settings.emailLog.col.template': { en: 'Template', bg: 'Шаблон' },
+  'admin.settings.emailLog.col.recipient': { en: 'Recipient', bg: 'Получател' },
+  'admin.settings.emailLog.col.sentAt': { en: 'Sent at', bg: 'Изпратено в' },
+  'admin.settings.emailLog.col.status': { en: 'Status', bg: 'Статус' },
+  'admin.settings.emailLog.filter.all': { en: 'All', bg: 'Всички' },
+  'admin.settings.emailLog.filter.sent': { en: 'sent', bg: 'изпратени' },
+  'admin.settings.emailLog.filter.failed': { en: 'failed', bg: 'неуспешни' },
+  'admin.settings.emailLog.filter.pending': { en: 'pending', bg: 'чакащи' },
+  'admin.settings.emailLog.allTemplates': { en: 'All templates', bg: 'Всички шаблони' },
+  'admin.settings.emailLog.empty': { en: 'No email log entries found.', bg: 'Няма намерени записи в журнала.' },
+  'admin.settings.emailLog.retryError': { en: 'Retry error:', bg: 'Грешка при повторен опит:' },
+  'admin.settings.emailLog.btn.retry': { en: 'Retry', bg: 'Повторен опит' },
+  'admin.settings.emailLog.btn.retrying': { en: 'Retrying…', bg: 'Повторен опит…' },
+  'admin.settings.emailLog.pagination.prev': { en: '← Prev', bg: '← Предишна' },
+  'admin.settings.emailLog.pagination.next': { en: 'Next →', bg: 'Следваща →' },
+
+  // -- Settings: Email Settings Panel --
+  'admin.settings.emailPanel.globalTitle': { en: 'System-wide Email', bg: 'Системни имейли' },
+  'admin.settings.emailPanel.globalDesc': { en: 'Enable or disable all automated outbound emails.', bg: 'Включете или изключете всички автоматизирани изходящи имейли.' },
+  'admin.settings.emailPanel.recipientTitle': { en: 'Admin Alert Recipient', bg: 'Получател на системни сигнали' },
+  'admin.settings.emailPanel.recipientDesc': { en: 'Receives bcc or system alerts if configured.', bg: 'Получава скрито копие или системни сигнали при конфигурация.' },
+  'admin.settings.emailPanel.btn.save': { en: 'Save', bg: 'Запази' },
+  'admin.settings.emailPanel.automatedTitle': { en: 'Automated Notifications', bg: 'Автоматизирани известия' },
 
 } as const


### PR DESCRIPTION
# [2604-CHORE-004e] i18n: wrap literal strings in t() — admin/operations/ + notifications/ + settings/\n\nCloses #47\n\n## What\n\nResolves all `i18next/no-literal-string` warnings across:\n- `app/admin/operations/components/TripForm.tsx`\n- `app/admin/operations/components/TripsTab.tsx`\n- `app/admin/operations/components/PaymentsTab.tsx`\n- `app/admin/operations/components/ItemsTab.tsx`\n- `app/admin/notifications/page.tsx`\n- `app/admin/settings/components/EmailLogTable.tsx`\n- `app/admin/settings/components/EmailSettingsPanel.tsx`\n- `app/admin/settings/page.tsx`\n\n## Approach decision\n\nExtended `lib/i18n/domains/admin.ts` with new key namespaces: `admin.operations.*`, `admin.notifications.*`, `admin.settings.*`. No suppressions — all literals are properly wrapped.\n\n- Client components use `useTranslation()` hook (`const { t } = useTranslation()`)\n- RSC pages (`notifications/page.tsx`, `settings/page.tsx`) use the server-side `t(key, lang)` import from `@/lib/i18n` with `'en'` hardcoded — consistent with the existing pattern for admin RSC pages; email i18n is a separate concern\n\n## Notes\n\n- `TEMPLATE_LABELS` object in `EmailLogTable.tsx` is left as-is — these are internal template identifiers mapped to display labels, not user-facing copy in the i18next sense. No warning is generated for object values that are not rendered directly as JSX children.\n- The `TripsTab` milestone count uses a string replace pattern (`.replace('{{count}} ', '')`) to strip the count placeholder since the count is rendered inline — same pattern established in earlier tickets.\n- `admin.ts` key collision guard (`assertNoDuplicateKeys`) will catch any conflicts with CHORE-005's additions at module init time if both PRs land.\n\n## Session State\n**Status:** DONE\n**Last touched:** `lib/i18n/domains/admin.ts`\n**Completed:**\n- [x] Extended `admin.ts` with `admin.operations.*`, `admin.notifications.*`, `admin.settings.*` keys\n- [x] Wrapped all literals in 8 source files\n- [x] PR opened\n**In flight:** nothing\n**Next:** verify Vercel preview is green, then merge