### PR TITLE
[2604-FEAT-103] /about redesign: remove map, relocate email bento, rewrite content

### DIFF
--- a/app/(dashboard)/about/components/AboutContent.tsx
+++ b/app/(dashboard)/about/components/AboutContent.tsx
@@ -1,8 +1,27 @@
 'use client'
 
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import type { Lang } from '@/lib/i18n'
 
 type HighlightSpec = { text: string; key: string }
+
+// Static lookup keyed by lang — defined at module scope to avoid
+// re-allocation on every render.
+const P1_HIGHLIGHTS: Record<Lang, HighlightSpec[]> = {
+  en: [{ text: 'good vibes', key: 'gv' }],
+  bg: [{ text: 'Добро настроение', key: 'gv' }],
+}
+
+const P2_HIGHLIGHTS: Record<Lang, HighlightSpec[]> = {
+  en: [
+    { text: 'meaningful connections', key: 'mc' },
+    { text: 'relationships', key: 'rel' },
+  ],
+  bg: [
+    { text: 'истински връзки', key: 'mc' },
+    { text: 'страст', key: 'rel' },
+  ],
+}
 
 function HighlightedParagraph({
   raw,
@@ -19,15 +38,18 @@ function HighlightedParagraph({
     )
   }
 
-  // Build a regex that captures all highlight phrases (case-insensitive)
-  const pattern = highlights.map(h => h.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  // Sort longest first so multi-word phrases match before constituent words.
+  const pattern = [...highlights]
+    .sort((a, b) => b.text.length - a.text.length)
+    .map(h => h.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')
   const parts = raw.split(new RegExp(`(${pattern})`, 'i'))
   const lookup = Object.fromEntries(highlights.map(h => [h.text.toLowerCase(), h.key]))
 
   return (
     <p className="text-sm leading-relaxed font-body" style={{ color: 'var(--text-secondary)' }}>
       {parts.map((part, i) =>
-        lookup[part.toLowerCase()] ? (
+        part.toLowerCase() in lookup ? (
           <em key={i} style={{ color: 'var(--brand-teal)', fontStyle: 'italic', fontWeight: 500 }}>
             {part}
           </em>
@@ -42,36 +64,19 @@ function HighlightedParagraph({
 export default function AboutContent() {
   const { lang, t } = useLanguage()
 
-  const p1Highlights: HighlightSpec[] =
-    lang === 'en'
-      ? [{ text: 'good vibes', key: 'gv' }]
-      : [{ text: 'Добро настроение', key: 'gv' }]
-
-  const p2Highlights: HighlightSpec[] =
-    lang === 'en'
-      ? [
-          { text: 'meaningful connections', key: 'mc' },
-          { text: 'relationships', key: 'rel' },
-          { text: 'special', key: 'sp' },
-        ]
-      : [
-          { text: 'истински връзки', key: 'mc' },
-          { text: 'страст', key: 'rel' },
-        ]
-
   return (
     <div className="flex flex-col justify-center gap-4 px-1 py-2">
       <div
         className="h-px w-8 rounded-full"
         style={{ backgroundColor: 'var(--brand-crimson)', opacity: 0.4 }}
       />
-      <HighlightedParagraph raw={t('about.body1')} highlights={p1Highlights} />
+      <HighlightedParagraph raw={t('about.body1')} highlights={P1_HIGHLIGHTS[lang]} />
 
       <div
         className="h-px w-8 rounded-full"
         style={{ backgroundColor: 'var(--brand-crimson)', opacity: 0.4 }}
       />
-      <HighlightedParagraph raw={t('about.body2')} highlights={p2Highlights} />
+      <HighlightedParagraph raw={t('about.body2')} highlights={P2_HIGHLIGHTS[lang]} />
 
       <div
         className="h-px w-8 rounded-full"

--- a/app/(dashboard)/about/components/AboutContent.tsx
+++ b/app/(dashboard)/about/components/AboutContent.tsx
@@ -2,61 +2,82 @@
 
 import { useLanguage } from '@/lib/hooks/useLanguage'
 
-const MISSION_WORD: Record<'en' | 'bg', string> = {
-  en: 'mission',
-  bg: '\u043c\u0438\u0441\u0438\u044f',
+type HighlightSpec = { text: string; key: string }
+
+function HighlightedParagraph({
+  raw,
+  highlights,
+}: {
+  raw: string
+  highlights: HighlightSpec[]
+}) {
+  if (highlights.length === 0) {
+    return (
+      <p className="text-sm leading-relaxed font-body" style={{ color: 'var(--text-secondary)' }}>
+        {raw}
+      </p>
+    )
+  }
+
+  // Build a regex that captures all highlight phrases (case-insensitive)
+  const pattern = highlights.map(h => h.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')
+  const parts = raw.split(new RegExp(`(${pattern})`, 'i'))
+  const lookup = Object.fromEntries(highlights.map(h => [h.text.toLowerCase(), h.key]))
+
+  return (
+    <p className="text-sm leading-relaxed font-body" style={{ color: 'var(--text-secondary)' }}>
+      {parts.map((part, i) =>
+        lookup[part.toLowerCase()] ? (
+          <em key={i} style={{ color: 'var(--brand-teal)', fontStyle: 'italic', fontWeight: 500 }}>
+            {part}
+          </em>
+        ) : (
+          part
+        )
+      )}
+    </p>
+  )
 }
 
 export default function AboutContent() {
   const { lang, t } = useLanguage()
 
-  const title = t('about.title')
-  const keyword = MISSION_WORD[lang]
-  // Capturing group in the regex preserves the matched text in the split array,
-  // and the 'i' flag makes the match case-insensitive.
-  const titleParts = title.split(new RegExp(`(${keyword})`, 'i'))
+  const p1Highlights: HighlightSpec[] =
+    lang === 'en'
+      ? [{ text: 'good vibes', key: 'gv' }]
+      : [{ text: 'Добро настроение', key: 'gv' }]
+
+  const p2Highlights: HighlightSpec[] =
+    lang === 'en'
+      ? [
+          { text: 'meaningful connections', key: 'mc' },
+          { text: 'relationships', key: 'rel' },
+          { text: 'special', key: 'sp' },
+        ]
+      : [
+          { text: 'истински връзки', key: 'mc' },
+          { text: 'страст', key: 'rel' },
+        ]
 
   return (
-    <div className="flex flex-col justify-center gap-3 px-1 py-2">
-      {/* Eyebrow */}
-      <p
-        className="text-[11px] font-semibold tracking-widest uppercase"
-        style={{ color: 'var(--brand-crimson)' }}
-      >
-        {t('about.eyebrow')}
-      </p>
-
-      {/* Display title — italic teal on the mission/мисия keyword */}
-      <h1
-        className="font-display text-2xl font-semibold leading-snug"
-        style={{ color: 'var(--text-primary)' }}
-      >
-        {titleParts.map((part, i) =>
-          part.toLowerCase() === keyword.toLowerCase() ? (
-            <em key={i} style={{ color: 'var(--brand-teal)', fontStyle: 'italic' }}>{part}</em>
-          ) : (
-            part
-          )
-        )}
-      </h1>
-
-      {/* Rule + body paragraph 1 */}
+    <div className="flex flex-col justify-center gap-4 px-1 py-2">
       <div
         className="h-px w-8 rounded-full"
         style={{ backgroundColor: 'var(--brand-crimson)', opacity: 0.4 }}
       />
-      <p className="text-sm leading-relaxed font-body" style={{ color: 'var(--text-secondary)' }}>
-        {t('about.body1')}
-      </p>
+      <HighlightedParagraph raw={t('about.body1')} highlights={p1Highlights} />
 
-      {/* Rule + body paragraph 2 */}
       <div
         className="h-px w-8 rounded-full"
         style={{ backgroundColor: 'var(--brand-crimson)', opacity: 0.4 }}
       />
-      <p className="text-sm leading-relaxed font-body" style={{ color: 'var(--text-secondary)' }}>
-        {t('about.body2')}
-      </p>
+      <HighlightedParagraph raw={t('about.body2')} highlights={p2Highlights} />
+
+      <div
+        className="h-px w-8 rounded-full"
+        style={{ backgroundColor: 'var(--brand-crimson)', opacity: 0.4 }}
+      />
+      <HighlightedParagraph raw={t('about.body3')} highlights={[]} />
     </div>
   )
 }

--- a/app/(dashboard)/about/page.tsx
+++ b/app/(dashboard)/about/page.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image'
-import AboutMapTileDynamic from './components/AboutMapTileDynamic'
 import MailtoTile from './components/MailtoTile'
 import AboutContent from './components/AboutContent'
 
@@ -12,8 +11,8 @@ export default function AboutPage() {
       {/* ════════════════════════════════════════════════════════════════════
           DESKTOP layout (md+)
           12-col CSS grid, max-w-[860px] centred
-          Row 1: [1–2 gutter] [3–6 heading+content island] [7–10 photo] [11–12 gutter]
-          Row 2: [1–2 gutter] [3–6 mailto]                 [7–10 map]   [11–12 gutter]
+          Row 1: [1–2 gutter] [3–6 content — spans 2 rows] [7–10 photo]  [11–12 gutter]
+          Row 2: [1–2 gutter] [3–6 content continued]      [7–10 mailto] [11–12 gutter]
           ════════════════════════════════════════════════════════════════════ */}
       <div className="hidden md:block max-w-[860px] mx-auto px-4">
         <div
@@ -24,11 +23,11 @@ export default function AboutPage() {
             gridAutoRows: 'minmax(160px, auto)',
           }}
         >
-          {/* Row 1 col 3–6: heading + content island (transparent) */}
+          {/* Rows 1–2 col 3–6: content island spans both rows */}
           <div
             style={{
               gridColumn: '3 / span 4',
-              gridRow: '1',
+              gridRow: '1 / span 2',
               borderRadius: 'var(--bento-radius)',
               padding: 'var(--bento-padding)',
             }}
@@ -53,20 +52,11 @@ export default function AboutPage() {
             />
           </div>
 
-          {/* Row 2 col 3–6: mailto tile */}
+          {/* Row 2 col 7–10: mailto tile */}
           <MailtoTile
-            style={{
-              gridColumn: '3 / span 4',
-              gridRow: '2',
-            }}
-          />
-
-          {/* Row 2 col 7–10: map tile */}
-          <AboutMapTileDynamic
             style={{
               gridColumn: '7 / span 4',
               gridRow: '2',
-              minHeight: 160,
             }}
           />
         </div>
@@ -74,7 +64,7 @@ export default function AboutPage() {
 
       {/* ════════════════════════════════════════════════════════════════════
           MOBILE layout (< md)
-          Stack: photo → heading/content island → mailto + map (2-col row)
+          Stack: photo → content island → mailto (full-width)
           ════════════════════════════════════════════════════════════════════ */}
       <div className="md:hidden flex flex-col gap-3 px-4">
 
@@ -92,7 +82,7 @@ export default function AboutPage() {
           />
         </div>
 
-        {/* Heading + body content island */}
+        {/* Content island */}
         <div
           style={{
             borderRadius: 'var(--bento-radius)',
@@ -102,11 +92,8 @@ export default function AboutPage() {
           <AboutContent />
         </div>
 
-        {/* Mailto + map side-by-side */}
-        <div className="grid grid-cols-2 gap-3">
-          <MailtoTile style={{ minHeight: 96 }} />
-          <AboutMapTileDynamic style={{ minHeight: 96 }} />
-        </div>
+        {/* Mailto — full width */}
+        <MailtoTile style={{ minHeight: 96 }} />
 
       </div>
 

--- a/lib/i18n/domains/about.ts
+++ b/lib/i18n/domains/about.ts
@@ -1,12 +1,14 @@
 export const about = {
-  'about.eyebrow': { en: 'Team Enjoy VD',                bg: 'Тийм Enjoy VD'                                              },
-  'about.title':   { en: 'Two people, one mission.',     bg: 'Двама души, една мисия.'                                    },
-  'about.body1':   {
+  'about.body1': {
     en: "We're Vera & Deniz, two folks living it up in the vibrant city of Sofia, Bulgaria. We're all about good vibes, delicious grub, and that perfect cup of coffee ☕️",
     bg: 'Ние сме Вера и Дениз — двама души, влюбени в пъстрия живот на София. Добро настроение, вкусна храна и перфектното кафе ☕️'
   },
-  'about.body2':   {
+  'about.body2': {
     en: "But there's more to us than just our love for the simple pleasures. We're all about forging meaningful connections that stand the test of time — on a mission to build rock-solid relationships with like-minded individuals who share our passion and vision.",
     bg: 'Но има нещо повече от обичта към простите радости. Изграждаме истински връзки, издържащи изпитанието на времето — с хора, споделящи нашата страст и визия.'
+  },
+  'about.body3': {
+    en: "Reach out to the person who directed you here to dig deeper into what we're all about. And if you stumbled upon us all by yourself, kudos! Slide into our DMs and let's have a chat. We love meeting new folks.",
+    bg: 'Свържи се с човека, насочил те тук, за да разбереш повече за нас. А ако си ни намерил сам — браво! Пишни ни и нека поговорим. Обичаме да опознаваме нови хора.'
   },
 } as const

--- a/lib/i18n/domains/about.ts
+++ b/lib/i18n/domains/about.ts
@@ -9,6 +9,6 @@ export const about = {
   },
   'about.body3': {
     en: "Reach out to the person who directed you here to dig deeper into what we're all about. And if you stumbled upon us all by yourself, kudos! Slide into our DMs and let's have a chat. We love meeting new folks.",
-    bg: 'Свържи се с човека, насочил те тук, за да разбереш повече за нас. А ако си ни намерил сам — браво! Пишни ни и нека поговорим. Обичаме да опознаваме нови хора.'
+    bg: 'Свържи се с човека, насочил те тук, за да разбереш повече за нас. А ако си ни намерил сам — браво! Пиши ни и нека поговорим. Обичаме да опознаваме нови хора.'
   },
 } as const


### PR DESCRIPTION
# [2604-FEAT-103] /about redesign

Closes #103

## Changes

- **`lib/i18n/domains/about.ts`** — removed `about.eyebrow` and `about.title`; added `about.body3` (EN + BG); `body1` and `body2` EN strings aligned to spec
- **`app/(dashboard)/about/components/AboutContent.tsx`** — full rewrite: no eyebrow, no `<h1>`, no `MISSION_WORD` regex; three paragraphs with inline teal-italic highlights via `HighlightedParagraph`; highlights: p1 → _good vibes_, p2 → _meaningful connections_, _relationships_, _special_ (BG equivalents), p3 → no highlights
- **`app/(dashboard)/about/page.tsx`** — desktop: `AboutContent` now spans `gridRow: '1 / span 2'`, `MailtoTile` moved to col 7–10 row 2, `AboutMapTileDynamic` removed; mobile: `grid grid-cols-2` wrapper removed, `MailtoTile` full-width, map removed
- `AboutMapTile.tsx` and `AboutMapTileDynamic.tsx` are orphaned (no imports remain); they cannot be deleted via `push_files` but cause no build errors

## DoD Verification

- [x] `about.eyebrow` + `about.title` removed, `about.body3` added — `TranslationKey` union auto-derived, no manual edit needed
- [x] `AboutContent.tsx` rewritten — no title, no eyebrow, no h1, three paras with highlights
- [x] Desktop grid: `AboutContent` spans 2 rows, `MailtoTile` at col 7–10 row 2, map removed
- [x] Mobile: map removed, `MailtoTile` full-width, grid wrapper gone
- [x] No Mapbox import remains in the about route tree
- [ ] 390px renders without overflow — pending Vercel Preview
- [ ] CI green — pending

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] All file changes pushed
- [x] PR opened
**Next:** Verify Vercel Preview READY and CI green → mark DONE
