### PR TITLE
[2604-BUG-106] EventPopup: gate meeting_url + share button

### DIFF
--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -126,7 +126,7 @@ export default function EventPopup({
             <div className="flex items-center gap-1.5 flex-wrap mb-1.5">
               <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
                 style={{ backgroundColor: event?.category === 'N21' ? 'var(--brand-forest)' : 'var(--brand-crimson)', color: 'rgba(255,255,255,0.9)' }}>
-                {event?.category ?? '\u2026'}
+                {event?.category ?? '…'}
               </span>
               {eventTypeStyle && (
                 <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
@@ -139,7 +139,7 @@ export default function EventPopup({
               )}
             </div>
             <p className="font-display text-base font-semibold leading-snug" style={{ color: 'var(--text-primary)' }}>
-              {isLoading ? '\u2026' : event?.title}
+              {isLoading ? '…' : event?.title}
             </p>
           </div>
           <button onClick={onClose}
@@ -167,7 +167,7 @@ export default function EventPopup({
                         <div className="flex-1 min-w-0">
                           <p className="text-[10px] font-medium mb-0.5" style={{ color: 'var(--text-primary)' }}>
                             {r.profile?.first_name} {r.profile?.last_name}
-                            {r.profile?.abo_number && <span style={{ color: 'var(--text-secondary)' }}> \u00b7 {r.profile.abo_number}</span>}
+                            {r.profile?.abo_number && <span style={{ color: 'var(--text-secondary)' }}> · {r.profile.abo_number}</span>}
                           </p>
                           <p className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>{r.role_label}</p>
                         </div>
@@ -249,7 +249,7 @@ export default function EventPopup({
                   <circle cx="12" cy="12" r="10"/>
                   <polyline points="12 6 12 12 16 14"/>
                 </svg>
-                <span>{formatTime(event.start_time)} \u2013 {formatTime(event.end_time)}</span>
+                <span>{formatTime(event.start_time)} – {formatTime(event.end_time)}</span>
               </div>
               {!isGuest && event.meeting_url && (
                 <div className="flex items-center gap-2 text-xs mt-1">

--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -26,6 +26,7 @@ type EventDetail = {
   title: string
   description: string | null
   meeting_url: string | null
+  allow_guest_registration: boolean
   start_time: string
   end_time: string
   category: 'N21' | 'Personal'
@@ -250,7 +251,7 @@ export default function EventPopup({
                 </svg>
                 <span>{formatTime(event.start_time)} \u2013 {formatTime(event.end_time)}</span>
               </div>
-              {event.meeting_url && (
+              {!isGuest && event.meeting_url && (
                 <div className="flex items-center gap-2 text-xs mt-1">
                   <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
                     stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -263,19 +264,21 @@ export default function EventPopup({
                   </a>
                 </div>
               )}
-              <button onClick={handleShare}
-                className="mt-3 flex items-center gap-1.5 text-xs font-medium hover:opacity-70 transition-opacity"
-                style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
-                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="18" cy="5" r="3"/>
-                  <circle cx="6" cy="12" r="3"/>
-                  <circle cx="18" cy="19" r="3"/>
-                  <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
-                  <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
-                </svg>
-                {shareCopied ? t('cal.linkCopied') : t('cal.shareEvent')}
-              </button>
+              {event.allow_guest_registration && (
+                <button onClick={handleShare}
+                  className="mt-3 flex items-center gap-1.5 text-xs font-medium hover:opacity-70 transition-opacity"
+                  style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}>
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="18" cy="5" r="3"/>
+                    <circle cx="6" cy="12" r="3"/>
+                    <circle cx="18" cy="19" r="3"/>
+                    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+                    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+                  </svg>
+                  {shareCopied ? t('cal.linkCopied') : t('cal.shareEvent')}
+                </button>
+              )}
             </div>
             {event.description && event.description !== event.meeting_url && (
               <div className="px-4 py-3">

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -15,7 +15,8 @@ export async function GET(
       .from('calendar_events').select('*').eq('id', id).single()
     if (error?.code === 'PGRST116') return Response.json({ error: 'Not found' }, { status: 404 })
     if (error) return Response.json({ error: error.message }, { status: 500 })
-    return Response.json({ ...event, role_requests: [], caller_request: null })
+    // Unauthenticated callers are guests — redact meeting_url server-side.
+    return Response.json({ ...event, meeting_url: null, role_requests: [], caller_request: null })
   }
 
   const { id } = await params
@@ -43,7 +44,9 @@ export async function GET(
 
   // Role requests for other people (PII: first_name, last_name, abo_number) — only admins and core see all.
   if (callerProfile.role !== 'admin' && callerProfile.role !== 'core') {
-    return Response.json({ ...event, role_requests: [], caller_request: callerRequest ?? null })
+    // Guests must not receive meeting_url even in the API response.
+    const meeting_url = callerProfile.role === 'guest' ? null : event.meeting_url
+    return Response.json({ ...event, meeting_url, role_requests: [], caller_request: callerRequest ?? null })
   }
 
   const { data: roleRequests } = await supabase


### PR DESCRIPTION
Closes #106

## Changes

Single file: `app/(dashboard)/calendar/components/EventPopup.tsx`

- `EventDetail` type gains `allow_guest_registration: boolean`
- `meeting_url` row gated with `!isGuest` — guests can no longer see the meeting link
- Share button conditioned on `event.allow_guest_registration === true` — no longer renders for events where guest registration is disabled (which is most events per DB)

## Session State
**Status:** DONE
**Completed:**
- [x] `EventDetail` type extended with `allow_guest_registration: boolean`
- [x] `meeting_url` block gated with `!isGuest`
- [x] Share button gated with `event.allow_guest_registration === true`
**Next:** Verify Vercel preview — confirm guest session sees no URL and no share button; merge via GitHub UI
