### PR TITLE
[REFACTOR-002] fix: enforce visibility_roles on trip detail page

### DIFF
--- a/app/(dashboard)/trips/[id]/page.tsx
+++ b/app/(dashboard)/trips/[id]/page.tsx
@@ -59,17 +59,24 @@ export default async function TripDetailPage({
 
   const supabase = createServiceClient()
 
-  // profile + trip in parallel; registration + payments need profile.id so they follow
-  const [{ data: profile }, { data: trip }] = await Promise.all([
-    supabase
-      .from('profiles')
-      .select('id, role, valid_through, document_active_type')
-      .eq('clerk_id', userId)
-      .single(),
-    supabase.from('trips').select('*').eq('id', id).single(),
-  ])
+  // Fetch profile first — we need the role for visibility filtering
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id, role, valid_through, document_active_type')
+    .eq('clerk_id', userId)
+    .single()
 
-  if (!profile || !trip) redirect('/trips')
+  if (!profile) redirect('/trips')
+
+  // Enforce visibility_roles — only return trip if user's role is included
+  const { data: trip } = await supabase
+    .from('trips')
+    .select('*')
+    .eq('id', id)
+    .contains('visibility_roles', [profile.role])
+    .single()
+
+  if (!trip) redirect('/trips')
 
   const [{ data: registration }, { data: payments }] = await Promise.all([
     supabase


### PR DESCRIPTION
## Summary
Fixes an IDOR vulnerability where any authenticated user could view concealed trips by guessing their IDs.

### Changes
- **`app/(dashboard)/trips/[id]/page.tsx`** — Added `.contains('visibility_roles', [profile.role])` filter to the trip detail query

### Before
Trip detail fetched by ID only — any authenticated user could view any trip regardless of visibility settings.

### After
Trip detail query now enforces `visibility_roles` containment check. If the user's role is not in the trip's `visibility_roles` array, they are redirected to `/trips` (same behavior as a non-existent trip).

### Pattern Consistency
This matches the existing trips list endpoint (`app/api/trips/route.ts`) which already does `.contains('visibility_roles', [role])`.

### Findings Addressed
- SEC-004: Trip visibility IDOR (high severity)

Closes #129

## Session State
**Status:** DONE
**Completed:**
- [x] Trip detail query filters by visibility_roles containing user's role
- [x] Unauthorized access redirects to /trips
- [x] No files outside declared scope touched
- [x] Zero-Refactor Rule: behaviour-equivalent changes only
**Next:** Merge when CI green