### PR TITLE
[REFACTOR-004] feat: add error.tsx boundaries to dashboard and admin layouts

### DIFF
--- a/app/(dashboard)/error.tsx
+++ b/app/(dashboard)/error.tsx
@@ -44,7 +44,7 @@ export default function DashboardError({
         </button>
         <a
           href="/"
-          className="px-5 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
+          className="px-5 py-2.5 rounded-xl text-sm font-semibold border transition-opacity hover:opacity-90"
           style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
         >
           {t('error.home')}

--- a/app/(dashboard)/error.tsx
+++ b/app/(dashboard)/error.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useLanguage } from '@/lib/hooks/useLanguage'
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const { t } = useLanguage()
+
+  return (
+    <div
+      className="min-h-[60vh] flex flex-col items-center justify-center px-6 text-center"
+      style={{ backgroundColor: 'var(--bg-global)' }}
+    >
+      <p
+        className="text-4xl mb-4"
+        aria-hidden="true"
+      >
+        &#x26A0;
+      </p>
+      <h1
+        className="font-display text-xl font-semibold mb-2"
+        style={{ color: 'var(--text-primary)' }}
+      >
+        {t('error.title')}
+      </h1>
+      <p
+        className="text-sm mb-6 max-w-xs"
+        style={{ color: 'var(--text-secondary)' }}
+      >
+        {t('error.desc')}
+      </p>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={reset}
+          className="px-5 py-2.5 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
+          style={{ backgroundColor: 'var(--brand-crimson)' }}
+        >
+          {t('error.retry')}
+        </button>
+        <a
+          href="/"
+          className="px-5 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
+        >
+          {t('error.home')}
+        </a>
+      </div>
+      {process.env.NODE_ENV !== 'production' && error.message && (
+        <p
+          className="mt-6 text-xs font-mono px-3 py-2 rounded-lg max-w-sm break-all"
+          style={{ backgroundColor: 'var(--bg-card)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}
+        >
+          {error.message}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/admin/error.tsx
+++ b/app/admin/error.tsx
@@ -14,7 +14,7 @@ export default function AdminError({
   return (
     <div
       className="min-h-[60vh] flex flex-col items-center justify-center px-6 text-center"
-      style={{ backgroundColor: 'var(--bg-global)' }}
+      style={{ backgroundColor: 'var(--bg-card)' }}
     >
       <p
         className="text-4xl mb-4"
@@ -44,7 +44,7 @@ export default function AdminError({
         </button>
         <a
           href="/admin"
-          className="px-5 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
+          className="px-5 py-2.5 rounded-xl text-sm font-semibold border transition-opacity hover:opacity-90"
           style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
         >
           {t('error.home')}
@@ -53,7 +53,7 @@ export default function AdminError({
       {process.env.NODE_ENV !== 'production' && error.message && (
         <p
           className="mt-6 text-xs font-mono px-3 py-2 rounded-lg max-w-sm break-all"
-          style={{ backgroundColor: 'var(--bg-card)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}
+          style={{ backgroundColor: 'var(--bg-global)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}
         >
           {error.message}
         </p>

--- a/app/admin/error.tsx
+++ b/app/admin/error.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useLanguage } from '@/lib/hooks/useLanguage'
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  const { t } = useLanguage()
+
+  return (
+    <div
+      className="min-h-[60vh] flex flex-col items-center justify-center px-6 text-center"
+      style={{ backgroundColor: 'var(--bg-global)' }}
+    >
+      <p
+        className="text-4xl mb-4"
+        aria-hidden="true"
+      >
+        &#x26A0;
+      </p>
+      <h1
+        className="font-display text-xl font-semibold mb-2"
+        style={{ color: 'var(--text-primary)' }}
+      >
+        {t('error.title')}
+      </h1>
+      <p
+        className="text-sm mb-6 max-w-xs"
+        style={{ color: 'var(--text-secondary)' }}
+      >
+        {t('error.desc')}
+      </p>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={reset}
+          className="px-5 py-2.5 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
+          style={{ backgroundColor: 'var(--brand-crimson)' }}
+        >
+          {t('error.retry')}
+        </button>
+        <a
+          href="/admin"
+          className="px-5 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
+        >
+          {t('error.home')}
+        </a>
+      </div>
+      {process.env.NODE_ENV !== 'production' && error.message && (
+        <p
+          className="mt-6 text-xs font-mono px-3 py-2 rounded-lg max-w-sm break-all"
+          style={{ backgroundColor: 'var(--bg-card)', color: 'var(--text-secondary)', border: '1px solid var(--border-default)' }}
+        >
+          {error.message}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/lib/i18n/domains/error.ts
+++ b/lib/i18n/domains/error.ts
@@ -1,0 +1,6 @@
+export const error = {
+  'error.title':   { en: 'Something went wrong',  bg: 'Нещо се обърка'          },
+  'error.desc':    { en: 'An unexpected error occurred. You can try again or reload the page.', bg: 'Възникна неочаквана грешка. Можете да опитате отново или да презаредите страницата.' },
+  'error.retry':   { en: 'Try again',             bg: 'Опитай отново'           },
+  'error.home':    { en: '← Home',                bg: '← Начало'                },
+} as const

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -12,6 +12,7 @@ import { admin }         from './domains/admin'
 import { payment }       from './domains/payment'
 import { home }          from './domains/home'
 import { about }         from './domains/about'
+import { error }         from './domains/error'
 
 export type Lang = 'en' | 'bg'
 
@@ -42,7 +43,7 @@ function assertNoDuplicateKeys(
 
 assertNoDuplicateKeys([
   nav, roles, time, guides,
-  notifications, profile, trips, calendar, events, los, admin, payment, home, about,
+  notifications, profile, trips, calendar, events, los, admin, payment, home, about, error,
 ])
 
 export const translations = {
@@ -60,6 +61,7 @@ export const translations = {
   ...payment,
   ...home,
   ...about,
+  ...error,
 } as const
 
 export type TranslationKey = keyof typeof translations


### PR DESCRIPTION
## Summary
Adds Next.js `error.tsx` error boundaries to `app/(dashboard)` and `app/admin`, replacing hard crashes with a translated fallback UI + retry button.

## Changes

### `lib/i18n/domains/error.ts` (NEW)
New domain with 4 keys: `error.title`, `error.desc`, `error.retry`, `error.home` — EN + BG.

### `lib/i18n/index.ts`
- Import `error` domain
- Add to `assertNoDuplicateKeys` call
- Spread into `translations`

### `app/(dashboard)/error.tsx` (NEW)
- `'use client'` — required by Next.js error boundary contract
- Renders: warning icon, translated title + description, **Try again** button (`reset()`), **← Home** link (`/`)
- Dev-only: shows `error.message` in a monospace pill (stripped in production)
- Styled with project CSS vars; no hardcoded colours

### `app/admin/error.tsx` (NEW)
- Identical structure to dashboard boundary
- **← Home** link points to `/admin` instead of `/`

## Files Changed
- `lib/i18n/domains/error.ts` — new
- `lib/i18n/index.ts` — error domain wired in
- `app/(dashboard)/error.tsx` — new
- `app/admin/error.tsx` — new

## Verification
To manually verify: temporarily add `throw new Error('test')` inside any dashboard or admin server component, confirm the boundary renders with retry + home buttons, remove the throw.

Closes #131

## Session State
**Status:** DONE
**Completed:**
- [x] `app/(dashboard)/error.tsx` created — `'use client'`, translated, retry + home
- [x] `app/admin/error.tsx` created — same pattern, home → `/admin`
- [x] `error` i18n domain added with 4 keys (EN + BG)
- [x] `lib/i18n/index.ts` updated — import, collision guard, spread
- [x] No files outside declared scope touched
- [x] Zero-Refactor Rule: net-new files only, no existing behaviour changed
**Next:** Merge when CI green and Vercel preview confirmed