### PR TITLE
[2604-BUG-198] fix: add /news/(.*) to public routes

### DIFF
--- a/lib/public-routes.ts
+++ b/lib/public-routes.ts
@@ -6,6 +6,7 @@ export const PUBLIC_ROUTE_PATTERNS = [
   '/calendar',
   '/trips',
   '/news/(.*)',
+  '/guides(.*)',
   '/events/(.*)',
   '/sign-in(.*)',
   '/sign-up(.*)',

--- a/lib/public-routes.ts
+++ b/lib/public-routes.ts
@@ -5,6 +5,7 @@ export const PUBLIC_ROUTE_PATTERNS = [
   '/about',
   '/calendar',
   '/trips',
+  '/news/(.*)',
   '/events/(.*)',
   '/sign-in(.*)',
   '/sign-up(.*)',


### PR DESCRIPTION
Closes #198

## Changes

**`lib/public-routes.ts`** — adds `/news/(.*)` to `PUBLIC_ROUTE_PATTERNS`. Without this, `proxy.ts` redirects unauthenticated requests to `/sign-in` before the RSC runs. The in-page `accessRoles` check in `news/[slug]/page.tsx` already handles member-only slugs correctly — guests attempting a member-only URL are redirected to `/guides?type=news`.

## Session State
**Status:** DONE
**Completed:**
- [x] `/news/(.*)` added to `PUBLIC_ROUTE_PATTERNS`
- [x] PR open
**Next:** Verify Vercel preview — signed-out user clicks [more] on homepage announcement tile, lands on detail page without hitting sign-in