### PR TITLE
[2604-BUG-193] Footer nav shows member-only links to guests — filterNav not applied

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -2,13 +2,16 @@
 
 import Link from 'next/link'
 import Image from 'next/image'
+import { useUser } from '@clerk/nextjs'
 import { useLanguage } from '@/lib/hooks/useLanguage'
-import { PUBLIC_NAV, FOOTER_MEMBER_NAV } from '@/lib/nav'
-
-const FOOTER_NAV = [...PUBLIC_NAV, ...FOOTER_MEMBER_NAV]
+import { PUBLIC_NAV, FOOTER_MEMBER_NAV, filterNav } from '@/lib/nav'
 
 export default function Footer() {
   const { lang } = useLanguage()
+  const { user } = useUser()
+
+  const role = user?.publicMetadata?.role as string | undefined
+  const FOOTER_NAV = filterNav([...PUBLIC_NAV, ...FOOTER_MEMBER_NAV], role)
 
   return (
     <footer style={{ backgroundColor: 'var(--brand-forest)' }}>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -9,7 +9,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import UserDropdown from '@/components/layout/UserDropdown'
 import UserPopup from '@/components/layout/UserPopup'
 import BellButton from '@/components/layout/BellButton'
-import { PUBLIC_NAV, MEMBER_NAV } from '@/lib/nav'
+import { PUBLIC_NAV, MEMBER_NAV, filterNav } from '@/lib/nav'
 
 export default function Header() {
   const { isSignedIn, user } = useUser()
@@ -31,15 +31,13 @@ export default function Header() {
   const isActive = (href: string) =>
     href === '/' ? pathname === '/' : pathname?.startsWith(href)
 
-  const isNonGuest = !!user && (user?.publicMetadata?.role as string) !== 'guest'
+  const role = user?.publicMetadata?.role as string | undefined
 
-  // Header shows guides + profile for members, but not /los
-  const HEADER_MEMBER_NAV = MEMBER_NAV.filter(item => item.href !== '/los')
-
-  const NAV_LINKS = [
-    ...PUBLIC_NAV,
-    ...(isNonGuest ? HEADER_MEMBER_NAV : []),
-  ]
+  // Header shows library + profile for members, but not /los
+  const NAV_LINKS = filterNav(
+    [...PUBLIC_NAV, ...MEMBER_NAV.filter(item => item.href !== '/los')],
+    role
+  )
 
   return (
     <header className="fixed top-4 left-0 right-0 z-50 px-4">

--- a/lib/nav.ts
+++ b/lib/nav.ts
@@ -3,13 +3,32 @@
 //
 // Consumer guide:
 //   Header    — PUBLIC_NAV + MEMBER_NAV (filters /los)
-//   Footer    — PUBLIC_NAV + FOOTER_MEMBER_NAV (guides + profile, no /los)
+//   Footer    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + profile, no /los)
 //   AdminNav  — ADMIN_NAV
 
 export type NavItem = {
   href: string
   labels: { en: string; bg: string }
   minRole?: 'member' | 'core' | 'admin'
+}
+
+// Role hierarchy — higher rank = more access.
+// Signed-out users receive rank -1 (filtered from all member items).
+const ROLE_RANK: Record<string, number> = {
+  guest:  0,
+  member: 1,
+  core:   2,
+  admin:  3,
+}
+
+/**
+ * Returns only the nav items the given role is permitted to see.
+ * Items without minRole are always included.
+ * Pass `role = undefined` for signed-out users — they see PUBLIC_NAV only.
+ */
+export function filterNav(items: NavItem[], role: string | undefined): NavItem[] {
+  const rank = role !== undefined ? (ROLE_RANK[role] ?? -1) : -1
+  return items.filter(item => !item.minRole || rank >= ROLE_RANK[item.minRole])
 }
 
 export const PUBLIC_NAV: NavItem[] = [
@@ -20,12 +39,12 @@ export const PUBLIC_NAV: NavItem[] = [
 ]
 
 export const MEMBER_NAV: NavItem[] = [
-  { href: '/library', labels: { en: 'Library',    bg: 'Библиотека'   }, minRole: 'member' },
-  { href: '/los',     labels: { en: 'My Network', bg: 'Моята мрежа'  }, minRole: 'member' },
-  { href: '/profile', labels: { en: 'Profile',    bg: 'Профил'       }, minRole: 'member' },
+  { href: '/library', labels: { en: 'Library',    bg: 'Библиотека'  }, minRole: 'member' },
+  { href: '/los',     labels: { en: 'My Network', bg: 'Моята мрежа' }, minRole: 'member' },
+  { href: '/profile', labels: { en: 'Profile',    bg: 'Профил'      }, minRole: 'member' },
 ]
 
-// Footer shows guides + profile but not /los
+// Footer shows library + profile but not /los
 export const FOOTER_MEMBER_NAV: NavItem[] = MEMBER_NAV.filter(
   item => item.href !== '/los'
 )


### PR DESCRIPTION
Closes #193

## Changes

**`lib/nav.ts`** — adds `filterNav(items, role)` using a `ROLE_RANK` map. `minRole` on `NavItem` is now load-bearing. Signed-out users (`role = undefined`) receive rank `-1` and are filtered from all member items. Adding a new role-gated nav item propagates correctly to all consumers without touching them.

**`components/layout/Footer.tsx`** — imports `useUser()`, derives `role` from `user?.publicMetadata?.role`, calls `filterNav([...PUBLIC_NAV, ...FOOTER_MEMBER_NAV], role)` inside the component body. Guests and signed-out users no longer see Library or Profile links.

**`components/layout/Header.tsx`** — replaces the `isNonGuest` manual gate and `HEADER_MEMBER_NAV` derived constant with `filterNav([...PUBLIC_NAV, ...MEMBER_NAV.filter(item => item.href !== '/los')], role)`. Behaviour is identical for existing roles; logic is now driven by `minRole` rather than ad-hoc boolean.

## Session State
**Status:** DONE
**Completed:**
- [x] `filterNav` added to `lib/nav.ts`
- [x] `Footer.tsx` uses `filterNav` — member-only links hidden from guests/signed-out
- [x] `Header.tsx` uses `filterNav` — replaces `isNonGuest` manual gate
- [x] `/los` exclusion from header preserved
- [x] PR open, Vercel preview pending
**Next:** Verify preview — sign out and confirm footer shows only Home/About/Calendar/Trips, then merge