### PR TITLE
[REFACTOR-010b] Migrate all remaining dashboard fetch calls to apiClient

### DIFF
--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatTime, formatLongDate } from '@/lib/format'
 import { X, Check } from 'lucide-react'
+import { apiClient } from '@/lib/apiClient'
 
 type RoleRequest = {
   id: string
@@ -65,7 +66,7 @@ export default function EventPopup({
 
   const { data: event, isLoading } = useQuery<EventDetail>({
     queryKey: ['event', eventId],
-    queryFn: () => fetch(`/api/events/${eventId}`).then(r => r.json()),
+    queryFn: () => apiClient(`/api/events/${eventId}`),
   })
 
   const isAdmin = userRole === 'admin'
@@ -78,24 +79,24 @@ export default function EventPopup({
 
   const requestMutation = useMutation({
     mutationFn: (role_label: string) =>
-      fetch(`/api/events/${eventId}/request-role`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
+      apiClient(`/api/events/${eventId}/request-role`, {
+        method: 'POST',
         body: JSON.stringify({ role_label }),
-      }).then(async r => { if (!r.ok) throw new Error((await r.json()).error); return r.json() }),
+      }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['event', eventId] }),
   })
 
   const cancelMutation = useMutation({
-    mutationFn: () => fetch(`/api/events/${eventId}/request-role`, { method: 'DELETE' }).then(r => r.json()),
+    mutationFn: () => apiClient(`/api/events/${eventId}/request-role`, { method: 'DELETE' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['event', eventId] }),
   })
 
   const adminApproveMutation = useMutation({
     mutationFn: ({ requestId, status }: { requestId: string; status: 'approved' | 'denied' }) =>
-      fetch(`/api/admin/event-role-requests/${requestId}`, {
-        method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+      apiClient(`/api/admin/event-role-requests/${requestId}`, {
+        method: 'PATCH',
         body: JSON.stringify({ status }),
-      }).then(r => r.json()),
+      }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['event', eventId] }),
   })
 

--- a/app/(dashboard)/components/tiles/GuidesTile.tsx
+++ b/app/(dashboard)/components/tiles/GuidesTile.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import { useTileMaxItems } from '@/lib/hooks/useBentoConfig'
 import BentoCard from '@/components/bento/BentoCard'
 import { Eyebrow } from '@/components/bento/BentoCard'
+import { apiClient } from '@/lib/apiClient'
 
 type Guide = {
   id: string
@@ -22,7 +23,7 @@ export default function GuidesTile({ colSpan = 6, rowSpan, mobileColSpan }: { co
 
   const { data: guides = [], isLoading } = useQuery<Guide[]>({
     queryKey: ['guides', 'tile', maxItems],
-    queryFn: () => fetch(`/api/guides?limit=${maxItems}`).then(r => r.json()),
+    queryFn: () => apiClient(`/api/guides?limit=${maxItems}`),
     enabled: isLoaded,
     staleTime: 5 * 60 * 1000,
   })

--- a/app/(dashboard)/components/tiles/ProfileTile.tsx
+++ b/app/(dashboard)/components/tiles/ProfileTile.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query'
 import BentoCard from '@/components/bento/BentoCard'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import type { TranslationKey } from '@/lib/i18n/translations'
+import { apiClient } from '@/lib/apiClient'
 
 type VerifRequest = { status: 'pending' | 'approved' | 'denied' } | null
 type Upline = { upline_name: string | null; upline_abo_number: string | null } | null
@@ -39,7 +40,7 @@ export default function ProfileTile({
 
   const { data: profile } = useQuery<Profile>({
     queryKey: ['profile'],
-    queryFn: () => fetch('/api/profile').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile'),
     enabled: !!isSignedIn,
     staleTime: 5 * 60 * 1000,
   })

--- a/app/(dashboard)/components/tiles/SocialsTile.tsx
+++ b/app/(dashboard)/components/tiles/SocialsTile.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import BentoCard from '@/components/bento/BentoCard'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { timeAgoMs } from '@/lib/format'
+import { apiClient } from '@/lib/apiClient'
 
 type SocialPost = {
   id: string
@@ -64,7 +65,7 @@ export default function SocialsTile({
   const { t } = useLanguage()
   const { data, isLoading } = useQuery<SocialsData>({
     queryKey: ['socials'],
-    queryFn: () => fetch('/api/socials').then(r => r.json()),
+    queryFn: () => apiClient('/api/socials'),
     staleTime: 300 * 1000,
   })
 

--- a/app/(dashboard)/components/tiles/SocialsTileDesktop.tsx
+++ b/app/(dashboard)/components/tiles/SocialsTileDesktop.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import BentoCard from '@/components/bento/BentoCard'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { timeAgoMs } from '@/lib/format'
+import { apiClient } from '@/lib/apiClient'
 
 type SocialPost = {
   id: string
@@ -58,7 +59,7 @@ export default function SocialsTileDesktop({
   const { t } = useLanguage()
   const { data, isLoading } = useQuery<SocialsData>({
     queryKey: ['socials'],
-    queryFn: () => fetch('/api/socials').then(r => r.json()),
+    queryFn: () => apiClient('/api/socials'),
     staleTime: 300 * 1000,
   })
 

--- a/app/(dashboard)/components/tiles/SocialsTileMobile.tsx
+++ b/app/(dashboard)/components/tiles/SocialsTileMobile.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import BentoCard from '@/components/bento/BentoCard'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { timeAgoMs } from '@/lib/format'
+import { apiClient } from '@/lib/apiClient'
 
 type SocialPost = {
   id: string
@@ -50,7 +51,7 @@ export default function SocialsTileMobile() {
   const { t } = useLanguage()
   const { data, isLoading } = useQuery<SocialsData>({
     queryKey: ['socials'],
-    queryFn: () => fetch('/api/socials').then(r => r.json()),
+    queryFn: () => apiClient('/api/socials'),
     staleTime: 300 * 1000,
   })
 

--- a/app/(dashboard)/guides/GuidesClient.tsx
+++ b/app/(dashboard)/guides/GuidesClient.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from '@/components/ui/Skeleton'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { formatDate } from '@/lib/format'
 import type { Guide, SiteLink, NewsItem } from '@/lib/server/guides'
+import { apiClient } from '@/lib/apiClient'
 
 type Props = {
   initialGuides: Guide[]
@@ -86,21 +87,21 @@ function GuidesInner({ initialGuides, initialLinks, initialNews, initialDataUpda
 
   const { data: guides = initialGuides, isLoading: guidesLoading } = useQuery<Guide[]>({
     queryKey: ['guides', 'list'],
-    queryFn: () => fetch('/api/guides').then(r => r.json()),
+    queryFn: () => apiClient('/api/guides'),
     initialData: initialGuides,
     initialDataUpdatedAt,
   })
 
   const { data: links = initialLinks, isLoading: linksLoading } = useQuery<SiteLink[]>({
     queryKey: ['links', 'list'],
-    queryFn: () => fetch('/api/links').then(r => r.json()),
+    queryFn: () => apiClient('/api/links'),
     initialData: initialLinks,
     initialDataUpdatedAt,
   })
 
   const { data: news = initialNews, isLoading: newsLoading } = useQuery<NewsItem[]>({
     queryKey: ['news', 'list'],
-    queryFn: () => fetch('/api/news').then(r => r.json()),
+    queryFn: () => apiClient('/api/news'),
     initialData: initialNews,
     initialDataUpdatedAt,
   })

--- a/app/(dashboard)/library/GuidesClient.tsx
+++ b/app/(dashboard)/library/GuidesClient.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from '@/components/ui/Skeleton'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { formatDate } from '@/lib/format'
 import type { Guide, SiteLink, NewsItem } from '@/lib/server/guides'
+import { apiClient } from '@/lib/apiClient'
 
 type Props = {
   initialGuides: Guide[]
@@ -86,21 +87,21 @@ function GuidesInner({ initialGuides, initialLinks, initialNews, initialDataUpda
 
   const { data: guides = initialGuides, isLoading: guidesLoading } = useQuery<Guide[]>({
     queryKey: ['guides', 'list'],
-    queryFn: () => fetch('/api/guides').then(r => r.json()),
+    queryFn: () => apiClient('/api/guides'),
     initialData: initialGuides,
     initialDataUpdatedAt,
   })
 
   const { data: links = initialLinks, isLoading: linksLoading } = useQuery<SiteLink[]>({
     queryKey: ['links', 'list'],
-    queryFn: () => fetch('/api/links').then(r => r.json()),
+    queryFn: () => apiClient('/api/links'),
     initialData: initialLinks,
     initialDataUpdatedAt,
   })
 
   const { data: news = initialNews, isLoading: newsLoading } = useQuery<NewsItem[]>({
     queryKey: ['news', 'list'],
-    queryFn: () => fetch('/api/news').then(r => r.json()),
+    queryFn: () => apiClient('/api/news'),
     initialData: initialNews,
     initialDataUpdatedAt,
   })

--- a/app/(dashboard)/los/page.tsx
+++ b/app/(dashboard)/los/page.tsx
@@ -7,6 +7,7 @@ import { formatDate } from '@/lib/format'
 import { OrgChartCanvas } from './components/OrgChartCanvas'
 import { displayName, roleColors, isVitalRecorded } from './lib/los-utils'
 import type { LOSNode, TreeResponse } from './lib/los-utils'
+import { apiClient } from '@/lib/apiClient'
 
 // ── Tree builder ──────────────────────────────────────────────────────────────
 
@@ -227,7 +228,7 @@ function LOSPageInner() {
 
   const { data, isLoading, isError } = useQuery<TreeResponse>({
     queryKey: ['los-tree'],
-    queryFn: () => fetch('/api/los/tree').then(r => r.json()),
+    queryFn: () => apiClient('/api/los/tree'),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { apiClient } from '@/lib/apiClient'
 
 export const CALENDAR_MIN_HEIGHT = 160
 
@@ -12,13 +13,13 @@ export function CalendarSection({ profileId }: { profileId: string }) {
 
   const { data: calData, refetch: refetchCal } = useQuery<{ url: string }>({
     queryKey: ['cal-feed-token'],
-    queryFn: () => fetch('/api/calendar/feed-token').then(r => r.json()),
+    queryFn: () => apiClient('/api/calendar/feed-token'),
     enabled: !!profileId,
     staleTime: Infinity,
   })
 
   const regenerateCal = useMutation({
-    mutationFn: () => fetch('/api/calendar/feed-token', { method: 'POST' }).then(r => r.json()),
+    mutationFn: () => apiClient('/api/calendar/feed-token', { method: 'POST' }),
     onSuccess: () => refetchCal(),
   })
 

--- a/app/(dashboard)/profile/components/EmailPrefsSection.tsx
+++ b/app/(dashboard)/profile/components/EmailPrefsSection.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { type NotificationPrefs } from '../types'
+import { apiClient } from '@/lib/apiClient'
 
 export const EMAIL_PREFS_MIN_HEIGHT = 280
 
@@ -69,13 +70,9 @@ export function EmailPrefsSection({
 
   const save = useMutation({
     mutationFn: (next: NotificationPrefs) =>
-      fetch('/api/profile', {
+      apiClient('/api/profile', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ notification_prefs: next }),
-      }).then(async r => {
-        if (!r.ok) throw new Error((await r.json()).error)
-        return r.json()
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['profile'] })

--- a/app/(dashboard)/profile/components/ParticipationSection.tsx
+++ b/app/(dashboard)/profile/components/ParticipationSection.tsx
@@ -7,6 +7,7 @@ import { Drawer } from '@/components/ui/Drawer'
 import { formatDate } from '@/lib/format'
 import { type EventRoleRequest, VARIABLE_CAP, REG_STATUS_STYLES } from '../types'
 import { ShowMoreButton } from './shared'
+import { apiClient } from '@/lib/apiClient'
 
 export const PARTICIPATION_MIN_HEIGHT = 280
 
@@ -16,7 +17,7 @@ export function ParticipationSection({ profileId, role }: { profileId: string; r
 
   const { data: eventRolesData, isLoading } = useQuery<EventRoleRequest[]>({
     queryKey: ['profile-event-roles'],
-    queryFn: () => fetch('/api/profile/event-roles').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile/event-roles'),
     enabled: !!profileId && role !== 'guest',
     staleTime: 5 * 60 * 1000,
   })

--- a/app/(dashboard)/profile/components/PaymentsSection.tsx
+++ b/app/(dashboard)/profile/components/PaymentsSection.tsx
@@ -8,6 +8,7 @@ import { PaymentForm } from '@/components/payment/PaymentForm'
 import { formatCurrency } from '@/lib/format'
 import { type TripEntry, type GenericPayment, type PayableItem, VARIABLE_CAP } from '../types'
 import { PaymentRow, ShowMoreButton } from './shared'
+import { apiClient } from '@/lib/apiClient'
 
 export const PAYMENTS_MIN_HEIGHT = 280
 
@@ -54,21 +55,21 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
 
   const { data: paymentsData, isLoading } = useQuery<GenericPayment[]>({
     queryKey: ['profile-generic-payments'],
-    queryFn: () => fetch('/api/payments').then(r => r.json()),
+    queryFn: () => apiClient('/api/payments'),
     enabled,
     staleTime: 2 * 60 * 1000,
   })
 
   const { data: payableItems } = useQuery<PayableItem[]>({
     queryKey: ['payable-items'],
-    queryFn: () => fetch('/api/payable-items').then(r => r.json()),
+    queryFn: () => apiClient('/api/payable-items'),
     enabled,
     staleTime: 5 * 60 * 1000,
   })
 
   const { data: tripsData } = useQuery<TripEntry[]>({
     queryKey: ['profile-trips'],
-    queryFn: () => fetch('/api/profile/payments').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile/payments'),
     enabled,
     staleTime: 2 * 60 * 1000,
   })

--- a/app/(dashboard)/profile/components/PersonalDetailsContent.tsx
+++ b/app/(dashboard)/profile/components/PersonalDetailsContent.tsx
@@ -6,6 +6,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/Drawer'
 import { PersonalDrawerForm } from './PersonalDrawerForm'
 import { type Profile } from '../types'
+import { apiClient } from '@/lib/apiClient'
 
 // ── Validation ────────────────────────────────────────────────────────────────
 
@@ -93,13 +94,10 @@ export const PersonalDetailsContent = memo(function PersonalDetailsContent({
         phone:         form.phone || null,
         contact_email: form.contact_email || null,
       }
-      const r = await fetch('/api/profile', {
+      return apiClient<Profile>('/api/profile', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       })
-      if (!r.ok) throw new Error((await r.json()).error ?? 'Save failed')
-      return r.json() as Promise<Profile>
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['profile'] })

--- a/app/(dashboard)/profile/components/StatsSection.tsx
+++ b/app/(dashboard)/profile/components/StatsSection.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { type LosSummaryData } from '../types'
+import { apiClient } from '@/lib/apiClient'
 
 export const STATS_MIN_HEIGHT = 160
 
@@ -11,7 +12,7 @@ export function StatsSection({ role, aboNumber }: { role: string; aboNumber: str
 
   const { data: losSummary, isLoading } = useQuery<LosSummaryData>({
     queryKey: ['profile-los-summary'],
-    queryFn: () => fetch('/api/profile/los-summary').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile/los-summary'),
     enabled: !!aboNumber,
     staleTime: 5 * 60 * 1000,
   })

--- a/app/(dashboard)/profile/components/TravelDocContent.tsx
+++ b/app/(dashboard)/profile/components/TravelDocContent.tsx
@@ -7,6 +7,7 @@ import { formatDate } from '@/lib/format'
 import { Drawer } from '@/components/ui/Drawer'
 import { TravelDocDrawerForm } from './TravelDocDrawerForm'
 import { type Profile } from '../types'
+import { apiClient } from '@/lib/apiClient'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -76,13 +77,10 @@ export const TravelDocContent = memo(function TravelDocContent({
         passport_number: form.passport_number || null,
         valid_through:   form.valid_through   || null,
       }
-      const r = await fetch('/api/profile', {
+      return apiClient<Profile>('/api/profile', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       })
-      if (!r.ok) throw new Error((await r.json()).error ?? 'Save failed')
-      return r.json() as Promise<Profile>
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['profile'] })

--- a/app/(dashboard)/profile/components/TripsSection.tsx
+++ b/app/(dashboard)/profile/components/TripsSection.tsx
@@ -6,6 +6,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/Drawer'
 import { type TripEntry, VARIABLE_CAP } from '../types'
 import { TripRow, ShowMoreButton } from './shared'
+import { apiClient } from '@/lib/apiClient'
 
 export const TRIPS_MIN_HEIGHT = 280
 
@@ -16,17 +17,14 @@ export function TripsSection({ profileId, role }: { profileId: string; role: str
 
   const { data: tripsData, isLoading } = useQuery<TripEntry[]>({
     queryKey: ['profile-trips'],
-    queryFn: () => fetch('/api/profile/payments').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile/payments'),
     enabled: !!profileId && role !== 'guest',
     staleTime: 2 * 60 * 1000,
   })
 
   const cancelTrip = useMutation({
     mutationFn: (tripId: string) =>
-      fetch(`/api/profile/trips/${tripId}/cancel`, { method: 'POST' }).then(async r => {
-        if (!r.ok) throw new Error((await r.json()).error)
-        return r.json()
-      }),
+      apiClient(`/api/profile/trips/${tripId}/cancel`, { method: 'POST' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['profile-trips'] }),
   })
 

--- a/app/(dashboard)/profile/components/VitalsSection.tsx
+++ b/app/(dashboard)/profile/components/VitalsSection.tsx
@@ -7,6 +7,7 @@ import { Drawer } from '@/components/ui/Drawer'
 import { isVitalRecorded } from '@/lib/vitals'
 import { type ProfileVitalSign, VARIABLE_CAP } from '../types'
 import { ShowMoreButton } from './shared'
+import { apiClient } from '@/lib/apiClient'
 
 export const VITALS_MIN_HEIGHT = 280
 
@@ -16,7 +17,7 @@ export function VitalsSection({ profileId, role }: { profileId: string; role: st
 
   const { data: vitalsData, isLoading } = useQuery<ProfileVitalSign[]>({
     queryKey: ['profile-vitals'],
-    queryFn: () => fetch('/api/profile/vital-signs').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile/vital-signs'),
     enabled: !!profileId && role !== 'guest',
     staleTime: 5 * 60 * 1000,
   })

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -31,6 +31,7 @@ import { StatsSection, STATS_MIN_HEIGHT } from './components/StatsSection'
 import { AdminSection } from './components/AdminSection'
 import { EmailPrefsSection, EMAIL_PREFS_MIN_HEIGHT } from './components/EmailPrefsSection'
 import { type Profile, type VerificationRequest, type UplineData, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from './types'
+import { apiClient } from '@/lib/apiClient'
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -98,7 +99,7 @@ export default function ProfilePage() {
   // ── Profile query (page gate) ─────────────────────────────────────────────
   const { data: profile, isLoading } = useQuery<Profile>({
     queryKey: ['profile'],
-    queryFn: () => fetch('/api/profile').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile'),
   })
 
   const validProfile = profile?.id ? profile : null
@@ -106,36 +107,32 @@ export default function ProfilePage() {
   // ── ABO queries (needed for AboInfoContent + bento gating) ───────────────
   const { data: verRequest } = useQuery<VerificationRequest | null>({
     queryKey: ['verify-abo'],
-    queryFn: () => fetch('/api/profile/verify-abo').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile/verify-abo'),
     enabled: !!validProfile && validProfile.role === 'guest',
   })
 
   const { data: uplineData } = useQuery<UplineData>({
     queryKey: ['profile-upline'],
-    queryFn: () => fetch('/api/profile/upline').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile/upline'),
     enabled: !!validProfile?.abo_number,
     staleTime: 10 * 60 * 1000,
   })
 
   const submitVerification = useMutation({
     mutationFn: (params: { claimed_abo?: string; claimed_upline_abo: string; request_type: 'standard' | 'manual' }) =>
-      fetch('/api/profile/verify-abo', {
+      apiClient('/api/profile/verify-abo', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(
           params.request_type === 'manual'
             ? { request_type: 'manual', claimed_upline_abo: params.claimed_upline_abo }
             : { claimed_abo: params.claimed_abo, claimed_upline_abo: params.claimed_upline_abo }
         ),
-      }).then(async r => {
-        if (!r.ok) throw new Error((await r.json()).error)
-        return r.json()
       }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['verify-abo'] }),
   })
 
   const cancelVerification = useMutation({
-    mutationFn: () => fetch('/api/profile/verify-abo', { method: 'DELETE' }).then(r => r.json()),
+    mutationFn: () => apiClient('/api/profile/verify-abo', { method: 'DELETE' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['verify-abo'] }),
   })
 
@@ -161,9 +158,8 @@ export default function ProfilePage() {
   const persistPrefs = useCallback((order: string[], collapsed: Record<string, boolean>) => {
     if (persistDebounceRef.current) clearTimeout(persistDebounceRef.current)
     persistDebounceRef.current = setTimeout(() => {
-      fetch('/api/profile', {
+      apiClient('/api/profile', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ui_prefs: { bento_order: order, bento_collapsed: collapsed } }),
       }).catch(() => { /* silent */ })
     }, 500)

--- a/app/(dashboard)/trips/TripsClient.tsx
+++ b/app/(dashboard)/trips/TripsClient.tsx
@@ -11,6 +11,7 @@ import { PinIcon } from './components/TripShared'
 import TripCardMobile from './components/TripCardMobile'
 import TripCardDesktop from './components/TripCardDesktop'
 import type { Trip } from './page'
+import { apiClient } from '@/lib/apiClient'
 
 type ProfilePaymentRow = {
   registration_id: string
@@ -163,13 +164,13 @@ export default function TripsClient({ initialTrips }: { initialTrips: Trip[] }) 
 
   const { data: profile, isLoading: profileLoading } = useQuery<UserProfile>({
     queryKey: ['profile'],
-    queryFn: () => fetch('/api/profile').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile'),
     enabled: !!isSignedIn,
   })
 
   const { data: trips = initialTrips } = useQuery<Trip[]>({
     queryKey: ['trips'],
-    queryFn: () => fetch('/api/trips').then(r => r.json()),
+    queryFn: () => apiClient('/api/trips'),
     initialData: initialTrips,
     enabled: isLoaded,
     staleTime: 30_000,
@@ -177,7 +178,7 @@ export default function TripsClient({ initialTrips }: { initialTrips: Trip[] }) 
 
   const { data: profilePayments = [], isLoading: regLoading } = useQuery<ProfilePaymentRow[]>({
     queryKey: ['profile-payments'],
-    queryFn: () => fetch('/api/profile/payments').then(r => r.json()),
+    queryFn: () => apiClient('/api/profile/payments'),
     enabled: !!isSignedIn,
   })
 
@@ -189,10 +190,7 @@ export default function TripsClient({ initialTrips }: { initialTrips: Trip[] }) 
 
   const cancelMutation = useMutation({
     mutationFn: (tripId: string) =>
-      fetch(`/api/profile/trips/${tripId}/cancel`, { method: 'POST' }).then(async r => {
-        if (!r.ok) throw new Error((await r.json()).error)
-        return r.json()
-      }),
+      apiClient(`/api/profile/trips/${tripId}/cancel`, { method: 'POST' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['profile-payments'] }),
   })
 

--- a/app/(dashboard)/trips/[id]/components/PendingView.tsx
+++ b/app/(dashboard)/trips/[id]/components/PendingView.tsx
@@ -6,6 +6,7 @@ import { formatDate } from '@/lib/format'
 import { BackButton, TripHero } from './shared'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile } from '../page'
+import { apiClient } from '@/lib/apiClient'
 
 type Trip = Tables<'trips'>
 type Registration = Tables<'trip_registrations'>
@@ -17,10 +18,7 @@ export function PendingView({
 
   const cancelMutation = useMutation({
     mutationFn: () =>
-      fetch(`/api/profile/trips/${trip.id}/cancel`, { method: 'POST' }).then(async r => {
-        if (!r.ok) throw new Error((await r.json()).error ?? 'Cancel failed')
-        return r.json()
-      }),
+      apiClient(`/api/profile/trips/${trip.id}/cancel`, { method: 'POST' }),
     onSuccess: () => router.push('/trips'),
   })
 

--- a/app/(dashboard)/trips/[id]/components/RegisterButton.tsx
+++ b/app/(dashboard)/trips/[id]/components/RegisterButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/lib/apiClient'
 
 type Props = {
   tripId: string
@@ -14,13 +15,9 @@ export default function RegisterButton({ tripId, profileId }: Props) {
 
   const mutation = useMutation({
     mutationFn: () =>
-      fetch(`/api/trips/${tripId}/register`, {
+      apiClient(`/api/trips/${tripId}/register`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
-      }).then(async r => {
-        if (!r.ok) throw new Error((await r.json()).error)
-        return r.json()
       }),
     onSuccess: () => {
       setLocalSuccess(true)

--- a/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
@@ -3,18 +3,13 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
-import { apiClient } from '@/lib/apiClient'
+import { apiClient, ApiError } from '@/lib/apiClient'
 
 interface Attachment {
   id: string
   file_url: string
   file_name: string
   file_type: 'pdf' | 'image'
-}
-
-interface ApiError {
-  status?: number
-  message: string
 }
 
 function PdfIcon() {
@@ -47,21 +42,14 @@ export function TripDocumentsTile({ tripId }: { tripId: string }) {
 
   const { data: attachments, isLoading, isError, error, refetch } = useQuery<Attachment[], ApiError>({
     queryKey: ['trip-attachments', tripId],
-    queryFn: async () => {
-        try {
-          return await apiClient<Attachment[]>(`/api/trips/${tripId}/attachments`)
-        } catch (e) {
-          const err: ApiError = { status: (e as { status?: number }).status, message: (e as Error).message }
-          throw err
-        }
-      },
+    queryFn: () => apiClient<Attachment[]>(`/api/trips/${tripId}/attachments`),
     retry: false,
   })
 
   if (isLoading) return null
 
   // 403 = no approved registration — expected, render nothing
-  if (isError && (error as ApiError)?.status === 403) return null
+  if (isError && error?.status === 403) return null
 
   // 5xx or network error — show discreet retry, no alarming message
   if (isError) {

--- a/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { apiClient } from '@/lib/apiClient'
 
 interface Attachment {
   id: string
@@ -46,15 +47,14 @@ export function TripDocumentsTile({ tripId }: { tripId: string }) {
 
   const { data: attachments, isLoading, isError, error, refetch } = useQuery<Attachment[], ApiError>({
     queryKey: ['trip-attachments', tripId],
-    queryFn: () =>
-      fetch(`/api/trips/${tripId}/attachments`).then(async r => {
-        if (!r.ok) {
-          const body = await r.json().catch(() => ({}))
-          const err: ApiError = { status: r.status, message: body.error ?? 'Failed' }
+    queryFn: async () => {
+        try {
+          return await apiClient<Attachment[]>(`/api/trips/${tripId}/attachments`)
+        } catch (e) {
+          const err: ApiError = { status: (e as { status?: number }).status, message: (e as Error).message }
           throw err
         }
-        return r.json()
-      }),
+      },
     retry: false,
   })
 

--- a/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
@@ -4,17 +4,12 @@ import { type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { formatDateTime } from '@/lib/format'
 import { useLanguage } from '@/lib/hooks/useLanguage'
-import { apiClient } from '@/lib/apiClient'
+import { apiClient, ApiError } from '@/lib/apiClient'
 
 interface TripMessage {
   id: string
   body: string
   created_at: string
-}
-
-interface ApiError {
-  status?: number
-  message: string
 }
 
 const URL_PATTERN = /https?:\/\/[^\s<>"']+/g
@@ -63,14 +58,7 @@ export function TripMessagesTile({ tripId }: { tripId: string }) {
   const { data: messages, isLoading, isError, error, refetch, isFetching } =
     useQuery<TripMessage[], ApiError>({
       queryKey: ['trip-messages', tripId],
-      queryFn: async () => {
-        try {
-          return await apiClient<TripMessage[]>(`/api/trips/${encodeURIComponent(tripId)}/messages`)
-        } catch (e) {
-          const err: ApiError = { status: (e as { status?: number }).status, message: (e as Error).message }
-          throw err
-        }
-      },
+      queryFn: () => apiClient<TripMessage[]>(`/api/trips/${encodeURIComponent(tripId)}/messages`),
       retry: false,
       select: (data) =>
         [...data].sort(
@@ -81,7 +69,7 @@ export function TripMessagesTile({ tripId }: { tripId: string }) {
   if (isLoading) return null
 
   // 403 = not an approved attendee — expected, render nothing
-  if (isError && (error as ApiError)?.status === 403) return null
+  if (isError && error?.status === 403) return null
 
   // 5xx or network error — discreet retry, no alarming message
   if (isError) {

--- a/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripMessagesTile.tsx
@@ -4,6 +4,7 @@ import { type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { formatDateTime } from '@/lib/format'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { apiClient } from '@/lib/apiClient'
 
 interface TripMessage {
   id: string
@@ -62,15 +63,14 @@ export function TripMessagesTile({ tripId }: { tripId: string }) {
   const { data: messages, isLoading, isError, error, refetch, isFetching } =
     useQuery<TripMessage[], ApiError>({
       queryKey: ['trip-messages', tripId],
-      queryFn: () =>
-        fetch(`/api/trips/${encodeURIComponent(tripId)}/messages`).then(async r => {
-          if (!r.ok) {
-            const body = await r.json().catch(() => ({}))
-            const err: ApiError = { status: r.status, message: body.error ?? 'Failed' }
-            throw err
-          }
-          return r.json()
-        }),
+      queryFn: async () => {
+        try {
+          return await apiClient<TripMessage[]>(`/api/trips/${encodeURIComponent(tripId)}/messages`)
+        } catch (e) {
+          const err: ApiError = { status: (e as { status?: number }).status, message: (e as Error).message }
+          throw err
+        }
+      },
       retry: false,
       select: (data) =>
         [...data].sort(


### PR DESCRIPTION
## Summary
Migrates **all 24 remaining dashboard files** from raw `fetch('/api/...')` to `apiClient<T>()`. After this PR, **zero** raw fetch calls remain in `app/(dashboard)`.

### Migration Stats
- **24 files changed**, 83 insertions, 89 deletions
- **~40 call sites** migrated (queries + mutations)
- All `response.ok` checks now handled centrally
- All `Content-Type: application/json` headers now set automatically
- 401 interception with redirect to `/sign-in` now applies to all calls

### Migration Patterns
| Pattern | Before | After |
|---|---|---|
| Simple query | `fetch('/api/x').then(r => r.json())` | `apiClient('/api/x')` |
| Typed query | `fetch(url).then(r => r.json())` | `apiClient<T>(url)` |
| Mutation POST | `fetch(url, { method: 'POST', headers, body }).then(...)` | `apiClient(url, { method: 'POST', body })` |
| Mutation DELETE | `fetch(url, { method: 'DELETE' }).then(r => r.json())` | `apiClient(url, { method: 'DELETE' })` |
| Error-aware query | Custom `.then(async r => { if (!r.ok) ... })` | `try { apiClient<T>() } catch { rethrow as ApiError }` |

### Verification
- `npx tsc --noEmit` — all new errors: 0 (only pre-existing unrelated issues)
- `grep -r "fetch('/api" app/(dashboard)` — 0 results

Closes #161