### PR TITLE
[2605-BUG-221] Guide body list rendering — scoped CSS for ol/ul/li

### DIFF
--- a/app/(dashboard)/library/[slug]/components/GuideBody.tsx
+++ b/app/(dashboard)/library/[slug]/components/GuideBody.tsx
@@ -54,7 +54,7 @@ export default function GuideBody({
 
   return (
     <>
-      <div className="max-w-2xl space-y-6">
+      <div className="guide-body max-w-2xl space-y-6">
         {(blocks as Block[]).map((block, i) => {
           if (block.type === 'image') {
             if (!block.url) return null

--- a/app/globals.css
+++ b/app/globals.css
@@ -104,3 +104,20 @@ body {
 [data-radix-popper-content-wrapper] {
   z-index: 100 !important;
 }
+
+/* ── Guide body — list styling ── */
+/* Tailwind preflight strips browser default list styles globally.
+   .guide-body scopes the restore to guide content only. */
+.guide-body ol {
+  list-style-type: decimal;
+  margin-left: 1.5rem;
+}
+
+.guide-body ul {
+  list-style-type: disc;
+  margin-left: 1.5rem;
+}
+
+.guide-body li + li {
+  margin-top: 0.25rem;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -105,9 +105,15 @@ body {
   z-index: 100 !important;
 }
 
-/* ── Guide body — list styling ── */
-/* Tailwind preflight strips browser default list styles globally.
+/* ── Guide body — list and paragraph styling ── */
+/* Tailwind preflight strips browser default list styles and margins globally.
    .guide-body scopes the restore to guide content only. */
+.guide-body p,
+.guide-body ul,
+.guide-body ol {
+  margin-bottom: 1rem;
+}
+
 .guide-body ol {
   list-style-type: decimal;
   margin-left: 1.5rem;
@@ -120,4 +126,10 @@ body {
 
 .guide-body li + li {
   margin-top: 0.25rem;
+}
+
+.guide-body p:last-child,
+.guide-body ul:last-child,
+.guide-body ol:last-child {
+  margin-bottom: 0;
 }


### PR DESCRIPTION
Closes #221

## Changes

- `app/globals.css`: `.guide-body ol/ul/li` rules restore list styling stripped by Tailwind preflight, scoped so nothing else on the page is affected
- `app/(dashboard)/library/[slug]/components/GuideBody.tsx`: `guide-body` class added to outer wrapper div

## Session State
**Status:** DONE
**Completed:**
- [x] `globals.css` updated with scoped `.guide-body` rules
- [x] `GuideBody.tsx` wrapper div has `guide-body` class
**Next:** Vercel preview READY → merge