### PR TITLE
[2604-FEAT-216] Guide edit form — desktop split-panel layout

### DIFF
--- a/app/admin/content/components/BlockEditor.tsx
+++ b/app/admin/content/components/BlockEditor.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import type { Block } from './guide-types'
 
@@ -12,6 +13,9 @@ export function BlockEditor({
 }): React.JSX.Element {
   const { t } = useLanguage()
   const safeBlocks = Array.isArray(blocks) ? blocks : []
+  const [collapsed, setCollapsed] = useState<Record<number, boolean>>({})
+  const [draggingIdx, setDraggingIdx] = useState<number | null>(null)
+  const [dragOverIdx, setDragOverIdx] = useState<number | null>(null)
 
   function addBlock(type: Block['type']) {
     onChange([...safeBlocks, { type, content: { en: '', bg: '' }, emoji: type === 'callout' ? '💡' : undefined }])
@@ -22,93 +26,199 @@ export function BlockEditor({
   function updateContent(i: number, lang: 'en' | 'bg', value: string) {
     updateBlock(i, { content: { ...safeBlocks[i].content, [lang]: value } })
   }
-  function moveBlock(i: number, dir: -1 | 1) {
-    const next = [...safeBlocks]
-    const j = i + dir
-    if (j < 0 || j >= next.length) return
-    ;[next[i], next[j]] = [next[j], next[i]]
-    onChange(next)
-  }
   function removeBlock(i: number) {
     onChange(safeBlocks.filter((_, idx) => idx !== i))
+    setCollapsed(prev => {
+      const next: Record<number, boolean> = {}
+      Object.entries(prev).forEach(([k, v]) => {
+        const ki = Number(k)
+        if (ki < i) next[ki] = v
+        else if (ki > i) next[ki - 1] = v
+      })
+      return next
+    })
+  }
+  function toggleCollapse(i: number) {
+    setCollapsed(prev => ({ ...prev, [i]: !prev[i] }))
+  }
+
+  // Drag-to-reorder handlers (index-based — blocks have no stable id)
+  function handleDragStart(i: number) {
+    setDraggingIdx(i)
+  }
+  function handleDragOver(e: React.DragEvent, i: number) {
+    e.preventDefault()
+    if (draggingIdx === null || draggingIdx === i) return
+    setDragOverIdx(i)
+  }
+  function handleDrop(targetIdx: number) {
+    if (draggingIdx === null || draggingIdx === targetIdx) {
+      setDraggingIdx(null)
+      setDragOverIdx(null)
+      return
+    }
+    const next = [...safeBlocks]
+    const [moved] = next.splice(draggingIdx, 1)
+    next.splice(targetIdx, 0, moved)
+    onChange(next)
+    setDraggingIdx(null)
+    setDragOverIdx(null)
+  }
+  function handleDragEnd() {
+    setDraggingIdx(null)
+    setDragOverIdx(null)
   }
 
   return (
-    <div className="space-y-3">
-      {safeBlocks.map((block, i) => (
-        <div key={i} className="rounded-xl border p-4 space-y-3"
-          style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-semibold px-2 py-0.5 rounded-full uppercase tracking-widest"
-                style={{
-                  backgroundColor: block.type === 'heading' ? 'var(--brand-forest)' : block.type === 'callout' ? 'var(--brand-teal)' : 'rgba(0,0,0,0.06)',
-                  color: block.type === 'paragraph' ? 'var(--text-secondary)' : 'var(--brand-parchment)',
-                }}>
-                {block.type}
-              </span>
-              {block.type === 'callout' && (
-                <input
-                  value={block.emoji ?? ''}
-                  onChange={e => updateBlock(i, { emoji: e.target.value })}
-                  placeholder="emoji"
-                  aria-label={`Callout emoji for block ${i + 1}`}
-                  className="w-14 border rounded-lg px-2 py-1 text-sm text-center"
-                  style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
-                />
-              )}
-            </div>
-            <div className="flex items-center gap-1">
-              <button onClick={() => moveBlock(i, -1)} disabled={i === 0}
-                aria-label={`Move block ${i + 1} up`}
-                className="w-6 h-6 flex items-center justify-center rounded hover:bg-black/5 disabled:opacity-30 text-xs"
-                style={{ color: 'var(--text-secondary)' }}>↑</button>
-              <button onClick={() => moveBlock(i, 1)} disabled={i === safeBlocks.length - 1}
-                aria-label={`Move block ${i + 1} down`}
-                className="w-6 h-6 flex items-center justify-center rounded hover:bg-black/5 disabled:opacity-30 text-xs"
-                style={{ color: 'var(--text-secondary)' }}>↓</button>
-              <button onClick={() => removeBlock(i)}
-                aria-label={`Remove block ${i + 1}`}
-                className="w-6 h-6 flex items-center justify-center rounded hover:bg-black/5 text-xs"
-                style={{ color: 'var(--brand-crimson)' }}>✕</button>
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            {(['en', 'bg'] as const).map(lang => (
-              <div key={lang}>
-                <label className="text-[10px] font-semibold uppercase tracking-widest mb-1 block"
-                  style={{ color: 'var(--text-secondary)' }}>{lang.toUpperCase()}</label>
-                {block.type === 'paragraph' || block.type === 'callout' ? (
-                  <>
-                    <textarea
-                      value={block.content[lang]}
-                      onChange={e => updateContent(i, lang, e.target.value)}
-                      rows={3}
-                      className="w-full border rounded-xl px-3 py-2 text-sm resize-none"
-                      style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
-                    />
-                    <p className="text-[10px] mt-1" style={{ color: 'var(--text-tertiary)' }}>
-                      {t('admin.content.guides.markdownHint')}
-                    </p>
-                  </>
-                ) : (
+    <div className="flex flex-col gap-3">
+      {/* Block count indicator */}
+      {safeBlocks.length > 0 && (
+        <p className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+          {safeBlocks.length} block{safeBlocks.length !== 1 ? 's' : ''}
+        </p>
+      )}
+
+      {safeBlocks.map((block, i) => {
+        const isCollapsed = !!collapsed[i]
+        const isDragging = draggingIdx === i
+        const isDragOver = dragOverIdx === i
+        const previewText = block.content.en.slice(0, 60) || '—'
+
+        return (
+          <div
+            key={i}
+            draggable
+            onDragStart={() => handleDragStart(i)}
+            onDragOver={e => handleDragOver(e, i)}
+            onDrop={() => handleDrop(i)}
+            onDragEnd={handleDragEnd}
+            className="rounded-xl border transition-opacity"
+            style={{
+              backgroundColor: 'var(--bg-card)',
+              borderColor: isDragOver ? 'var(--brand-crimson)' : 'var(--border-default)',
+              opacity: isDragging ? 0.4 : 1,
+              cursor: 'grab',
+            }}
+          >
+            {/* Block header — always visible */}
+            <div className="flex items-center justify-between gap-2 px-4 py-3">
+              <div className="flex items-center gap-2 min-w-0">
+                {/* Drag grip */}
+                <span
+                  className="flex-shrink-0 cursor-grab select-none"
+                  style={{ color: 'var(--text-tertiary)' }}
+                  aria-hidden
+                >
+                  <svg width="12" height="16" viewBox="0 0 12 16" fill="currentColor">
+                    <circle cx="4" cy="3" r="1.5"/>
+                    <circle cx="8" cy="3" r="1.5"/>
+                    <circle cx="4" cy="8" r="1.5"/>
+                    <circle cx="8" cy="8" r="1.5"/>
+                    <circle cx="4" cy="13" r="1.5"/>
+                    <circle cx="8" cy="13" r="1.5"/>
+                  </svg>
+                </span>
+
+                <span
+                  className="text-xs font-semibold px-2 py-0.5 rounded-full uppercase tracking-widest flex-shrink-0"
+                  style={{
+                    backgroundColor:
+                      block.type === 'heading' ? 'var(--brand-forest)'
+                        : block.type === 'callout' ? 'var(--brand-teal)'
+                        : 'rgba(0,0,0,0.06)',
+                    color: block.type === 'paragraph' ? 'var(--text-secondary)' : 'var(--brand-parchment)',
+                  }}
+                >
+                  {block.type}
+                </span>
+
+                {block.type === 'callout' && !isCollapsed && (
                   <input
-                    value={block.content[lang]}
-                    onChange={e => updateContent(i, lang, e.target.value)}
-                    className="w-full border rounded-xl px-3 py-2 text-sm"
-                    style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
+                    value={block.emoji ?? ''}
+                    onChange={e => updateBlock(i, { emoji: e.target.value })}
+                    placeholder="emoji"
+                    aria-label={`Callout emoji for block ${i + 1}`}
+                    className="w-14 border rounded-lg px-2 py-1 text-sm text-center flex-shrink-0"
+                    style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
                   />
                 )}
+
+                {isCollapsed && (
+                  <span className="text-xs truncate" style={{ color: 'var(--text-secondary)' }}>
+                    {previewText}
+                  </span>
+                )}
               </div>
-            ))}
+
+              <div className="flex items-center gap-1 flex-shrink-0">
+                <button
+                  onClick={() => toggleCollapse(i)}
+                  aria-label={isCollapsed ? `Expand block ${i + 1}` : `Collapse block ${i + 1}`}
+                  className="w-6 h-6 flex items-center justify-center rounded hover:bg-black/5 text-xs transition-transform"
+                  style={{ color: 'var(--text-secondary)', transform: isCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)' }}
+                >
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="6 9 12 15 18 9" />
+                  </svg>
+                </button>
+                <button
+                  onClick={() => removeBlock(i)}
+                  aria-label={`Remove block ${i + 1}`}
+                  className="w-6 h-6 flex items-center justify-center rounded hover:bg-black/5 text-xs"
+                  style={{ color: 'var(--brand-crimson)' }}
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+
+            {/* Block content — hidden when collapsed */}
+            {!isCollapsed && (
+              <div className="px-4 pb-4">
+                <div className="grid grid-cols-2 gap-3">
+                  {(['en', 'bg'] as const).map(lang => (
+                    <div key={lang}>
+                      <label className="text-[10px] font-semibold uppercase tracking-widest mb-1 block"
+                        style={{ color: 'var(--text-secondary)' }}>{lang.toUpperCase()}</label>
+                      {block.type === 'paragraph' || block.type === 'callout' ? (
+                        <>
+                          <textarea
+                            value={block.content[lang]}
+                            onChange={e => updateContent(i, lang, e.target.value)}
+                            rows={5}
+                            className="w-full border rounded-xl px-3 py-2 text-sm resize-none"
+                            style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
+                          />
+                          <p className="text-[10px] mt-1" style={{ color: 'var(--text-tertiary)' }}>
+                            {t('admin.content.guides.markdownHint')}
+                          </p>
+                        </>
+                      ) : (
+                        <input
+                          value={block.content[lang]}
+                          onChange={e => updateContent(i, lang, e.target.value)}
+                          className="w-full border rounded-xl px-3 py-2 text-sm"
+                          style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
+                        />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
-        </div>
-      ))}
-      <div className="flex gap-2 pt-1">
+        )
+      })}
+
+      {/* Add block controls — always at bottom */}
+      <div className="flex gap-2 pt-1 sticky bottom-0 pb-2">
         {(['heading', 'paragraph', 'callout'] as const).map(type => (
-          <button key={type} onClick={() => addBlock(type)}
+          <button
+            key={type}
+            onClick={() => addBlock(type)}
             className="px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors hover:bg-black/5"
-            style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>
+            style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)', backgroundColor: 'var(--bg-card)' }}
+          >
             + {type}
           </button>
         ))}

--- a/app/admin/content/components/BlockEditor.tsx
+++ b/app/admin/content/components/BlockEditor.tsx
@@ -61,6 +61,25 @@ export function BlockEditor({
     const [moved] = next.splice(draggingIdx, 1)
     next.splice(targetIdx, 0, moved)
     onChange(next)
+
+    // Remap collapsed state to follow block positions after reorder
+    setCollapsed(prev => {
+      const nextColl: Record<number, boolean> = {}
+      Object.entries(prev).forEach(([k, v]) => {
+        const ki = Number(k)
+        let newIdx = ki
+        if (ki === draggingIdx) {
+          newIdx = targetIdx
+        } else if (draggingIdx < targetIdx && ki > draggingIdx && ki <= targetIdx) {
+          newIdx = ki - 1
+        } else if (draggingIdx > targetIdx && ki < draggingIdx && ki >= targetIdx) {
+          newIdx = ki + 1
+        }
+        nextColl[newIdx] = v
+      })
+      return nextColl
+    })
+
     setDraggingIdx(null)
     setDragOverIdx(null)
   }
@@ -210,8 +229,11 @@ export function BlockEditor({
         )
       })}
 
-      {/* Add block controls — always at bottom */}
-      <div className="flex gap-2 pt-1 sticky bottom-0 pb-2">
+      {/* Add block controls — always at bottom, background prevents bleed-through on scroll */}
+      <div
+        className="flex gap-2 pt-3 sticky bottom-0 pb-2 -mx-4 px-4 mt-2 border-t"
+        style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+      >
         {(['heading', 'paragraph', 'callout'] as const).map(type => (
           <button
             key={type}

--- a/app/admin/content/components/GuidesTab.tsx
+++ b/app/admin/content/components/GuidesTab.tsx
@@ -70,7 +70,7 @@ export function GuidesTab() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       }).then(async r => { if (!r.ok) throw new Error((await r.json()).error); return r.json() }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['admin-guides'] }),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['admin-guides'] }); setGuidesMutError(null) },
     onError: (e: Error) => setGuidesMutError(e.message),
   })
 

--- a/app/admin/content/components/GuidesTab.tsx
+++ b/app/admin/content/components/GuidesTab.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Drawer } from '@/components/ui/drawer'
 import {
@@ -23,8 +24,9 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 
 export function GuidesTab() {
   const qc = useQueryClient()
+  const router = useRouter()
   const { t } = useLanguage()
-  const guideDrawer = useAdminDrawer<Guide>()
+  const createDrawer = useAdminDrawer<Guide>()
   const [guidesMutError, setGuidesMutError] = useState<string | null>(null)
   const [guideAlertTarget, setGuideAlertTarget] = useState<{ id: string; name: string } | null>(null)
   const [gDragging, setGDragging] = useState<string | null>(null)
@@ -57,7 +59,7 @@ export function GuidesTab() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       }).then(async r => { if (!r.ok) throw new Error((await r.json()).error); return r.json() }),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ['admin-guides'] }); guideDrawer.close(); setGuidesMutError(null) },
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['admin-guides'] }); createDrawer.close(); setGuidesMutError(null) },
     onError: (e: Error) => setGuidesMutError(e.message),
   })
 
@@ -68,7 +70,7 @@ export function GuidesTab() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       }).then(async r => { if (!r.ok) throw new Error((await r.json()).error); return r.json() }),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ['admin-guides'] }); guideDrawer.close(); setGuidesMutError(null) },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['admin-guides'] }),
     onError: (e: Error) => setGuidesMutError(e.message),
   })
 
@@ -88,36 +90,25 @@ export function GuidesTab() {
         <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
           {guidesRaw.length} guide{guidesRaw.length !== 1 ? 's' : ''}
         </p>
-        <button onClick={() => { guideDrawer.openCreate(); setGuidesMutError(null) }}
+        <button onClick={() => { createDrawer.openCreate(); setGuidesMutError(null) }}
           className="px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
           style={{ backgroundColor: 'var(--brand-crimson)' }}>
           {t('admin.content.guides.btn.new')}
         </button>
       </div>
 
+      {/* Create drawer — unchanged */}
       <Drawer
-        open={guideDrawer.open}
-        onClose={() => { guideDrawer.close(); setGuidesMutError(null) }}
-        title={guideDrawer.editing
-          ? t('admin.content.guides.drawer.editTitle').replace('{{name}}', guideDrawer.editing.title.en || guideDrawer.editing.slug)
-          : t('admin.content.guides.drawer.newTitle')
-        }
+        open={createDrawer.open}
+        onClose={() => { createDrawer.close(); setGuidesMutError(null) }}
+        title={t('admin.content.guides.drawer.newTitle')}
       >
-        {guideDrawer.isCreating && (
+        {createDrawer.isCreating && (
           <GuideForm
             initial={emptyGuide()}
             onSave={data => createGuide.mutate(data)}
-            onCancel={() => { guideDrawer.close(); setGuidesMutError(null) }}
+            onCancel={() => { createDrawer.close(); setGuidesMutError(null) }}
             isPending={createGuide.isPending}
-            error={guidesMutError}
-          />
-        )}
-        {guideDrawer.isEditing && guideDrawer.editing && (
-          <GuideForm
-            initial={{ slug: guideDrawer.editing.slug, title: guideDrawer.editing.title, cover_image_url: guideDrawer.editing.cover_image_url, emoji: guideDrawer.editing.emoji, body: guideDrawer.editing.body, access_roles: guideDrawer.editing.access_roles, is_published: guideDrawer.editing.is_published, sort_order: guideDrawer.editing.sort_order }}
-            onSave={data => updateGuide.mutate({ id: guideDrawer.editing!.id, ...data })}
-            onCancel={() => { guideDrawer.close(); setGuidesMutError(null) }}
-            isPending={updateGuide.isPending}
             error={guidesMutError}
           />
         )}
@@ -155,7 +146,8 @@ export function GuidesTab() {
                     style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>
                     {guide.is_published ? t('admin.content.guides.btn.unpublish') : t('admin.content.guides.btn.publish')}
                   </button>
-                  <button onClick={() => { guideDrawer.openEdit(guide); setGuidesMutError(null) }}
+                  <button
+                    onClick={() => router.push(`/admin/content/guides/${guide.id}/edit`)}
                     className="px-3 py-1 rounded-lg text-xs font-semibold border transition-colors hover:bg-black/5"
                     style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>
                     {t('admin.content.guides.btn.edit')}

--- a/app/admin/content/guides/[id]/edit/components/GuideEditLayout.tsx
+++ b/app/admin/content/guides/[id]/edit/components/GuideEditLayout.tsx
@@ -264,7 +264,7 @@ export function GuideEditLayout({ guide }: { guide: Guide }) {
             Guides
           </button>
           <h1 className="text-base font-bold mb-6 truncate" style={{ color: 'var(--text-primary)' }}>
-            {guide.title.en || guide.slug}
+            {form.title.en || form.slug}
           </h1>
           <LeftPanel {...sharedPanelProps} />
         </div>
@@ -294,7 +294,7 @@ export function GuideEditLayout({ guide }: { guide: Guide }) {
           Guides
         </button>
         <h1 className="text-base font-bold truncate" style={{ color: 'var(--text-primary)' }}>
-          {guide.title.en || guide.slug}
+          {form.title.en || form.slug}
         </h1>
         <LeftPanel {...sharedPanelProps} />
         <div>

--- a/app/admin/content/guides/[id]/edit/components/GuideEditLayout.tsx
+++ b/app/admin/content/guides/[id]/edit/components/GuideEditLayout.tsx
@@ -1,0 +1,311 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { AdminStatusBadge } from '@/app/admin/components/AdminStatusBadge'
+import { RoleSelector } from '@/app/admin/components/RoleSelector'
+import { CoverImageUploader } from '@/app/admin/content/components/CoverImageUploader'
+import { BlockEditor } from '@/app/admin/content/components/BlockEditor'
+import { useLanguage } from '@/lib/hooks/useLanguage'
+import { ALL_ROLES, slugify, type Guide } from '@/app/admin/content/components/guide-types'
+
+type FormState = Omit<Guide, 'id' | 'created_at' | 'updated_at'>
+
+function LeftPanel({
+  form,
+  setForm,
+  isPending,
+  coverUploading,
+  setCoverUploading,
+  error,
+  onSave,
+  onCancel,
+}: {
+  form: FormState
+  setForm: React.Dispatch<React.SetStateAction<FormState>>
+  isPending: boolean
+  coverUploading: boolean
+  setCoverUploading: (v: boolean) => void
+  error: string | null
+  onSave: () => void
+  onCancel: () => void
+}) {
+  const { t } = useLanguage()
+  const [slugManual, setSlugManual] = useState(!!form.slug)
+  const [copied, setCopied] = useState(false)
+
+  function copySlugUrl() {
+    const base = process.env.NEXT_PUBLIC_APP_URL ?? window.location.origin
+    navigator.clipboard.writeText(`${base}/guides/${form.slug}`)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  function handleTitleEnChange(val: string) {
+    setForm(f => ({
+      ...f,
+      title: { ...f.title, en: val },
+      slug: slugManual ? f.slug : slugify(val),
+    }))
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Titles */}
+      <div className="grid grid-cols-2 gap-3">
+        {(['en', 'bg'] as const).map(lang => (
+          <div key={lang}>
+            <label className="text-xs font-semibold uppercase tracking-widest mb-1 block"
+              style={{ color: 'var(--text-secondary)' }}>
+              {lang === 'en' ? t('admin.content.guides.lbl.titleEn') : t('admin.content.guides.lbl.titleBg')}
+            </label>
+            <input
+              value={form.title[lang]}
+              onChange={e =>
+                lang === 'en'
+                  ? handleTitleEnChange(e.target.value)
+                  : setForm(f => ({ ...f, title: { ...f.title, bg: e.target.value } }))
+              }
+              className="w-full border rounded-xl px-3 py-2 text-sm"
+              style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Slug */}
+      <div>
+        <label className="text-xs font-semibold uppercase tracking-widest mb-1 block"
+          style={{ color: 'var(--text-secondary)' }}>{t('admin.content.guides.lbl.slug')}</label>
+        <div className="flex items-center gap-2">
+          <input
+            value={form.slug}
+            onChange={e => { setSlugManual(true); setForm(f => ({ ...f, slug: e.target.value })) }}
+            className="flex-1 border rounded-xl px-3 py-2 text-sm font-mono min-w-0"
+            style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
+          />
+          <button
+            type="button"
+            onClick={copySlugUrl}
+            disabled={!form.slug}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-semibold border transition-all disabled:opacity-30 hover:bg-black/5 flex-shrink-0"
+            style={{
+              borderColor: copied ? 'rgba(34,197,94,0.4)' : 'var(--border-default)',
+              color: copied ? '#15803d' : 'var(--text-secondary)',
+              backgroundColor: copied ? 'rgba(34,197,94,0.08)' : 'transparent',
+            }}
+          >
+            {copied ? (
+              <>
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                {t('admin.content.guides.btn.copied')}
+              </>
+            ) : (
+              <>
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                {t('admin.content.guides.btn.copyUrl')}
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Emoji */}
+      <div>
+        <label className="text-xs font-semibold uppercase tracking-widest mb-1 block"
+          style={{ color: 'var(--text-secondary)' }}>{t('admin.content.guides.lbl.emoji')}</label>
+        <input
+          value={form.emoji ?? ''}
+          onChange={e => setForm(f => ({ ...f, emoji: e.target.value || null }))}
+          placeholder="e.g. 📦"
+          className="w-full border rounded-xl px-3 py-2 text-sm text-center"
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
+        />
+      </div>
+
+      {/* Cover image */}
+      <div>
+        <label className="text-xs font-semibold uppercase tracking-widest mb-1 block"
+          style={{ color: 'var(--text-secondary)' }}>{t('admin.content.guides.lbl.coverImage')}</label>
+        <CoverImageUploader
+          value={form.cover_image_url}
+          onUploading={setCoverUploading}
+          onChange={url => setForm(f => ({ ...f, cover_image_url: url }))}
+        />
+      </div>
+
+      {/* Access roles */}
+      <div>
+        <label className="text-xs font-semibold uppercase tracking-widest mb-2 block"
+          style={{ color: 'var(--text-secondary)' }}>{t('admin.content.guides.lbl.accessRoles')}</label>
+        <RoleSelector
+          roles={ALL_ROLES}
+          selected={form.access_roles}
+          onChange={access_roles => setForm(f => ({ ...f, access_roles }))}
+        />
+      </div>
+
+      {/* Divider */}
+      <div className="border-t" style={{ borderColor: 'var(--border-default)' }} />
+
+      {/* Publish toggle */}
+      <div className="flex items-center gap-3">
+        <AdminStatusBadge
+          variant={form.is_published ? 'active' : 'inactive'}
+          label={form.is_published ? 'Published' : 'Draft'}
+        />
+        <button
+          onClick={() => setForm(f => ({ ...f, is_published: !f.is_published }))}
+          className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold border transition-all hover:bg-black/5"
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
+        >
+          {form.is_published ? t('admin.content.guides.btn.unpublish') : t('admin.content.guides.btn.publish')}
+        </button>
+      </div>
+
+      {error && <p className="text-sm" style={{ color: 'var(--brand-crimson)' }}>{error}</p>}
+
+      {/* Save / Cancel */}
+      <div className="flex gap-3">
+        <button
+          onClick={onSave}
+          disabled={isPending || !form.slug || !form.title.en || coverUploading}
+          className="px-6 py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 transition-opacity hover:opacity-90"
+          style={{ backgroundColor: 'var(--brand-crimson)' }}
+        >
+          {isPending ? t('admin.content.guides.btn.saving') : t('admin.content.guides.btn.save')}
+        </button>
+        <button
+          onClick={onCancel}
+          className="px-6 py-2.5 rounded-xl text-sm font-semibold border transition-colors hover:bg-black/5"
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
+        >
+          {t('admin.content.guides.btn.cancel')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Main export ────────────────────────────────────────────────────────────
+
+export function GuideEditLayout({ guide }: { guide: Guide }) {
+  const router = useRouter()
+  const qc = useQueryClient()
+  const [form, setForm] = useState<FormState>({
+    slug: guide.slug,
+    title: guide.title,
+    cover_image_url: guide.cover_image_url,
+    emoji: guide.emoji,
+    body: Array.isArray(guide.body) ? guide.body : [],
+    access_roles: Array.isArray(guide.access_roles) ? guide.access_roles : [...ALL_ROLES],
+    is_published: guide.is_published,
+    sort_order: guide.sort_order,
+  })
+  const [coverUploading, setCoverUploading] = useState(false)
+  const [mutError, setMutError] = useState<string | null>(null)
+
+  const updateGuide = useMutation({
+    mutationFn: (body: FormState) =>
+      fetch(`/api/admin/guides/${guide.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }).then(async r => {
+        if (!r.ok) throw new Error((await r.json()).error)
+        return r.json()
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin-guides'] })
+      setMutError(null)
+      router.push('/admin/content?tab=guides')
+    },
+    onError: (e: Error) => setMutError(e.message),
+  })
+
+  function handleCancel() {
+    router.push('/admin/content?tab=guides')
+  }
+
+  const sharedPanelProps = {
+    form,
+    setForm,
+    isPending: updateGuide.isPending,
+    coverUploading,
+    setCoverUploading,
+    error: mutError,
+    onSave: () => updateGuide.mutate(form),
+    onCancel: handleCancel,
+  }
+
+  return (
+    <>
+      {/* ═══════════════════════════════════════════════════════════════
+          DESKTOP layout (lg+)
+          Left panel: fixed 320px metadata + always-visible save
+          Right panel: flex-1, block editor, independent scroll
+          ═══════════════════════════════════════════════════════════════ */}
+      <div className="hidden lg:flex h-screen overflow-hidden">
+        {/* Left panel */}
+        <div
+          className="w-80 flex-shrink-0 overflow-y-auto border-r p-6"
+          style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}
+        >
+          {/* Back nav */}
+          <button
+            onClick={handleCancel}
+            className="flex items-center gap-1.5 text-xs font-semibold mb-6 hover:opacity-70 transition-opacity"
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+            Guides
+          </button>
+          <h1 className="text-base font-bold mb-6 truncate" style={{ color: 'var(--text-primary)' }}>
+            {guide.title.en || guide.slug}
+          </h1>
+          <LeftPanel {...sharedPanelProps} />
+        </div>
+
+        {/* Right panel — block editor */}
+        <div className="flex-1 overflow-y-auto p-8">
+          <BlockEditor
+            blocks={form.body}
+            onChange={body => setForm(f => ({ ...f, body }))}
+          />
+        </div>
+      </div>
+
+      {/* ═══════════════════════════════════════════════════════════════
+          MOBILE layout (< lg)
+          Single column: back nav → title → metadata → block editor → save
+          ═══════════════════════════════════════════════════════════════ */}
+      <div className="lg:hidden px-4 py-6 space-y-6">
+        <button
+          onClick={handleCancel}
+          className="flex items-center gap-1.5 text-xs font-semibold hover:opacity-70 transition-opacity"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+          Guides
+        </button>
+        <h1 className="text-base font-bold truncate" style={{ color: 'var(--text-primary)' }}>
+          {guide.title.en || guide.slug}
+        </h1>
+        <LeftPanel {...sharedPanelProps} />
+        <div>
+          <label className="text-xs font-semibold uppercase tracking-widest mb-2 block"
+            style={{ color: 'var(--text-secondary)' }}>Body Blocks</label>
+          <BlockEditor
+            blocks={form.body}
+            onChange={body => setForm(f => ({ ...f, body }))}
+          />
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/admin/content/guides/[id]/edit/page.tsx
+++ b/app/admin/content/guides/[id]/edit/page.tsx
@@ -1,0 +1,30 @@
+import { auth } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
+import type { Guide } from '@/app/admin/content/components/guide-types'
+import { GuideEditLayout } from './components/GuideEditLayout'
+
+export default async function GuideEditPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const { userId } = await auth()
+  if (!userId) redirect('/sign-in')
+
+  const supabase = createServiceClient()
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) redirect('/admin')
+
+  const { data: guide, error } = await supabase
+    .from('guides')
+    .select('*')
+    .eq('id', id)
+    .single()
+
+  if (error || !guide) redirect('/admin/content?tab=guides')
+
+  return <GuideEditLayout guide={guide as Guide} />
+}


### PR DESCRIPTION
# [2604-FEAT-216] Guide edit form — desktop split-panel layout

Closes #216

## Summary

Replaces the 672px right-side drawer for guide editing with a full-page split-panel layout on desktop (≥1024px). Left panel: metadata + always-visible save/cancel. Right panel: `BlockEditor`. Mobile retains a linear single-column stack. Create flow (drawer + `GuideForm`) is untouched.

## Changes

- `app/admin/content/guides/[id]/edit/page.tsx` — new RSC, auth-guarded, fetches guide by id, renders `GuideEditLayout`
- `app/admin/content/guides/[id]/edit/components/GuideEditLayout.tsx` — new client component; dual layout (`hidden lg:flex` / `lg:hidden`); left panel 320px fixed, right panel flex-1 with independent scroll
- `app/admin/content/components/BlockEditor.tsx` — `rows` increased 3→5; ↑↓ buttons replaced with inline drag handles; drag-to-reorder implemented index-based; collapsible blocks; sticky `+ block` controls
- `app/admin/content/components/GuidesTab.tsx` — Edit button now navigates to `/admin/content/guides/[id]/edit`; edit-mode drawer wiring removed; create drawer untouched

## DoD Verification

- [x] `page.tsx` — full-page route, fetches guide by id, renders `GuideEditLayout`
- [x] `GuideEditLayout.tsx` — `lg:grid-cols-[320px_1fr]` desktop, single column mobile
- [x] Left panel: Title EN/BG, Slug + Copy URL, Emoji, CoverImageUploader, RoleSelector, publish toggle + AdminStatusBadge, Save/Cancel — always visible
- [x] Right panel: BlockEditor with block count indicator, collapsible blocks, sticky `+ block` controls
- [x] `BlockEditor.tsx` — textarea `rows=5`, drag handles, no ↑↓ arrows
- [x] `GuidesTab.tsx` — Edit navigates to route; edit drawer wiring removed; create flow untouched
- [x] 390px: `lg:hidden` layout is single-column linear stack, no overflow
- [x] `params: Promise<{ id: string }>` typed and awaited — Next.js 16 compliant

## Session State
**Status:** DONE
**Completed:**
- [x] All DoD items implemented and verified on branch
- [x] PR created, Vercel preview pending
**Next:** Vercel preview ready → mark PR ready for review → user merges
