### PR TITLE
[2605-BUG-225] Homepage QA fixes — BG translations, tile polish

### DIFF
--- a/app/(dashboard)/components/tiles/AboutTile.tsx
+++ b/app/(dashboard)/components/tiles/AboutTile.tsx
@@ -1,11 +1,16 @@
+'use client'
+
 import Link from 'next/link'
+import { useLanguage } from '@/lib/hooks/useLanguage'
 
 export default function AboutTile() {
+  const { t } = useLanguage()
+
   return (
     <>
       <div className="flex items-center justify-end mb-4">
         <Link href="/about" className="font-body text-[11px] font-bold tracking-widest uppercase pill-link-crimson">
-          About us →
+          {t('home.about.aboutLink')}
         </Link>
       </div>
       <div className="flex-1">

--- a/app/(dashboard)/components/tiles/AnnouncementTile.tsx
+++ b/app/(dashboard)/components/tiles/AnnouncementTile.tsx
@@ -4,13 +4,16 @@ import Link from 'next/link'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 
 type Props = {
-  title: string
-  content: string | null
+  titles: Record<string, string>
+  contents: Record<string, string> | null
   slug?: string | null
 }
 
-export default function AnnouncementTile({ title, content, slug }: Props) {
-  const { t } = useLanguage()
+export default function AnnouncementTile({ titles, contents, slug }: Props) {
+  const { lang, t } = useLanguage()
+
+  const title   = titles[lang] ?? titles['en'] ?? Object.values(titles)[0] ?? ''
+  const content = contents ? (contents[lang] ?? contents['en'] ?? Object.values(contents)[0] ?? null) : null
 
   return (
     <>

--- a/app/(dashboard)/components/tiles/AnnouncementTile.tsx
+++ b/app/(dashboard)/components/tiles/AnnouncementTile.tsx
@@ -12,8 +12,10 @@ type Props = {
 export default function AnnouncementTile({ titles, contents, slug }: Props) {
   const { lang, t } = useLanguage()
 
-  const title   = titles[lang] ?? titles['en'] ?? Object.values(titles)[0] ?? ''
-  const content = contents ? (contents[lang] ?? contents['en'] ?? Object.values(contents)[0] ?? null) : null
+  const resolve = (obj: Record<string, string> | null) =>
+    obj ? (obj[lang] ?? obj['en'] ?? Object.values(obj)[0] ?? null) : null
+  const title   = resolve(titles) ?? ''
+  const content = resolve(contents)
 
   return (
     <>

--- a/app/(dashboard)/components/tiles/HeroTile.tsx
+++ b/app/(dashboard)/components/tiles/HeroTile.tsx
@@ -4,7 +4,7 @@ export default function HeroTile() {
   return (
     <>
       {/*
-        Founders image — occupies right 45% of the card, full height, bleeds off right edge.
+        Founders image — occupies right 40% of the card, full height, bleeds off right edge.
         `fill` requires a positioned ancestor with explicit dimensions — that's the BentoCard
         wrapper which has `relative overflow-hidden` and a defined grid row height (desktop: 2×row,
         mobile: minHeight 200px). The inner div is absolutely positioned to cover only the right
@@ -12,14 +12,14 @@ export default function HeroTile() {
       */}
       <div
         className="absolute inset-y-0 right-0 pointer-events-none select-none"
-        style={{ width: '45%' }}
+        style={{ width: '40%' }}
         aria-hidden
       >
         <Image
           src="/founders-hero.png"
           alt=""
           fill
-          sizes="(max-width: 768px) 45vw, 30vw"
+          sizes="(max-width: 768px) 40vw, 27vw"
           className="object-contain object-right-bottom"
           priority
         />

--- a/app/(dashboard)/components/tiles/LinksGuidesTile.tsx
+++ b/app/(dashboard)/components/tiles/LinksGuidesTile.tsx
@@ -85,25 +85,22 @@ export default function LinksGuidesTile({
           className="flex items-center gap-2.5 px-2 py-[7px] rounded-lg hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors"
         >
           <span
-            className="flex-shrink-0 flex items-center justify-center rounded-[6px]"
-            style={{ width: 22, height: 22, background: '#bc474914' }}
-          >
-            <svg
-              width="11" height="11" viewBox="0 0 24 24" fill="none"
-              stroke="var(--text-secondary)" strokeWidth="2.5"
-              strokeLinecap="round" strokeLinejoin="round"
-            >
-              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-              <polyline points="15 3 21 3 21 9" />
-              <line x1="10" y1="14" x2="21" y2="3" />
-            </svg>
-          </span>
-          <span
             className="flex-1 text-[13px] font-medium truncate"
             style={{ color: 'var(--text-primary)' }}
           >
             {resolveLabel(link)}
           </span>
+          <svg
+            width="10" height="10" viewBox="0 0 24 24" fill="none"
+            stroke="var(--text-secondary)" strokeWidth="2.5"
+            strokeLinecap="round" strokeLinejoin="round"
+            aria-hidden="true"
+            style={{ flexShrink: 0 }}
+          >
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+            <polyline points="15 3 21 3 21 9" />
+            <line x1="10" y1="14" x2="21" y2="3" />
+          </svg>
         </a>
       ))}
 

--- a/app/(dashboard)/components/tiles/TripHeroTile.tsx
+++ b/app/(dashboard)/components/tiles/TripHeroTile.tsx
@@ -40,13 +40,13 @@ export default function TripHeroTile({ trip }: Props) {
       )}
       <div className="absolute top-0 left-0 right-0 flex items-start justify-end px-5 pt-5 z-10">
         <Link href="/trips" className="font-body text-[11px] font-bold tracking-widest uppercase pill-link-parchment">
-          Trips →
+          {t('home.trips.tripsLink')}
         </Link>
       </div>
       <div className="absolute bottom-0 left-0 right-0 px-5 pb-5 z-10">
         <span
-          className="inline-block font-body text-[10px] font-bold tracking-widest uppercase px-2.5 py-1 rounded-full mb-2"
-          style={{ backgroundColor: 'rgba(255,255,255,0.18)', color: 'var(--brand-parchment)' }}
+          className="inline-block font-body text-[9px] font-bold tracking-widest uppercase px-2.5 py-1 rounded-full mb-2"
+          style={{ backgroundColor: 'rgba(255,255,255,0.18)', color: 'var(--brand-parchment)', opacity: 0.55 }}
         >
           {t('home.trips.nextTrip')}
         </span>

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -109,7 +109,7 @@ export default async function HomePage() {
             style={{ gridColumn: '7 / span 3', gridRow: '2 / span 2' }}
           />
 
-          {featuredAnnouncement && (
+          {featuredAnnouncement && Object.keys(featuredAnnouncement.titles).length > 0 && (
             <BentoCard
               variant="default"
               colSpan={3}
@@ -187,7 +187,7 @@ export default async function HomePage() {
           </BentoCard>
         )}
 
-        {featuredAnnouncement && (
+        {featuredAnnouncement && Object.keys(featuredAnnouncement.titles).length > 0 && (
           <BentoCard variant="default" className="flex flex-col" style={{ minHeight: 200 }}>
             <AnnouncementTile
               titles={featuredAnnouncement.titles}

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -61,9 +61,7 @@ export default async function HomePage() {
   const events         = (eventsRes.data ?? []) as unknown as CalendarEvent[]
 
   const featuredAnnouncement = announcements[0] ?? null
-  const announcementTitle   = featuredAnnouncement?.titles?.en ?? featuredAnnouncement?.titles?.bg ?? null
-  const announcementContent = featuredAnnouncement?.contents?.en ?? featuredAnnouncement?.contents?.bg ?? null
-  const announcementSlug    = featuredAnnouncement?.slug ?? null
+  const announcementSlug     = featuredAnnouncement?.slug ?? null
   const nextTrip = trips[0] ?? null
 
   return (
@@ -111,7 +109,7 @@ export default async function HomePage() {
             style={{ gridColumn: '7 / span 3', gridRow: '2 / span 2' }}
           />
 
-          {featuredAnnouncement && announcementTitle && (
+          {featuredAnnouncement && (
             <BentoCard
               variant="default"
               colSpan={3}
@@ -119,7 +117,11 @@ export default async function HomePage() {
               className="bento-tile flex flex-col"
               style={{ gridColumn: '1 / span 3', gridRow: '3 / span 1', animationDelay: '250ms' }}
             >
-              <AnnouncementTile title={announcementTitle} content={announcementContent} slug={announcementSlug} />
+              <AnnouncementTile
+                titles={featuredAnnouncement.titles}
+                contents={featuredAnnouncement.contents}
+                slug={announcementSlug}
+              />
             </BentoCard>
           )}
 
@@ -185,9 +187,13 @@ export default async function HomePage() {
           </BentoCard>
         )}
 
-        {featuredAnnouncement && announcementTitle && (
+        {featuredAnnouncement && (
           <BentoCard variant="default" className="flex flex-col" style={{ minHeight: 200 }}>
-            <AnnouncementTile title={announcementTitle} content={announcementContent} slug={announcementSlug} />
+            <AnnouncementTile
+              titles={featuredAnnouncement.titles}
+              contents={featuredAnnouncement.contents}
+              slug={announcementSlug}
+            />
           </BentoCard>
         )}
 

--- a/lib/i18n/domains/home.ts
+++ b/lib/i18n/domains/home.ts
@@ -15,6 +15,9 @@ export const home = {
   'home.guides.libraryLink': { en: 'Library →',            bg: 'Библиотека →'            },
   // TripHeroTile
   'home.trips.nextTrip':     { en: 'NEXT TRIP',            bg: 'СЛЕДВАЩО ПЪТУВАНЕ'       },
+  'home.trips.tripsLink':    { en: 'Trips →',              bg: 'Пътувания →'             },
+  // AboutTile
+  'home.about.aboutLink':    { en: 'About us →',           bg: 'За нас →'                },
   // ProfileTile
   'home.profile.there':      { en: 'there',                bg: 'приятел'                 },
   // SocialsTile


### PR DESCRIPTION
Closes #225

## Changes

- **AnnouncementTile** — now a client component; receives `titles`/`contents` as `Record<string,string>` and resolves by active language. Fixes news bento showing EN only in BG mode.
- **TripHeroTile** — "Trips →" pill-link wired to `t('home.trips.tripsLink')` (BG: "Пътувания →"). "NEXT TRIP" badge: `text-[10px]` → `text-[9px]`, `opacity: 0.55`.
- **AboutTile** — converted to client component; "About us →" pill-link wired to `t('home.about.aboutLink')` (BG: "За нас →").
- **LinksGuidesTile** — removed leading icon container from external link rows; trailing 10×10 external-link SVG added after label, preserving row homogeneity while signalling new-tab behaviour.
- **HeroTile** — image container `width: '45%'` → `'40%'`; `sizes` hint updated to match.
- **home.ts** — added `home.trips.tripsLink` and `home.about.aboutLink` keys.
- **page.tsx** — passes `titles`/`contents` objects directly to `AnnouncementTile`; removed now-unused server-side string resolution.

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] `home.ts` — 2 new translation keys
- [x] `page.tsx` — announcement props refactored
- [x] `AnnouncementTile.tsx` — client, lang-aware
- [x] `TripHeroTile.tsx` — link translated, badge resized/dimmed
- [x] `AboutTile.tsx` — client, link translated
- [x] `LinksGuidesTile.tsx` — icon removed, trailing ↗ SVG added
- [x] `HeroTile.tsx` — width 40%
**Next:** Verify Vercel Preview READY + CI green → mark DONE