### PR TITLE
[2605-CHORE-218] Rename visibility_roles → access_roles on calendar_events and trips; bump homepage query limits

### DIFF
--- a/app/(dashboard)/calendar/types.ts
+++ b/app/(dashboard)/calendar/types.ts
@@ -12,7 +12,7 @@ export type CalendarEvent = {
   category: 'N21' | 'Personal'
   event_type: 'in-person' | 'online' | 'hybrid' | null
   week_number: number
-  visibility_roles: string[]
+  access_roles: string[]
 }
 
 export type View = 'month' | 'agenda'

--- a/app/(dashboard)/components/tiles/CalendarTile.tsx
+++ b/app/(dashboard)/components/tiles/CalendarTile.tsx
@@ -83,7 +83,7 @@ export default function CalendarTile({ events = [], colSpan, mobileColSpan, rowS
       mobileColSpan={mobileColSpan}
       rowSpan={rowSpan}
       className="bento-tile flex flex-col"
-      style={{ animationDelay: '150ms', paddingTop: 10, paddingBottom: 10, ...style }}
+      style={{ animationDelay: '150ms', ...style }}
     >
       <div className="flex items-center justify-end mb-3">
         <Link href="/calendar" className="font-body text-[11px] font-bold tracking-widest uppercase pill-link-crimson">

--- a/app/(dashboard)/components/tiles/LinksGuidesTile.tsx
+++ b/app/(dashboard)/components/tiles/LinksGuidesTile.tsx
@@ -17,8 +17,8 @@ export type Guide = {
   emoji: string | null
 }
 
-const MAX_LINKS  = 2
-const MAX_GUIDES = 2
+const MAX_LINKS  = 6
+const MAX_GUIDES = 6
 
 function normaliseUrl(raw: string): string {
   const trimmed = raw.trim()

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -40,18 +40,18 @@ export default async function HomePage() {
   const [announcementsRes, linksRes, tripsRes, guidesRes, eventsRes] = await Promise.all([
     supabase.from('announcements').select('id, titles, contents, is_active, slug').eq('is_active', true)
       .contains('access_roles', [role]).order('created_at', { ascending: false }).limit(5),
-    supabase.from('links').select('id, label, url').eq('is_active', true).contains('access_roles', [role]).order('sort_order').limit(4),
+    supabase.from('links').select('id, label, url').eq('is_active', true).contains('access_roles', [role]).order('sort_order').limit(6),
     supabase.from('trips').select('id, title, destination, start_date, image_url')
-      .contains('visibility_roles', [role]).order('start_date').limit(3),
+      .contains('access_roles', [role]).order('start_date').limit(3),
     supabase.from('guides').select('id, slug, title, emoji')
       .eq('is_published', true).contains('access_roles', [role])
-      .order('created_at', { ascending: false }).limit(4),
+      .order('created_at', { ascending: false }).limit(6),
     supabase.from('calendar_events')
       .select('id, title, start_time, end_time, event_type')
-      .contains('visibility_roles', [role])
+      .contains('access_roles', [role])
       .gte('start_time', new Date().toISOString())
       .order('start_time')
-      .limit(3),
+      .limit(5),
   ])
 
   const announcements  = (announcementsRes.data ?? []) as unknown as Announcement[]

--- a/app/(dashboard)/trips/[id]/page.tsx
+++ b/app/(dashboard)/trips/[id]/page.tsx
@@ -59,7 +59,7 @@ export default async function TripDetailPage({
 
   const supabase = createServiceClient()
 
-  // Fetch profile first — we need the role for visibility filtering
+  // Fetch profile first — we need the role for access filtering
   const { data: profile } = await supabase
     .from('profiles')
     .select('id, role, valid_through, document_active_type')
@@ -68,12 +68,12 @@ export default async function TripDetailPage({
 
   if (!profile) redirect('/trips')
 
-  // Enforce visibility_roles — only return trip if user's role is included
+  // Enforce access_roles — only return trip if user's role is included
   const { data: trip } = await supabase
     .from('trips')
     .select('*')
     .eq('id', id)
-    .contains('visibility_roles', [profile.role])
+    .contains('access_roles', [profile.role])
     .single()
 
   if (!trip) redirect('/trips')

--- a/app/(dashboard)/trips/page.tsx
+++ b/app/(dashboard)/trips/page.tsx
@@ -15,7 +15,7 @@ type Trip = {
   currency: 'EUR'
   total_cost: number
   milestones: unknown[]
-  visibility_roles: string[]
+  access_roles: string[]
   location: string | null
   accommodation_type: string | null
   inclusions: string[]
@@ -42,7 +42,7 @@ export default async function TripsPage() {
   const { data } = await supabase
     .from('trips')
     .select('*')
-    .contains('visibility_roles', [role])
+    .contains('access_roles', [role])
     .order('start_date')
 
   const initialTrips = (data ?? []) as Trip[]

--- a/app/admin/calendar/components/AdminCalendarClient.tsx
+++ b/app/admin/calendar/components/AdminCalendarClient.tsx
@@ -288,7 +288,7 @@ export default function AdminCalendarClient() {
                 </div>
                 <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
                   {formatDateTime(ev.start_time)} → {formatDateTime(ev.end_time)} · W{ev.week_number}
-                  {' · '}{ev.access_roles.join(', ')}
+                  {' · '}{(ev.access_roles ?? []).join(', ')}
                 </p>
               </div>
               <div className="flex items-center gap-3 flex-shrink-0">

--- a/app/admin/calendar/components/AdminCalendarClient.tsx
+++ b/app/admin/calendar/components/AdminCalendarClient.tsx
@@ -17,7 +17,7 @@ type CalEvent = {
   week_number: number
   category: 'N21' | 'Personal'
   event_type: 'in-person' | 'online' | 'hybrid' | null
-  visibility_roles: string[]
+  access_roles: string[]
   google_event_id: string | null
   meeting_url: string | null
   allow_guest_registration: boolean
@@ -138,7 +138,7 @@ export default function AdminCalendarClient() {
       week_number: ev.week_number,
       category: ev.category,
       event_type: ev.event_type,
-      visibility_roles: Array.isArray(ev.visibility_roles) ? ev.visibility_roles : [...ALL_ROLES],
+      access_roles: Array.isArray(ev.access_roles) ? ev.access_roles : [...ALL_ROLES],
       meeting_url: ev.meeting_url ?? '',
       allow_guest_registration: ev.allow_guest_registration,
       available_roles: Array.isArray(ev.available_roles)
@@ -288,7 +288,7 @@ export default function AdminCalendarClient() {
                 </div>
                 <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
                   {formatDateTime(ev.start_time)} → {formatDateTime(ev.end_time)} · W{ev.week_number}
-                  {' · '}{ev.visibility_roles.join(', ')}
+                  {' · '}{ev.access_roles.join(', ')}
                 </p>
               </div>
               <div className="flex items-center gap-3 flex-shrink-0">

--- a/app/admin/calendar/components/EventForm.tsx
+++ b/app/admin/calendar/components/EventForm.tsx
@@ -17,7 +17,7 @@ export type EventFormState = {
   week_number: number
   category: 'N21' | 'Personal'
   event_type: 'in-person' | 'online' | 'hybrid' | null
-  visibility_roles: string[]
+  access_roles: string[]
   meeting_url: string
   allow_guest_registration: boolean
   available_roles: string[]
@@ -32,7 +32,7 @@ export function emptyForm(): EventFormState {
     week_number: 0,
     category: 'N21',
     event_type: null,
-    visibility_roles: [...ALL_ROLES],
+    access_roles: [...ALL_ROLES],
     meeting_url: '',
     allow_guest_registration: true,
     available_roles: [...DEFAULT_AVAILABLE_ROLES],
@@ -151,12 +151,12 @@ export function EventForm({
             {ALL_ROLES.map(role => (
               <button key={role} type="button" onClick={() => setF(p => ({
                 ...p,
-                visibility_roles: p.visibility_roles.includes(role)
-                  ? p.visibility_roles.filter(r => r !== role)
-                  : [...p.visibility_roles, role],
+                access_roles: p.access_roles.includes(role)
+                  ? p.access_roles.filter(r => r !== role)
+                  : [...p.access_roles, role],
               }))}
                 className="px-3 py-1.5 rounded-full text-xs font-semibold transition-all"
-                style={{ backgroundColor: f.visibility_roles.includes(role) ? 'var(--brand-forest)' : 'rgba(0,0,0,0.06)', color: f.visibility_roles.includes(role) ? 'var(--brand-parchment)' : 'var(--text-secondary)' }}>
+                style={{ backgroundColor: f.access_roles.includes(role) ? 'var(--brand-forest)' : 'rgba(0,0,0,0.06)', color: f.access_roles.includes(role) ? 'var(--brand-parchment)' : 'var(--text-secondary)' }}>
                 {role}
               </button>
             ))}

--- a/app/api/admin/calendar/[id]/route.ts
+++ b/app/api/admin/calendar/[id]/route.ts
@@ -17,7 +17,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 
   const allowed = [
     'title', 'description', 'start_time', 'end_time', 'category',
-    'event_type', 'meeting_url', 'visibility_roles', 'available_roles',
+    'event_type', 'meeting_url', 'access_roles', 'available_roles',
     'allow_guest_registration', 'week_number',
   ]
   const update: Record<string, unknown> = {}

--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
   const { data, error } = await supabase
     .from('trips')
     .select('*')
-    .contains('visibility_roles', [role])
+    .contains('access_roles', [role])
     .order('start_date')
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
@@ -48,7 +48,7 @@ export async function POST(req: Request) {
       currency:           'EUR',
       total_cost:         body.total_cost ?? 0,
       milestones:         body.milestones ?? [],
-      visibility_roles:   body.visibility_roles ?? ['guest', 'member', 'core', 'admin'],
+      access_roles:       body.access_roles ?? ['guest', 'member', 'core', 'admin'],
       location:           body.location ?? null,
       accommodation_type: body.accommodation_type ?? null,
       inclusions:         body.inclusions ?? [],

--- a/supabase/migrations/20260502075427_rename_visibility_roles_to_access_roles.sql
+++ b/supabase/migrations/20260502075427_rename_visibility_roles_to_access_roles.sql
@@ -1,0 +1,3 @@
+-- Rename visibility_roles → access_roles on calendar_events and trips
+ALTER TABLE calendar_events RENAME COLUMN visibility_roles TO access_roles;
+ALTER TABLE trips RENAME COLUMN visibility_roles TO access_roles;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -111,6 +111,7 @@ export type Database = {
       }
       calendar_events: {
         Row: {
+          access_roles: Database["public"]["Enums"]["user_role"][]
           allow_guest_registration: boolean
           available_roles: string[]
           category: Database["public"]["Enums"]["event_category"]
@@ -124,10 +125,10 @@ export type Database = {
           meeting_url: string | null
           start_time: string
           title: string
-          visibility_roles: Database["public"]["Enums"]["user_role"][]
           week_number: number
         }
         Insert: {
+          access_roles?: Database["public"]["Enums"]["user_role"][]
           allow_guest_registration?: boolean
           available_roles?: string[]
           category?: Database["public"]["Enums"]["event_category"]
@@ -141,10 +142,10 @@ export type Database = {
           meeting_url?: string | null
           start_time: string
           title: string
-          visibility_roles?: Database["public"]["Enums"]["user_role"][]
           week_number: number
         }
         Update: {
+          access_roles?: Database["public"]["Enums"]["user_role"][]
           allow_guest_registration?: boolean
           available_roles?: string[]
           category?: Database["public"]["Enums"]["event_category"]
@@ -158,7 +159,6 @@ export type Database = {
           meeting_url?: string | null
           start_time?: string
           title?: string
-          visibility_roles?: Database["public"]["Enums"]["user_role"][]
           week_number?: number
         }
         Relationships: [
@@ -1088,6 +1088,7 @@ export type Database = {
       }
       trips: {
         Row: {
+          access_roles: string[]
           accommodation_type: string | null
           created_at: string
           currency: string
@@ -1103,9 +1104,9 @@ export type Database = {
           title: string
           total_cost: number
           trip_type: string | null
-          visibility_roles: string[]
         }
         Insert: {
+          access_roles?: string[]
           accommodation_type?: string | null
           created_at?: string
           currency?: string
@@ -1121,9 +1122,9 @@ export type Database = {
           title: string
           total_cost?: number
           trip_type?: string | null
-          visibility_roles?: string[]
         }
         Update: {
+          access_roles?: string[]
           accommodation_type?: string | null
           created_at?: string
           currency?: string
@@ -1139,7 +1140,6 @@ export type Database = {
           title?: string
           total_cost?: number
           trip_type?: string | null
-          visibility_roles?: string[]
         }
         Relationships: []
       }


### PR DESCRIPTION
Closes #218

## Summary

- **Migration** (`20260502075427_rename_visibility_roles_to_access_roles.sql`): renames `visibility_roles` → `access_roles` on `calendar_events` and `trips`
- **`types/supabase.ts`**: regenerated — both tables now show `access_roles`
- **`calendar/types.ts`**: `CalendarEvent.visibility_roles` → `access_roles`
- **`page.tsx`**: trips and calendar queries switched to `.contains('access_roles', …)`; links `limit(4)→6`, guides `limit(4)→6`, calendar `limit(3)→5`
- **`api/trips/route.ts`**: GET filter and POST insert key → `access_roles`
- **`trips/[id]/page.tsx`**: `.contains('access_roles', …)`
- **`api/admin/calendar/[id]/route.ts`**: PATCH allowlist `'visibility_roles'` → `'access_roles'`
- **`EventForm.tsx`**: `EventFormState.access_roles`, `emptyForm()`, toggle handler
- **`AdminCalendarClient.tsx`**: `CalEvent.access_roles`, `openEdit` mapping, row display
- **`LinksGuidesTile.tsx`**: `MAX_LINKS = 6`, `MAX_GUIDES = 6`
- **`CalendarTile.tsx`**: removed `paddingTop: 10, paddingBottom: 10` from `BentoCard` style — these were overriding card-level padding and causing the CALENDAR pill-link to have less top spacing than other tiles

## Session State
**Status:** DONE
**Completed:**
- [x] Migration applied and file saved
- [x] Types regenerated
- [x] All `visibility_roles` references renamed to `access_roles` across 8 files
- [x] Homepage query limits bumped (links 4→6, guides 4→6, calendar 3→5)
- [x] `CalendarTile` padding override removed
- [x] PR opened
**Next:** Verify Vercel Preview READY, CI green
