### PR TITLE
[2604-CHORE-170] Lang architecture — LangProvider context + fix React Query waterfall

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,14 +1,34 @@
+import { cookies } from 'next/headers'
+import type { Lang } from '@/lib/i18n/translations'
+import { LangProvider } from '@/lib/context/LangProvider'
 import Header from '@/components/layout/Header'
 import Footer from '@/components/layout/Footer'
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+export default async function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const cookieStore = await cookies()
+  const lang = (
+    cookieStore.get('tevd_lang')?.value === 'bg' ? 'bg' : 'en'
+  ) as Lang
+
   return (
-    <div className="min-h-screen flex flex-col" style={{ backgroundColor: 'var(--bg-global)' }}>
-      <Header />
-      <main className="flex-1 pt-20" style={{ backgroundColor: 'var(--bg-global)' }}>
-        {children}
-      </main>
-      <Footer />
-    </div>
+    <LangProvider initialLang={lang}>
+      <div
+        className="min-h-screen flex flex-col"
+        style={{ backgroundColor: 'var(--bg-global)' }}
+      >
+        <Header />
+        <main
+          className="flex-1 pt-20"
+          style={{ backgroundColor: 'var(--bg-global)' }}
+        >
+          {children}
+        </main>
+        <Footer />
+      </div>
+    </LangProvider>
   )
 }

--- a/app/(dashboard)/library/page.tsx
+++ b/app/(dashboard)/library/page.tsx
@@ -15,7 +15,7 @@ export default async function LibraryPage() {
       initialGuides={guides}
       initialLinks={links}
       initialNews={news}
-      initialDataUpdatedAt={Date.now()}
+      initialDataUpdatedAt={Infinity}
     />
   )
 }

--- a/lib/context/LangProvider.tsx
+++ b/lib/context/LangProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useState, useCallback } from 'react'
+import { createContext, useContext, useState, useCallback, useMemo } from 'react'
 import { translate, TranslationKey, Lang } from '@/lib/i18n/translations'
 
 const COOKIE_KEY = 'tevd_lang'
@@ -35,8 +35,10 @@ export function LangProvider({
     [lang],
   )
 
+  const value = useMemo(() => ({ lang, toggle, t }), [lang, toggle, t])
+
   return (
-    <LangContext.Provider value={{ lang, toggle, t }}>
+    <LangContext.Provider value={value}>
       {children}
     </LangContext.Provider>
   )

--- a/lib/context/LangProvider.tsx
+++ b/lib/context/LangProvider.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { createContext, useContext, useState, useCallback } from 'react'
+import { translate, TranslationKey, Lang } from '@/lib/i18n/translations'
+
+const COOKIE_KEY = 'tevd_lang'
+
+type LangContextValue = {
+  lang: Lang
+  toggle: () => void
+  t: (key: TranslationKey) => string
+}
+
+const LangContext = createContext<LangContextValue | null>(null)
+
+export function LangProvider({
+  initialLang,
+  children,
+}: {
+  initialLang: Lang
+  children: React.ReactNode
+}) {
+  const [lang, setLang] = useState<Lang>(initialLang)
+
+  const toggle = useCallback(() => {
+    const next: Lang = lang === 'en' ? 'bg' : 'en'
+    setLang(next)
+    document.cookie = `${COOKIE_KEY}=${next}; path=/; max-age=${
+      60 * 60 * 24 * 365
+    }; SameSite=Lax`
+  }, [lang])
+
+  const t = useCallback(
+    (key: TranslationKey) => translate(key, lang),
+    [lang],
+  )
+
+  return (
+    <LangContext.Provider value={{ lang, toggle, t }}>
+      {children}
+    </LangContext.Provider>
+  )
+}
+
+export function useLang(): LangContextValue {
+  const ctx = useContext(LangContext)
+  if (!ctx) throw new Error('useLang must be used within LangProvider')
+  return ctx
+}

--- a/lib/hooks/useLanguage.ts
+++ b/lib/hooks/useLanguage.ts
@@ -1,47 +1,15 @@
 'use client'
 
-import { useSyncExternalStore, useCallback } from 'react'
-import { translate, TranslationKey, Lang } from '@/lib/i18n/translations'
-
-const COOKIE_KEY = 'tevd_lang'
-const LANG_EVENT = 'language-changed'
-const DEFAULT: Lang = 'en'
-
-function getCookieLang(): Lang {
-  if (typeof document === 'undefined') return DEFAULT
-  const match = document.cookie
-    .split('; ')
-    .find(row => row.startsWith(`${COOKIE_KEY}=`))
-  const value = match?.split('=')[1]
-  return value === 'bg' ? 'bg' : DEFAULT
-}
-
-function setCookieLang(lang: Lang): void {
-  // 1-year expiry, path=/ so all routes see it
-  document.cookie = `${COOKIE_KEY}=${lang}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`
-}
-
-function subscribe(callback: () => void): () => void {
-  window.addEventListener(LANG_EVENT, callback)
-  return () => window.removeEventListener(LANG_EVENT, callback)
-}
-
-export function useLanguage() {
-  const lang = useSyncExternalStore(
-    subscribe,
-    getCookieLang,
-    () => DEFAULT, // getServerSnapshot — SSR always gets default
-  )
-
-  const toggle = useCallback(() => {
-    const next: Lang = getCookieLang() === 'en' ? 'bg' : 'en'
-    setCookieLang(next)
-    window.dispatchEvent(new Event(LANG_EVENT))
-  }, [])
-
-  const t = useCallback((key: TranslationKey): string => {
-    return translate(key, lang)
-  }, [lang])
-
-  return { lang, toggle, t }
-}
+/**
+ * Thin re-export — useLanguage delegates to the LangProvider context.
+ * Public API (lang, toggle, t) is unchanged; all callsites require zero edits.
+ *
+ * Previous implementation used useSyncExternalStore + document.cookie which:
+ *   - always returned 'en' from getServerSnapshot, causing a hydration flash for BG users
+ *   - relied on a window event bus for cross-component updates
+ *
+ * LangProvider in app/(dashboard)/layout.tsx resolves the correct lang server-side
+ * from the tevd_lang cookie and passes it as initialLang, fixing the SSR mismatch.
+ * All consumers update synchronously via React state — no window events needed.
+ */
+export { useLang as useLanguage } from '@/lib/context/LangProvider'


### PR DESCRIPTION
Closes #170

## What

Two root-cause bugs fixed:

1. **SSR hydration flash** — `useLanguage` used `useSyncExternalStore` with `getServerSnapshot: () => 'en'`. BG users got an `'en'` SSR render that flashed to `'bg'` after hydration on every page load.
2. **React Query waterfall** — `library/page.tsx` passed `initialDataUpdatedAt={Date.now()}`, marking server-fetched data as immediately stale. Three redundant HTTP calls fired on every library page mount.

## Why the original approach was wrong

The issue proposed resolving `lang` server-side in each RSC page and prop-drilling it into client components. This only works for the 3 components with RSC parents. The remaining 6 `useLanguage` consumers (`Header`, `Footer`, `UserDropdown`, `UserPopup`, `CalendarTile`, `GuidesTile`) are layout/autonomous — no RSC parent in their data path, prop-drilling can't reach them.

## How

`LangProvider` — a thin `'use client'` Context provider — wraps the entire `app/(dashboard)/layout.tsx` subtree. The layout RSC reads `tevd_lang` from the cookie server-side and passes the correct `initialLang` to the provider. All 9 `useLanguage()` consumers read from context and update synchronously when the toggle fires. `useLanguage` becomes a one-line re-export of `useLang`.

Layout tree verified before writing: `Header`, `Footer`, `UserDropdown`, `UserPopup` exist **exclusively** inside `app/(dashboard)/layout.tsx`. No consumer exists outside the provider boundary.

## Files changed

| File | Change |
|---|---|
| `lib/context/LangProvider.tsx` | NEW — Context, Provider, `useLang` hook |
| `lib/hooks/useLanguage.ts` | Drop `useSyncExternalStore` + event bus, delegate to `useLang()` |
| `app/(dashboard)/layout.tsx` | `async`, `await cookies()`, wrap children in `<LangProvider>` |
| `app/(dashboard)/library/page.tsx` | `initialDataUpdatedAt={Date.now()}` → `Infinity` |

**Zero changes to any `useLanguage()` callsite.**

## Verification checklist

- [ ] BG user: first render shows BG — no flash
- [ ] Language toggle flips all consumers in one frame (Header, Footer, tile labels, page content)
- [ ] Library page: Network tab shows no guide/links/news requests after initial SSR load
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes
- [ ] Vercel Preview READY

## Session state

```
STATUS: PIU
ISSUE: #170
BRANCH: refactor/REFACTOR-026-rsc-lang-architecture
COMMITS: 4
FILES: lib/context/LangProvider.tsx · lib/hooks/useLanguage.ts · app/(dashboard)/layout.tsx · app/(dashboard)/library/page.tsx
NEXT: Verify Vercel preview, run tsc + lint, merge
```
