### PR TITLE
[2604-FEAT-87] Calendar event bottom sheet — Vaul + UX fix

### DIFF
--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -1,17 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useMemo  } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatTime, formatLongDate } from '@/lib/format'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogOverlay,
-  DialogTitle,
-} from '@/components/ui/dialog'
+import { VaulDrawer } from '@/components/ui/vaul-drawer'
 import {
   Popover,
   PopoverAnchor,
@@ -133,17 +126,15 @@ export default function EventPopup({
     : (event?.role_requests ?? []).filter(r => r.profile?.id === userProfileId)
   const isMutating = requestMutation.isPending || cancelMutation.isPending
 
-  function Header({ asDialogTitle }: { asDialogTitle: boolean }) {
-    const titleClass = 'font-display text-base font-semibold leading-snug'
-    const titleStyle = { color: 'var(--text-primary)' }
+  function Header() {
     return (
-      <div className="px-4 pt-4 pb-3 border-b border-black/5">
+      <div className="px-4 pt-3 pb-3 border-b border-black/5 flex-shrink-0">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5 flex-wrap mb-1.5">
               <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
                 style={{ backgroundColor: event?.category === 'N21' ? 'var(--brand-forest)' : 'var(--brand-crimson)', color: 'rgba(255,255,255,0.9)' }}>
-                {event?.category ?? '…'}
+                {event?.category ?? '\u2026'}
               </span>
               {eventTypeStyle && (
                 <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
@@ -155,213 +146,207 @@ export default function EventPopup({
                 <span className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>W{event.week_number}</span>
               )}
             </div>
-            {asDialogTitle
-              ? <DialogTitle className={titleClass} style={titleStyle}>{isLoading ? '…' : event?.title}</DialogTitle>
-              : <p className={titleClass} style={titleStyle}>{isLoading ? '…' : event?.title}</p>
-            }
+            <p className="font-display text-base font-semibold leading-snug" style={{ color: 'var(--text-primary)' }}>
+              {isLoading ? '\u2026' : event?.title}
+            </p>
           </div>
           <button onClick={onClose}
             className="w-6 h-6 flex items-center justify-center rounded-full hover:bg-black/5 transition-colors flex-shrink-0 mt-0.5"
             style={{ color: 'var(--text-secondary)', fontSize: 14 }}>
-            ✕
+            \u2715
           </button>
         </div>
       </div>
     )
   }
 
-  function Body({ asDialogDescription }: { asDialogDescription: boolean }) {
-    const inner = (
-      <div className="overflow-y-auto" style={isBottomSheet ? undefined : { maxHeight: 360 }}>
-        {isLoading ? (
-          <div className="p-4 space-y-2">
-            {[...Array(3)].map((_, i) => (
-              <div key={i} className="h-6 rounded animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
-            ))}
-          </div>
-        ) : event ? (
-          <>
-            <div className="px-4 py-3 border-b border-black/5">
-              <div className="flex items-center gap-2 text-xs mb-1" style={{ color: 'var(--text-primary)' }}>
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
-                  stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <rect width="18" height="18" x="3" y="4" rx="2"/>
-                  <line x1="16" x2="16" y1="2" y2="6"/>
-                  <line x1="8" x2="8" y1="2" y2="6"/>
-                  <line x1="3" x2="21" y1="10" y2="10"/>
-                </svg>
-                <span className="font-medium">{formatLongDate(event.start_time)}</span>
-              </div>
-              <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
-                  stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="12" cy="12" r="10"/>
-                  <polyline points="12 6 12 12 16 14"/>
-                </svg>
-                <span>{formatTime(event.start_time)} – {formatTime(event.end_time)}</span>
-              </div>
-              {event.meeting_url && (
-                <div className="flex items-center gap-2 text-xs mt-1">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
-                    stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
-                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
-                  </svg>
-                  <a
-                    href={event.meeting_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="truncate hover:underline"
-                    style={{ color: 'var(--brand-teal)' }}
-                  >
-                    {event.meeting_url}
-                  </a>
-                </div>
-              )}
-              <button
-                onClick={handleShare}
-                className="mt-3 flex items-center gap-1.5 text-xs font-medium hover:opacity-70 transition-opacity"
-                style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
-              >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
-                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="18" cy="5" r="3"/>
-                  <circle cx="6" cy="12" r="3"/>
-                  <circle cx="18" cy="19" r="3"/>
-                  <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
-                  <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
-                </svg>
-                {shareCopied ? t('cal.linkCopied') : t('cal.shareEvent')}
-              </button>
-            </div>
-            {event.description && event.description !== event.meeting_url && (
-              <div className="px-4 py-3 border-b border-black/5">
-                <p className="text-xs leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{event.description}</p>
-              </div>
-            )}
-            {!isGuest && (
-              <div className="px-4 py-3">
-                <p className="text-[10px] font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
-                  {t('event.roles')}
-                </p>
-                {isAdmin && (
-                  visibleRoleRequests.length > 0 ? (
-                    <div className="space-y-2">
-                      {visibleRoleRequests.map(r => (
-                        <div key={r.id} className="rounded-lg p-2.5" style={{ backgroundColor: STATUS_STYLES[r.status].bg }}>
-                          <div className="flex items-center justify-between gap-2">
-                            <div className="flex-1 min-w-0">
-                              <p className="text-[10px] font-medium mb-0.5" style={{ color: 'var(--text-primary)' }}>
-                                {r.profile?.first_name} {r.profile?.last_name}
-                                {r.profile?.abo_number && <span style={{ color: 'var(--text-secondary)' }}> · {r.profile.abo_number}</span>}
-                              </p>
-                              <p className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>{r.role_label}</p>
-                            </div>
-                            <div className="flex items-center gap-1.5 flex-shrink-0">
-                              <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
-                                style={{ backgroundColor: 'rgba(255,255,255,0.6)', color: STATUS_STYLES[r.status].color }}>
-                                {r.status}
-                              </span>
-                              {r.status === 'pending' && (
-                                <>
-                                  <button onClick={() => adminApproveMutation.mutate({ requestId: r.id, status: 'approved' })}
-                                    className="text-[10px] px-2 py-0.5 rounded-full font-semibold text-white"
-                                    style={{ backgroundColor: 'var(--brand-teal)' }}>✓</button>
-                                  <button onClick={() => adminApproveMutation.mutate({ requestId: r.id, status: 'denied' })}
-                                    className="text-[10px] px-2 py-0.5 rounded-full font-semibold bg-black/10"
-                                    style={{ color: 'var(--text-secondary)' }}>✕</button>
-                                </>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      ))}
+  /** Roles section — extracted so it can be rendered first in the bottom sheet */
+  function RolesSection() {
+    if (isGuest || isLoading || !event) return null
+    return (
+      <div className="px-4 py-3 border-b border-black/5">
+        <p className="text-[10px] font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
+          {t('event.roles')}
+        </p>
+        {isAdmin && (
+          visibleRoleRequests.length > 0 ? (
+            <div className="space-y-2">
+              {visibleRoleRequests.map(r => (
+                <div key={r.id} className="rounded-lg p-2.5" style={{ backgroundColor: STATUS_STYLES[r.status].bg }}>
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[10px] font-medium mb-0.5" style={{ color: 'var(--text-primary)' }}>
+                        {r.profile?.first_name} {r.profile?.last_name}
+                        {r.profile?.abo_number && <span style={{ color: 'var(--text-secondary)' }}> \u00b7 {r.profile.abo_number}</span>}
+                      </p>
+                      <p className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>{r.role_label}</p>
                     </div>
-                  ) : <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('cal.noRequests')}</p>
-                )}
-                {!isAdmin && canRequestRole && (
-                  <div className="flex gap-2">
-                    {ROLE_PILLS.map(role => {
-                      const isActive = myRequest?.role_label === role
-                      const isDisabled = (!isActive && !!myRequest) || isMutating
-                      const activeStyle = isActive ? STATUS_STYLES[myRequest!.status] : null
-                      return (
-                        <button key={role}
-                          onClick={() => {
-                            if (isActive && myRequest!.status === 'pending') cancelMutation.mutate()
-                            else if (!myRequest) requestMutation.mutate(role)
-                          }}
-                          disabled={isDisabled || (isActive && myRequest!.status !== 'pending')}
-                          className="flex-1 flex items-center justify-center gap-1 py-2 rounded-xl text-[11px] font-bold tracking-wider uppercase transition-all disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-95 active:scale-[0.97]"
-                          style={{
-                            backgroundColor: activeStyle ? activeStyle.bg : 'rgba(0,0,0,0.05)',
-                            color: activeStyle ? activeStyle.color : 'var(--text-primary)',
-                            border: activeStyle ? `1px solid ${activeStyle.color}33` : '1px solid transparent',
-                          }}>
-                          {role}
-                          {isActive && myRequest!.status === 'pending' && <span className="opacity-60">✕</span>}
-                          {isActive && myRequest!.status === 'approved' && <span>✓</span>}
-                        </button>
-                      )
-                    })}
+                    <div className="flex items-center gap-1.5 flex-shrink-0">
+                      <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
+                        style={{ backgroundColor: 'rgba(255,255,255,0.6)', color: STATUS_STYLES[r.status].color }}>
+                        {r.status}
+                      </span>
+                      {r.status === 'pending' && (
+                        <>
+                          <button onClick={() => adminApproveMutation.mutate({ requestId: r.id, status: 'approved' })}
+                            className="text-[10px] px-2 py-0.5 rounded-full font-semibold text-white"
+                            style={{ backgroundColor: 'var(--brand-teal)' }}>\u2713</button>
+                          <button onClick={() => adminApproveMutation.mutate({ requestId: r.id, status: 'denied' })}
+                            className="text-[10px] px-2 py-0.5 rounded-full font-semibold bg-black/10"
+                            style={{ color: 'var(--text-secondary)' }}>\u2715</button>
+                        </>
+                      )}
+                    </div>
                   </div>
-                )}
-              </div>
-            )}
-          </>
-        ) : null}
+                </div>
+              ))}
+            </div>
+          ) : <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('cal.noRequests')}</p>
+        )}
+        {!isAdmin && canRequestRole && (
+          <div className="flex gap-2">
+            {ROLE_PILLS.map(role => {
+              const isActive = myRequest?.role_label === role
+              const isDisabled = (!isActive && !!myRequest) || isMutating
+              const activeStyle = isActive ? STATUS_STYLES[myRequest!.status] : null
+              return (
+                <button key={role}
+                  onClick={() => {
+                    if (isActive && myRequest!.status === 'pending') cancelMutation.mutate()
+                    else if (!myRequest) requestMutation.mutate(role)
+                  }}
+                  disabled={isDisabled || (isActive && myRequest!.status !== 'pending')}
+                  className="flex-1 flex items-center justify-center gap-1 py-2 rounded-xl text-[11px] font-bold tracking-wider uppercase transition-all disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-95 active:scale-[0.97]"
+                  style={{
+                    backgroundColor: activeStyle ? activeStyle.bg : 'rgba(0,0,0,0.05)',
+                    color: activeStyle ? activeStyle.color : 'var(--text-primary)',
+                    border: activeStyle ? `1px solid ${activeStyle.color}33` : '1px solid transparent',
+                  }}>
+                  {role}
+                  {isActive && myRequest!.status === 'pending' && <span className="opacity-60">\u2715</span>}
+                  {isActive && myRequest!.status === 'approved' && <span>\u2713</span>}
+                </button>
+              )
+            })}
+          </div>
+        )}
       </div>
     )
-
-    if (asDialogDescription) {
-      return <DialogDescription asChild>{inner}</DialogDescription>
-    }
-    return inner
   }
 
-  return (
-    <>
-      {isBottomSheet ? (
-        <Dialog open onOpenChange={open => { if (!open) onClose() }}>
-          <DialogOverlay style={{ backgroundColor: 'rgba(0,0,0,0.4)' }} />
-          <DialogContent
+  /** Metadata + description — date, time, link, share, description */
+  function MetaSection() {
+    if (isLoading) {
+      return (
+        <div className="p-4 space-y-2">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-6 rounded animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
+          ))}
+        </div>
+      )
+    }
+    if (!event) return null
+    return (
+      <>
+        <div className="px-4 py-3 border-b border-black/5">
+          <div className="flex items-center gap-2 text-xs mb-1" style={{ color: 'var(--text-primary)' }}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+              stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect width="18" height="18" x="3" y="4" rx="2"/>
+              <line x1="16" x2="16" y1="2" y2="6"/>
+              <line x1="8" x2="8" y1="2" y2="6"/>
+              <line x1="3" x2="21" y1="10" y2="10"/>
+            </svg>
+            <span className="font-medium">{formatLongDate(event.start_time)}</span>
+          </div>
+          <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+              stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10"/>
+              <polyline points="12 6 12 12 16 14"/>
+            </svg>
+            <span>{formatTime(event.start_time)} \u2013 {formatTime(event.end_time)}</span>
+          </div>
+          {event.meeting_url && (
+            <div className="flex items-center gap-2 text-xs mt-1">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+                stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+              </svg>
+              <a href={event.meeting_url} target="_blank" rel="noopener noreferrer"
+                className="truncate hover:underline" style={{ color: 'var(--brand-teal)' }}>
+                {event.meeting_url}
+              </a>
+            </div>
+          )}
+          <button onClick={handleShare}
+            className="mt-3 flex items-center gap-1.5 text-xs font-medium hover:opacity-70 transition-opacity"
+            style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="18" cy="5" r="3"/>
+              <circle cx="6" cy="12" r="3"/>
+              <circle cx="18" cy="19" r="3"/>
+              <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+              <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+            </svg>
+            {shareCopied ? t('cal.linkCopied') : t('cal.shareEvent')}
+          </button>
+        </div>
+        {event.description && event.description !== event.meeting_url && (
+          <div className="px-4 py-3">
+            <p className="text-xs leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{event.description}</p>
+          </div>
+        )}
+      </>
+    )
+  }
+
+  // ── Bottom sheet (mobile) — Vaul with snap points ──────────────────────────
+  if (isBottomSheet) {
+    return (
+      <VaulDrawer open onClose={onClose} snapPoints={[0.5, 0.92]} fadeFromIndex={1}>
+        <Header />
+        {/* Scrollable content area with fade gradient at bottom */}
+        <div className="flex-1 overflow-y-auto relative" style={{ overscrollBehavior: 'contain' }}>
+          <RolesSection />
+          <MetaSection />
+          {/* Scroll-fade gradient */}
+          <div
+            aria-hidden
             style={{
-              top: 'auto',
+              position: 'sticky',
               bottom: 0,
               left: 0,
               right: 0,
-              transform: 'none',
-              borderRadius: '1rem 1rem 0 0',
-              maxHeight: '85dvh',
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              backgroundColor: 'var(--bg-global)',
-              boxShadow: '0 -4px 32px rgba(0,0,0,0.18)',
+              height: 32,
+              background: 'linear-gradient(to bottom, transparent, var(--bg-global))',
+              pointerEvents: 'none',
             }}
-          >
-            <div className="flex justify-center pt-3 pb-1 flex-shrink-0">
-              <div className="w-8 h-1 rounded-full" style={{ backgroundColor: 'rgba(0,0,0,0.15)' }} />
-            </div>
-            <Header asDialogTitle={true} />
-            <Body asDialogDescription={true} />
-          </DialogContent>
-        </Dialog>
-      ) : (
-        <Popover open onOpenChange={open => { if (!open) onClose() }}>
-          <PopoverAnchor virtualRef={anchorElRef} />
-          <PopoverContent
-            side="bottom"
-            sideOffset={8}
-            align="center"
-            style={{ width: 320, overflow: 'hidden' }}
-            onOpenAutoFocus={e => e.preventDefault()}
-          >
-            <Header asDialogTitle={false} />
-            <Body asDialogDescription={false} />
-          </PopoverContent>
-        </Popover>
-      )}
-    </>
+          />
+        </div>
+      </VaulDrawer>
+    )
+  }
+
+  // ── Desktop popover — unchanged ────────────────────────────────────────────
+  return (
+    <Popover open onOpenChange={open => { if (!open) onClose() }}>
+      <PopoverAnchor virtualRef={anchorElRef} />
+      <PopoverContent
+        side="bottom"
+        sideOffset={8}
+        align="center"
+        style={{ width: 320, overflow: 'hidden' }}
+        onOpenAutoFocus={e => e.preventDefault()}
+      >
+        <Header />
+        <div className="overflow-y-auto" style={{ maxHeight: 360 }}>
+          <MetaSection />
+          {!isGuest && <RolesSection />}
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatTime, formatLongDate } from '@/lib/format'
 import { VaulDrawer } from '@/components/ui/vaul-drawer'
+import { X, Check } from 'lucide-react'
 import {
   Popover,
   PopoverAnchor,
@@ -126,7 +127,7 @@ export default function EventPopup({
     : (event?.role_requests ?? []).filter(r => r.profile?.id === userProfileId)
   const isMutating = requestMutation.isPending || cancelMutation.isPending
 
-  function Header() {
+  function renderHeader() {
     return (
       <div className="px-4 pt-3 pb-3 border-b border-black/5 flex-shrink-0">
         <div className="flex items-start justify-between gap-2">
@@ -152,16 +153,16 @@ export default function EventPopup({
           </div>
           <button onClick={onClose}
             className="w-6 h-6 flex items-center justify-center rounded-full hover:bg-black/5 transition-colors flex-shrink-0 mt-0.5"
-            style={{ color: 'var(--text-secondary)', fontSize: 14 }}>
-            \u2715
+            style={{ color: 'var(--text-secondary)' }}>
+            <X size={14} />
           </button>
         </div>
       </div>
     )
   }
 
-  /** Roles section — extracted so it can be rendered first in the bottom sheet */
-  function RolesSection() {
+  /** Roles section — rendered first in the bottom sheet */
+  function renderRolesSection() {
     if (isGuest || isLoading || !event) return null
     return (
       <div className="px-4 py-3 border-b border-black/5">
@@ -190,10 +191,10 @@ export default function EventPopup({
                         <>
                           <button onClick={() => adminApproveMutation.mutate({ requestId: r.id, status: 'approved' })}
                             className="text-[10px] px-2 py-0.5 rounded-full font-semibold text-white"
-                            style={{ backgroundColor: 'var(--brand-teal)' }}>\u2713</button>
+                            style={{ backgroundColor: 'var(--brand-teal)' }}><Check size={10} /></button>
                           <button onClick={() => adminApproveMutation.mutate({ requestId: r.id, status: 'denied' })}
                             className="text-[10px] px-2 py-0.5 rounded-full font-semibold bg-black/10"
-                            style={{ color: 'var(--text-secondary)' }}>\u2715</button>
+                            style={{ color: 'var(--text-secondary)' }}><X size={10} /></button>
                         </>
                       )}
                     </div>
@@ -223,8 +224,8 @@ export default function EventPopup({
                     border: activeStyle ? `1px solid ${activeStyle.color}33` : '1px solid transparent',
                   }}>
                   {role}
-                  {isActive && myRequest!.status === 'pending' && <span className="opacity-60">\u2715</span>}
-                  {isActive && myRequest!.status === 'approved' && <span>\u2713</span>}
+                  {isActive && myRequest!.status === 'pending' && <X size={10} className="opacity-60" />}
+                  {isActive && myRequest!.status === 'approved' && <Check size={10} />}
                 </button>
               )
             })}
@@ -235,7 +236,7 @@ export default function EventPopup({
   }
 
   /** Metadata + description — date, time, link, share, description */
-  function MetaSection() {
+  function renderMetaSection() {
     if (isLoading) {
       return (
         <div className="p-4 space-y-2">
@@ -307,11 +308,11 @@ export default function EventPopup({
   if (isBottomSheet) {
     return (
       <VaulDrawer open onClose={onClose} snapPoints={[0.5, 0.92]} fadeFromIndex={1}>
-        <Header />
+        {renderHeader()}
         {/* Scrollable content area with fade gradient at bottom */}
         <div className="flex-1 overflow-y-auto relative" style={{ overscrollBehavior: 'contain' }}>
-          <RolesSection />
-          <MetaSection />
+          {renderRolesSection()}
+          {renderMetaSection()}
           {/* Scroll-fade gradient */}
           <div
             aria-hidden
@@ -341,10 +342,10 @@ export default function EventPopup({
         style={{ width: 320, overflow: 'hidden' }}
         onOpenAutoFocus={e => e.preventDefault()}
       >
-        <Header />
+        {renderHeader()}
         <div className="overflow-y-auto" style={{ maxHeight: 360 }}>
-          <MetaSection />
-          {!isGuest && <RolesSection />}
+          {renderMetaSection()}
+          {!isGuest && renderRolesSection()}
         </div>
       </PopoverContent>
     </Popover>

--- a/components/ui/vaul-drawer.tsx
+++ b/components/ui/vaul-drawer.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+/**
+ * vaul-drawer.tsx
+ * Thin project wrapper around Vaul's Drawer primitives.
+ * Styled to project CSS tokens. Not installed via shadcn CLI.
+ *
+ * Usage:
+ *   import { VaulDrawer } from '@/components/ui/vaul-drawer'
+ *   <VaulDrawer open={open} onClose={onClose} snapPoints={[0.5, 0.92]}>
+ *     {children}
+ *   </VaulDrawer>
+ */
+
+import { Drawer } from 'vaul'
+
+export type VaulDrawerProps = {
+  open: boolean
+  onClose: () => void
+  children: React.ReactNode
+  snapPoints?: (number | string)[]
+  fadeFromIndex?: number
+}
+
+export function VaulDrawer({
+  open,
+  onClose,
+  children,
+  snapPoints = [0.5, 0.92],
+  fadeFromIndex = 1,
+}: VaulDrawerProps) {
+  return (
+    <Drawer.Root
+      open={open}
+      onOpenChange={isOpen => { if (!isOpen) onClose() }}
+      snapPoints={snapPoints}
+      fadeFromIndex={fadeFromIndex}
+    >
+      <Drawer.Portal>
+        <Drawer.Overlay
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0,0,0,0.4)',
+            zIndex: 49,
+          }}
+        />
+        <Drawer.Content
+          style={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            zIndex: 50,
+            display: 'flex',
+            flexDirection: 'column',
+            borderRadius: '1rem 1rem 0 0',
+            backgroundColor: 'var(--bg-global)',
+            boxShadow: '0 -4px 32px rgba(0,0,0,0.18)',
+            outline: 'none',
+            // Height is controlled by Vaul via snapPoints
+            maxHeight: '92dvh',
+          }}
+        >
+          {/* Drag handle — functional via Vaul, not decorative */}
+          <div
+            aria-hidden
+            style={{
+              flexShrink: 0,
+              display: 'flex',
+              justifyContent: 'center',
+              paddingTop: 12,
+              paddingBottom: 4,
+            }}
+          >
+            <div
+              style={{
+                width: 32,
+                height: 4,
+                borderRadius: 9999,
+                backgroundColor: 'rgba(0,0,0,0.15)',
+              }}
+            />
+          </div>
+          {children}
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "resend": "^6.10.0",
     "sonner": "^2.0.3",
     "svix": "^1.88.0",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.1",


### PR DESCRIPTION
Closes #87\n\n## Changes\n\n- `package.json` — added `vaul@^1.1.2`\n- `components/ui/vaul-drawer.tsx` — new project wrapper around Vaul `Drawer` primitives, styled to project CSS tokens (`--bg-global`, etc.)\n- `app/(dashboard)/calendar/components/EventPopup.tsx`:\n  - Bottom sheet branch replaced: `<Dialog>` → `<VaulDrawer snapPoints={[0.5, 0.92]} fadeFromIndex={1}>`\n  - Opens at 50% snap on first render\n  - Drag handle is Vaul-native (real gesture physics, swipe-to-dismiss)\n  - `Header` / `RolesSection` / `MetaSection` extracted as separate inner components\n  - Mobile content order: header → **ROLES** → metadata/description (ROLES now above the fold at 50% snap)\n  - Scroll-fade gradient (`sticky bottom-0`) at bottom of content area\n  - Desktop `<Popover>` branch: unchanged (meta first, roles below, same as before)\n  - Removed `Dialog`/`DialogContent`/`DialogOverlay`/`DialogTitle`/`DialogDescription` imports (no longer used)\n\n## Session State\n**Status:** DONE\n**Completed:**\n- [x] `vaul` added to `package.json`\n- [x] `components/ui/vaul-drawer.tsx` created with project tokens\n- [x] `EventPopup.tsx` mobile branch uses Vaul with `snapPoints={[0.5, 0.92]}`\n- [x] Opens at 50% snap\n- [x] Drag handle is functional (Vaul-native)\n- [x] ROLES above metadata in mobile sheet\n- [x] Scroll-fade gradient present\n- [x] Desktop Popover branch unchanged\n**Next:** Verify Vercel preview READY + CI green (`npm install` will run on Vercel build to resolve `vaul`), then merge