### PR TITLE
fix: rename visibility_roles → access_roles in calendar API filter

### DIFF
--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -20,9 +20,9 @@ export async function GET(req: Request) {
   let query = supabase
     .from('calendar_events')
     .select('*')
-    // Include events where visibility_roles contains the user's role,
-    // OR where visibility_roles is null (safe fallback for manually created events).
-    .or(`visibility_roles.cs.{${role}},visibility_roles.is.null`)
+    // Include events where access_roles contains the user's role,
+    // OR where access_roles is null (safe fallback for manually created events).
+    .or(`access_roles.cs.{${role}},access_roles.is.null`)
     .order('start_time')
 
   if (month) {


### PR DESCRIPTION
## Root cause

#218 migrated `visibility_roles` → `access_roles` on `calendar_events` but missed the string literal in `app/api/calendar/route.ts` line 22:

```ts
// Before (broken)
.or(`visibility_roles.cs.{${role}},visibility_roles.is.null`)

// After
.or(`access_roles.cs.{${role}},access_roles.is.null`)
```

PostgREST was filtering on a non-existent column and returning zero rows for every calendar query. Month view and agenda view both showed empty.

## Changes

- `app/api/calendar/route.ts` — column name corrected in `.or()` filter string; stale comment updated

## Session State
**Status:** DONE
**Completed:**
- [x] Column name fixed in filter string
- [x] Stale comment updated
- [x] PR opened
**Next:** Verify Vercel Preview READY, merge