### PR TITLE
[2605-BUG-234] fix: hero title single-line, remove about heading, remove guide emoji

### DIFF
--- a/app/(dashboard)/components/tiles/AboutTile.tsx
+++ b/app/(dashboard)/components/tiles/AboutTile.tsx
@@ -14,9 +14,6 @@ export default function AboutTile() {
         </Link>
       </div>
       <div className="flex-1">
-        <h2 className="font-display text-xl font-semibold mb-3" style={{ color: 'var(--text-primary)' }}>
-          Hey there!
-        </h2>
         <p
           className="font-body text-sm leading-relaxed"
           style={{

--- a/app/(dashboard)/components/tiles/HeroTile.tsx
+++ b/app/(dashboard)/components/tiles/HeroTile.tsx
@@ -29,7 +29,7 @@ export default function HeroTile() {
       <div className="absolute inset-0 flex flex-col justify-end px-8 py-10 z-10">
         <div className="max-w-[58%]">
           <h1
-            className="font-serif leading-tight mb-2 text-[22px] md:text-[34px] font-black text-brand-parchment tracking-[-0.01em]"
+            className="font-serif leading-tight mb-2 text-[17px] md:text-[34px] font-black text-brand-parchment tracking-[-0.01em] whitespace-nowrap"
           >
             TEAMENJOYVD
           </h1>

--- a/app/(dashboard)/components/tiles/LinksGuidesTile.tsx
+++ b/app/(dashboard)/components/tiles/LinksGuidesTile.tsx
@@ -111,12 +111,6 @@ export default function LinksGuidesTile({
           className="flex items-center gap-2.5 px-2 py-[7px] rounded-lg hover:bg-black/[0.04] dark:hover:bg-white/[0.06] transition-colors"
         >
           <span
-            className="flex-shrink-0 flex items-center justify-center"
-            style={{ width: 22, height: 22, fontSize: 14 }}
-          >
-            {g.emoji ?? '📄'}
-          </span>
-          <span
             className="flex-1 text-[13px] font-medium truncate"
             style={{ color: 'var(--text-primary)' }}
           >


### PR DESCRIPTION
## Summary

Three cosmetic fixes to the homepage bento:

- **HeroTile:** `text-[22px]` → `text-[17px]` + `whitespace-nowrap` — TEAMENJOYVD now renders on a single line at 390px across all font-scale levels. `px` value is immune to `--font-scale`.
- **AboutTile:** removed `<h2>Hey there!</h2>` heading — body copy reads directly without the redundant label.
- **LinksGuidesTile:** removed emoji `<span>` from guide rows — guide links now match the visual weight of external links above them.

Closes #234

## Session State
**Status:** DONE
**Completed:**
- [x] `HeroTile.tsx` — single-line fix applied
- [x] `AboutTile.tsx` — heading removed
- [x] `LinksGuidesTile.tsx` — guide emoji removed
**Next:** Verify Vercel Preview READY, CI green, then merge