### PR TITLE
[REFACTOR-022] decompose: AboInfoContent + EmailPrefsSection own their data

### DIFF
--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -26,7 +26,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
   const [aboInput, setAboInput] = useState('')
   const [uplineInput, setUplineInput] = useState('')
 
-  const { data: verRequest } = useQuery<VerificationRequest | null>({
+  const { data: verRequest, isPending: isVerPending } = useQuery<VerificationRequest | null>({
     queryKey: ['verify-abo'],
     queryFn: () => apiClient('/api/profile/verify-abo'),
     enabled: role === 'guest',
@@ -56,6 +56,22 @@ export const AboInfoContent = memo(function AboInfoContent() {
     mutationFn: () => apiClient('/api/profile/verify-abo', { method: 'DELETE' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['verify-abo'] }),
   })
+
+  // While the verify-abo query is in flight for a guest, defer mode resolution
+  // to avoid the form flashing before the pending/denied state is known.
+  if (role === 'guest' && isVerPending) {
+    return (
+      <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+        <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-5 pr-16" style={{ color: 'var(--brand-crimson)' }}>
+          {t('profile.tile.aboInfo')}
+        </p>
+        <div className="space-y-3 animate-pulse">
+          <div className="h-4 rounded-lg w-3/4" style={{ backgroundColor: 'var(--border-default)' }} />
+          <div className="h-4 rounded-lg w-1/2" style={{ backgroundColor: 'var(--border-default)' }} />
+        </div>
+      </div>
+    )
+  }
 
   let aboMode: AboInfoMode = 'form'
   if (aboNumber) {

--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -1,23 +1,11 @@
 'use client'
 
 import { memo, useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { getRoleColors } from '@/lib/role-colors'
-
-type VerificationRequest = {
-  id: string
-  claimed_abo: string | null
-  claimed_upline_abo: string
-  status: 'pending' | 'approved' | 'denied'
-  admin_note: string | null
-  created_at: string
-  request_type: string
-}
-
-type UplineData = {
-  upline_name: string | null
-  upline_abo_number: string | null
-}
+import { type VerificationRequest, type UplineData, type Profile } from '../types'
+import { apiClient } from '@/lib/apiClient'
 
 type AboInfoMode = 'form' | 'pending' | 'confirmed' | 'member_manual'
 
@@ -25,34 +13,58 @@ const ROLE_LABELS: Record<string, string> = {
   admin: 'Admin', core: 'Core', member: 'Member', guest: 'Guest',
 }
 
-export const AboInfoContent = memo(function AboInfoContent({
-  mode,
-  role,
-  aboNumber,
-  uplineData,
-  verRequest,
-  onSubmitVerification,
-  onCancelVerification,
-  submitPending,
-  cancelPending,
-  submitError,
-}: {
-  mode: AboInfoMode
-  role: string
-  aboNumber: string | null
-  uplineData: UplineData | undefined
-  verRequest: VerificationRequest | null | undefined
-  onSubmitVerification: (params: { claimed_abo?: string; claimed_upline_abo: string; request_type: 'standard' | 'manual' }) => void
-  onCancelVerification: () => void
-  submitPending: boolean
-  cancelPending: boolean
-  submitError: string | null
-}) {
+export const AboInfoContent = memo(function AboInfoContent() {
+  const qc = useQueryClient()
   const { t } = useLanguage()
+
+  const { data: profile } = useQuery<Profile>({ queryKey: ['profile'] })
+  const role = profile?.role ?? 'guest'
+  const aboNumber = profile?.abo_number ?? null
+
   const rc = getRoleColors(role)
   const [verificationMode, setVerificationMode] = useState<'standard' | 'manual'>('standard')
   const [aboInput, setAboInput] = useState('')
   const [uplineInput, setUplineInput] = useState('')
+
+  const { data: verRequest } = useQuery<VerificationRequest | null>({
+    queryKey: ['verify-abo'],
+    queryFn: () => apiClient('/api/profile/verify-abo'),
+    enabled: role === 'guest',
+  })
+
+  const { data: uplineData } = useQuery<UplineData>({
+    queryKey: ['profile-upline'],
+    queryFn: () => apiClient('/api/profile/upline'),
+    enabled: !!aboNumber,
+    staleTime: 10 * 60 * 1000,
+  })
+
+  const submitVerification = useMutation({
+    mutationFn: (params: { claimed_abo?: string; claimed_upline_abo: string; request_type: 'standard' | 'manual' }) =>
+      apiClient('/api/profile/verify-abo', {
+        method: 'POST',
+        body: JSON.stringify(
+          params.request_type === 'manual'
+            ? { request_type: 'manual', claimed_upline_abo: params.claimed_upline_abo }
+            : { claimed_abo: params.claimed_abo, claimed_upline_abo: params.claimed_upline_abo }
+        ),
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['verify-abo'] }),
+  })
+
+  const cancelVerification = useMutation({
+    mutationFn: () => apiClient('/api/profile/verify-abo', { method: 'DELETE' }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['verify-abo'] }),
+  })
+
+  let aboMode: AboInfoMode = 'form'
+  if (aboNumber) {
+    aboMode = 'confirmed'
+  } else if (role !== 'guest') {
+    aboMode = 'member_manual'
+  } else if (verRequest && (verRequest.status === 'pending' || verRequest.status === 'denied')) {
+    aboMode = 'pending'
+  }
 
   return (
     <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
@@ -60,7 +72,7 @@ export const AboInfoContent = memo(function AboInfoContent({
         {t('profile.tile.aboInfo')}
       </p>
 
-      {mode === 'confirmed' && (
+      {aboMode === 'confirmed' && (
         <div className="space-y-3">
           <div className="grid grid-cols-2 gap-3">
             <p className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>{t('profile.access')}</p>
@@ -94,7 +106,7 @@ export const AboInfoContent = memo(function AboInfoContent({
         </div>
       )}
 
-      {mode === 'member_manual' && (
+      {aboMode === 'member_manual' && (
         <div className="space-y-3">
           <div className="grid grid-cols-2 gap-3">
             <p className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>{t('profile.access')}</p>
@@ -126,7 +138,7 @@ export const AboInfoContent = memo(function AboInfoContent({
         </div>
       )}
 
-      {mode === 'pending' && (
+      {aboMode === 'pending' && (
         <div className="space-y-3">
           {verRequest?.status === 'denied' && (
             <div className="rounded-xl px-4 py-3 mb-2" style={{ backgroundColor: '#bc474915' }}>
@@ -154,8 +166,8 @@ export const AboInfoContent = memo(function AboInfoContent({
                   : `ABO ${verRequest.claimed_abo} · Upline ${verRequest.claimed_upline_abo}`}
               </p>
               <button
-                onClick={onCancelVerification}
-                disabled={cancelPending}
+                onClick={() => cancelVerification.mutate()}
+                disabled={cancelVerification.isPending}
                 className="text-xs mt-2 font-medium hover:underline disabled:opacity-50"
                 style={{ color: 'var(--brand-crimson)' }}
               >
@@ -171,20 +183,20 @@ export const AboInfoContent = memo(function AboInfoContent({
               onModeChange={setVerificationMode}
               onAboChange={setAboInput}
               onUplineChange={setUplineInput}
-              onSubmit={() => onSubmitVerification(
+              onSubmit={() => submitVerification.mutate(
                 verificationMode === 'manual'
                   ? { request_type: 'manual', claimed_upline_abo: uplineInput.trim() }
                   : { request_type: 'standard', claimed_abo: aboInput.trim(), claimed_upline_abo: uplineInput.trim() }
               )}
-              submitPending={submitPending}
-              submitError={submitError}
+              submitPending={submitVerification.isPending}
+              submitError={submitVerification.isError ? (submitVerification.error as Error).message : null}
               t={t}
             />
           )}
         </div>
       )}
 
-      {mode === 'form' && (
+      {aboMode === 'form' && (
         <VerificationForm
           verificationMode={verificationMode}
           aboInput={aboInput}
@@ -192,13 +204,13 @@ export const AboInfoContent = memo(function AboInfoContent({
           onModeChange={setVerificationMode}
           onAboChange={setAboInput}
           onUplineChange={setUplineInput}
-          onSubmit={() => onSubmitVerification(
+          onSubmit={() => submitVerification.mutate(
             verificationMode === 'manual'
               ? { request_type: 'manual', claimed_upline_abo: uplineInput.trim() }
               : { request_type: 'standard', claimed_abo: aboInput.trim(), claimed_upline_abo: uplineInput.trim() }
           )}
-          submitPending={submitPending}
-          submitError={submitError}
+          submitPending={submitVerification.isPending}
+          submitError={submitVerification.isError ? (submitVerification.error as Error).message : null}
           t={t}
         />
       )}

--- a/app/(dashboard)/profile/components/EmailPrefsSection.tsx
+++ b/app/(dashboard)/profile/components/EmailPrefsSection.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useState, useCallback } from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
-import { type NotificationPrefs } from '../types'
+import { type Profile, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '../types'
 import { apiClient } from '@/lib/apiClient'
 
 export const EMAIL_PREFS_MIN_HEIGHT = 280
@@ -57,13 +57,12 @@ function Toggle({ enabled, onToggle }: { enabled: boolean; onToggle: () => void 
   )
 }
 
-export function EmailPrefsSection({
-  prefs,
-}: {
-  prefs: NotificationPrefs
-}) {
+export function EmailPrefsSection() {
   const { t } = useLanguage()
   const qc = useQueryClient()
+
+  const { data: profile } = useQuery<Profile>({ queryKey: ['profile'] })
+  const prefs = profile?.notification_prefs ?? DEFAULT_NOTIFICATION_PREFS
 
   const [local, setLocal] = useState<NotificationPrefs>(prefs)
   const [saved, setSaved] = useState(false)

--- a/app/(dashboard)/profile/components/EmailPrefsSection.tsx
+++ b/app/(dashboard)/profile/components/EmailPrefsSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { type Profile, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '../types'
@@ -66,6 +66,12 @@ export function EmailPrefsSection() {
 
   const [local, setLocal] = useState<NotificationPrefs>(prefs)
   const [saved, setSaved] = useState(false)
+
+  // Sync local toggle state when the profile cache is refreshed externally
+  // (e.g. after a save invalidation or background refetch).
+  useEffect(() => {
+    setLocal(profile?.notification_prefs ?? DEFAULT_NOTIFICATION_PREFS)
+  }, [profile])
 
   const save = useMutation({
     mutationFn: (next: NotificationPrefs) =>

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import {
@@ -30,7 +30,7 @@ import { CalendarSection, CALENDAR_MIN_HEIGHT } from './components/CalendarSecti
 import { StatsSection, STATS_MIN_HEIGHT } from './components/StatsSection'
 import { AdminSection } from './components/AdminSection'
 import { EmailPrefsSection, EMAIL_PREFS_MIN_HEIGHT } from './components/EmailPrefsSection'
-import { type Profile, type VerificationRequest, type UplineData, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from './types'
+import { type Profile, type NotificationPrefs } from './types'
 import { apiClient } from '@/lib/apiClient'
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -103,38 +103,6 @@ export default function ProfilePage() {
   })
 
   const validProfile = profile?.id ? profile : null
-
-  // ── ABO queries (needed for AboInfoContent + bento gating) ───────────────
-  const { data: verRequest } = useQuery<VerificationRequest | null>({
-    queryKey: ['verify-abo'],
-    queryFn: () => apiClient('/api/profile/verify-abo'),
-    enabled: !!validProfile && validProfile.role === 'guest',
-  })
-
-  const { data: uplineData } = useQuery<UplineData>({
-    queryKey: ['profile-upline'],
-    queryFn: () => apiClient('/api/profile/upline'),
-    enabled: !!validProfile?.abo_number,
-    staleTime: 10 * 60 * 1000,
-  })
-
-  const submitVerification = useMutation({
-    mutationFn: (params: { claimed_abo?: string; claimed_upline_abo: string; request_type: 'standard' | 'manual' }) =>
-      apiClient('/api/profile/verify-abo', {
-        method: 'POST',
-        body: JSON.stringify(
-          params.request_type === 'manual'
-            ? { request_type: 'manual', claimed_upline_abo: params.claimed_upline_abo }
-            : { claimed_abo: params.claimed_abo, claimed_upline_abo: params.claimed_upline_abo }
-        ),
-      }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['verify-abo'] }),
-  })
-
-  const cancelVerification = useMutation({
-    mutationFn: () => apiClient('/api/profile/verify-abo', { method: 'DELETE' }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['verify-abo'] }),
-  })
 
   // ── Restore persisted bento layout ───────────────────────────────────────
   useEffect(() => {
@@ -215,16 +183,6 @@ export default function ProfilePage() {
   const isGuest = p.role === 'guest' && !p.abo_number
   const isAdmin = p.role === 'admin'
 
-  type AboMode = 'form' | 'pending' | 'confirmed' | 'member_manual'
-  let aboMode: AboMode = 'form'
-  if (p.abo_number) {
-    aboMode = 'confirmed'
-  } else if (p.role !== 'guest') {
-    aboMode = 'member_manual'
-  } else if (verRequest && (verRequest.status === 'pending' || verRequest.status === 'denied')) {
-    aboMode = 'pending'
-  }
-
   // ── Bento map ─────────────────────────────────────────────────────────────
   type BentoEntry = { colSpan: number; minHeight: number; node: React.ReactNode }
 
@@ -235,17 +193,7 @@ export default function ProfilePage() {
     },
     [BENTO_IDS.ABO_INFO]: {
       colSpan: 6, minHeight: BENTO_HEIGHT.M,
-      node: (
-        <AboInfoContent
-          mode={aboMode} role={p.role} aboNumber={p.abo_number}
-          uplineData={uplineData} verRequest={verRequest}
-          onSubmitVerification={params => submitVerification.mutate(params)}
-          onCancelVerification={() => cancelVerification.mutate()}
-          submitPending={submitVerification.isPending}
-          cancelPending={cancelVerification.isPending}
-          submitError={submitVerification.isError ? (submitVerification.error as Error).message : null}
-        />
-      ),
+      node: <AboInfoContent />,
     },
     [BENTO_IDS.TRAVEL_DOC]: !isGuest ? {
       colSpan: 6, minHeight: BENTO_HEIGHT.S,
@@ -265,11 +213,7 @@ export default function ProfilePage() {
     } : null,
     [BENTO_IDS.EMAIL_PREFS]: !isGuest ? {
       colSpan: 6, minHeight: EMAIL_PREFS_MIN_HEIGHT,
-      node: (
-        <EmailPrefsSection
-          prefs={p.notification_prefs ?? DEFAULT_NOTIFICATION_PREFS}
-        />
-      ),
+      node: <EmailPrefsSection />,
     } : null,
     [BENTO_IDS.VITALS]: !isGuest ? {
       colSpan: 6, minHeight: VITALS_MIN_HEIGHT,


### PR DESCRIPTION
Closes #149

## Changes

- `AboInfoContent` — props 9 → 0. Now owns `verify-abo` query, `profile-upline` query, `submitVerification` and `cancelVerification` mutations internally. Reads `role` and `aboNumber` from `['profile']` cache. Local type redeclarations of `VerificationRequest` and `UplineData` replaced with imports from `../types`.
- `EmailPrefsSection` — props 1 → 0. Reads `['profile']` cache internally, derives `prefs` from it.
- `page.tsx` — `useMutation`, `VerificationRequest`, `UplineData`, `DEFAULT_NOTIFICATION_PREFS` all removed. Bento entries for both components simplified to zero-prop JSX.

## Session State
**Status:** DONE
**Completed:**
- [x] Commit pushed to branch
- [x] Vercel Preview READY — `tevd-portal-94zbmp7mx-teamenjoyvd.vercel.app`
**Next:** Merge via GitHub UI