### PR TITLE
[2604-CHORE-42] fix: resolve ESLint correctness violations

### DIFF
--- a/app/(dashboard)/components/tiles/LocationTile.tsx
+++ b/app/(dashboard)/components/tiles/LocationTile.tsx
@@ -7,8 +7,7 @@ const TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN
 const SOFIA: [number, number] = [23.3219, 42.6977]
 const LIGHT_SHIMMER = '#8A8577'
 
-function getMapStyle(): string {
-  const theme = document.documentElement.getAttribute('data-theme')
+function getMapStyle(theme: string | null): string {
   return theme === 'dark'
     ? 'mapbox://styles/mapbox/dark-v11'
     : 'mapbox://styles/mapbox/light-v11'
@@ -61,15 +60,15 @@ export default function LocationTile({
   rowSpan?: number
   style?: React.CSSProperties
 }) {
+  const { theme, mounted } = useTheme()
+  const isDark = mounted ? theme === 'dark' : false
   const mapContainer = useRef<HTMLDivElement>(null)
   const mapRef = useRef<{ remove: () => void; setStyle: (s: string) => void; once: (e: string, cb: () => void) => void } | null>(null)
   const [ready, setReady] = useState(false)
-  const [isDark, setIsDark] = useState(false)
 
+  // Initialization
   useEffect(() => {
     if (!TOKEN || !mapContainer.current) return
-
-    setIsDark(document.documentElement.getAttribute('data-theme') === 'dark')
 
     function initMap() {
       if (!mapContainer.current) return
@@ -79,7 +78,7 @@ export default function LocationTile({
       mapboxgl.accessToken = TOKEN
       const map = new mapboxgl.Map({
         container: mapContainer.current,
-        style: getMapStyle(),
+        style: getMapStyle(theme),
         center: SOFIA,
         zoom: 12,
         interactive: false,
@@ -109,26 +108,20 @@ export default function LocationTile({
       existing.addEventListener('load', initMap, { once: true })
     }
 
-    const observer = new MutationObserver(() => {
-      const dark = document.documentElement.getAttribute('data-theme') === 'dark'
-      setIsDark(dark)
-      if (mapRef.current) {
-        setReady(false)
-        mapRef.current.setStyle(getMapStyle())
-        mapRef.current.once('styledata', () => setReady(true))
-      }
-    })
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['data-theme'],
-    })
-
     return () => {
-      observer.disconnect()
       mapRef.current?.remove()
       mapRef.current = null
     }
-  }, [])
+  }, []) // Empty deps for single initialization
+
+  // Theme update
+  useEffect(() => {
+    if (mapRef.current && mounted) {
+      setReady(false)
+      mapRef.current.setStyle(getMapStyle(theme))
+      mapRef.current.once('styledata', () => setReady(true))
+    }
+  }, [theme, mounted])
 
   if (!TOKEN) return <LocationFallback colSpan={colSpan} mobileColSpan={mobileColSpan} rowSpan={rowSpan} style={style} />
 

--- a/app/(dashboard)/components/tiles/LocationTile.tsx
+++ b/app/(dashboard)/components/tiles/LocationTile.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import BentoCard from '@/components/bento/BentoCard'
+import { useTheme } from '@/lib/hooks/useTheme'
 
 const TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN
 const SOFIA: [number, number] = [23.3219, 42.6977]

--- a/app/(dashboard)/components/tiles/SocialsTile.tsx
+++ b/app/(dashboard)/components/tiles/SocialsTile.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import BentoCard from '@/components/bento/BentoCard'
 import { useLanguage } from '@/lib/hooks/useLanguage'
@@ -69,8 +70,9 @@ export default function SocialsTile({
 
   const post = data?.post ?? null
 
+  const [now] = useState(() => Date.now())
   function timeAgo(dateStr: string): string {
-    return timeAgoMs(Date.now() - new Date(dateStr).getTime(), t)
+    return timeAgoMs(now - new Date(dateStr).getTime(), t)
   }
 
   return (

--- a/app/(dashboard)/components/tiles/SocialsTile.tsx
+++ b/app/(dashboard)/components/tiles/SocialsTile.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import BentoCard from '@/components/bento/BentoCard'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { TranslationKey } from '@/lib/i18n/translations'
 
 type SocialPost = {
   id: string
@@ -23,7 +24,7 @@ function thumbnailSrc(url: string): string {
   return `/api/socials/thumbnail?src=${encodeURIComponent(url)}`
 }
 
-function timeAgoMs(diff: number, t: (k: string) => string): string {
+function timeAgoMs(diff: number, t: (k: TranslationKey) => string): string {
   const mins  = Math.floor(diff / 60000)
   const hours = Math.floor(diff / 3600000)
   const days  = Math.floor(diff / 86400000)

--- a/app/(dashboard)/components/tiles/SocialsTile.tsx
+++ b/app/(dashboard)/components/tiles/SocialsTile.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import BentoCard from '@/components/bento/BentoCard'
 import { useLanguage } from '@/lib/hooks/useLanguage'
-import { TranslationKey } from '@/lib/i18n/translations'
+import { timeAgoMs } from '@/lib/format'
 
 type SocialPost = {
   id: string
@@ -22,15 +22,6 @@ type SocialsData = {
 
 function thumbnailSrc(url: string): string {
   return `/api/socials/thumbnail?src=${encodeURIComponent(url)}`
-}
-
-function timeAgoMs(diff: number, t: (k: TranslationKey) => string): string {
-  const mins  = Math.floor(diff / 60000)
-  const hours = Math.floor(diff / 3600000)
-  const days  = Math.floor(diff / 86400000)
-  if (mins < 60)  return `${mins}${t('home.time.minutesAgo')}`
-  if (hours < 24) return `${hours}${t('home.time.hoursAgo')}`
-  return `${days}${t('home.time.daysAgo')}`
 }
 
 function InstagramIcon() {

--- a/app/(dashboard)/components/tiles/SocialsTile.tsx
+++ b/app/(dashboard)/components/tiles/SocialsTile.tsx
@@ -22,6 +22,15 @@ function thumbnailSrc(url: string): string {
   return `/api/socials/thumbnail?src=${encodeURIComponent(url)}`
 }
 
+function timeAgoMs(diff: number, t: (k: string) => string): string {
+  const mins  = Math.floor(diff / 60000)
+  const hours = Math.floor(diff / 3600000)
+  const days  = Math.floor(diff / 86400000)
+  if (mins < 60)  return `${mins}${t('home.time.minutesAgo')}`
+  if (hours < 24) return `${hours}${t('home.time.hoursAgo')}`
+  return `${days}${t('home.time.daysAgo')}`
+}
+
 function InstagramIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -61,13 +70,7 @@ export default function SocialsTile({
   const post = data?.post ?? null
 
   function timeAgo(dateStr: string): string {
-    const diff = Date.now() - new Date(dateStr).getTime()
-    const mins  = Math.floor(diff / 60000)
-    const hours = Math.floor(diff / 3600000)
-    const days  = Math.floor(diff / 86400000)
-    if (mins < 60)  return `${mins}${t('home.time.minutesAgo')}`
-    if (hours < 24) return `${hours}${t('home.time.hoursAgo')}`
-    return `${days}${t('home.time.daysAgo')}`
+    return timeAgoMs(Date.now() - new Date(dateStr).getTime(), t)
   }
 
   return (

--- a/app/(dashboard)/guides/page.tsx
+++ b/app/(dashboard)/guides/page.tsx
@@ -14,7 +14,7 @@ export default async function GuidesPage() {
     <GuidesClient
       initialGuides={guides}
       initialLinks={links}
-      initialDataUpdatedAt={Date.now()}
+      initialDataUpdatedAt={0}
     />
   )
 }

--- a/app/(dashboard)/los/components/OrgChartCanvas.tsx
+++ b/app/(dashboard)/los/components/OrgChartCanvas.tsx
@@ -200,40 +200,18 @@ function OrgChartEdge({ x1, y1, x2, y2 }: { x1: number; y1: number; x2: number; 
 
 // ── Main canvas ───────────────────────────────────────────────────────────────
 
-export function OrgChartCanvas({ roots, maxDepth }: { roots: LOSNode[]; maxDepth: number }) {
+type OrgChartInnerProps = {
+  nodes: LayoutNode[]
+  edges: Array<{ x1: number; y1: number; x2: number; y2: number }>
+  svgW: number
+  svgH: number
+}
+
+function OrgChartInner({ nodes, edges, svgW, svgH }: OrgChartInnerProps) {
   const [transform, setTransform] = useState({ x: 0, y: 0, scale: 1 })
   const dragging = useRef(false)
   const lastPos = useRef({ x: 0, y: 0 })
   const containerRef = useRef<HTMLDivElement>(null)
-
-  const { nodes, edges, svgW, svgH } = useMemo(() => {
-    const PADDING = 40
-    const cappedRoots = roots.map(r => capDepth(r, maxDepth))
-
-    // Single bottom-up pass: build width map for all nodes before layout
-    const widthMap = new Map<LOSNode, number>()
-    cappedRoots.forEach(r => buildWidthMap(r, widthMap))
-
-    const rootLayouts: LayoutNode[] = []
-    let cursor = PADDING
-    for (const root of cappedRoots) {
-      const w = widthMap.get(root) ?? CARD_W
-      rootLayouts.push(layoutNode(root, cursor + w / 2, PADDING, widthMap))
-      cursor += w + GAP_X * 2
-    }
-
-    const allNodes = rootLayouts.flatMap(flattenLayout)
-    const allEdges = rootLayouts.flatMap(collectEdges)
-    const bounds = canvasBounds(allNodes)
-    return {
-      nodes: allNodes,
-      edges: allEdges,
-      svgW: Math.max(bounds.maxX + PADDING, 320),
-      svgH: bounds.maxY + PADDING,
-    }
-  }, [roots, maxDepth])
-
-  useEffect(() => { setTransform({ x: 0, y: 0, scale: 1 }) }, [roots, maxDepth])
 
   // ── Pointer drag ─────────────────────────────────────────────────────────────
 
@@ -311,4 +289,40 @@ export function OrgChartCanvas({ roots, maxDepth }: { roots: LOSNode[]; maxDepth
       </div>
     </div>
   )
+}
+
+// OrgChartCanvas computes the layout and passes a `resetKey` as the `key` prop
+// to OrgChartInner so that React remounts it (resetting transform state) when
+// roots or maxDepth change — no effect-based setState required.
+export function OrgChartCanvas({ roots, maxDepth }: { roots: LOSNode[]; maxDepth: number }) {
+  const { nodes, edges, svgW, svgH, resetKey } = useMemo(() => {
+    const PADDING = 40
+    const cappedRoots = roots.map(r => capDepth(r, maxDepth))
+
+    // Single bottom-up pass: build width map for all nodes before layout
+    const widthMap = new Map<LOSNode, number>()
+    cappedRoots.forEach(r => buildWidthMap(r, widthMap))
+
+    const rootLayouts: LayoutNode[] = []
+    let cursor = PADDING
+    for (const root of cappedRoots) {
+      const w = widthMap.get(root) ?? CARD_W
+      rootLayouts.push(layoutNode(root, cursor + w / 2, PADDING, widthMap))
+      cursor += w + GAP_X * 2
+    }
+
+    const allNodes = rootLayouts.flatMap(flattenLayout)
+    const allEdges = rootLayouts.flatMap(collectEdges)
+    const bounds = canvasBounds(allNodes)
+    const key = `${maxDepth}:${roots.map(r => r.abo_number ?? r.profile_id ?? '').join(',')}`
+    return {
+      nodes: allNodes,
+      edges: allEdges,
+      svgW: Math.max(bounds.maxX + PADDING, 320),
+      svgH: bounds.maxY + PADDING,
+      resetKey: key,
+    }
+  }, [roots, maxDepth])
+
+  return <OrgChartInner key={resetKey} nodes={nodes} edges={edges} svgW={svgW} svgH={svgH} />
 }

--- a/app/(dashboard)/los/page.tsx
+++ b/app/(dashboard)/los/page.tsx
@@ -160,9 +160,9 @@ function TreeNode({ node, depth, expanded, onToggleExpand }: {
       <MemberCard node={node} isExpanded={isExpanded} onToggle={() => onToggleExpand(key)} />
       {hasChildren && (
         <div style={{ borderLeft: '2px solid var(--border-default)', marginLeft: 10, paddingLeft: 10 }}>
-          {node.children!.map(child => (
+          {node.children!.map((child, ci) => (
             <TreeNode
-              key={child.abo_number ?? child.profile_id ?? Math.random()}
+              key={child.abo_number ?? child.profile_id ?? `child-${ci}`}
               node={child}
               depth={depth + 1}
               expanded={expanded}
@@ -175,37 +175,39 @@ function TreeNode({ node, depth, expanded, onToggleExpand }: {
   )
 }
 
+// ── Guest view helper ────────────────────────────────────────────────────────
+
+function SimpleRow({ node, label }: { node: LOSNode; label: string }) {
+  const rc = roleColors(node.role)
+  return (
+    <div>
+      <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>
+        {label}
+      </p>
+      <div
+        className="rounded-xl px-4 py-3 flex items-center gap-3"
+        style={{ backgroundColor: 'var(--bg-card)', border: `1px solid ${rc.border}` }}
+      >
+        <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{displayName(node)}</span>
+        {node.abo_number && (
+          <span className="text-xs font-mono" style={{ color: 'var(--text-tertiary)' }}>{node.abo_number}</span>
+        )}
+        <span
+          className="text-[10px] font-bold px-2 py-0.5 rounded-full uppercase ml-auto"
+          style={{ backgroundColor: rc.labelBg, color: rc.labelColor }}
+        >
+          {node.role ?? 'member'}
+        </span>
+      </div>
+    </div>
+  )
+}
+
 // ── Guest view ────────────────────────────────────────────────────────────────
 
 function GuestView({ nodes, callerAbo }: { nodes: LOSNode[]; callerAbo: string | null }) {
   const self = nodes.find(n => n.abo_number === callerAbo) ?? nodes[0]
   const upline = nodes.find(n => n.abo_number !== callerAbo)
-
-  function SimpleRow({ node, label }: { node: LOSNode; label: string }) {
-    const rc = roleColors(node.role)
-    return (
-      <div>
-        <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>
-          {label}
-        </p>
-        <div
-          className="rounded-xl px-4 py-3 flex items-center gap-3"
-          style={{ backgroundColor: 'var(--bg-card)', border: `1px solid ${rc.border}` }}
-        >
-          <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{displayName(node)}</span>
-          {node.abo_number && (
-            <span className="text-xs font-mono" style={{ color: 'var(--text-tertiary)' }}>{node.abo_number}</span>
-          )}
-          <span
-            className="text-[10px] font-bold px-2 py-0.5 rounded-full uppercase ml-auto"
-            style={{ backgroundColor: rc.labelBg, color: rc.labelColor }}
-          >
-            {node.role ?? 'member'}
-          </span>
-        </div>
-      </div>
-    )
-  }
 
   return (
     <div className="space-y-4">
@@ -426,9 +428,9 @@ function LOSPageInner() {
                 {searchLower ? 'No members match your search.' : 'No data available.'}
               </p>
             )}
-            {filteredTree.map(node => (
+            {filteredTree.map((node, ni) => (
               <TreeNode
-                key={node.abo_number ?? node.profile_id ?? Math.random()}
+                key={node.abo_number ?? node.profile_id ?? `node-${ni}`}
                 node={node}
                 depth={0}
                 expanded={expanded}

--- a/app/(dashboard)/notifications/page.tsx
+++ b/app/(dashboard)/notifications/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useNotifications, useMarkRead, useMarkAllRead, useDeleteNotification, useClearAllNotifications } from '@/lib/hooks/useNotifications'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { TranslationKey } from '@/lib/i18n/translations'
 import PageHeading from '@/components/layout/PageHeading'
 import PageContainer from '@/components/layout/PageContainer'
 
@@ -17,7 +18,7 @@ const TYPE_STYLES: Record<string, { bg: string; color: string }> = {
 
 const ALL_TYPES = ['role_request', 'trip_request', 'trip_created', 'event_fetched', 'doc_expiry', 'los_digest']
 
-function computeTimeAgo(dateStr: string, t: (k: string) => string): string {
+function computeTimeAgo(dateStr: string, t: (key: TranslationKey) => string): string {
   const diff = Date.now() - new Date(dateStr).getTime()
   const mins  = Math.floor(diff / 60000)
   const hours = Math.floor(diff / 3600000)

--- a/app/(dashboard)/notifications/page.tsx
+++ b/app/(dashboard)/notifications/page.tsx
@@ -17,6 +17,17 @@ const TYPE_STYLES: Record<string, { bg: string; color: string }> = {
 
 const ALL_TYPES = ['role_request', 'trip_request', 'trip_created', 'event_fetched', 'doc_expiry', 'los_digest']
 
+function computeTimeAgo(dateStr: string, t: (k: string) => string): string {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const mins  = Math.floor(diff / 60000)
+  const hours = Math.floor(diff / 3600000)
+  const days  = Math.floor(diff / 86400000)
+  if (mins < 1)   return t('home.time.justNow')
+  if (mins < 60)  return `${mins}${t('home.time.minutesAgo')}`
+  if (hours < 24) return `${hours}${t('home.time.hoursAgo')}`
+  return `${days}${t('home.time.daysAgo')}`
+}
+
 export default function NotificationsPage() {
   const { data: notifications = [], isLoading } = useNotifications()
   const markRead      = useMarkRead()
@@ -29,16 +40,6 @@ export default function NotificationsPage() {
   const [typeFilter, setTypeFilter] = useState<string>('all')
   const [readFilter, setReadFilter] = useState<'all' | 'unread' | 'read'>('all')
 
-  function timeAgo(dateStr: string): string {
-    const diff = Date.now() - new Date(dateStr).getTime()
-    const mins  = Math.floor(diff / 60000)
-    const hours = Math.floor(diff / 3600000)
-    const days  = Math.floor(diff / 86400000)
-    if (mins < 1)   return t('home.time.justNow')
-    if (mins < 60)  return `${mins}${t('home.time.minutesAgo')}`
-    if (hours < 24) return `${hours}${t('home.time.hoursAgo')}`
-    return `${days}${t('home.time.daysAgo')}`
-  }
 
   const TYPE_LABELS: Record<string, string> = {
     role_request:  t('notif.type.roleRequest'),
@@ -254,7 +255,7 @@ export default function NotificationsPage() {
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0 mt-0.5">
                       <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-                        {timeAgo(n.created_at)}
+                        {computeTimeAgo(n.created_at, t)}
                       </span>
                       <button
                         onClick={(e) => {

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -28,7 +28,7 @@ export function CalendarSection({ profileId }: { profileId: string }) {
       setCalCopied(true)
       setTimeout(() => setCalCopied(false), 2000)
     }
-  }, [calData?.url])
+  }, [calData])
 
   const handleRegenerate = useCallback(() => {
     if (confirm('Regenerate your calendar link? Your old link will stop working.')) regenerateCal.mutate()

--- a/app/(dashboard)/profile/components/PaymentsSection.tsx
+++ b/app/(dashboard)/profile/components/PaymentsSection.tsx
@@ -11,6 +11,39 @@ import { PaymentRow, ShowMoreButton } from './shared'
 
 export const PAYMENTS_MIN_HEIGHT = 280
 
+function groupByItem(payments: GenericPayment[]): Record<string, GenericPayment[]> {
+  const map: Record<string, GenericPayment[]> = {}
+  for (const pay of payments) {
+    const key = pay.payable_items?.title ?? 'Unknown'
+    if (!map[key]) map[key] = []
+    map[key].push(pay)
+  }
+  return map
+}
+
+function PaymentGroups({
+  groups,
+  cancelledTripIds,
+}: {
+  groups: Record<string, GenericPayment[]>
+  cancelledTripIds: Set<string>
+}) {
+  return (
+    <div className="space-y-4">
+      {Object.entries(groups).map(([itemTitle, itemPayments]) => (
+        <div key={itemTitle}>
+          <p className="text-[11px] font-semibold tracking-widest uppercase mb-1.5" style={{ color: 'var(--text-secondary)' }}>{itemTitle}</p>
+          <div className="space-y-1.5">
+            {itemPayments.map(pay => (
+              <PaymentRow key={pay.id} pay={pay} cancelledTripIds={cancelledTripIds} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export function PaymentsSection({ profileId, role }: { profileId: string; role: string }) {
   const { t } = useLanguage()
   const qc = useQueryClient()
@@ -58,33 +91,8 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
   const visiblePayments = allPayments.slice(0, VARIABLE_CAP)
   const overflow = allPayments.length - VARIABLE_CAP
 
-  const groupByItem = (payments: GenericPayment[]) => {
-    const map: Record<string, GenericPayment[]> = {}
-    for (const pay of payments) {
-      const key = pay.payable_items?.title ?? 'Unknown'
-      if (!map[key]) map[key] = []
-      map[key].push(pay)
-    }
-    return map
-  }
-
   const visibleByItem = groupByItem(visiblePayments)
   const allByItem     = groupByItem(allPayments)
-
-  const PaymentGroups = ({ groups }: { groups: Record<string, GenericPayment[]> }) => (
-    <div className="space-y-4">
-      {Object.entries(groups).map(([itemTitle, itemPayments]) => (
-        <div key={itemTitle}>
-          <p className="text-[11px] font-semibold tracking-widest uppercase mb-1.5" style={{ color: 'var(--text-secondary)' }}>{itemTitle}</p>
-          <div className="space-y-1.5">
-            {itemPayments.map(pay => (
-              <PaymentRow key={pay.id} pay={pay} cancelledTripIds={cancelledTripIds} />
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  )
 
   return (
     <>
@@ -98,7 +106,7 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
         {Object.keys(visibleByItem).length === 0 ? (
           <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('payment.none')}</p>
         ) : (
-          <PaymentGroups groups={visibleByItem} />
+          <PaymentGroups groups={visibleByItem} cancelledTripIds={cancelledTripIds} />
         )}
         {overflow > 0 && <ShowMoreButton count={overflow} onClick={() => setListDrawerOpen(true)} />}
       </div>
@@ -114,7 +122,7 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
 
       <Drawer open={listDrawerOpen} onClose={() => setListDrawerOpen(false)} title={t('payment.allPayments')}>
         <div className="space-y-4 mb-6">
-          <PaymentGroups groups={allByItem} />
+          <PaymentGroups groups={allByItem} cancelledTripIds={cancelledTripIds} />
         </div>
         <div className="border-t pt-4" style={{ borderColor: 'var(--border-default)' }}>
           <button

--- a/app/(dashboard)/profile/components/PersonalDetailsContent.tsx
+++ b/app/(dashboard)/profile/components/PersonalDetailsContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { memo, useState, useEffect } from 'react'
+import { memo, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/Drawer'
@@ -75,18 +75,14 @@ export const PersonalDetailsContent = memo(function PersonalDetailsContent({
     display_names?: Record<string, string>
     phone?: string
     contact_email?: string
-  }>({})
+  }>(() => ({
+    first_name:    profile.first_name,
+    last_name:     profile.last_name,
+    display_names: profile.display_names ?? {},
+    phone:         profile.phone ?? '',
+    contact_email: profile.contact_email ?? '',
+  }))
   const [errors, setErrors] = useState<Partial<Record<keyof PersonalFormFields, string>>>({})
-
-  useEffect(() => {
-    setForm({
-      first_name:    profile.first_name,
-      last_name:     profile.last_name,
-      display_names: profile.display_names ?? {},
-      phone:         profile.phone ?? '',
-      contact_email: profile.contact_email ?? '',
-    })
-  }, [profile])
 
   const savePersonal = useMutation({
     mutationFn: async () => {

--- a/app/(dashboard)/profile/components/TravelDocContent.tsx
+++ b/app/(dashboard)/profile/components/TravelDocContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { memo, useState, useEffect } from 'react'
+import { memo, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatDate } from '@/lib/format'
@@ -60,17 +60,13 @@ export const TravelDocContent = memo(function TravelDocContent({
     id_number?: string
     passport_number?: string
     valid_through?: string
-  }>({})
+  }>(() => ({
+    document_active_type: profile.document_active_type,
+    id_number:            profile.id_number ?? '',
+    passport_number:      profile.passport_number ?? '',
+    valid_through:        profile.valid_through ?? '',
+  }))
   const [errors, setErrors] = useState<{ doc_number?: string; valid_through?: string }>({})
-
-  useEffect(() => {
-    setForm({
-      document_active_type: profile.document_active_type,
-      id_number:            profile.id_number ?? '',
-      passport_number:      profile.passport_number ?? '',
-      valid_through:        profile.valid_through ?? '',
-    })
-  }, [profile])
 
   const saveTravelDoc = useMutation({
     mutationFn: async () => {

--- a/app/admin/content/components/AnnouncementsTab.tsx
+++ b/app/admin/content/components/AnnouncementsTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Drawer } from '@/components/ui/Drawer'
 import {
@@ -59,8 +59,12 @@ export function AnnouncementsTab() {
     queryKey: ['announcements'],
     queryFn: () => fetch('/api/admin/announcements').then(r => r.json()),
   })
-  const [localAnnouncements, setLocalAnnouncements] = useState<Announcement[]>([])
-  useEffect(() => { setLocalAnnouncements([...announcementsRaw]) }, [announcementsRaw])
+  const [localAnnouncements, setLocalAnnouncements] = useState<Announcement[]>(() => [...announcementsRaw])
+  const prevAnnouncementsRaw = useRef(announcementsRaw)
+  if (prevAnnouncementsRaw.current !== announcementsRaw) {
+    prevAnnouncementsRaw.current = announcementsRaw
+    setLocalAnnouncements([...announcementsRaw])
+  }
 
   const reorderAnnouncements = useMutation({
     mutationFn: (items: { id: string; sort_order: number }[]) =>

--- a/app/admin/content/components/AnnouncementsTab.tsx
+++ b/app/admin/content/components/AnnouncementsTab.tsx
@@ -60,9 +60,9 @@ export function AnnouncementsTab() {
     queryFn: () => fetch('/api/admin/announcements').then(r => r.json()),
   })
   const [localAnnouncements, setLocalAnnouncements] = useState<Announcement[]>(() => [...announcementsRaw])
-  const prevAnnouncementsRaw = useRef(announcementsRaw)
-  if (prevAnnouncementsRaw.current !== announcementsRaw) {
-    prevAnnouncementsRaw.current = announcementsRaw
+  const [prevAnnouncementsRaw, setPrevAnnouncementsRaw] = useState(announcementsRaw)
+  if (prevAnnouncementsRaw !== announcementsRaw) {
+    setPrevAnnouncementsRaw(announcementsRaw)
     setLocalAnnouncements([...announcementsRaw])
   }
 

--- a/app/admin/content/components/AnnouncementsTab.tsx
+++ b/app/admin/content/components/AnnouncementsTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Drawer } from '@/components/ui/Drawer'
 import {
@@ -20,6 +20,7 @@ import { makeDragHandlers } from './useDragSort'
 import { RoleSelector } from '@/app/admin/components/RoleSelector'
 import { LangTabs } from '@/app/admin/components/LangTabs'
 import { I18nField } from '@/app/admin/components/I18nField'
+import { formatDate } from '@/lib/format'
 
 type Announcement = {
   id: string; titles: Record<string,string>; contents: Record<string,string>
@@ -168,7 +169,7 @@ export function AnnouncementsTab() {
             key={a.id}
             grip
             title={a.titles.en ?? a.titles.bg ?? 'Untitled'}
-            sub={new Date(a.created_at).toLocaleDateString('en-GB').replace(/\//g, '.')}
+            sub={formatDate(a.created_at)}
             dragging={aDrag.isDragging(a.id)}
             onDragStart={() => aDrag.onDragStart(a.id)}
             onDragOver={e => aDrag.onDragOver(e, a.id)}

--- a/app/admin/content/components/GuidesTab.tsx
+++ b/app/admin/content/components/GuidesTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Drawer } from '@/components/ui/Drawer'
 import {
@@ -30,8 +30,12 @@ export function GuidesTab() {
     queryKey: ['admin-guides'],
     queryFn: () => fetch('/api/admin/guides').then(r => r.json()),
   })
-  const [localGuides, setLocalGuides] = useState<Guide[]>([])
-  useEffect(() => { setLocalGuides([...guidesRaw]) }, [guidesRaw])
+  const [localGuides, setLocalGuides] = useState<Guide[]>(() => [...guidesRaw])
+  const prevGuidesRaw = useRef(guidesRaw)
+  if (prevGuidesRaw.current !== guidesRaw) {
+    prevGuidesRaw.current = guidesRaw
+    setLocalGuides([...guidesRaw])
+  }
 
   const reorderGuides = useMutation({
     mutationFn: (items: { id: string; sort_order: number }[]) =>

--- a/app/admin/content/components/GuidesTab.tsx
+++ b/app/admin/content/components/GuidesTab.tsx
@@ -31,9 +31,9 @@ export function GuidesTab() {
     queryFn: () => fetch('/api/admin/guides').then(r => r.json()),
   })
   const [localGuides, setLocalGuides] = useState<Guide[]>(() => [...guidesRaw])
-  const prevGuidesRaw = useRef(guidesRaw)
-  if (prevGuidesRaw.current !== guidesRaw) {
-    prevGuidesRaw.current = guidesRaw
+  const [prevGuidesRaw, setPrevGuidesRaw] = useState(guidesRaw)
+  if (prevGuidesRaw !== guidesRaw) {
+    setPrevGuidesRaw(guidesRaw)
     setLocalGuides([...guidesRaw])
   }
 

--- a/app/admin/content/components/LinksTab.tsx
+++ b/app/admin/content/components/LinksTab.tsx
@@ -52,9 +52,9 @@ export function LinksTab() {
     queryFn: () => fetch('/api/admin/links').then(r => r.json()),
   })
   const [localLinks, setLocalLinks] = useState<SiteLink[]>(() => [...linksRaw])
-  const prevLinksRaw = useRef(linksRaw)
-  if (prevLinksRaw.current !== linksRaw) {
-    prevLinksRaw.current = linksRaw
+  const [prevLinksRaw, setPrevLinksRaw] = useState(linksRaw)
+  if (prevLinksRaw !== linksRaw) {
+    setPrevLinksRaw(linksRaw)
     setLocalLinks([...linksRaw])
   }
 

--- a/app/admin/content/components/LinksTab.tsx
+++ b/app/admin/content/components/LinksTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Drawer } from '@/components/ui/Drawer'
 import {
@@ -51,8 +51,12 @@ export function LinksTab() {
     queryKey: ['admin-links'],
     queryFn: () => fetch('/api/admin/links').then(r => r.json()),
   })
-  const [localLinks, setLocalLinks] = useState<SiteLink[]>([])
-  useEffect(() => { setLocalLinks([...linksRaw]) }, [linksRaw])
+  const [localLinks, setLocalLinks] = useState<SiteLink[]>(() => [...linksRaw])
+  const prevLinksRaw = useRef(linksRaw)
+  if (prevLinksRaw.current !== linksRaw) {
+    prevLinksRaw.current = linksRaw
+    setLocalLinks([...linksRaw])
+  }
 
   const reorderLinks = useMutation({
     mutationFn: (items: { id: string; sort_order: number }[]) =>

--- a/app/admin/content/components/SocialTab.tsx
+++ b/app/admin/content/components/SocialTab.tsx
@@ -164,8 +164,12 @@ export function SocialTab() {
     queryKey: ['admin-social-posts'],
     queryFn: () => fetch('/api/admin/social-posts').then(r => r.json()),
   })
-  const [localSocials, setLocalSocials] = useState<SocialPost[]>([])
-  useEffect(() => { setLocalSocials([...socialPostsRaw]) }, [socialPostsRaw])
+  const [localSocials, setLocalSocials] = useState<SocialPost[]>(() => [...socialPostsRaw])
+  const [prevSocialsRaw, setPrevSocialsRaw] = useState(socialPostsRaw)
+  if (prevSocialsRaw !== socialPostsRaw) {
+    setPrevSocialsRaw(socialPostsRaw)
+    setLocalSocials([...socialPostsRaw])
+  }
 
   const reorderSocials = useMutation({
     mutationFn: (items: { id: string; sort_order: number }[]) =>

--- a/app/admin/members/components/LosTab.tsx
+++ b/app/admin/members/components/LosTab.tsx
@@ -82,9 +82,9 @@ function VitalSignsConfig({ definitions, onRefetch }: {
   )
 
   const defsKey = definitions.map(d => d.id + d.is_active + d.sort_order).join(',')
-  const prevKey = useRef(defsKey)
-  if (prevKey.current !== defsKey) {
-    prevKey.current = defsKey
+  const [prevKey, setPrevKey] = useState(defsKey)
+  if (prevKey !== defsKey) {
+    setPrevKey(defsKey)
     setLocalDefs([...definitions].sort((a, b) => a.sort_order - b.sort_order))
   }
 

--- a/app/api/admin/event-role-requests/[id]/route.ts
+++ b/app/api/admin/event-role-requests/[id]/route.ts
@@ -29,8 +29,9 @@ export async function PATCH(
   if (!error && data?.profile) {
     const profileData = data.profile as { first_name: string | null; contact_email: string | null }
     const eventData = data.event as { title: string; start_time: string }
+    const contactEmail = profileData.contact_email
 
-    if (profileData.contact_email) {
+    if (contactEmail) {
       import('@/lib/email/send').then(({ sendNotificationEmail }) => {
         import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
           import('@/lib/email/templates/EventRoleRequestEmail').then(({ EventRoleRequestEmail }) => {
@@ -44,7 +45,7 @@ export async function PATCH(
               })
             ).then(html => {
               sendNotificationEmail({
-                to: profileData.contact_email,
+                to: contactEmail,
                 subject: `Event Role Request ${status === 'approved' ? 'Approved ✓' : 'Declined'}`,
                 html,
                 template: 'event_role_request_result',

--- a/app/api/admin/event-role-requests/[id]/route.ts
+++ b/app/api/admin/event-role-requests/[id]/route.ts
@@ -27,8 +27,8 @@ export async function PATCH(
     .single()
 
   if (!error && data?.profile) {
-    const profileData = data.profile as any
-    const eventData = data.event as any
+    const profileData = data.profile as { first_name: string | null; contact_email: string | null }
+    const eventData = data.event as { title: string; start_time: string }
 
     if (profileData.contact_email) {
       import('@/lib/email/send').then(({ sendNotificationEmail }) => {

--- a/app/api/admin/members/verify/[id]/route.ts
+++ b/app/api/admin/members/verify/[id]/route.ts
@@ -61,7 +61,7 @@ export async function PATCH(
     }
 
     // Notify the user. Best-effort: failure here does not affect approval state.
-    const profile = verReq.profile as any
+    const profile = verReq.profile as { id: string; role: string; first_name: string | null; contact_email: string | null }
     const notifMessage = verReq.request_type === 'manual'
       ? `Welcome ${profile?.first_name ?? ''}! Your manual verification has been approved. You are now a Member.`
       : `Welcome ${profile?.first_name ?? ''}! Your ABO number ${verReq.claimed_abo} has been verified. You are now a Member.`
@@ -142,7 +142,7 @@ export async function PATCH(
       .eq('id', id)
       .select().single()
 
-    const profile = verReq.profile as any
+    const profile = verReq.profile as { id: string; role: string; first_name: string | null; contact_email: string | null }
     if (!error && profile?.contact_email) {
       import('@/lib/email/send').then(({ sendNotificationEmail }) => {
         import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {

--- a/app/api/admin/members/verify/[id]/route.ts
+++ b/app/api/admin/members/verify/[id]/route.ts
@@ -62,6 +62,7 @@ export async function PATCH(
 
     // Notify the user. Best-effort: failure here does not affect approval state.
     const profile = verReq.profile as { id: string; role: string; first_name: string | null; contact_email: string | null }
+    const approveContactEmail = profile?.contact_email
     const notifMessage = verReq.request_type === 'manual'
       ? `Welcome ${profile?.first_name ?? ''}! Your manual verification has been approved. You are now a Member.`
       : `Welcome ${profile?.first_name ?? ''}! Your ABO number ${verReq.claimed_abo} has been verified. You are now a Member.`
@@ -74,7 +75,7 @@ export async function PATCH(
       action_url: '/profile',
     })
 
-    if (profile?.contact_email) {
+    if (approveContactEmail) {
       import('@/lib/email/send').then(({ sendNotificationEmail }) => {
         import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
           import('@/lib/email/templates/AboVerificationEmail').then(({ AboVerificationEmail }) => {
@@ -87,7 +88,7 @@ export async function PATCH(
               })
             ).then(html => {
               sendNotificationEmail({
-                to: profile.contact_email,
+                to: approveContactEmail,
                 subject: `ABO Verification Approved ✓`,
                 html,
                 template: 'abo_verification_result',
@@ -101,7 +102,7 @@ export async function PATCH(
               renderEmailTemplate(WelcomeEmail({ firstName: profile.first_name || 'Member' }))
                 .then(html => {
                   sendNotificationEmail({
-                    to: profile.contact_email,
+                    to: approveContactEmail,
                     subject: 'Welcome to Team Enjoy VD!',
                     html,
                     template: 'abo_verification_result',
@@ -143,7 +144,8 @@ export async function PATCH(
       .select().single()
 
     const profile = verReq.profile as { id: string; role: string; first_name: string | null; contact_email: string | null }
-    if (!error && profile?.contact_email) {
+    const denyContactEmail = profile?.contact_email
+    if (!error && denyContactEmail) {
       import('@/lib/email/send').then(({ sendNotificationEmail }) => {
         import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
           import('@/lib/email/templates/AboVerificationEmail').then(({ AboVerificationEmail }) => {
@@ -156,7 +158,7 @@ export async function PATCH(
               })
             ).then(html => {
               sendNotificationEmail({
-                to: profile.contact_email,
+                to: denyContactEmail,
                 subject: `ABO Verification Declined`,
                 html,
                 template: 'abo_verification_result',

--- a/app/api/admin/registrations/[id]/route.ts
+++ b/app/api/admin/registrations/[id]/route.ts
@@ -31,7 +31,8 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   // Trigger email asynchronously
   const regProfile = data.profile as { id: string; first_name: string | null; contact_email: string | null }
   const regTrip = data.trip as { id: string; title: string; destination: string | null; start_date: string | null; end_date: string | null }
-  if (regProfile?.contact_email) {
+  const regContactEmail = regProfile?.contact_email
+  if (regContactEmail) {
     renderEmailTemplate(
       TripRegistrationEmail({
         firstName: regProfile.first_name || 'Member',
@@ -43,7 +44,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
       })
     ).then((html) => {
       sendNotificationEmail({
-        to: regProfile.contact_email,
+        to: regContactEmail,
         subject: `Trip Registration ${status === 'approved' ? 'Approved ✓' : 'Declined'}`,
         html,
         template: 'trip_registration_status',

--- a/app/api/admin/registrations/[id]/route.ts
+++ b/app/api/admin/registrations/[id]/route.ts
@@ -29,8 +29,8 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   if (error) return Response.json({ error: error.message }, { status: 500 })
 
   // Trigger email asynchronously
-  const regProfile = data.profile as any
-  const regTrip = data.trip as any
+  const regProfile = data.profile as { id: string; first_name: string | null; contact_email: string | null }
+  const regTrip = data.trip as { id: string; title: string; destination: string | null; start_date: string | null; end_date: string | null }
   if (regProfile?.contact_email) {
     renderEmailTemplate(
       TripRegistrationEmail({

--- a/app/api/admin/registrations/[id]/route.ts
+++ b/app/api/admin/registrations/[id]/route.ts
@@ -37,9 +37,9 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
       TripRegistrationEmail({
         firstName: regProfile.first_name || 'Member',
         tripTitle: regTrip.title,
-        destination: regTrip.destination,
-        startDate: regTrip.start_date,
-        endDate: regTrip.end_date,
+        destination: regTrip.destination ?? '',
+        startDate: regTrip.start_date ?? '',
+        endDate: regTrip.end_date ?? '',
         status: status as 'approved' | 'denied',
       })
     ).then((html) => {

--- a/app/api/admin/settings/email/retry/[id]/route.ts
+++ b/app/api/admin/settings/email/retry/[id]/route.ts
@@ -1,3 +1,4 @@
+import type * as React from 'react'
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { requireAdmin } from '@/lib/supabase/guards'
@@ -11,7 +12,7 @@ import { PaymentSubmittedEmail } from '@/lib/email/templates/PaymentSubmittedEma
 import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
 import { WelcomeEmail } from '@/lib/email/templates/WelcomeEmail'
 
-type EmailTemplateComponent = (props: Record<string, unknown>) => JSX.Element
+type EmailTemplateComponent = (props: Record<string, unknown>) => React.ReactElement
 
 // Map template keys to their visual components for rendering during retry
 const TEMPLATE_COMPONENTS: Record<string, EmailTemplateComponent> = {

--- a/app/api/admin/settings/email/retry/[id]/route.ts
+++ b/app/api/admin/settings/email/retry/[id]/route.ts
@@ -11,8 +11,10 @@ import { PaymentSubmittedEmail } from '@/lib/email/templates/PaymentSubmittedEma
 import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
 import { WelcomeEmail } from '@/lib/email/templates/WelcomeEmail'
 
+type EmailTemplateComponent = (props: Record<string, unknown>) => JSX.Element
+
 // Map template keys to their visual components for rendering during retry
-const TEMPLATE_COMPONENTS: Record<string, any> = {
+const TEMPLATE_COMPONENTS: Record<string, EmailTemplateComponent> = {
   welcome: WelcomeEmail,
   payment_status: PaymentStatusEmail,
   document_expiring_soon: DocumentExpiryEmail,
@@ -52,7 +54,7 @@ export async function POST(
   if (!TemplateComponent) return Response.json({ error: `No renderer for template: ${log.template}` }, { status: 500 })
 
   try {
-    const html = await renderEmailTemplate(TemplateComponent(log.payload as any))
+    const html = await renderEmailTemplate(TemplateComponent(log.payload as Record<string, unknown>))
 
     // 3. Re-invoke sendNotificationEmail — bypasses no gates since this is an
     //    admin-triggered retry; a new email_log row is written by the dispatcher.
@@ -68,7 +70,7 @@ export async function POST(
     await supabase.from('email_log').update({ status: 'retried' }).eq('id', id)
 
     return Response.json({ success: true })
-  } catch (err: any) {
-    return Response.json({ error: err.message }, { status: 500 })
+  } catch (err: unknown) {
+    return Response.json({ error: (err as Error).message }, { status: 500 })
   }
 }

--- a/app/api/admin/settings/email/retry/[id]/route.ts
+++ b/app/api/admin/settings/email/retry/[id]/route.ts
@@ -12,19 +12,19 @@ import { PaymentSubmittedEmail } from '@/lib/email/templates/PaymentSubmittedEma
 import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
 import { WelcomeEmail } from '@/lib/email/templates/WelcomeEmail'
 
-type EmailTemplateComponent = (props: Record<string, unknown>) => React.ReactElement
+type EmailTemplateComponent = React.ComponentType<Record<string, unknown>>
 
 // Map template keys to their visual components for rendering during retry
 const TEMPLATE_COMPONENTS: Record<string, EmailTemplateComponent> = {
-  welcome: WelcomeEmail,
-  payment_status: PaymentStatusEmail,
-  document_expiring_soon: DocumentExpiryEmail,
-  doc_expiry: DocumentExpiryEmail,
-  abo_verification_result: AboVerificationEmail,
-  trip_registration_status: TripRegistrationEmail,
-  event_role_request_result: EventRoleRequestEmail,
-  trip_registration_cancelled: TripRegistrationEmail,
-  payment_submitted: PaymentSubmittedEmail,
+  welcome: WelcomeEmail as EmailTemplateComponent,
+  payment_status: PaymentStatusEmail as EmailTemplateComponent,
+  document_expiring_soon: DocumentExpiryEmail as EmailTemplateComponent,
+  doc_expiry: DocumentExpiryEmail as EmailTemplateComponent,
+  abo_verification_result: AboVerificationEmail as EmailTemplateComponent,
+  trip_registration_status: TripRegistrationEmail as EmailTemplateComponent,
+  event_role_request_result: EventRoleRequestEmail as EmailTemplateComponent,
+  trip_registration_cancelled: TripRegistrationEmail as EmailTemplateComponent,
+  payment_submitted: PaymentSubmittedEmail as EmailTemplateComponent,
 }
 
 export async function POST(

--- a/app/api/admin/settings/email/retry/[id]/route.ts
+++ b/app/api/admin/settings/email/retry/[id]/route.ts
@@ -1,4 +1,4 @@
-import type * as React from 'react'
+import * as React from 'react'
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { requireAdmin } from '@/lib/supabase/guards'
@@ -12,21 +12,22 @@ import { PaymentSubmittedEmail } from '@/lib/email/templates/PaymentSubmittedEma
 import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
 import { WelcomeEmail } from '@/lib/email/templates/WelcomeEmail'
 
-// React.FC<P> is always callable — React.ComponentType<P> is FC | ComponentClass,
-// and ComponentClass has no call signature, causing a TS error at the call site.
-type EmailTemplateFC = React.FC<Record<string, unknown>>
+// Use ComponentType so React.createElement can accept it.
+// Calling an FC directly returns ReactNode (which includes undefined in React 18+),
+// not ReactElement — so React.createElement is the correct call site.
+type EmailTemplateComponent = React.ComponentType<Record<string, unknown>>
 
 // Map template keys to their visual components for rendering during retry
-const TEMPLATE_COMPONENTS: Record<string, EmailTemplateFC> = {
-  welcome: WelcomeEmail as EmailTemplateFC,
-  payment_status: PaymentStatusEmail as EmailTemplateFC,
-  document_expiring_soon: DocumentExpiryEmail as EmailTemplateFC,
-  doc_expiry: DocumentExpiryEmail as EmailTemplateFC,
-  abo_verification_result: AboVerificationEmail as EmailTemplateFC,
-  trip_registration_status: TripRegistrationEmail as EmailTemplateFC,
-  event_role_request_result: EventRoleRequestEmail as EmailTemplateFC,
-  trip_registration_cancelled: TripRegistrationEmail as EmailTemplateFC,
-  payment_submitted: PaymentSubmittedEmail as EmailTemplateFC,
+const TEMPLATE_COMPONENTS: Record<string, EmailTemplateComponent> = {
+  welcome: WelcomeEmail as EmailTemplateComponent,
+  payment_status: PaymentStatusEmail as EmailTemplateComponent,
+  document_expiring_soon: DocumentExpiryEmail as EmailTemplateComponent,
+  doc_expiry: DocumentExpiryEmail as EmailTemplateComponent,
+  abo_verification_result: AboVerificationEmail as EmailTemplateComponent,
+  trip_registration_status: TripRegistrationEmail as EmailTemplateComponent,
+  event_role_request_result: EventRoleRequestEmail as EmailTemplateComponent,
+  trip_registration_cancelled: TripRegistrationEmail as EmailTemplateComponent,
+  payment_submitted: PaymentSubmittedEmail as EmailTemplateComponent,
 }
 
 export async function POST(
@@ -57,7 +58,10 @@ export async function POST(
   if (!TemplateComponent) return Response.json({ error: `No renderer for template: ${log.template}` }, { status: 500 })
 
   try {
-    const html = await renderEmailTemplate(TemplateComponent(log.payload as Record<string, unknown>))
+    // React.createElement always returns ReactElement — safe to pass to renderEmailTemplate.
+    // Calling TemplateComponent(props) directly returns ReactNode (includes undefined in React 18).
+    const element = React.createElement(TemplateComponent, log.payload as Record<string, unknown>)
+    const html = await renderEmailTemplate(element)
 
     // 3. Re-invoke sendNotificationEmail — bypasses no gates since this is an
     //    admin-triggered retry; a new email_log row is written by the dispatcher.

--- a/app/api/admin/settings/email/retry/[id]/route.ts
+++ b/app/api/admin/settings/email/retry/[id]/route.ts
@@ -12,19 +12,21 @@ import { PaymentSubmittedEmail } from '@/lib/email/templates/PaymentSubmittedEma
 import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
 import { WelcomeEmail } from '@/lib/email/templates/WelcomeEmail'
 
-type EmailTemplateComponent = React.ComponentType<Record<string, unknown>>
+// React.FC<P> is always callable — React.ComponentType<P> is FC | ComponentClass,
+// and ComponentClass has no call signature, causing a TS error at the call site.
+type EmailTemplateFC = React.FC<Record<string, unknown>>
 
 // Map template keys to their visual components for rendering during retry
-const TEMPLATE_COMPONENTS: Record<string, EmailTemplateComponent> = {
-  welcome: WelcomeEmail as EmailTemplateComponent,
-  payment_status: PaymentStatusEmail as EmailTemplateComponent,
-  document_expiring_soon: DocumentExpiryEmail as EmailTemplateComponent,
-  doc_expiry: DocumentExpiryEmail as EmailTemplateComponent,
-  abo_verification_result: AboVerificationEmail as EmailTemplateComponent,
-  trip_registration_status: TripRegistrationEmail as EmailTemplateComponent,
-  event_role_request_result: EventRoleRequestEmail as EmailTemplateComponent,
-  trip_registration_cancelled: TripRegistrationEmail as EmailTemplateComponent,
-  payment_submitted: PaymentSubmittedEmail as EmailTemplateComponent,
+const TEMPLATE_COMPONENTS: Record<string, EmailTemplateFC> = {
+  welcome: WelcomeEmail as EmailTemplateFC,
+  payment_status: PaymentStatusEmail as EmailTemplateFC,
+  document_expiring_soon: DocumentExpiryEmail as EmailTemplateFC,
+  doc_expiry: DocumentExpiryEmail as EmailTemplateFC,
+  abo_verification_result: AboVerificationEmail as EmailTemplateFC,
+  trip_registration_status: TripRegistrationEmail as EmailTemplateFC,
+  event_role_request_result: EventRoleRequestEmail as EmailTemplateFC,
+  trip_registration_cancelled: TripRegistrationEmail as EmailTemplateFC,
+  payment_submitted: PaymentSubmittedEmail as EmailTemplateFC,
 }
 
 export async function POST(

--- a/app/api/admin/settings/email/route.ts
+++ b/app/api/admin/settings/email/route.ts
@@ -23,7 +23,7 @@ export async function PATCH(req: Request) {
     }
 
     return Response.json({ success: true, email_config: payload })
-  } catch (err: any) {
-    return Response.json({ error: err.message }, { status: 400 })
+  } catch (err: unknown) {
+    return Response.json({ error: (err as Error).message }, { status: 400 })
   }
 }

--- a/app/api/profile/payments/route.ts
+++ b/app/api/profile/payments/route.ts
@@ -91,8 +91,8 @@ export async function POST(req: Request): Promise<Response> {
   if (error) return Response.json({ error: error.message }, { status: 500 })
 
   // Trigger admin alert asynchronously
-  const tripsData = data.trips as any
-  const itemsData = data.payable_items as any
+  const tripsData = data.trips as { title: string } | null
+  const itemsData = data.payable_items as { title: string } | null
   const itemTitle = tripsData?.title || itemsData?.title || 'Unknown Item'
 
   import('@/lib/email/send').then(({ sendNotificationEmail, getEmailConfig }) => {

--- a/components/layout/NotificationPopup.tsx
+++ b/components/layout/NotificationPopup.tsx
@@ -30,7 +30,7 @@ export default function NotificationPopup({ onClose }: Props) {
   function handleItemClick(id: string, actionUrl: string | null) {
     if (!markRead.isPending) markRead.mutate(id)
     onClose()
-    if (actionUrl) window.location.href = actionUrl
+    if (actionUrl) window.location.assign(actionUrl)
   }
 
   return (

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -4,6 +4,8 @@
 // timeZone is explicit on every formatter — Vercel server runs UTC; without
 // this, server and client produce different strings → React hydration error #418.
 
+import { TranslationKey } from '@/lib/i18n/translations'
+
 const TZ = 'Europe/Sofia'
 
 /** 18.03.2026 */
@@ -87,4 +89,24 @@ export function formatDateLongEn(iso: string): string {
     year: 'numeric',
     timeZone: TZ,
   })
+}
+
+/**
+ * Canonical relative-time formatter. Accepts an elapsed-ms diff and a typed
+ * translation function. Handles clock skew (negative diff) and sub-minute
+ * resolution via the 'home.time.justNow' key.
+ *
+ * Used by: SocialsTile (and any future component needing "X ago" strings).
+ */
+export function timeAgoMs(
+  diff: number,
+  t: (k: TranslationKey) => string,
+): string {
+  if (diff < 60000) return t('home.time.justNow')
+  const mins  = Math.floor(diff / 60000)
+  const hours = Math.floor(diff / 3600000)
+  const days  = Math.floor(diff / 86400000)
+  if (mins < 60)  return `${mins}${t('home.time.minutesAgo')}`
+  if (hours < 24) return `${hours}${t('home.time.hoursAgo')}`
+  return `${days}${t('home.time.daysAgo')}`
 }

--- a/lib/hooks/useTheme.ts
+++ b/lib/hooks/useTheme.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useSyncExternalStore } from 'react'
 
 export type Theme = 'light' | 'dark'
 
@@ -12,6 +12,35 @@ export function applyTheme(t: Theme) {
   localStorage.setItem(STORAGE_KEY, t)
 }
 
+function subscribe(callback: () => void) {
+  if (typeof window === 'undefined') return () => {}
+
+  const onCustom = () => callback()
+  const onStorage = (e: StorageEvent) => {
+    // eslint-disable-next-line i18next/no-literal-string
+    if (e.key === STORAGE_KEY && (e.newValue === 'light' || e.newValue === 'dark')) {
+      document.documentElement.setAttribute('data-theme', e.newValue)
+    }
+    callback()
+  }
+
+  window.addEventListener('tevd-theme-change', onCustom)
+  window.addEventListener('storage', onStorage)
+  return () => {
+    window.removeEventListener('tevd-theme-change', onCustom)
+    window.removeEventListener('storage', onStorage)
+  }
+}
+
+function getSnapshot() {
+  if (typeof window === 'undefined') return 'light'
+  return (localStorage.getItem(STORAGE_KEY) as Theme | null) ?? 'light'
+}
+
+function getServerSnapshot() {
+  return 'light' as Theme
+}
+
 /**
  * Single-source-of-truth theme hook.
  * All consumers (ThemeTile, UserDropdown, UserPopup) use this.
@@ -19,42 +48,16 @@ export function applyTheme(t: Theme) {
  * and across tabs via the standard 'storage' event.
  */
 export function useTheme() {
-  // eslint-disable-next-line i18next/no-literal-string
-  const [theme, setTheme] = useState<Theme>('light')
+  const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
-    // Read initial value — the inline script in layout.tsx will already have
-    // applied it to <html>, so no flash. We just need the React state to match.
-    // eslint-disable-next-line i18next/no-literal-string
-    const stored = (localStorage.getItem(STORAGE_KEY) as Theme | null) ?? 'light'
-    setTheme(stored)
     setMounted(true)
-
-    function onCustom(e: Event) {
-      const next = (e as CustomEvent<Theme>).detail
-      setTheme(next)
-    }
-    function onStorage(e: StorageEvent) {
-      // eslint-disable-next-line i18next/no-literal-string
-      if (e.key === STORAGE_KEY && (e.newValue === 'light' || e.newValue === 'dark')) {
-        setTheme(e.newValue)
-        document.documentElement.setAttribute('data-theme', e.newValue)
-      }
-    }
-
-    window.addEventListener('tevd-theme-change', onCustom)
-    window.addEventListener('storage', onStorage)
-    return () => {
-      window.removeEventListener('tevd-theme-change', onCustom)
-      window.removeEventListener('storage', onStorage)
-    }
   }, [])
 
   const toggle = useCallback(() => {
     // eslint-disable-next-line i18next/no-literal-string
     const next: Theme = theme === 'light' ? 'dark' : 'light'
-    setTheme(next)
     applyTheme(next)
     window.dispatchEvent(new CustomEvent('tevd-theme-change', { detail: next }))
   }, [theme])


### PR DESCRIPTION
## Summary

Resolves all ESLint correctness violations surfaced by the lint step added in `2604-CHORE-007`. Fixed: `react-hooks/rules-of-hooks` (static component definitions inside render), impure render expressions (`Math.random()`, `Date.now()`), `useEffect+setState` anti-patterns, render-time ref mutation, immutability violations, broken memoization deps, `no-explicit-any` in API routes.

Closes #42

## Session State
**Status:** DONE
**Completed:**
- [x] `SimpleRow` hoisted out of `GuestView` — `app/(dashboard)/los/page.tsx`
- [x] `Math.random()` keys replaced with index — `app/(dashboard)/los/page.tsx`
- [x] `Date.now()` in RSC render → `0` — `app/(dashboard)/guides/page.tsx`
- [x] `PaymentGroup` hoisted out of `PaymentsSection` — `app/(dashboard)/profile/components/PaymentsSection.tsx`
- [x] `OrgChartCanvas` reset-on-prop-change → `key` pattern — `app/(dashboard)/los/components/OrgChartCanvas.tsx`
- [x] `LocationTile` — `setIsDark` + `MutationObserver` → `useTheme()` — `app/(dashboard)/components/tiles/LocationTile.tsx`
- [x] `useTheme.ts` — refactored to `useSyncExternalStore` — `lib/hooks/useTheme.ts`
- [x] `CalendarSection` — `useCallback` dep broadened — `app/(dashboard)/profile/components/CalendarSection.tsx`
- [x] `NotificationPopup` — `window.location.href` → `window.location.assign()` — `components/layout/NotificationPopup.tsx`
- [x] `LosTab` — render-time ref mutation → `useState` derived — `app/admin/members/components/LosTab.tsx`
- [x] `PersonalDetailsContent` / `TravelDocContent` — `useEffect+setForm` → lazy `useState` — profile components
- [x] `AnnouncementsTab`, `GuidesTab`, `LinksTab`, `SocialTab` — `useEffect+setState` → render-time derived — `app/admin/content/components/`
- [x] `SocialsTile` — `Date.now()` → `useState(() => Date.now())` — `app/(dashboard)/components/tiles/SocialsTile.tsx`
- [x] `NotificationsPage` — `timeAgo` hoisted to module scope — `app/(dashboard)/notifications/page.tsx`
- [x] `admin/event-role-requests/[id]` — `any` → typed shapes
- [x] `admin/members/verify/[id]` — `any` → typed shapes
- [x] 4 additional API routes — `any` removed (`settings/email/retry/[id]`, `settings/email`, `registrations/[id]`, `profile/payments`)
- [x] `useTheme.ts` `setMounted` — confirmed non-issue (stable setter, `exhaustive-deps` does not flag stable dispatchers)
- [x] `MembersTab.tsx` `useReactTable` — confirmed non-issue, correct usage
- [x] `EventRolesTab.tsx` `no-unescaped-entities` — file does not exist in repo, violation resolved by prior work
**Next:** Merge via GitHub UI → confirm production Vercel deployment READY
