### PR TITLE
[2604-FEAT-122] Replace Collapse All with Toggle All on profile bento grid

### DIFF
--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -190,15 +190,15 @@ export default function ProfilePage() {
   }, [persistPrefs])
 
   const toggleAll = useCallback(() => {
+    const ids = orderedBentosRef.current.map(b => b.id)
+    if (ids.length === 0) return
     setBentoCollapsed(prev => {
-      const ids = orderedBentosRef.current.map(b => b.id)
       const allCollapsed = ids.every(id => !!prev[id])
       const next = { ...prev }
       ids.forEach(id => { next[id] = !allCollapsed })
       setBentoOrder(order => { persistPrefs(order, next); return order })
       return next
     })
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [persistPrefs])
 
   const resetLayout = useCallback(() => {

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -189,12 +189,12 @@ export default function ProfilePage() {
     })
   }, [persistPrefs])
 
-  const collapseAll = useCallback(() => {
+  const toggleAll = useCallback(() => {
     setBentoCollapsed(prev => {
+      const ids = orderedBentosRef.current.map(b => b.id)
+      const allCollapsed = ids.every(id => !!prev[id])
       const next = { ...prev }
-      orderedBentosRef.current.forEach(({ id }) => {
-        next[id] = true
-      })
+      ids.forEach(id => { next[id] = !allCollapsed })
       setBentoOrder(order => { persistPrefs(order, next); return order })
       return next
     })
@@ -301,9 +301,11 @@ export default function ProfilePage() {
     .map(id => ({ id, entry: bentoMap[id] ?? null }))
     .filter((b): b is { id: string; entry: BentoEntry } => b.entry !== null)
 
-  // Stable ref for collapseAll to read current orderedBentos without stale closure
+  // Stable ref for toggleAll to read current orderedBentos without stale closure
   const orderedBentosRef = useRef(orderedBentos)
   orderedBentosRef.current = orderedBentos
+
+  const allCollapsed = orderedBentos.every(({ id }) => !!bentoCollapsed[id])
 
   return (
     <div className="py-8 pb-16">
@@ -311,11 +313,11 @@ export default function ProfilePage() {
 
         <div className="flex justify-end gap-4 mb-3">
           <button
-            onClick={collapseAll}
+            onClick={toggleAll}
             className="text-xs font-medium hover:opacity-70 transition-opacity"
             style={{ color: 'var(--text-secondary)' }}
           >
-            {t('profile.collapseAll')}
+            {allCollapsed ? t('profile.expandAll') : t('profile.collapseAll')}
           </button>
           <button
             onClick={resetLayout}

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -46,6 +46,7 @@ export const profile = {
   'profile.incompleteHint':     { en: 'Complete your profile to get started.', bg: 'Попълнете профила си, за да започнете.' },
   'profile.resetLayout':        { en: 'Reset layout',            bg: 'Нулирай оформлението'     },
   'profile.collapseAll':        { en: 'Collapse all',            bg: 'Свий всички'              },
+  'profile.expandAll':          { en: 'Expand all',              bg: 'Разгъни всички'           },
   'profile.tile.personalDetails': { en: 'Personal Details', bg: 'Лични данни'           },
   'profile.tile.aboInfo':         { en: 'ABO Information',  bg: 'ABO Информация'        },
   'profile.tile.travelDoc':       { en: 'Travel Document',  bg: 'Документ за пътуване'  },


### PR DESCRIPTION
# [2604-FEAT-122] Replace Collapse All with Toggle All on profile bento grid

## Summary
Replaces the static "Collapse all" button with a context-aware "Toggle all" that expands when all bentos are collapsed and collapses otherwise. Label reflects current state at render time.

## Changes
- `app/(dashboard)/profile/page.tsx` — renamed `collapseAll` → `toggleAll`; logic reads `orderedBentosRef.current` to avoid stale closure; `allCollapsed` derived from filtered `orderedBentos` (excludes null-gated bentos)
- `lib/i18n/domains/profile.ts` — added `profile.expandAll` key (EN: "Expand all", BG: "Разгъни всички")

## DoD
- [x] `app/(dashboard)/profile/page.tsx` — `toggleAll` logic: all collapsed → expand all, otherwise collapse all
- [x] Button label derives from render-time `allCollapsed` state
- [x] `profile.expandAll` added to both `bg` and `en`
- [x] `profile.collapseAll` unchanged

Closes #122

## Session State
**Status:** DONE
**Completed:**
- [x] `toggleAll` logic implemented with stale-closure guard via `orderedBentosRef`
- [x] `allCollapsed` derived from filtered visible bentos only
- [x] `profile.expandAll` i18n key added
- [x] PR opened
**Next:** User merges via GitHub UI; confirm production Vercel deploy READY