### PR TITLE
[2604-CHORE-195] Address Gemini PR #194 review — nav.ts type + Header dedup

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -9,7 +9,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import UserDropdown from '@/components/layout/UserDropdown'
 import UserPopup from '@/components/layout/UserPopup'
 import BellButton from '@/components/layout/BellButton'
-import { PUBLIC_NAV, MEMBER_NAV, filterNav } from '@/lib/nav'
+import { PUBLIC_NAV, FOOTER_MEMBER_NAV, filterNav } from '@/lib/nav'
 
 export default function Header() {
   const { isSignedIn, user } = useUser()
@@ -33,11 +33,7 @@ export default function Header() {
 
   const role = user?.publicMetadata?.role as string | undefined
 
-  // Header shows library + profile for members, but not /los
-  const NAV_LINKS = filterNav(
-    [...PUBLIC_NAV, ...MEMBER_NAV.filter(item => item.href !== '/los')],
-    role
-  )
+  const NAV_LINKS = filterNav([...PUBLIC_NAV, ...FOOTER_MEMBER_NAV], role)
 
   return (
     <header className="fixed top-4 left-0 right-0 z-50 px-4">

--- a/lib/nav.ts
+++ b/lib/nav.ts
@@ -2,7 +2,7 @@
 // Adding, removing, or renaming a route = one edit here, propagates everywhere.
 //
 // Consumer guide:
-//   Header    — PUBLIC_NAV + MEMBER_NAV (filters /los)
+//   Header    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + profile, no /los)
 //   Footer    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + profile, no /los)
 //   AdminNav  — ADMIN_NAV
 
@@ -14,7 +14,7 @@ export type NavItem = {
 
 // Role hierarchy — higher rank = more access.
 // Signed-out users receive rank -1 (filtered from all member items).
-const ROLE_RANK: Record<string, number> = {
+const ROLE_RANK: Record<'guest' | NonNullable<NavItem['minRole']>, number> = {
   guest:  0,
   member: 1,
   core:   2,
@@ -27,7 +27,7 @@ const ROLE_RANK: Record<string, number> = {
  * Pass `role = undefined` for signed-out users — they see PUBLIC_NAV only.
  */
 export function filterNav(items: NavItem[], role: string | undefined): NavItem[] {
-  const rank = role !== undefined ? (ROLE_RANK[role] ?? -1) : -1
+  const rank = role !== undefined ? (ROLE_RANK[role as keyof typeof ROLE_RANK] ?? -1) : -1
   return items.filter(item => !item.minRole || rank >= ROLE_RANK[item.minRole])
 }
 
@@ -44,7 +44,7 @@ export const MEMBER_NAV: NavItem[] = [
   { href: '/profile', labels: { en: 'Profile',    bg: 'Профил'      }, minRole: 'member' },
 ]
 
-// Footer shows library + profile but not /los
+// Footer and Header both show library + profile but not /los
 export const FOOTER_MEMBER_NAV: NavItem[] = MEMBER_NAV.filter(
   item => item.href !== '/los'
 )


### PR DESCRIPTION
Closes #195\n\n## Changes\n\n**`lib/nav.ts`** — `ROLE_RANK` tightened from `Record<string, number>` to `Record<'guest' | NonNullable<NavItem['minRole']>, number>`. TypeScript will now error at compile time if `NavItem['minRole']` gains a new value without a corresponding rank entry. The `filterNav` lookup cast is updated accordingly (`role as keyof typeof ROLE_RANK`).\n\n**`components/layout/Header.tsx`** — replaces `MEMBER_NAV` import with `FOOTER_MEMBER_NAV`. The inline `.filter(item => item.href !== '/los')` is removed; `FOOTER_MEMBER_NAV` already encapsulates this. No behaviour change — `/los` remains excluded from the header.\n\n## GCR resolution\n\n| Comment | Priority | Resolution |\n|---|---|---|\n| `ROLE_RANK` type too broad (`Record<string, number>`) | MEDIUM | ✅ Applied |\n| Import `FOOTER_MEMBER_NAV` instead of `MEMBER_NAV` | MEDIUM | ✅ Applied |\n| `NAV_LINKS` inline `/los` filter duplicates `FOOTER_MEMBER_NAV` | MEDIUM | ✅ Applied |\n\n## Session State\n**Status:** DONE\n**Completed:**\n- [x] `lib/nav.ts` `ROLE_RANK` typed strictly\n- [x] `Header.tsx` uses `FOOTER_MEMBER_NAV`, `MEMBER_NAV` import removed, inline filter removed\n- [x] PR open\n**Next:** Verify Vercel preview — sign out, confirm header shows Home/About/Calendar/Trips only; sign in as member, confirm Library/Profile appear, /los absent