### PR TITLE
[2604-FEAT-63] Trip messages: member view (TripMessagesTile)

### DIFF
--- a/app/(dashboard)/trips/[id]/components/ArchivedView.tsx
+++ b/app/(dashboard)/trips/[id]/components/ArchivedView.tsx
@@ -2,6 +2,7 @@
 
 import { formatDate, formatCurrency } from '@/lib/format'
 import { BackButton } from './shared'
+import { TripMessagesTile } from './TripMessagesTile'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile, TripPayment } from '../page'
 
@@ -49,6 +50,9 @@ export function ArchivedView({
             </div>
           </div>
         </div>
+
+        {/* Trip Messages — between hero card and Final Ledger */}
+        <TripMessagesTile tripId={trip.id} />
 
         <div className="rounded-2xl overflow-hidden"
           style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>

--- a/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
@@ -7,6 +7,7 @@ import { getRoleColors } from '@/lib/role-colors'
 import { Drawer } from '@/components/ui/Drawer'
 import { PaymentForm } from '@/components/payment/PaymentForm'
 import { TripDocumentsTile } from './TripDocumentsTile'
+import { TripMessagesTile } from './TripMessagesTile'
 import { BackButton, TripHero } from './shared'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile, TripPayment, TeamAttendee } from '../page'
@@ -254,6 +255,9 @@ export function AttendeeView({
 
         {/* Who's Going */}
         <WhosGoingTile attendees={teamAttendees} />
+
+        {/* Trip Messages */}
+        <TripMessagesTile tripId={trip.id} />
 
         {/* Trip Documents */}
         <TripDocumentsTile tripId={trip.id} />

--- a/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { useLanguage } from '@/lib/hooks/useLanguage'
 
 interface Attachment {
   id: string
@@ -40,6 +41,7 @@ function ImageIcon() {
 }
 
 export function TripDocumentsTile({ tripId }: { tripId: string }) {
+  const { t } = useLanguage()
   const [retrying, setRetrying] = useState(false)
 
   const { data: attachments, isLoading, isError, error, refetch } = useQuery<Attachment[], ApiError>({
@@ -71,7 +73,7 @@ export function TripDocumentsTile({ tripId }: { tripId: string }) {
         <div className="px-6 py-4 flex items-center justify-between">
           <p className="text-xs font-semibold tracking-widest uppercase"
             style={{ color: 'var(--text-secondary)' }}>
-            Trip Documents
+            {t('trips.documents')}
           </p>
           <button
             onClick={async () => { setRetrying(true); await refetch(); setRetrying(false) }}
@@ -79,7 +81,7 @@ export function TripDocumentsTile({ tripId }: { tripId: string }) {
             className="text-xs hover:opacity-70 transition-opacity disabled:opacity-40"
             style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer' }}
           >
-            {retrying ? 'Retrying…' : '↺ Retry'}
+            {retrying ? t('trips.retrying') : t('trips.retry')}
           </button>
         </div>
       </div>
@@ -98,7 +100,7 @@ export function TripDocumentsTile({ tripId }: { tripId: string }) {
           className="text-xs font-semibold tracking-widest uppercase"
           style={{ color: 'var(--text-secondary)' }}
         >
-          Trip Documents
+          {t('trips.documents')}
         </p>
       </div>
       <div className="px-6 pb-5">
@@ -127,7 +129,7 @@ export function TripDocumentsTile({ tripId }: { tripId: string }) {
                 className="text-xs flex-shrink-0 hover:opacity-70 transition-opacity"
                 style={{ color: 'var(--brand-teal)' }}
               >
-                Open ↗
+                {t('trips.openFile')}
               </a>
             </div>
           ))}

--- a/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
@@ -62,7 +62,7 @@ export function TripMessagesTile({ tripId }: { tripId: string }) {
             className="text-xs hover:opacity-70 transition-opacity disabled:opacity-40"
             style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer' }}
           >
-            {isFetching ? 'Retrying…' : '↺ Retry'}
+            {isFetching ? t('trips.retrying') : t('trips.retry')}
           </button>
         </div>
       </div>

--- a/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { formatDateTime } from '@/lib/format'
+
+interface TripMessage {
+  id: string
+  body: string
+  created_at: string
+}
+
+interface ApiError {
+  status?: number
+  message: string
+}
+
+export function TripMessagesTile({ tripId }: { tripId: string }) {
+  const [retrying, setRetrying] = useState(false)
+
+  const { data: messages, isLoading, isError, error, refetch } = useQuery<TripMessage[], ApiError>({
+    queryKey: ['trip-messages', tripId],
+    queryFn: () =>
+      fetch(`/api/trips/${tripId}/messages`).then(async r => {
+        if (!r.ok) {
+          const body = await r.json().catch(() => ({}))
+          const err: ApiError = { status: r.status, message: body.error ?? 'Failed' }
+          throw err
+        }
+        return r.json()
+      }),
+    retry: false,
+  })
+
+  if (isLoading) return null
+
+  // 403 = not an approved attendee — expected, render nothing
+  if (isError && (error as ApiError)?.status === 403) return null
+
+  // 5xx or network error — discreet retry, no alarming message
+  if (isError) {
+    return (
+      <div
+        className="rounded-2xl overflow-hidden"
+        style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+      >
+        <div className="px-6 py-4 flex items-center justify-between">
+          <p
+            className="text-xs font-semibold tracking-widest uppercase"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            Trip Messages
+          </p>
+          <button
+            onClick={async () => { setRetrying(true); await refetch(); setRetrying(false) }}
+            disabled={retrying}
+            className="text-xs hover:opacity-70 transition-opacity disabled:opacity-40"
+            style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer' }}
+          >
+            {retrying ? 'Retrying…' : '↺ Retry'}
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!messages || messages.length === 0) return null
+
+  // Newest-first
+  const sorted = [...messages].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  )
+
+  return (
+    <div
+      className="rounded-2xl overflow-hidden"
+      style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+    >
+      <div className="px-6 pt-5 pb-2">
+        <p
+          className="text-xs font-semibold tracking-widest uppercase"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          Trip Messages
+        </p>
+      </div>
+      <div className="px-6 pb-5">
+        <div className="space-y-1 mt-1">
+          {sorted.map(m => (
+            <div
+              key={m.id}
+              className="py-3 border-b last:border-0"
+              style={{ borderColor: 'var(--border-default)' }}
+            >
+              <p
+                className="text-sm"
+                style={{ color: 'var(--text-primary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+              >
+                {m.body}
+              </p>
+              <p
+                className="text-xs mt-1"
+                style={{ color: 'var(--text-secondary)' }}
+              >
+                {formatDateTime(m.created_at)}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { formatDateTime } from '@/lib/format'
+import { useLanguage } from '@/lib/hooks/useLanguage'
 
 interface TripMessage {
   id: string
@@ -16,21 +16,26 @@ interface ApiError {
 }
 
 export function TripMessagesTile({ tripId }: { tripId: string }) {
-  const [retrying, setRetrying] = useState(false)
+  const { t } = useLanguage()
 
-  const { data: messages, isLoading, isError, error, refetch } = useQuery<TripMessage[], ApiError>({
-    queryKey: ['trip-messages', tripId],
-    queryFn: () =>
-      fetch(`/api/trips/${tripId}/messages`).then(async r => {
-        if (!r.ok) {
-          const body = await r.json().catch(() => ({}))
-          const err: ApiError = { status: r.status, message: body.error ?? 'Failed' }
-          throw err
-        }
-        return r.json()
-      }),
-    retry: false,
-  })
+  const { data: messages, isLoading, isError, error, refetch, isFetching } =
+    useQuery<TripMessage[], ApiError>({
+      queryKey: ['trip-messages', tripId],
+      queryFn: () =>
+        fetch(`/api/trips/${encodeURIComponent(tripId)}/messages`).then(async r => {
+          if (!r.ok) {
+            const body = await r.json().catch(() => ({}))
+            const err: ApiError = { status: r.status, message: body.error ?? 'Failed' }
+            throw err
+          }
+          return r.json()
+        }),
+      retry: false,
+      select: (data) =>
+        [...data].sort(
+          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        ),
+    })
 
   if (isLoading) return null
 
@@ -49,15 +54,15 @@ export function TripMessagesTile({ tripId }: { tripId: string }) {
             className="text-xs font-semibold tracking-widest uppercase"
             style={{ color: 'var(--text-secondary)' }}
           >
-            Trip Messages
+            {t('trips.messages')}
           </p>
           <button
-            onClick={async () => { setRetrying(true); await refetch(); setRetrying(false) }}
-            disabled={retrying}
+            onClick={() => refetch()}
+            disabled={isFetching}
             className="text-xs hover:opacity-70 transition-opacity disabled:opacity-40"
             style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer' }}
           >
-            {retrying ? 'Retrying…' : '↺ Retry'}
+            {isFetching ? 'Retrying…' : '↺ Retry'}
           </button>
         </div>
       </div>
@@ -65,11 +70,6 @@ export function TripMessagesTile({ tripId }: { tripId: string }) {
   }
 
   if (!messages || messages.length === 0) return null
-
-  // Newest-first
-  const sorted = [...messages].sort(
-    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-  )
 
   return (
     <div
@@ -81,12 +81,12 @@ export function TripMessagesTile({ tripId }: { tripId: string }) {
           className="text-xs font-semibold tracking-widest uppercase"
           style={{ color: 'var(--text-secondary)' }}
         >
-          Trip Messages
+          {t('trips.messages')}
         </p>
       </div>
       <div className="px-6 pb-5">
         <div className="space-y-1 mt-1">
-          {sorted.map(m => (
+          {messages.map(m => (
             <div
               key={m.id}
               className="py-3 border-b last:border-0"

--- a/lib/i18n/domains/trips.ts
+++ b/lib/i18n/domains/trips.ts
@@ -32,4 +32,8 @@ export const trips = {
   'trips.daysToGo':           { en: 'days to go',              bg: 'дни до тръгване'                    },
   'trips.todayBadge':         { en: 'Today!',                  bg: 'Днес!'                              },
   'trips.messages':           { en: 'Trip Messages',           bg: 'Съобщения за пътуването'            },
+  'trips.documents':          { en: 'Trip Documents',          bg: 'Документи от пътуването'            },
+  'trips.retry':              { en: '↺ Retry',                 bg: '↺ Опитай отново'                    },
+  'trips.retrying':           { en: 'Retrying…',               bg: 'Зарежда…'                           },
+  'trips.openFile':           { en: 'Open ↗',                  bg: 'Отвори ↗'                           },
 } as const

--- a/lib/i18n/domains/trips.ts
+++ b/lib/i18n/domains/trips.ts
@@ -31,4 +31,5 @@ export const trips = {
   'trips.noTeamRegistered':   { en: 'None of your team are registered yet.', bg: 'Все още никой от отбора ви не е регистриран.' },
   'trips.daysToGo':           { en: 'days to go',              bg: 'дни до тръгване'                    },
   'trips.todayBadge':         { en: 'Today!',                  bg: 'Днес!'                              },
+  'trips.messages':           { en: 'Trip Messages',           bg: 'Съобщения за пътуването'            },
 } as const


### PR DESCRIPTION
## Summary

New `TripMessagesTile` client component. Renders above `TripDocumentsTile` in `AttendeeView` and between the hero card and Final Ledger in `ArchivedView`. 403 and empty → renders nothing.

Also i18n-wraps all hardcoded strings in `TripDocumentsTile` and fixes the `TripMessagesTile` retry labels which were hardcoded (`'Retrying…'` / `'↺ Retry'`).

Closes #63

## Changes

- `app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx` — new; mirrors `TripDocumentsTile` structure; 403 → null; 5xx → retry button; 0 messages → null; newest-first; no author shown; retry labels use `t()`
- `app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx` — i18n-wrapped: heading, retry labels, open link (`trips.documents`, `trips.retry`, `trips.retrying`, `trips.openFile`)
- `app/(dashboard)/trips/[id]/components/AttendeeView.tsx` — `<TripMessagesTile>` inserted above `<TripDocumentsTile>`
- `app/(dashboard)/trips/[id]/components/ArchivedView.tsx` — `<TripMessagesTile>` inserted between hero card and Final Ledger tile
- `lib/i18n/domains/trips.ts` — 4 new keys: `trips.documents`, `trips.retry`, `trips.retrying`, `trips.openFile`

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] `TripMessagesTile.tsx` — new component, retry labels i18n-fixed
- [x] `TripDocumentsTile.tsx` — all hardcoded strings wrapped with `t()`
- [x] `AttendeeView.tsx` — tile inserted above `TripDocumentsTile`
- [x] `ArchivedView.tsx` — tile inserted between hero card and Final Ledger
- [x] `lib/i18n/domains/trips.ts` — 4 new keys added
**Next:** Verify Vercel Preview reflects new commit → mark DONE → merge
