### PR TITLE
[2604-FEAT-88] About page — i18n + visual redesign

### DIFF
--- a/app/(dashboard)/about/components/AboutContent.tsx
+++ b/app/(dashboard)/about/components/AboutContent.tsx
@@ -2,12 +2,18 @@
 
 import { useLanguage } from '@/lib/hooks/useLanguage'
 
+const MISSION_WORD: Record<'en' | 'bg', string> = {
+  en: 'mission',
+  bg: '\u043c\u0438\u0441\u0438\u044f',
+}
+
 export default function AboutContent() {
-  const { t } = useLanguage()
+  const { lang, t } = useLanguage()
 
   const title = t('about.title')
-  const titleParts = title.split('mission')
-  const hasMissionWord = titleParts.length > 1
+  const keyword = MISSION_WORD[lang]
+  const titleParts = title.split(keyword)
+  const hasKeyword = titleParts.length > 1
 
   return (
     <div className="flex flex-col justify-center gap-3 px-1 py-2">
@@ -19,15 +25,15 @@ export default function AboutContent() {
         {t('about.eyebrow')}
       </p>
 
-      {/* Display title — italic teal on the word "mission" (EN only) */}
+      {/* Display title — italic teal on the mission/мисия keyword */}
       <h1
         className="font-display text-2xl font-semibold leading-snug"
         style={{ color: 'var(--text-primary)' }}
       >
-        {hasMissionWord ? (
+        {hasKeyword ? (
           <>
             {titleParts[0]}
-            <em style={{ color: 'var(--brand-teal)', fontStyle: 'italic' }}>mission</em>
+            <em style={{ color: 'var(--brand-teal)', fontStyle: 'italic' }}>{keyword}</em>
             {titleParts[1]}
           </>
         ) : (

--- a/app/(dashboard)/about/components/AboutContent.tsx
+++ b/app/(dashboard)/about/components/AboutContent.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useLanguage } from '@/lib/hooks/useLanguage'
+
+export default function AboutContent() {
+  const { t } = useLanguage()
+
+  const title = t('about.title')
+  const titleParts = title.split('mission')
+  const hasMissionWord = titleParts.length > 1
+
+  return (
+    <div className="flex flex-col justify-center gap-3 px-1 py-2">
+      {/* Eyebrow */}
+      <p
+        className="text-[11px] font-semibold tracking-widest uppercase"
+        style={{ color: 'var(--brand-crimson)' }}
+      >
+        {t('about.eyebrow')}
+      </p>
+
+      {/* Display title — italic teal on the word "mission" (EN only) */}
+      <h1
+        className="font-display text-2xl font-semibold leading-snug"
+        style={{ color: 'var(--text-primary)' }}
+      >
+        {hasMissionWord ? (
+          <>
+            {titleParts[0]}
+            <em style={{ color: 'var(--brand-teal)', fontStyle: 'italic' }}>mission</em>
+            {titleParts[1]}
+          </>
+        ) : (
+          title
+        )}
+      </h1>
+
+      {/* Rule + body paragraph 1 */}
+      <div
+        className="h-px w-8 rounded-full"
+        style={{ backgroundColor: 'var(--brand-crimson)', opacity: 0.4 }}
+      />
+      <p className="text-sm leading-relaxed font-body" style={{ color: 'var(--text-secondary)' }}>
+        {t('about.body1')}
+      </p>
+
+      {/* Rule + body paragraph 2 */}
+      <div
+        className="h-px w-8 rounded-full"
+        style={{ backgroundColor: 'var(--brand-crimson)', opacity: 0.4 }}
+      />
+      <p className="text-sm leading-relaxed font-body" style={{ color: 'var(--text-secondary)' }}>
+        {t('about.body2')}
+      </p>
+    </div>
+  )
+}

--- a/app/(dashboard)/about/components/AboutContent.tsx
+++ b/app/(dashboard)/about/components/AboutContent.tsx
@@ -12,8 +12,9 @@ export default function AboutContent() {
 
   const title = t('about.title')
   const keyword = MISSION_WORD[lang]
-  const titleParts = title.split(keyword)
-  const hasKeyword = titleParts.length > 1
+  // Capturing group in the regex preserves the matched text in the split array,
+  // and the 'i' flag makes the match case-insensitive.
+  const titleParts = title.split(new RegExp(`(${keyword})`, 'i'))
 
   return (
     <div className="flex flex-col justify-center gap-3 px-1 py-2">
@@ -30,14 +31,12 @@ export default function AboutContent() {
         className="font-display text-2xl font-semibold leading-snug"
         style={{ color: 'var(--text-primary)' }}
       >
-        {hasKeyword ? (
-          <>
-            {titleParts[0]}
-            <em style={{ color: 'var(--brand-teal)', fontStyle: 'italic' }}>{keyword}</em>
-            {titleParts[1]}
-          </>
-        ) : (
-          title
+        {titleParts.map((part, i) =>
+          part.toLowerCase() === keyword.toLowerCase() ? (
+            <em key={i} style={{ color: 'var(--brand-teal)', fontStyle: 'italic' }}>{part}</em>
+          ) : (
+            part
+          )
         )}
       </h1>
 

--- a/app/(dashboard)/about/page.tsx
+++ b/app/(dashboard)/about/page.tsx
@@ -63,7 +63,6 @@ export default function AboutPage() {
 
           {/* Row 2 col 7–10: map tile */}
           <AboutMapTileDynamic
-            gridColumn="7 / span 4"
             style={{
               gridColumn: '7 / span 4',
               gridRow: '2',

--- a/app/(dashboard)/about/page.tsx
+++ b/app/(dashboard)/about/page.tsx
@@ -1,42 +1,9 @@
 import Image from 'next/image'
 import AboutMapTileDynamic from './components/AboutMapTileDynamic'
 import MailtoTile from './components/MailtoTile'
+import AboutContent from './components/AboutContent'
 
-// ── Shared content blocks ────────────────────────────────────────────────────
-
-const HEADING = (
-  <div className="flex items-center justify-end h-full px-2 py-4">
-    <h1
-      className="font-display text-3xl font-semibold text-right"
-      style={{ color: 'var(--text-primary)' }}
-    >
-      About Us
-    </h1>
-  </div>
-)
-
-const BODY = (
-  <div className="flex flex-col gap-4">
-    <p className="text-base leading-relaxed font-body" style={{ color: 'var(--text-secondary)' }}>
-      We&apos;re Vera &amp; Deniz, two folks living it up in the vibrant city of Sofia, Bulgaria.
-      We&apos;re all about good vibes, delicious grub, and that perfect cup of coffee ☕️
-    </p>
-    <p className="text-base leading-relaxed font-body" style={{ color: 'var(--text-secondary)' }}>
-      But hey, there&apos;s more to us than just our love for the simple pleasures. We&apos;re all
-      about forging meaningful connections that stand the test of time. We&apos;re on a mission
-      to build rock-solid relationships with like-minded individuals who share our passion
-      and vision.
-    </p>
-    <p className="text-base leading-relaxed font-body" style={{ color: 'var(--text-secondary)' }}>
-      So, if you&apos;ve made it to our corner of the web, you must be on the hunt for
-      something special. Reach out to the person who directed you here to dig deeper into
-      what we&apos;re all about. If you stumbled upon us all by yourself, kudos! Slide into
-      our DMs and let&apos;s have a chat. We love meeting new folks.
-    </p>
-  </div>
-)
-
-// ── Page ─────────────────────────────────────────────────────────────────────────────
+// ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function AboutPage() {
   return (
@@ -44,63 +11,37 @@ export default function AboutPage() {
 
       {/* ════════════════════════════════════════════════════════════════════
           DESKTOP layout (md+)
-          12-col CSS grid, explicit placement
-          Row 1: [col 1–3 empty][col 4–6 heading][col 7–9 text rowspan 2][col 10–12 empty]
-          Row 2: [col 1–6 empty]               [col 7–9 text cont.]    [col 10–12 empty]
-          Row 3: [col 1–3 hero][col 4–6 empty] [col 7–9 mailto]        [col 10–12 map]
+          12-col CSS grid, max-w-[860px] centred
+          Row 1: [1–2 gutter] [3–6 heading+content island] [7–10 photo] [11–12 gutter]
+          Row 2: [1–2 gutter] [3–6 mailto]                 [7–10 map]   [11–12 gutter]
           ════════════════════════════════════════════════════════════════════ */}
-      <div className="hidden md:block max-w-[1280px] mx-auto px-4 sm:px-6 xl:px-8">
+      <div className="hidden md:block max-w-[860px] mx-auto px-4">
         <div
           style={{
             display: 'grid',
             gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
             gap: '12px',
-            gridAutoRows: 'minmax(120px, auto)',
+            gridAutoRows: 'minmax(160px, auto)',
           }}
         >
-          {/* Row 1 col 1–3: empty */}
-          <div style={{ gridColumn: '1 / span 3', gridRow: '1' }} />
-
-          {/* Row 1 col 4–6: heading — transparent */}
+          {/* Row 1 col 3–6: heading + content island (transparent) */}
           <div
             style={{
-              gridColumn: '4 / span 3',
+              gridColumn: '3 / span 4',
               gridRow: '1',
               borderRadius: 'var(--bento-radius)',
               padding: 'var(--bento-padding)',
             }}
           >
-            {HEADING}
+            <AboutContent />
           </div>
 
-          {/* Row 1–2 col 7–9: body text — transparent, rowspan 2 */}
-          <div
-            style={{
-              gridColumn: '7 / span 3',
-              gridRow: '1 / span 2',
-              borderRadius: 'var(--bento-radius)',
-              padding: 'var(--bento-padding)',
-            }}
-          >
-            {BODY}
-          </div>
-
-          {/* Row 1 col 10–12: empty */}
-          <div style={{ gridColumn: '10 / span 3', gridRow: '1' }} />
-
-          {/* Row 2 col 1–6: empty */}
-          <div style={{ gridColumn: '1 / span 6', gridRow: '2' }} />
-
-          {/* Row 2 col 10–12: empty */}
-          <div style={{ gridColumn: '10 / span 3', gridRow: '2' }} />
-
-          {/* Row 3 col 1–3: square hero image */}
+          {/* Row 1 col 7–10: hero photo */}
           <div
             className="rounded-2xl overflow-hidden relative"
             style={{
-              gridColumn: '1 / span 3',
-              gridRow: '3',
-              aspectRatio: '1 / 1',
+              gridColumn: '7 / span 4',
+              gridRow: '1',
             }}
           >
             <Image
@@ -112,38 +53,36 @@ export default function AboutPage() {
             />
           </div>
 
-          {/* Row 3 col 4–6: empty */}
-          <div style={{ gridColumn: '4 / span 3', gridRow: '3' }} />
-
-          {/* Row 3 col 7–9: mailto tile (client component — interactive-lift) */}
-          <MailtoTile style={{ gridColumn: '7 / span 3', gridRow: '3' }} />
-
-          {/* Row 3 col 10–12: map — client-only via dynamic wrapper */}
-          <AboutMapTileDynamic
-            gridColumn="10 / span 3"
-            style={{ gridColumn: '10 / span 3', gridRow: '3', minHeight: 120 }}
+          {/* Row 2 col 3–6: mailto tile */}
+          <MailtoTile
+            style={{
+              gridColumn: '3 / span 4',
+              gridRow: '2',
+            }}
           />
 
+          {/* Row 2 col 7–10: map tile */}
+          <AboutMapTileDynamic
+            gridColumn="7 / span 4"
+            style={{
+              gridColumn: '7 / span 4',
+              gridRow: '2',
+              minHeight: 160,
+            }}
+          />
         </div>
       </div>
 
       {/* ════════════════════════════════════════════════════════════════════
           MOBILE layout (< md)
+          Stack: photo → heading/content island → mailto + map (2-col row)
           ════════════════════════════════════════════════════════════════════ */}
       <div className="md:hidden flex flex-col gap-3 px-4">
 
+        {/* Photo */}
         <div
-          style={{
-            borderRadius: 'var(--bento-radius)',
-            padding: 'var(--bento-padding)',
-          }}
-        >
-          {HEADING}
-        </div>
-
-        <div
-          className="rounded-2xl overflow-hidden relative"
-          style={{ aspectRatio: '1 / 1', width: '100%' }}
+          className="rounded-2xl overflow-hidden relative w-full"
+          style={{ aspectRatio: '4 / 3' }}
         >
           <Image
             src="/about-hero.png"
@@ -154,15 +93,17 @@ export default function AboutPage() {
           />
         </div>
 
+        {/* Heading + body content island */}
         <div
           style={{
             borderRadius: 'var(--bento-radius)',
             padding: 'var(--bento-padding)',
           }}
         >
-          {BODY}
+          <AboutContent />
         </div>
 
+        {/* Mailto + map side-by-side */}
         <div className="grid grid-cols-2 gap-3">
           <MailtoTile style={{ minHeight: 96 }} />
           <AboutMapTileDynamic style={{ minHeight: 96 }} />

--- a/lib/i18n/domains/about.ts
+++ b/lib/i18n/domains/about.ts
@@ -1,0 +1,12 @@
+export const about = {
+  'about.eyebrow': { en: 'Team Enjoy VD',                bg: 'Тийм Enjoy VD'                                              },
+  'about.title':   { en: 'Two people, one mission.',     bg: 'Двама души, една мисия.'                                    },
+  'about.body1':   {
+    en: "We're Vera & Deniz, two folks living it up in the vibrant city of Sofia, Bulgaria. We're all about good vibes, delicious grub, and that perfect cup of coffee ☕️",
+    bg: 'Ние сме Вера и Дениз — двама души, влюбени в пъстрия живот на София. Добро настроение, вкусна храна и перфектното кафе ☕️'
+  },
+  'about.body2':   {
+    en: "But there's more to us than just our love for the simple pleasures. We're all about forging meaningful connections that stand the test of time — on a mission to build rock-solid relationships with like-minded individuals who share our passion and vision.",
+    bg: 'Но има нещо повече от обичта към простите радости. Изграждаме истински връзки, издържащи изпитанието на времето — с хора, споделящи нашата страст и визия.'
+  },
+} as const

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -12,6 +12,7 @@ import { los }           from './domains/los'
 import { admin }         from './domains/admin'
 import { payment }       from './domains/payment'
 import { home }          from './domains/home'
+import { about }         from './domains/about'
 
 export type Lang = 'en' | 'bg'
 
@@ -42,7 +43,7 @@ function assertNoDuplicateKeys(
 
 assertNoDuplicateKeys([
   nav, roles, announcements, time, guides,
-  notifications, profile, trips, calendar, events, los, admin, payment, home,
+  notifications, profile, trips, calendar, events, los, admin, payment, home, about,
 ])
 
 export const translations = {
@@ -60,6 +61,7 @@ export const translations = {
   ...admin,
   ...payment,
   ...home,
+  ...about,
 } as const
 
 export type TranslationKey = keyof typeof translations


### PR DESCRIPTION
Closes #88

## Changes

- `lib/i18n/domains/about.ts` — new domain file with 4 keys: `about.eyebrow`, `about.title`, `about.body1`, `about.body2` (EN + BG)
- `lib/i18n/index.ts` — imports and spreads `about` domain; added to `assertNoDuplicateKeys` guard
- `app/(dashboard)/about/components/AboutContent.tsx` — new `'use client'` island; calls `useLanguage()`, renders eyebrow (crimson), display title with italic teal `mission` word (EN only, BG falls through cleanly), crimson rule dividers, both body paragraphs
- `app/(dashboard)/about/page.tsx` — full rewrite:
  - Remains RSC (no `'use client'`)
  - Desktop: `max-w-[860px] mx-auto`, 12-col grid, col 3–6 = `<AboutContent />`, col 7–10 = photo (row 1); col 3–6 = mailto, col 7–10 = map (row 2). Zero empty spacer divs.
  - Mobile: photo → content island → mailto + map 2-col row
  - `MailtoTile` and `AboutMapTileDynamic` unchanged except grid placement

## DoD Verification

- [x] `AboutContent.tsx` exists, `'use client'`, calls `useLanguage()`, renders all 4 translatable strings
- [x] `about.eyebrow`, `about.title`, `about.body1`, `about.body2` in both `en` and `bg`
- [x] `page.tsx` has no `'use client'` — stays RSC
- [x] Desktop: `max-w-[860px] mx-auto`, 12-col grid, content col 3–10, gutters 1–2 and 11–12
- [x] Row 1: heading col 3–6, photo col 7–10
- [x] Row 2: mailto col 3–6, map col 7–10 (issue specifies row 3 but with no separate body row the DoD row numbers collapse by 1 — same visual result)
- [x] Photo: `object-cover` fill
- [x] Mobile: photo → content → mailto+map 2-col
- [x] Language toggle will switch heading and body without reload (island re-renders on lang state change)
- [x] Zero empty spacer divs

## Session State
**Status:** DONE
**Completed:**
- [x] `lib/i18n/domains/about.ts` created
- [x] `lib/i18n/index.ts` updated
- [x] `AboutContent.tsx` created
- [x] `page.tsx` rewritten
**Next:** Verify Vercel preview READY + CI green, then merge