### PR TITLE
[2604-BUG-201] Guest public surface broken — /library(.*) missing from PUBLIC_ROUTE_PATTERNS after /guides rename

### DIFF
--- a/app/(dashboard)/news/[slug]/page.tsx
+++ b/app/(dashboard)/news/[slug]/page.tsx
@@ -34,11 +34,11 @@ export default async function NewsDetailPage({
     .eq('is_active', true)
     .single()
 
-  if (!announcement) redirect('/guides?type=news')
+  if (!announcement) redirect('/library?type=news')
 
   const a = announcement as unknown as Announcement
   const accessRoles = a.access_roles as string[]
-  if (!accessRoles.includes(role)) redirect('/guides?type=news')
+  if (!accessRoles.includes(role)) redirect('/library?type=news')
 
   const cookieStore = await cookies()
   const lang: Lang = cookieStore.get('tevd_lang')?.value === 'bg' ? 'bg' : 'en'
@@ -52,7 +52,7 @@ export default async function NewsDetailPage({
       {/* ── MOBILE ── */}
       <div className="md:hidden">
         <Link
-          href="/guides?type=news"
+          href="/library?type=news"
           className="inline-flex items-center gap-1.5 text-sm font-medium mb-6 pill-link-crimson"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
@@ -79,7 +79,7 @@ export default async function NewsDetailPage({
       {/* ── DESKTOP ── */}
       <div className="hidden md:block">
         <Link
-          href="/guides?type=news"
+          href="/library?type=news"
           className="inline-flex items-center gap-1.5 text-sm font-medium mb-8 pill-link-crimson"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none"

--- a/lib/public-routes.ts
+++ b/lib/public-routes.ts
@@ -2,19 +2,21 @@ import { createRouteMatcher } from '@clerk/nextjs/server'
 
 /**
  * Intended guest-accessible surface (keep this comment current on any route rename):
- *   /              homepage
- *   /about         about page
- *   /calendar      public calendar
- *   /trips         trips index
- *   /events/(.*)   event detail
- *   /news/(.*)     announcement detail
- *   /library(.*)   library index + guide detail (was /guides before rename)
- *   /sign-in       auth
- *   /sign-up       auth
- *   /api/webhooks  Clerk + Stripe webhooks
- *   /api/calendar  public calendar API
- *   /api/events    public event API
- *   /api/socials   public socials API
+ *   /                  homepage
+ *   /about             about page
+ *   /calendar          public calendar
+ *   /trips             trips index
+ *   /events/(.*)       event detail
+ *   /news/(.*)         announcement detail
+ *   /library(.*)       library index + guide detail (was /guides before rename)
+ *   /sign-in(.*)       auth
+ *   /sign-up(.*)       auth
+ *   /api/webhooks/(.*) Clerk + Stripe webhooks
+ *   /api/calendar      public calendar API
+ *   /api/calendar/(.*) public calendar API
+ *   /api/events/:id    public event detail API
+ *   /api/socials       public socials API
+ *   /api/socials/(.*) public socials API
  */
 export const PUBLIC_ROUTE_PATTERNS = [
   '/',

--- a/lib/public-routes.ts
+++ b/lib/public-routes.ts
@@ -1,12 +1,28 @@
 import { createRouteMatcher } from '@clerk/nextjs/server'
 
+/**
+ * Intended guest-accessible surface (keep this comment current on any route rename):
+ *   /              homepage
+ *   /about         about page
+ *   /calendar      public calendar
+ *   /trips         trips index
+ *   /events/(.*)   event detail
+ *   /news/(.*)     announcement detail
+ *   /library(.*)   library index + guide detail (was /guides before rename)
+ *   /sign-in       auth
+ *   /sign-up       auth
+ *   /api/webhooks  Clerk + Stripe webhooks
+ *   /api/calendar  public calendar API
+ *   /api/events    public event API
+ *   /api/socials   public socials API
+ */
 export const PUBLIC_ROUTE_PATTERNS = [
   '/',
   '/about',
   '/calendar',
   '/trips',
   '/news/(.*)',
-  '/guides(.*)',
+  '/library(.*)',
   '/events/(.*)',
   '/sign-in(.*)',
   '/sign-up(.*)',


### PR DESCRIPTION
Closes #201

## What

- `lib/public-routes.ts` — replaces stale `/guides(.*)` with `/library(.*)`. Adds a doc comment listing the full intended guest surface so future renames make staleness obvious.
- `app/(dashboard)/news/[slug]/page.tsx` — updates both back button `href` values (mobile + desktop) from `/guides?type=news` to `/library?type=news`.

## Why

`/guides` was renamed to `/library` but `PUBLIC_ROUTE_PATTERNS` was never updated. `next.config.ts` 308-redirects `/guides → /library` before `proxy.ts` runs, so unauthenticated requests land on `/library` — which was not in the allowlist — and hit the login wall. All three affected guest flows (`/library`, `/library?type=news`, `/library/[slug]`) were broken.

## Session State
**Status:** DONE
**Completed:**
- [x] `/library(.*)` added to `PUBLIC_ROUTE_PATTERNS`; stale `/guides(.*)` removed
- [x] Doc comment added listing full intended guest surface
- [x] Back button hrefs updated in both mobile and desktop layouts
**Next:** Verify Vercel Preview, CI green, then merge.