### PR TITLE
[REFACTOR-005] fix: payments route auth pattern + type safety

### DIFF
--- a/app/api/admin/payments/[id]/route.ts
+++ b/app/api/admin/payments/[id]/route.ts
@@ -1,16 +1,28 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
+
+/** Shape returned by the `.select()` join on the PATCH query. */
+interface PaymentWithJoins {
+  id: string
+  amount: number
+  currency: string
+  transaction_date: string
+  admin_status: string
+  admin_note: string | null
+  profile_id: string
+  profile: { first_name: string; contact_email: string | null } | null
+  trips: { title: string } | null
+  payable_items: { title: string } | null
+}
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
   const { userId } = await auth()
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (profile?.role !== 'admin' && profile?.role !== 'core') {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'adminOrCore')
+  if (ctx.guard) return ctx.guard
 
   const { id } = await params
   const body = await req.json()
@@ -24,39 +36,42 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     .from('payments')
     .update({ admin_status, admin_note: admin_note ?? null })
     .eq('id', id)
-    .select('*, profile:profiles(first_name, contact_email), trips(title), payable_items(title)')
+    .select('*, profile:profiles!profile_id(first_name, contact_email), trips(title), payable_items(title)')
     .single()
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
 
+  // Cast to the typed interface — Supabase cannot infer aliased join shapes
+  const typed = data as unknown as PaymentWithJoins
+
   // Trigger email asynchronously
-  const paymentProfile = data.profile as any
-  const tripsData = data.trips as any
-  const itemsData = data.payable_items as any
-  const itemTitle = tripsData?.title || itemsData?.title || 'Unknown Item'
+  const itemTitle = typed.trips?.title || typed.payable_items?.title || 'Unknown Item'
   const emailStatus = admin_status === 'rejected' ? 'denied' : 'approved'
 
-  if (paymentProfile?.contact_email) {
+  if (typed.profile?.contact_email) {
+    const profileEmail = typed.profile.contact_email
+    const profileFirstName = typed.profile.first_name || 'Member'
+
     import('@/lib/email/send').then(({ sendNotificationEmail }) => {
       import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
         import('@/lib/email/templates/PaymentStatusEmail').then(({ PaymentStatusEmail }) => {
           renderEmailTemplate(
             PaymentStatusEmail({
-              firstName: paymentProfile.first_name || 'Member',
-              amount: data.amount,
-              currency: data.currency,
-              transactionDate: data.transaction_date,
+              firstName: profileFirstName,
+              amount: typed.amount,
+              currency: typed.currency,
+              transactionDate: typed.transaction_date,
               adminStatus: emailStatus,
               itemTitle,
               adminNote: admin_note,
             })
           ).then(html => {
             sendNotificationEmail({
-              to: paymentProfile.contact_email,
+              to: profileEmail,
               subject: `Payment ${emailStatus === 'approved' ? 'Approved ✓' : 'Declined'}`,
               html,
               template: 'payment_status',
-              meta: { payment_id: data.id, profile_id: data.profile_id },
+              meta: { payment_id: typed.id, profile_id: typed.profile_id },
             }).catch(console.error)
           }).catch(console.error)
         }).catch(console.error)


### PR DESCRIPTION
## Summary
Fixes auth pattern duplication and `any` type casts in the payments detail PATCH route.

### Changes — `app/api/admin/payments/[id]/route.ts`

#### Auth pattern (ARCH-004)
- **Before:** Inline `profiles.select('role')` + manual `role !== 'admin' && role !== 'core'` check
- **After:** `getCallerContext(userId, supabase, 'adminOrCore')` from `@/lib/supabase/guards` — consistent with the payments list route

#### Type safety (ARCH-002)
- **Before:** `data.profile as any`, `data.trips as any`, `data.payable_items as any`
- **After:** Explicit `PaymentWithJoins` interface defining the join shape, single typed cast from `unknown`
- No `any` casts remain in the file

#### FK disambiguation
- Added `profiles!profile_id` hint to the `.select()` join (payments has two FKs to profiles — Gotcha table)

### Behaviour equivalence
- Same auth check (`adminOrCore` matches the original `admin || core`)
- Same update fields (`admin_status`, `admin_note`)
- Same email trigger logic (fire-and-forget, dynamic imports preserved)
- Same response shape

Closes #132

## Session State
**Status:** DONE
**Completed:**
- [x] PATCH handler uses getCallerContext(userId, supabase, 'adminOrCore')
- [x] Join types use PaymentWithJoins interface instead of `as any`
- [x] No `any` casts remain in the file
- [x] No files outside declared scope touched
- [x] Zero-Refactor Rule: behaviour-equivalent changes only
**Next:** Merge when CI green