### PR TITLE
[2604-BUG-78] fix: messages + attachments API routes always 403 for members

### DIFF
--- a/app/api/trips/[id]/attachments/route.ts
+++ b/app/api/trips/[id]/attachments/route.ts
@@ -1,5 +1,5 @@
 import { auth } from '@clerk/nextjs/server'
-import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
 import { NextResponse } from 'next/server'
 
 export async function GET(
@@ -9,7 +9,7 @@ export async function GET(
   const { userId } = await auth()
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const supabase = await createClient()
+  const supabase = createServiceClient()
 
   // Resolve profile
   const { data: profile, error: profileErr } = await supabase

--- a/app/api/trips/[id]/messages/route.ts
+++ b/app/api/trips/[id]/messages/route.ts
@@ -1,5 +1,5 @@
 import { auth } from '@clerk/nextjs/server'
-import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
 import { NextResponse } from 'next/server'
 
 export async function GET(
@@ -9,7 +9,7 @@ export async function GET(
   const { userId } = await auth()
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const supabase = await createClient()
+  const supabase = createServiceClient()
 
   const { data: profile, error: profileErr } = await supabase
     .from('profiles')


### PR DESCRIPTION
## Summary

Both `/api/trips/[id]/messages` and `/api/trips/[id]/attachments` were returning 403 for all members, causing `TripMessagesTile` and `TripDocumentsTile` to silently render nothing.

**Root cause:** routes used `createClient()` (anon SSR client). This app uses Clerk — no Supabase auth session cookie exists, so the profile RLS policy (`clerk_id = get_my_clerk_id()`) matched nothing, profile was null, and the route 403'd before ever reaching the registration check.

**Fix:** swap to `createServiceClient()` in both routes. Auth is enforced at the API level via Clerk `auth()` + explicit `status = 'approved'` registration check — service client is the correct pattern for all Clerk+Supabase routes.

Closes #78

## Changes

- `app/api/trips/[id]/messages/route.ts` — `createClient` → `createServiceClient`
- `app/api/trips/[id]/attachments/route.ts` — `createClient` → `createServiceClient`

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] Both routes fixed
- [x] PR open, Vercel preview deploying
**Next:** Verify preview — member sees tiles → mark DONE → merge
