### PR TITLE
[2604-BUG-212] add useLangSafe; fix error boundary crash outside LangProvider

### DIFF
--- a/app/(dashboard)/error.tsx
+++ b/app/(dashboard)/error.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useLanguage } from '@/lib/hooks/useLanguage'
+import { useLangSafe } from '@/lib/context/LangProvider'
 
 export default function DashboardError({
   error,
@@ -9,7 +9,7 @@ export default function DashboardError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
-  const { t } = useLanguage()
+  const { t } = useLangSafe()
 
   return (
     <div

--- a/lib/context/LangProvider.tsx
+++ b/lib/context/LangProvider.tsx
@@ -54,16 +54,19 @@ export function useLang(): LangContextValue {
   return ctx
 }
 
+// Stable fallback — defined at module level to avoid allocating a new object
+// on every render when useLangSafe is called outside the provider tree.
+const FALLBACK_CONTEXT: LangContextValue = {
+  lang: 'en',
+  toggle: () => {},
+  t: (key: TranslationKey) => translate(key, 'en'),
+}
+
 /**
  * Safe variant — returns an 'en' fallback when context is null.
  * Use ONLY in error boundaries (error.tsx), which Next.js mounts outside the
  * layout provider tree and therefore cannot access LangContext.
  */
 export function useLangSafe(): LangContextValue {
-  const ctx = useContext(LangContext)
-  return ctx ?? {
-    lang: 'en' as Lang,
-    toggle: () => {},
-    t: (key: TranslationKey) => translate(key, 'en'),
-  }
+  return useContext(LangContext) ?? FALLBACK_CONTEXT
 }

--- a/lib/context/LangProvider.tsx
+++ b/lib/context/LangProvider.tsx
@@ -44,8 +44,26 @@ export function LangProvider({
   )
 }
 
+/**
+ * Standard hook — throws if used outside LangProvider.
+ * Use in all components guaranteed to render inside app/(dashboard)/layout.tsx.
+ */
 export function useLang(): LangContextValue {
   const ctx = useContext(LangContext)
   if (!ctx) throw new Error('useLang must be used within LangProvider')
   return ctx
+}
+
+/**
+ * Safe variant — returns an 'en' fallback when context is null.
+ * Use ONLY in error boundaries (error.tsx), which Next.js mounts outside the
+ * layout provider tree and therefore cannot access LangContext.
+ */
+export function useLangSafe(): LangContextValue {
+  const ctx = useContext(LangContext)
+  return ctx ?? {
+    lang: 'en' as Lang,
+    toggle: () => {},
+    t: (key: TranslationKey) => translate(key, 'en'),
+  }
 }


### PR DESCRIPTION
Closes #212

## What

`app/(dashboard)/error.tsx` called `useLanguage()` → `useLang()`, which throws when context is null. Next.js mounts error boundaries **outside** the layout provider tree, so `LangProvider` is never in scope when the error UI renders. Result: any dashboard error triggered a second crash inside the error boundary itself, producing the "Application error" overlay.

## Fix

Added `useLangSafe` to `lib/context/LangProvider.tsx` — identical to `useLang` but returns an `'en'` fallback instead of throwing when context is null. `error.tsx` now imports `useLangSafe` instead of `useLanguage`. Zero changes to any other callsite.

## Files

| File | Change |
|---|---|
| `lib/context/LangProvider.tsx` | Add `useLangSafe` export |
| `app/(dashboard)/error.tsx` | `useLanguage` → `useLangSafe` |

## Session State

**Status:** DONE
**Completed:**
- [x] `useLangSafe` added to `LangProvider.tsx`
- [x] `error.tsx` updated
- [x] Commit pushed to `feature/2604-BUG-212`
- [x] Vercel Preview READY
**Next:** Merge via GitHub UI
