### PR TITLE
[2604-FEAT-55] /profile — increase bento box drag handle hit area

### DIFF
--- a/app/(dashboard)/profile/components/SortableBento.tsx
+++ b/app/(dashboard)/profile/components/SortableBento.tsx
@@ -13,7 +13,7 @@ const DragHandle = forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElem
         {...props}
         ref={ref}
         title="Drag to reorder"
-        style={{ cursor: 'grab', touchAction: 'none', userSelect: 'none', fontSize: 14, lineHeight: 1, color: 'var(--text-secondary)', opacity: 0.5, flexShrink: 0 }}
+        style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: 44, minHeight: 44, cursor: 'grab', touchAction: 'none', userSelect: 'none', fontSize: 14, lineHeight: 1, color: 'var(--text-secondary)', opacity: 0.5, flexShrink: 0 }}
       >
         ⠇
       </span>


### PR DESCRIPTION
## Summary

Increases the `DragHandle` tap target in the profile bento grid from ~14×14px to ≥44×44px (WCAG 2.5.5) by adding `display: inline-flex`, `alignItems: center`, `justifyContent: center`, `minWidth: 44`, `minHeight: 44` to the span's inline style. The `⠇` glyph remains at `fontSize: 14` — visual appearance unchanged.

One file changed. No logic, no data, no migration.

Closes #55

## Session State
**Status:** DONE
**Completed:**
- [x] `DragHandle` span has `display: inline-flex`, `alignItems/justifyContent: center`, `minWidth/minHeight: 44` → ≥44×44px hit zone
- [x] Glyph font-size unchanged at 14px
- [x] No other files modified
- [x] 390px: handle is contained within the tile header row in both collapsed and expanded states — no overflow risk (handle is inside `flex items-center gap-3` / absolute positioned row, both of which accommodate the 44px height gracefully)
**Next:** Merge via GitHub UI → confirm production Vercel deployment READY
