### PR TITLE
[2604-FEAT-62] Trip messages: admin UI (/admin/trips/[id])

### DIFF
--- a/app/admin/operations/components/TripsTab.tsx
+++ b/app/admin/operations/components/TripsTab.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { formatDate, formatCurrency } from '@/lib/format'
 import { Drawer } from '@/components/ui/Drawer'
@@ -152,6 +153,13 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
                 </p>
               </div>
               <div className="flex items-center gap-3 flex-shrink-0">
+                <Link
+                  href={`/admin/trips/${trip.id}`}
+                  className="text-xs hover:opacity-70 transition-opacity font-medium"
+                  style={{ color: 'var(--text-primary)' }}
+                >
+                  Manage →
+                </Link>
                 <button onClick={() => openEdit(trip)} className="text-xs hover:opacity-70 transition-opacity" style={{ color: 'var(--text-secondary)' }}>{t('admin.operations.trips.btn.edit', 'en')}</button>
                 <button
                   onClick={() => setAlertTarget({ id: trip.id, name: trip.title })}

--- a/app/admin/trips/[id]/components/TripFilesSection.tsx
+++ b/app/admin/trips/[id]/components/TripFilesSection.tsx
@@ -1,0 +1,5 @@
+'use client'
+// TODO: attachment list, upload, delete
+export function TripFilesSection({ tripId }: { tripId: string }) {
+  return null
+}

--- a/app/admin/trips/[id]/components/TripFilesSection.tsx
+++ b/app/admin/trips/[id]/components/TripFilesSection.tsx
@@ -61,10 +61,12 @@ export function TripFilesSection({ tripId }: { tripId: string }) {
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (attachmentId: string) =>
-      fetch(`/api/admin/trips/${tripId}/attachments/${attachmentId}`, {
+    mutationFn: async (attachmentId: string) => {
+      const r = await fetch(`/api/admin/trips/${tripId}/attachments/${attachmentId}`, {
         method: 'DELETE',
-      }),
+      })
+      if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || 'Failed to delete')
+    },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['trip-attachments-admin', tripId] }),
   })
 
@@ -96,7 +98,7 @@ export function TripFilesSection({ tripId }: { tripId: string }) {
           style={{ backgroundColor: 'var(--brand-crimson)' }}
         >
           <Upload size={13} />
-          {uploadMutation.isPending ? 'Uploading…' : 'Upload'}
+          {uploadMutation.isPending ? 'Uploading\u2026' : 'Upload'}
         </button>
         <input
           ref={fileInputRef}

--- a/app/admin/trips/[id]/components/TripFilesSection.tsx
+++ b/app/admin/trips/[id]/components/TripFilesSection.tsx
@@ -1,5 +1,175 @@
 'use client'
-// TODO: attachment list, upload, delete
+
+import { useRef, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Trash2, Upload } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+// ── Types ────────────────────────────────────────────────────────
+
+type Attachment = {
+  id: string
+  file_name: string
+  file_url: string
+  file_type: 'pdf' | 'image'
+  sort_order: number
+  created_at: string
+}
+
+// ── Component ────────────────────────────────────────────────────
+
 export function TripFilesSection({ tripId }: { tripId: string }) {
-  return null
+  const qc = useQueryClient()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+
+  const { data: attachments = [], isLoading } = useQuery<Attachment[]>({
+    queryKey: ['trip-attachments-admin', tripId],
+    queryFn: () =>
+      fetch(`/api/admin/trips/${tripId}/attachments`).then(async r => {
+        if (!r.ok) throw new Error((await r.json()).error)
+        return r.json()
+      }),
+  })
+
+  const uploadMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const fd = new FormData()
+      fd.append('file', file)
+      const r = await fetch(`/api/admin/trips/${tripId}/attachments`, {
+        method: 'POST',
+        body: fd,
+      })
+      if (!r.ok) throw new Error((await r.json()).error)
+      return r.json()
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['trip-attachments-admin', tripId] })
+      setUploadError(null)
+    },
+    onError: (e: Error) => setUploadError(e.message),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (attachmentId: string) =>
+      fetch(`/api/admin/trips/${tripId}/attachments/${attachmentId}`, {
+        method: 'DELETE',
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['trip-attachments-admin', tripId] }),
+  })
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    e.target.value = ''
+    if (file.size > 10 * 1024 * 1024) {
+      setUploadError('File exceeds 10 MB limit')
+      return
+    }
+    setUploadError(null)
+    uploadMutation.mutate(file)
+  }
+
+  return (
+    <section
+      className="rounded-2xl p-5 space-y-4"
+      style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-semibold" style={{ color: 'var(--text-primary)' }}>
+          Files
+        </h2>
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploadMutation.isPending}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+          style={{ backgroundColor: 'var(--brand-crimson)' }}
+        >
+          <Upload size={13} />
+          {uploadMutation.isPending ? 'Uploading…' : 'Upload'}
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".pdf,image/*"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+      </div>
+
+      {uploadError && (
+        <p className="text-xs" style={{ color: 'var(--brand-crimson)' }}>{uploadError}</p>
+      )}
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {[...Array(2)].map((_, i) => (
+            <div key={i} className="h-10 rounded-lg animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }} />
+          ))}
+        </div>
+      ) : attachments.length === 0 ? (
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No files uploaded yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {attachments.map(a => (
+            <li
+              key={a.id}
+              className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg"
+              style={{ backgroundColor: 'var(--bg-global)', border: '1px solid var(--border-default)' }}
+            >
+              <a
+                href={a.file_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm truncate hover:underline"
+                style={{ color: 'var(--text-primary)' }}
+              >
+                {a.file_name}
+              </a>
+              <button
+                onClick={() => setDeleteTarget({ id: a.id, name: a.file_name })}
+                className="flex-shrink-0 hover:opacity-70 transition-opacity"
+                style={{ color: 'var(--brand-crimson)' }}
+                aria-label={`Delete ${a.file_name}`}
+              >
+                <Trash2 size={14} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete file?</AlertDialogTitle>
+            <AlertDialogDescription>
+              &ldquo;{deleteTarget?.name}&rdquo; will be permanently removed.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deleteTarget) deleteMutation.mutate(deleteTarget.id)
+                setDeleteTarget(null)
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  )
 }

--- a/app/admin/trips/[id]/components/TripMessagesSection.tsx
+++ b/app/admin/trips/[id]/components/TripMessagesSection.tsx
@@ -1,5 +1,272 @@
 'use client'
-// TODO: message list, post form, inline edit, delete
+
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Pencil, Trash2 } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { formatDateTime } from '@/lib/format'
+
+// ── Types ────────────────────────────────────────────────────────
+
+type Message = {
+  id: string
+  body: string
+  created_at: string
+  updated_at: string
+}
+
+// ── Module-scope form components (CLAUDE.md hard rule) ───────────
+
+function PostForm({
+  tripId,
+  onSuccess,
+}: {
+  tripId: string
+  onSuccess: () => void
+}) {
+  const [body, setBody] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      fetch(`/api/admin/trips/${tripId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body: body.trim() }),
+      }).then(async r => {
+        if (!r.ok) throw new Error((await r.json()).error)
+        return r.json()
+      }),
+    onSuccess: () => {
+      setBody('')
+      setError(null)
+      onSuccess()
+    },
+    onError: (e: Error) => setError(e.message),
+  })
+
+  return (
+    <div className="space-y-2">
+      <textarea
+        value={body}
+        onChange={e => setBody(e.target.value)}
+        placeholder="Write a message…"
+        rows={3}
+        className="w-full rounded-lg px-3 py-2 text-sm resize-none outline-none focus:ring-2"
+        style={{
+          backgroundColor: 'var(--bg-global)',
+          border: '1px solid var(--border-default)',
+          color: 'var(--text-primary)',
+          // @ts-expect-error css var
+          '--tw-ring-color': 'var(--brand-crimson)',
+        }}
+      />
+      {error && <p className="text-xs" style={{ color: 'var(--brand-crimson)' }}>{error}</p>}
+      <button
+        onClick={() => mutation.mutate()}
+        disabled={mutation.isPending || !body.trim()}
+        className="px-4 py-1.5 rounded-lg text-xs font-semibold text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+        style={{ backgroundColor: 'var(--brand-crimson)' }}
+      >
+        {mutation.isPending ? 'Posting…' : 'Post'}
+      </button>
+    </div>
+  )
+}
+
+function EditForm({
+  tripId,
+  message,
+  onSuccess,
+  onCancel,
+}: {
+  tripId: string
+  message: Message
+  onSuccess: () => void
+  onCancel: () => void
+}) {
+  const [body, setBody] = useState(message.body)
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      fetch(`/api/admin/trips/${tripId}/messages/${message.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body: body.trim() }),
+      }).then(async r => {
+        if (!r.ok) throw new Error((await r.json()).error)
+        return r.json()
+      }),
+    onSuccess: () => {
+      setError(null)
+      onSuccess()
+    },
+    onError: (e: Error) => setError(e.message),
+  })
+
+  return (
+    <div className="space-y-2 mt-1">
+      <textarea
+        value={body}
+        onChange={e => setBody(e.target.value)}
+        rows={3}
+        className="w-full rounded-lg px-3 py-2 text-sm resize-none outline-none focus:ring-2"
+        style={{
+          backgroundColor: 'var(--bg-global)',
+          border: '1px solid var(--border-default)',
+          color: 'var(--text-primary)',
+          // @ts-expect-error css var
+          '--tw-ring-color': 'var(--brand-crimson)',
+        }}
+      />
+      {error && <p className="text-xs" style={{ color: 'var(--brand-crimson)' }}>{error}</p>}
+      <div className="flex gap-2">
+        <button
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending || !body.trim() || body.trim() === message.body}
+          className="px-3 py-1.5 rounded-lg text-xs font-semibold text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+          style={{ backgroundColor: 'var(--brand-crimson)' }}
+        >
+          {mutation.isPending ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          onClick={onCancel}
+          className="px-3 py-1.5 rounded-lg text-xs hover:opacity-70 transition-opacity"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Main component ───────────────────────────────────────────────
+
 export function TripMessagesSection({ tripId }: { tripId: string }) {
-  return null
+  const qc = useQueryClient()
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string } | null>(null)
+
+  const { data: messages = [], isLoading } = useQuery<Message[]>({
+    queryKey: ['trip-messages-admin', tripId],
+    queryFn: () =>
+      fetch(`/api/admin/trips/${tripId}/messages`).then(async r => {
+        if (!r.ok) throw new Error((await r.json()).error)
+        return r.json()
+      }),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (messageId: string) =>
+      fetch(`/api/admin/trips/${tripId}/messages/${messageId}`, { method: 'DELETE' }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['trip-messages-admin', tripId] }),
+  })
+
+  function invalidate() {
+    qc.invalidateQueries({ queryKey: ['trip-messages-admin', tripId] })
+  }
+
+  return (
+    <section
+      className="rounded-2xl p-5 space-y-4"
+      style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+    >
+      <h2 className="text-base font-semibold" style={{ color: 'var(--text-primary)' }}>
+        Messages
+      </h2>
+
+      <PostForm tripId={tripId} onSuccess={invalidate} />
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {[...Array(2)].map((_, i) => (
+            <div key={i} className="h-16 rounded-lg animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }} />
+          ))}
+        </div>
+      ) : messages.length === 0 ? (
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No messages yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {messages.map(msg => (
+            <li
+              key={msg.id}
+              className="rounded-lg px-4 py-3 space-y-1"
+              style={{ backgroundColor: 'var(--bg-global)', border: '1px solid var(--border-default)' }}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                  {formatDateTime(msg.created_at)}
+                  {msg.updated_at !== msg.created_at && ' (edited)'}
+                </p>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <button
+                    onClick={() => setEditingId(editingId === msg.id ? null : msg.id)}
+                    className="hover:opacity-70 transition-opacity"
+                    style={{ color: 'var(--text-secondary)' }}
+                    aria-label="Edit message"
+                  >
+                    <Pencil size={13} />
+                  </button>
+                  <button
+                    onClick={() => setDeleteTarget({ id: msg.id })}
+                    className="hover:opacity-70 transition-opacity"
+                    style={{ color: 'var(--brand-crimson)' }}
+                    aria-label="Delete message"
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                </div>
+              </div>
+
+              {editingId === msg.id ? (
+                <EditForm
+                  tripId={tripId}
+                  message={msg}
+                  onSuccess={() => { setEditingId(null); invalidate() }}
+                  onCancel={() => setEditingId(null)}
+                />
+              ) : (
+                <p className="text-sm whitespace-pre-wrap" style={{ color: 'var(--text-primary)' }}>
+                  {msg.body}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={open => { if (!open) setDeleteTarget(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete message?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This message will be permanently removed.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deleteTarget) deleteMutation.mutate(deleteTarget.id)
+                setDeleteTarget(null)
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  )
 }

--- a/app/admin/trips/[id]/components/TripMessagesSection.tsx
+++ b/app/admin/trips/[id]/components/TripMessagesSection.tsx
@@ -1,0 +1,5 @@
+'use client'
+// TODO: message list, post form, inline edit, delete
+export function TripMessagesSection({ tripId }: { tripId: string }) {
+  return null
+}

--- a/app/admin/trips/[id]/components/TripMessagesSection.tsx
+++ b/app/admin/trips/[id]/components/TripMessagesSection.tsx
@@ -59,7 +59,7 @@ function PostForm({
       <textarea
         value={body}
         onChange={e => setBody(e.target.value)}
-        placeholder="Write a message…"
+        placeholder="Write a message\u2026"
         rows={3}
         className="w-full rounded-lg px-3 py-2 text-sm resize-none outline-none focus:ring-2"
         style={{
@@ -77,7 +77,7 @@ function PostForm({
         className="px-4 py-1.5 rounded-lg text-xs font-semibold text-white hover:opacity-90 transition-opacity disabled:opacity-50"
         style={{ backgroundColor: 'var(--brand-crimson)' }}
       >
-        {mutation.isPending ? 'Posting…' : 'Post'}
+        {mutation.isPending ? 'Posting\u2026' : 'Post'}
       </button>
     </div>
   )
@@ -137,7 +137,7 @@ function EditForm({
           className="px-3 py-1.5 rounded-lg text-xs font-semibold text-white hover:opacity-90 transition-opacity disabled:opacity-50"
           style={{ backgroundColor: 'var(--brand-crimson)' }}
         >
-          {mutation.isPending ? 'Saving…' : 'Save'}
+          {mutation.isPending ? 'Saving\u2026' : 'Save'}
         </button>
         <button
           onClick={onCancel}
@@ -168,8 +168,10 @@ export function TripMessagesSection({ tripId }: { tripId: string }) {
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (messageId: string) =>
-      fetch(`/api/admin/trips/${tripId}/messages/${messageId}`, { method: 'DELETE' }),
+    mutationFn: async (messageId: string) => {
+      const r = await fetch(`/api/admin/trips/${tripId}/messages/${messageId}`, { method: 'DELETE' })
+      if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || 'Failed to delete')
+    },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['trip-messages-admin', tripId] }),
   })
 

--- a/app/admin/trips/[id]/page.tsx
+++ b/app/admin/trips/[id]/page.tsx
@@ -1,4 +1,71 @@
-// TODO: RSC — fetch trip title, render TripFilesSection + TripMessagesSection
-export default async function TripManagePage() {
-  return null
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { TripFilesSection } from './components/TripFilesSection'
+import { TripMessagesSection } from './components/TripMessagesSection'
+
+export const dynamic = 'force-dynamic'
+
+export default async function TripManagePage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id: tripId } = await params
+
+  const { userId } = await auth()
+  if (!userId) redirect('/sign-in')
+
+  const supabase = createServiceClient()
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (!profile || profile.role !== 'admin') redirect('/')
+
+  const { data: trip } = await supabase
+    .from('trips')
+    .select('title')
+    .eq('id', tripId)
+    .single()
+
+  if (!trip) redirect('/admin/operations?tab=trips')
+
+  return (
+    <div className="space-y-8">
+      {/* ── Header ── */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/admin/operations?tab=trips"
+          className="text-sm hover:opacity-70 transition-opacity"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          ← Operations
+        </Link>
+        <span style={{ color: 'var(--text-secondary)' }}>/</span>
+        <h1
+          className="font-display text-2xl font-semibold"
+          style={{ color: 'var(--text-primary)' }}
+        >
+          {trip.title}
+        </h1>
+      </div>
+
+      {/* ── Desktop layout ── */}
+      <div className="hidden md:grid md:grid-cols-2 gap-6">
+        <TripFilesSection tripId={tripId} />
+        <TripMessagesSection tripId={tripId} />
+      </div>
+
+      {/* ── Mobile layout ── */}
+      <div className="md:hidden flex flex-col gap-6">
+        <TripFilesSection tripId={tripId} />
+        <TripMessagesSection tripId={tripId} />
+      </div>
+    </div>
+  )
 }

--- a/app/admin/trips/[id]/page.tsx
+++ b/app/admin/trips/[id]/page.tsx
@@ -1,0 +1,4 @@
+// TODO: RSC — fetch trip title, render TripFilesSection + TripMessagesSection
+export default async function TripManagePage() {
+  return null
+}


### PR DESCRIPTION
## Summary

New admin management page for a single trip. Admin can upload/delete files and post/edit/delete messages. Reached via "Manage →" link added to each row in `TripsTab`.

Closes #62

## Changes

- `app/admin/trips/[id]/page.tsx` — RSC; fetches trip title server-side; admin role check; dual layout; `← Operations` back link
- `app/admin/trips/[id]/components/TripFilesSection.tsx` — attachment list, upload via FormData, client-side 10MB guard, delete via `AlertDialog`
- `app/admin/trips/[id]/components/TripMessagesSection.tsx` — message list newest-first, `PostForm` + `EditForm` at module scope, inline edit, delete via `AlertDialog`, `formatDateTime` timestamps
- `app/admin/operations/components/TripsTab.tsx` — `Manage →` link added per trip row

## Session State
**Status:** DONE
**Completed:**
- [x] `app/admin/trips/[id]/page.tsx` — RSC, auth, trip title fetch, dual layout, back link
- [x] `TripFilesSection.tsx` — list, upload (FormData + 10MB guard), delete (AlertDialog)
- [x] `TripMessagesSection.tsx` — list newest-first, PostForm + EditForm at module scope, delete (AlertDialog), formatDateTime
- [x] `TripsTab.tsx` — Manage → link per trip row
- [x] All forms defined at module scope (CLAUDE.md hard rule)
- [x] All deletes via AlertDialog (CLAUDE.md hard rule)
- [x] Dual layout law respected (hidden md:grid / md:hidden)
**Next:** Verify Vercel Preview READY + 390px check → merge via GitHub UI
