### PR TITLE
[2604-BUG-205] fix: VitalsSection useMemo above isLoading guard

### DIFF
--- a/app/(dashboard)/profile/components/VitalsSection.tsx
+++ b/app/(dashboard)/profile/components/VitalsSection.tsx
@@ -57,10 +57,7 @@ export function VitalsSection({ profileId, role }: { profileId: string; role: st
     staleTime: 5 * 60 * 1000,
   })
 
-  if (isLoading) {
-    return <div className="rounded-2xl animate-pulse h-full" style={{ backgroundColor: 'var(--border-default)' }} />
-  }
-
+  // Must be above the isLoading guard — hooks cannot be called conditionally.
   // Filter out rows with no definition (avoids rendering UUID fallback),
   // sort by sort_order ascending, then cap at VARIABLE_CAP for the bento view.
   const vitals = useMemo(
@@ -70,6 +67,10 @@ export function VitalsSection({ profileId, role }: { profileId: string; role: st
         .sort((a, b) => a.vital_sign_definitions!.sort_order - b.vital_sign_definitions!.sort_order),
     [vitalsData],
   )
+
+  if (isLoading) {
+    return <div className="rounded-2xl animate-pulse h-full" style={{ backgroundColor: 'var(--border-default)' }} />
+  }
 
   const visible = vitals.slice(0, VARIABLE_CAP)
   const overflow = vitals.length - VARIABLE_CAP


### PR DESCRIPTION
Closes #205

## What

Moves `useMemo` above the `if (isLoading) return` early return in `VitalsSection`. Calling a hook after a conditional return violates Rules of Hooks — React sees a different hook count between the loading render and the data render, and throws, hitting the error boundary on hard reload.

Introduced in the GCR pass for PR #204.

## Session State
**Status:** DONE
**Completed:**
- [x] `VitalsSection.tsx` — `useMemo` hoisted above `isLoading` guard
**Next:** Verify Vercel Preview READY, then merge.
