### PR TITLE
[2604-BUG-84] Profile page mobile portrait layout broken — Dual Layout Law violation

### DIFF
--- a/app/(dashboard)/profile/components/EmailPrefsSection.tsx
+++ b/app/(dashboard)/profile/components/EmailPrefsSection.tsx
@@ -56,50 +56,10 @@ function Toggle({ enabled, onToggle }: { enabled: boolean; onToggle: () => void 
   )
 }
 
-function ChevronButton({
-  open,
-  onToggle,
-  labelCollapse,
-  labelExpand,
-}: {
-  open: boolean
-  onToggle: () => void
-  labelCollapse: string
-  labelExpand: string
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      aria-label={open ? labelCollapse : labelExpand}
-      aria-expanded={open}
-      className="flex items-center justify-center w-7 h-7 rounded-lg border border-[var(--border-default)] bg-transparent text-[var(--text-secondary)] cursor-pointer p-0 shrink-0 transition-colors duration-150"
-    >
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className={`transition-transform duration-150 ${open ? 'rotate-0' : '-rotate-90'}`}
-      >
-        <polyline points="6 9 12 15 18 9" />
-      </svg>
-    </button>
-  )
-}
-
 export function EmailPrefsSection({
   prefs,
-  open,
-  onToggleOpen,
 }: {
   prefs: NotificationPrefs
-  open: boolean
-  onToggleOpen: () => void
 }) {
   const { t } = useLanguage()
   const qc = useQueryClient()
@@ -150,34 +110,24 @@ export function EmailPrefsSection({
               {t('profile.error')}
             </span>
           )}
-          <ChevronButton
-            open={open}
-            onToggle={onToggleOpen}
-            labelCollapse={t('profile.collapseNotifications')}
-            labelExpand={t('profile.expandNotifications')}
-          />
         </div>
       </div>
 
-      {open && (
-        <>
-          {/* Rows */}
-          <div className="space-y-3">
-            {PREF_ROWS.map(row => (
-              <div key={row.key} className="flex items-center justify-between gap-4">
-                <span className="text-sm leading-snug" style={{ color: 'var(--text-primary)' }}>
-                  {t(row.labelKey as Parameters<typeof t>[0])}
-                </span>
-                <Toggle enabled={local[row.key]} onToggle={() => handleToggle(row.key)} />
-              </div>
-            ))}
+      {/* Rows */}
+      <div className="space-y-3">
+        {PREF_ROWS.map(row => (
+          <div key={row.key} className="flex items-center justify-between gap-4">
+            <span className="text-sm leading-snug" style={{ color: 'var(--text-primary)' }}>
+              {t(row.labelKey as Parameters<typeof t>[0])}
+            </span>
+            <Toggle enabled={local[row.key]} onToggle={() => handleToggle(row.key)} />
           </div>
+        ))}
+      </div>
 
-          <p className="text-[11px] mt-5 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
-            {t('profile.emailOnlyNote')}
-          </p>
-        </>
-      )}
+      <p className="text-[11px] mt-5 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
+        {t('profile.emailOnlyNote')}
+      </p>
     </div>
   )
 }

--- a/app/(dashboard)/profile/components/SortableBento.tsx
+++ b/app/(dashboard)/profile/components/SortableBento.tsx
@@ -93,7 +93,7 @@ export function SortableBento({
     transition,
     opacity: isDragging ? 0.5 : 1,
     position: 'relative',
-    // Mobile stack (disableDrag): no minHeight — let content size the card
+    // Mobile stack (disableDrag): no minHeight — cards size to their content
     minHeight: disableDrag || collapsed ? undefined : minHeight,
   }
 
@@ -140,8 +140,12 @@ export function SortableBento({
               ▾
             </button>
           </div>
-          {/* Mobile stack: no height constraint — let section content determine card height */}
-          <div style={{ overflow: 'hidden', height: disableDrag ? undefined : '100%' }}>{children}</div>
+          {/*
+            Desktop: height 100% fills the grid cell (minHeight set on parent).
+            Mobile (disableDrag): height auto — parent has no fixed height, so
+            h-full children resolve to auto and the card sizes to its content.
+          */}
+          <div style={{ overflow: 'hidden', height: disableDrag ? 'auto' : '100%' }}>{children}</div>
         </>
       )}
     </div>

--- a/app/(dashboard)/profile/components/SortableBento.tsx
+++ b/app/(dashboard)/profile/components/SortableBento.tsx
@@ -85,7 +85,7 @@ export function SortableBento({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id })
+  } = useSortable({ id, disabled: disableDrag })
 
   const style: React.CSSProperties = {
     ...(disableDrag ? {} : { gridColumn: `span ${colSpan}` }),

--- a/app/(dashboard)/profile/components/SortableBento.tsx
+++ b/app/(dashboard)/profile/components/SortableBento.tsx
@@ -6,6 +6,26 @@ import { CSS } from '@dnd-kit/utilities'
 
 // ── Drag handle ───────────────────────────────────────────────────────────────
 
+function GripIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      className="flex-shrink-0"
+      style={{ color: 'var(--text-secondary)', cursor: 'grab' }}
+    >
+      <circle cx="4" cy="3" r="1.2" fill="currentColor" />
+      <circle cx="4" cy="7" r="1.2" fill="currentColor" />
+      <circle cx="4" cy="11" r="1.2" fill="currentColor" />
+      <circle cx="10" cy="3" r="1.2" fill="currentColor" />
+      <circle cx="10" cy="7" r="1.2" fill="currentColor" />
+      <circle cx="10" cy="11" r="1.2" fill="currentColor" />
+    </svg>
+  )
+}
+
 const DragHandle = forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
   function DragHandle(props, ref) {
     return (
@@ -13,9 +33,9 @@ const DragHandle = forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElem
         {...props}
         ref={ref}
         title="Drag to reorder"
-        style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: 44, minHeight: 44, cursor: 'grab', touchAction: 'none', userSelect: 'none', fontSize: 14, lineHeight: 1, color: 'var(--text-secondary)', opacity: 0.5, flexShrink: 0 }}
+        style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: 44, minHeight: 44, cursor: 'grab', touchAction: 'none', userSelect: 'none', opacity: 0.5, flexShrink: 0 }}
       >
-        ⠇
+        <GripIcon />
       </span>
     )
   }
@@ -46,6 +66,7 @@ export function SortableBento({
   onToggleCollapse,
   colSpan,
   minHeight,
+  disableDrag,
   children,
 }: {
   id: string
@@ -53,6 +74,7 @@ export function SortableBento({
   onToggleCollapse: () => void
   colSpan: number
   minHeight: number
+  disableDrag?: boolean
   children: ReactNode
 }) {
   const {
@@ -66,7 +88,7 @@ export function SortableBento({
   } = useSortable({ id })
 
   const style: React.CSSProperties = {
-    gridColumn: `span ${colSpan}`,
+    ...(disableDrag ? {} : { gridColumn: `span ${colSpan}` }),
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
@@ -77,7 +99,7 @@ export function SortableBento({
   return (
     <div
       ref={setNodeRef}
-      className={colSpan === 6 ? 'bento-mobile-full' : ''}
+      className={!disableDrag && colSpan === 6 ? 'bento-mobile-full' : ''}
       style={style}
     >
       {collapsed ? (
@@ -86,7 +108,9 @@ export function SortableBento({
           style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
         >
           <div className="flex items-center gap-3">
-            <DragHandle ref={setActivatorNodeRef} {...attributes} {...listeners} />
+            {!disableDrag && (
+              <DragHandle ref={setActivatorNodeRef} {...attributes} {...listeners} />
+            )}
             <span className="text-xs font-semibold tracking-[0.2em] uppercase" style={{ color: 'var(--text-secondary)' }}>
               {BENTO_LABELS[id] ?? id}
             </span>
@@ -103,7 +127,9 @@ export function SortableBento({
       ) : (
         <>
           <div style={{ position: 'absolute', top: 18, right: 16, display: 'flex', alignItems: 'center', gap: 6, zIndex: 10 }}>
-            <DragHandle ref={setActivatorNodeRef} {...attributes} {...listeners} />
+            {!disableDrag && (
+              <DragHandle ref={setActivatorNodeRef} {...attributes} {...listeners} />
+            )}
             <button
               type="button"
               onClick={onToggleCollapse}

--- a/app/(dashboard)/profile/components/SortableBento.tsx
+++ b/app/(dashboard)/profile/components/SortableBento.tsx
@@ -93,7 +93,8 @@ export function SortableBento({
     transition,
     opacity: isDragging ? 0.5 : 1,
     position: 'relative',
-    minHeight: collapsed ? undefined : minHeight,
+    // Mobile stack (disableDrag): no minHeight — let content size the card
+    minHeight: disableDrag || collapsed ? undefined : minHeight,
   }
 
   return (
@@ -139,7 +140,8 @@ export function SortableBento({
               ▾
             </button>
           </div>
-          <div style={{ overflow: 'hidden', height: '100%' }}>{children}</div>
+          {/* Mobile stack: no height constraint — let section content determine card height */}
+          <div style={{ overflow: 'hidden', height: disableDrag ? undefined : '100%' }}>{children}</div>
         </>
       )}
     </div>

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -191,10 +191,10 @@ export default function ProfilePage() {
 
   const collapseAll = useCallback(() => {
     setBentoCollapsed(prev => {
-      const next = orderedBentosRef.current.reduce<Record<string, boolean>>(
-        (acc, { id }) => ({ ...acc, [id]: true }),
-        prev
-      )
+      const next = { ...prev }
+      orderedBentosRef.current.forEach(({ id }) => {
+        next[id] = true
+      })
       setBentoOrder(order => { persistPrefs(order, next); return order })
       return next
     })

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -189,6 +189,18 @@ export default function ProfilePage() {
     })
   }, [persistPrefs])
 
+  const collapseAll = useCallback(() => {
+    setBentoCollapsed(prev => {
+      const next = orderedBentosRef.current.reduce<Record<string, boolean>>(
+        (acc, { id }) => ({ ...acc, [id]: true }),
+        prev
+      )
+      setBentoOrder(order => { persistPrefs(order, next); return order })
+      return next
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [persistPrefs])
+
   const resetLayout = useCallback(() => {
     setBentoOrder(DEFAULT_ORDER)
     setBentoCollapsed({})
@@ -260,8 +272,6 @@ export default function ProfilePage() {
       node: (
         <EmailPrefsSection
           prefs={p.notification_prefs ?? DEFAULT_NOTIFICATION_PREFS}
-          open={!bentoCollapsed[BENTO_IDS.EMAIL_PREFS]}
-          onToggleOpen={() => toggleCollapse(BENTO_IDS.EMAIL_PREFS)}
         />
       ),
     } : null,
@@ -291,11 +301,22 @@ export default function ProfilePage() {
     .map(id => ({ id, entry: bentoMap[id] ?? null }))
     .filter((b): b is { id: string; entry: BentoEntry } => b.entry !== null)
 
+  // Stable ref for collapseAll to read current orderedBentos without stale closure
+  const orderedBentosRef = useRef(orderedBentos)
+  orderedBentosRef.current = orderedBentos
+
   return (
     <div className="py-8 pb-16">
       <div className="max-w-[1280px] mx-auto px-4 sm:px-6 xl:px-8">
 
-        <div className="flex justify-end mb-3">
+        <div className="flex justify-end gap-4 mb-3">
+          <button
+            onClick={collapseAll}
+            className="text-xs font-medium hover:opacity-70 transition-opacity"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            {t('profile.collapseAll')}
+          </button>
           <button
             onClick={resetLayout}
             className="text-xs font-medium hover:opacity-70 transition-opacity"
@@ -305,24 +326,45 @@ export default function ProfilePage() {
           </button>
         </div>
 
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={orderedBentos.map(b => b.id)} strategy={rectSortingStrategy}>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, minmax(0, 1fr))', gap: '12px' }}>
-              {orderedBentos.map(({ id, entry }) => (
-                <SortableBento
-                  key={id}
-                  id={id}
-                  collapsed={!!bentoCollapsed[id]}
-                  onToggleCollapse={() => toggleCollapse(id)}
-                  colSpan={entry.colSpan}
-                  minHeight={entry.minHeight}
-                >
-                  {entry.node}
-                </SortableBento>
-              ))}
-            </div>
-          </SortableContext>
-        </DndContext>
+        {/* ── DESKTOP (md+) — DnD grid ──────────────────────────────────── */}
+        <div className="hidden md:block">
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={orderedBentos.map(b => b.id)} strategy={rectSortingStrategy}>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, minmax(0, 1fr))', gap: '12px' }}>
+                {orderedBentos.map(({ id, entry }) => (
+                  <SortableBento
+                    key={id}
+                    id={id}
+                    collapsed={!!bentoCollapsed[id]}
+                    onToggleCollapse={() => toggleCollapse(id)}
+                    colSpan={entry.colSpan}
+                    minHeight={entry.minHeight}
+                  >
+                    {entry.node}
+                  </SortableBento>
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        </div>
+
+        {/* ── MOBILE (< md) — stacked flex, no DnD ─────────────────────── */}
+        <div className="md:hidden flex flex-col gap-3">
+          {orderedBentos.map(({ id, entry }) => (
+            <SortableBento
+              key={id}
+              id={id}
+              collapsed={!!bentoCollapsed[id]}
+              onToggleCollapse={() => toggleCollapse(id)}
+              colSpan={entry.colSpan}
+              minHeight={entry.minHeight}
+              disableDrag
+            >
+              {entry.node}
+            </SortableBento>
+          ))}
+        </div>
+
       </div>
     </div>
   )

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -45,6 +45,7 @@ export const profile = {
   'profile.role.label.guest':   { en: 'Guest',                   bg: 'Гост'                     },
   'profile.incompleteHint':     { en: 'Complete your profile to get started.', bg: 'Попълнете профила си, за да започнете.' },
   'profile.resetLayout':        { en: 'Reset layout',            bg: 'Нулирай оформлението'     },
+  'profile.collapseAll':        { en: 'Collapse all',            bg: 'Свий всички'              },
   'profile.tile.personalDetails': { en: 'Personal Details', bg: 'Лични данни'           },
   'profile.tile.aboInfo':         { en: 'ABO Information',  bg: 'ABO Информация'        },
   'profile.tile.travelDoc':       { en: 'Travel Document',  bg: 'Документ за пътуване'  },


### PR DESCRIPTION
# [2604-BUG-84] Profile page mobile portrait layout broken — Dual Layout Law violation

Closes #84

## What

Four fixes in one commit across four files.

**1. Dual Layout Law — `page.tsx`**
Wrapped existing DnD grid in `hidden md:block`. Added `md:hidden` mobile block: `flex flex-col gap-3`, renders tiles via `<SortableBento disableDrag>` in `bentoOrder` order. Shares same `bentoCollapsed` state and `toggleCollapse` callback — persist path unchanged.

**2. Collapse all button — `page.tsx`**
Added `collapseAll` callback (sets `true` for every id in current `orderedBentos` via stable ref, persists). Button rendered next to `Reset layout` in the toolbar row.

**3. EmailPrefsSection inner collapse removed — `EmailPrefsSection.tsx`**
Dropped `open`, `onToggleOpen` props, `ChevronButton` component, and `{open && ...}` conditional. Toggles and footer note always render. Page no longer passes those props.

**4. Grip SVG — `SortableBento.tsx`**
Replaced `⠇` Braille glyph with the exact `GripIcon` SVG (6-dot 2×3 grid) from `AdminListCard.tsx`. `DragHandle` renders `GripIcon` inside the existing `<span>` wrapper.

**Translation — `lib/i18n/domains/profile.ts`**
Added `profile.collapseAll` key (`en: 'Collapse all'`, `bg: 'Свий всички'`).

## DoD

- [x] `SortableBento.tsx` accepts `disableDrag?: boolean`; when true, `DragHandle` not rendered and `useSortable` listeners not applied
- [x] `SortableBento` `DragHandle` renders a 6-dot 2×3 SVG (not `⠇`)
- [x] `page.tsx` has `hidden md:block` desktop block (DnD grid, existing logic unchanged) and `md:hidden` mobile block (`flex flex-col gap-3`, `SortableBento disableDrag`)
- [x] Mobile block reads `bentoCollapsed` and calls `toggleCollapse` — same state, same persist path
- [x] Collapse/expand works on mobile and state survives reload (persisted to `ui_prefs.bento_collapsed`)
- [x] `Collapse all` button appears next to `Reset layout`; clicking it collapses all tiles in `orderedBentos` and persists
- [x] Desktop DnD and collapse behaviour unchanged
- [x] `EmailPrefsSection.tsx` has no `open`/`onToggleOpen` props, no `ChevronButton`, always renders fully expanded
- [x] At 390px no tile is side-by-side; all tiles are full-width stacked cards

## Session State
**Status:** DONE
**Completed:**
- [x] All four DoD items implemented in single commit
**Next:** Merge via GitHub UI — issue closes automatically