### PR TITLE
[2604-BUG-187] Homepage redirects unauthenticated users to sign-in

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -12,6 +12,7 @@ const isPublicRoute = createRouteMatcher([
   '/api/webhooks/(.*)',
   '/api/calendar(.*)',
   '/api/events/:id',
+  '/api/socials(.*)',
 ])
 
 const isAdminApiRoute = createRouteMatcher(['/api/admin/(.*)'])

--- a/proxy.ts
+++ b/proxy.ts
@@ -12,7 +12,8 @@ const isPublicRoute = createRouteMatcher([
   '/api/webhooks/(.*)',
   '/api/calendar(.*)',
   '/api/events/:id',
-  '/api/socials(.*)',
+  '/api/socials',
+  '/api/socials/(.*)',
 ])
 
 const isAdminApiRoute = createRouteMatcher(['/api/admin/(.*)'])


### PR DESCRIPTION
## Summary

`/api/socials` was missing from `isPublicRoute` in `proxy.ts`. The middleware was returning 401 on every unauthenticated visit to `/`, which triggered `apiClient`'s 401 handler to redirect to `/sign-in`.

One-line fix: add `/api/socials(.*)` to the matcher array.

## Changes

- `proxy.ts`: `/api/socials(.*)` added to `isPublicRoute`

## Session State
**Status:** DONE
**Completed:**
- [x] `/api/socials(.*)` added to `isPublicRoute` in `proxy.ts`
- [x] PR opened
**Next:** Verify Vercel Preview — unauthenticated visit to `/` must not redirect. Merge when green.

Closes #187