### PR TITLE
[REFACTOR-010] feat: shared apiClient wrapper + CalendarClient migration

### DIFF
--- a/app/(dashboard)/calendar/components/CalendarClient.tsx
+++ b/app/(dashboard)/calendar/components/CalendarClient.tsx
@@ -7,6 +7,7 @@ import { DAYS_I18N, MONTHS_I18N } from '@/lib/i18n/translations'
 import { VaulDrawer } from '@/components/ui/vaul-drawer'
 import { Dialog, DialogContent, DialogOverlay, DialogPortal } from '@/components/ui/dialog'
 import EventPopup from '@/app/(dashboard)/calendar/components/EventPopup'
+import { apiClient } from '@/lib/apiClient'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -418,7 +419,7 @@ export default function CalendarClient({
   const { data: monthEvents = [] } = useQuery<CalendarEvent[]>({
     queryKey: ['events-month', toMonthParam(current)],
     queryFn: () =>
-      fetch(`/api/calendar?month=${toMonthParam(current)}`).then(r => r.json()),
+      apiClient<CalendarEvent[]>(`/api/calendar?month=${toMonthParam(current)}`),
     initialData: toMonthParam(current) === initialMonth ? initialEvents : undefined,
     staleTime: 60_000,
     enabled: view === 'month',
@@ -426,7 +427,7 @@ export default function CalendarClient({
 
   const { data: agendaEvents = [], isPending: agendaPending } = useQuery<CalendarEvent[]>({
     queryKey: ['events-agenda'],
-    queryFn: () => fetch('/api/calendar').then(r => r.json()),
+    queryFn: () => apiClient<CalendarEvent[]>('/api/calendar'),
     staleTime: 0,
     enabled: view === 'agenda',
   })

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared fetch wrapper for client-side API calls.
+ *
+ * Provides:
+ * - TypeScript generics (no `any` returns)
+ * - `response.ok` check (fetch does not throw on 4xx/5xx)
+ * - 401 interception (redirects to sign-in)
+ * - Baseline `Content-Type: application/json` header
+ *
+ * Client-only — do NOT import in RSC pages, route handlers, or server actions.
+ */
+
+export class ApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+export async function apiClient<T>(url: string, options?: RequestInit): Promise<T> {
+  const headers = new Headers(options?.headers)
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  const response = await fetch(url, { ...options, headers })
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      // Session expired — redirect to sign-in
+      if (typeof window !== 'undefined') {
+        window.location.href = '/sign-in'
+      }
+      throw new ApiError(401, 'Unauthorized')
+    }
+    const body = await response.text().catch(() => '')
+    throw new ApiError(response.status, body || `API Error: ${response.status}`)
+  }
+
+  return response.json() as Promise<T>
+}

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -5,7 +5,7 @@
  * - TypeScript generics (no `any` returns)
  * - `response.ok` check (fetch does not throw on 4xx/5xx)
  * - 401 interception (redirects to sign-in)
- * - Baseline `Content-Type: application/json` header
+ * - `Content-Type: application/json` header (skipped for FormData or bodyless requests)
  *
  * Client-only — do NOT import in RSC pages, route handlers, or server actions.
  */
@@ -19,7 +19,7 @@ export class ApiError extends Error {
 
 export async function apiClient<T>(url: string, options?: RequestInit): Promise<T> {
   const headers = new Headers(options?.headers)
-  if (!headers.has('Content-Type')) {
+  if (!headers.has('Content-Type') && options?.body && !(options.body instanceof FormData)) {
     headers.set('Content-Type', 'application/json')
   }
 
@@ -33,9 +33,19 @@ export async function apiClient<T>(url: string, options?: RequestInit): Promise<
       }
       throw new ApiError(401, 'Unauthorized')
     }
-    const body = await response.text().catch(() => '')
-    throw new ApiError(response.status, body || `API Error: ${response.status}`)
+    const text = await response.text().catch(() => '')
+    let message = `API Error: ${response.status}`
+    if (text) {
+      try {
+        const json = JSON.parse(text)
+        message = json?.error ?? json?.message ?? text
+      } catch {
+        message = text
+      }
+    }
+    throw new ApiError(response.status, message)
   }
 
-  return response.json() as Promise<T>
+  const text = await response.text()
+  return (text ? JSON.parse(text) : {}) as T
 }


### PR DESCRIPTION
## Summary
Creates a shared `apiClient<T>()` fetch wrapper and migrates `CalendarClient.tsx` as the first consumer.

### New file: `lib/apiClient.ts`
- Generic typed return `<T>` — no `any`
- `response.ok` check (native fetch does not throw on 4xx/5xx)
- 401 interception → redirect to `/sign-in`
- Baseline `Content-Type: application/json` header
- Client-only module

### Migrated: `CalendarClient.tsx`
```diff
- fetch(`/api/calendar?month=${toMonthParam(current)}`).then(r => r.json())
+ apiClient<CalendarEvent[]>(`/api/calendar?month=${toMonthParam(current)}`)

- fetch('/api/calendar').then(r => r.json())
+ apiClient<CalendarEvent[]>('/api/calendar')
```

### Grep Audit Results
40+ raw `fetch('/api/...')` calls found across 24 dashboard client files. Per execution rules (> 5 additional sites), only `CalendarClient.tsx` migrated in this PR. Follow-up ticket created for remaining sites.

### Behaviour equivalence
- Same endpoints, same query keys, same staleTime
- Added: `response.ok` check + 401 redirect (previously silent failures)

Closes #137