### PR TITLE
[2604-FEAT-102] Trip detail page — messages prominence + clickable links

### DIFF
--- a/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
@@ -136,6 +136,9 @@ export function AttendeeView({
           )}
         </div>
 
+        {/* Trip Messages — immediately below countdown */}
+        <TripMessagesTile tripId={trip.id} />
+
         {/* Payment ledger */}
         <div className="rounded-2xl overflow-hidden"
           style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
@@ -255,9 +258,6 @@ export function AttendeeView({
 
         {/* Who's Going */}
         <WhosGoingTile attendees={teamAttendees} />
-
-        {/* Trip Messages */}
-        <TripMessagesTile tripId={trip.id} />
 
         {/* Trip Documents */}
         <TripDocumentsTile tripId={trip.id} />

--- a/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { formatDateTime } from '@/lib/format'
 import { useLanguage } from '@/lib/hooks/useLanguage'
@@ -13,6 +14,39 @@ interface TripMessage {
 interface ApiError {
   status?: number
   message: string
+}
+
+const URL_PATTERN = /https?:\/\/[^\s<>"']+/g
+
+function renderMessageBody(body: string): ReactNode {
+  const parts: ReactNode[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  URL_PATTERN.lastIndex = 0
+  while ((match = URL_PATTERN.exec(body)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(<span key={lastIndex}>{body.slice(lastIndex, match.index)}</span>)
+    }
+    const url = match[0]
+    parts.push(
+      <a
+        key={match.index}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:opacity-70 transition-opacity underline"
+        style={{ color: 'var(--brand-teal)' }}
+      >
+        {url}
+      </a>
+    )
+    lastIndex = match.index + url.length
+  }
+  if (lastIndex < body.length) {
+    parts.push(<span key={lastIndex}>{body.slice(lastIndex)}</span>)
+  }
+  return <>{parts}</>
 }
 
 export function TripMessagesTile({ tripId }: { tripId: string }) {
@@ -47,12 +81,16 @@ export function TripMessagesTile({ tripId }: { tripId: string }) {
     return (
       <div
         className="rounded-2xl overflow-hidden"
-        style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+        style={{
+          backgroundColor: 'var(--bg-card)',
+          border: '1px solid var(--border-default)',
+          borderLeft: '3px solid var(--brand-teal)',
+        }}
       >
         <div className="px-6 py-4 flex items-center justify-between">
           <p
             className="text-xs font-semibold tracking-widest uppercase"
-            style={{ color: 'var(--text-secondary)' }}
+            style={{ color: 'var(--brand-teal)' }}
           >
             {t('trips.messages')}
           </p>
@@ -74,12 +112,16 @@ export function TripMessagesTile({ tripId }: { tripId: string }) {
   return (
     <div
       className="rounded-2xl overflow-hidden"
-      style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+      style={{
+        backgroundColor: 'var(--bg-card)',
+        border: '1px solid var(--border-default)',
+        borderLeft: '3px solid var(--brand-teal)',
+      }}
     >
       <div className="px-6 pt-5 pb-2">
         <p
           className="text-xs font-semibold tracking-widest uppercase"
-          style={{ color: 'var(--text-secondary)' }}
+          style={{ color: 'var(--brand-teal)' }}
         >
           {t('trips.messages')}
         </p>
@@ -96,7 +138,7 @@ export function TripMessagesTile({ tripId }: { tripId: string }) {
                 className="text-sm"
                 style={{ color: 'var(--text-primary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
               >
-                {m.body}
+                {renderMessageBody(m.body)}
               </p>
               <p
                 className="text-xs mt-1"

--- a/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
@@ -17,6 +17,7 @@ interface ApiError {
 }
 
 const URL_PATTERN = /https?:\/\/[^\s<>"']+/g
+const TRAILING_PUNCT = /[.,;:!?)]+$/
 
 function renderMessageBody(body: string): ReactNode {
   const parts: ReactNode[] = []
@@ -28,7 +29,10 @@ function renderMessageBody(body: string): ReactNode {
     if (match.index > lastIndex) {
       parts.push(<span key={lastIndex}>{body.slice(lastIndex, match.index)}</span>)
     }
-    const url = match[0]
+    const rawUrl = match[0]
+    const trailingMatch = rawUrl.match(TRAILING_PUNCT)
+    const url = trailingMatch ? rawUrl.slice(0, rawUrl.length - trailingMatch[0].length) : rawUrl
+    const trailing = trailingMatch ? trailingMatch[0] : ''
     parts.push(
       <a
         key={match.index}
@@ -41,7 +45,10 @@ function renderMessageBody(body: string): ReactNode {
         {url}
       </a>
     )
-    lastIndex = match.index + url.length
+    if (trailing) {
+      parts.push(<span key={`${match.index}-trail`}>{trailing}</span>)
+    }
+    lastIndex = match.index + rawUrl.length
   }
   if (lastIndex < body.length) {
     parts.push(<span key={lastIndex}>{body.slice(lastIndex)}</span>)


### PR DESCRIPTION
Closes #102

## Changes

**`AttendeeView.tsx`**
- `<TripMessagesTile>` moved immediately below the countdown header block, above the payment ledger. Removed from its previous position below `<WhosGoingTile>`.

**`TripMessagesTile.tsx`**
- Container gains `borderLeft: '3px solid var(--brand-teal)'` accent on both the normal and error states
- Section label colour changed from `var(--text-secondary)` to `var(--brand-teal)` in all render paths
- Message body now rendered via `renderMessageBody()` — splits on `https?://[^\s<>"']+`, URL segments render as `<a target="_blank" rel="noopener noreferrer" style={{ color: 'var(--brand-teal)' }} className="hover:opacity-70 transition-opacity underline">`, non-URL segments as inline `<span>`; existing `wordBreak: 'break-word'` handles wrap at 390px

## Session State
**Status:** DONE
**Completed:**
- [x] `TripMessagesTile` moved above payment ledger in `AttendeeView`
- [x] Left accent border + teal section label applied
- [x] URL linkifier implemented via `renderMessageBody`
**Next:** Verify Vercel preview — messages tile appears above ledger, URLs are clickable links; merge via GitHub UI
