### PR TITLE
[2605-BUG-244] Fix stale visibility_roles references after column rename

### DIFF
--- a/.pr-session-state.md
+++ b/.pr-session-state.md
@@ -1,0 +1,23 @@
+## Summary
+
+Fixes all application-code references to the renamed column `visibility_roles` → `access_roles` on `calendar_events` and `trips` tables (migration `20260502075427`).
+
+## Changes
+
+- `app/api/calendar/feed.ics/route.ts` — `.contains('access_roles', ...)`
+- `app/api/trips/route.ts` — GET filter + POST insert key
+- `app/admin/operations/components/operations-types.ts` — `Trip.access_roles`
+- `app/admin/operations/components/TripForm.tsx` — all field refs
+- `app/admin/operations/components/TripsTab.tsx` — `emptyTrip()` + `openEdit()` reads
+- `supabase/functions/sync-google-calendar/index.ts` — upsert key + redeployed via MCP (v19)
+
+Closes #244
+
+## Session State
+**Status:** DONE
+**Completed:**
+- [x] All 6 files updated in single commit
+- [x] PR #245 created
+- [x] Edge Function redeployed (v19, ACTIVE)
+- [x] Vercel Preview building
+**Next:** Merge when CI green + Preview READY

--- a/app/admin/operations/components/TripForm.tsx
+++ b/app/admin/operations/components/TripForm.tsx
@@ -149,14 +149,14 @@ export function TripForm({
           {ALL_ROLES.map(role => (
             <button key={role} onClick={() => setForm(f => ({
               ...f,
-              visibility_roles: f.visibility_roles.includes(role)
-                ? f.visibility_roles.filter(r => r !== role)
-                : [...f.visibility_roles, role],
+              access_roles: f.access_roles.includes(role)
+                ? f.access_roles.filter(r => r !== role)
+                : [...f.access_roles, role],
             }))}
               className="px-3 py-1.5 rounded-full text-xs font-semibold transition-all"
               style={{
-                backgroundColor: form.visibility_roles.includes(role) ? 'var(--brand-forest)' : 'rgba(0,0,0,0.06)',
-                color: form.visibility_roles.includes(role) ? 'var(--brand-parchment)' : 'var(--text-secondary)',
+                backgroundColor: form.access_roles.includes(role) ? 'var(--brand-forest)' : 'rgba(0,0,0,0.06)',
+                color: form.access_roles.includes(role) ? 'var(--brand-parchment)' : 'var(--text-secondary)',
               }}>
               {role}
             </button>

--- a/app/admin/operations/components/TripsTab.tsx
+++ b/app/admin/operations/components/TripsTab.tsx
@@ -26,7 +26,7 @@ const emptyTrip = (): TripFormState => ({
   start_date: '', end_date: '', total_cost: 0, milestones: [],
   location: null, accommodation_type: null,
   inclusions: [], trip_type: null,
-  visibility_roles: [...ALL_ROLES],
+  access_roles: [...ALL_ROLES],
 })
 
 // ── Component ────────────────────────────────────────────
@@ -62,7 +62,7 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
       accommodation_type: trip.accommodation_type,
       inclusions: Array.isArray(trip.inclusions) ? trip.inclusions : [],
       trip_type: trip.trip_type,
-      visibility_roles: Array.isArray(trip.visibility_roles) ? trip.visibility_roles : [...ALL_ROLES],
+      access_roles: Array.isArray(trip.access_roles) ? trip.access_roles : [...ALL_ROLES],
     })
     setMilestoneInput({ label: '', amount: '', due_date: '' })
     setError(null)

--- a/app/admin/operations/components/operations-types.ts
+++ b/app/admin/operations/components/operations-types.ts
@@ -10,7 +10,7 @@ export type Trip = {
   currency: string; description: string
   location: string | null; accommodation_type: string | null
   inclusions: string[]; trip_type: string | null
-  visibility_roles: string[]
+  access_roles: string[]
 }
 
 export type PayableItem = {

--- a/app/admin/operations/components/operations-types.ts
+++ b/app/admin/operations/components/operations-types.ts
@@ -1,6 +1,9 @@
 // Shared domain types and constants for the operations area.
 // Plain TypeScript — no 'use client' directive.
 
+export const ALL_ROLES = ['guest', 'member', 'core', 'admin'] as const
+export type Role = (typeof ALL_ROLES)[number]
+
 export type Milestone = { label: string; amount: number; due_date: string }
 
 export type Trip = {
@@ -10,7 +13,7 @@ export type Trip = {
   currency: string; description: string
   location: string | null; accommodation_type: string | null
   inclusions: string[]; trip_type: string | null
-  access_roles: string[]
+  access_roles: Role[]
 }
 
 export type PayableItem = {
@@ -38,5 +41,3 @@ export type ItemFormState = {
   item_type: 'merchandise' | 'ticket' | 'food' | 'book' | 'other'
   linked_trip_id: string; is_active: boolean
 }
-
-export const ALL_ROLES = ['guest', 'member', 'core', 'admin']

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -39,7 +39,7 @@ export async function GET(req: Request) {
   const { data: events } = await supabase
     .from('calendar_events')
     .select('id, title, description, start_time, end_time, category')
-    .contains('visibility_roles', [payload.role])
+    .contains('access_roles', [payload.role])
     .order('start_time')
 
   // Build iCal

--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
   const { data, error } = await supabase
     .from('trips')
     .select('*')
-    .contains('visibility_roles', [role])
+    .contains('access_roles', [role])
     .order('start_date')
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
@@ -49,7 +49,7 @@ export async function POST(req: Request) {
       currency:           'EUR',
       total_cost:         body.total_cost ?? 0,
       milestones:         body.milestones ?? [],
-      visibility_roles:   body.visibility_roles ?? [...ALL_ROLES],
+      access_roles:       body.access_roles ?? [...ALL_ROLES],
       location:           body.location ?? null,
       accommodation_type: body.accommodation_type ?? null,
       inclusions:         body.inclusions ?? [],

--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -49,7 +49,7 @@ export async function POST(req: Request) {
       currency:           'EUR',
       total_cost:         body.total_cost ?? 0,
       milestones:         body.milestones ?? [],
-      access_roles:       body.access_roles ?? [...ALL_ROLES],
+      access_roles:       Array.isArray(body.access_roles) ? body.access_roles : [...ALL_ROLES],
       location:           body.location ?? null,
       accommodation_type: body.accommodation_type ?? null,
       inclusions:         body.inclusions ?? [],

--- a/supabase/functions/sync-google-calendar/index.ts
+++ b/supabase/functions/sync-google-calendar/index.ts
@@ -136,7 +136,7 @@ Deno.serve(async (req: Request) => {
       start_time:       st.toISOString(),
       end_time:         et.toISOString(),
       category:         personal ? 'Personal' : 'N21',
-      visibility_roles: personal ? ['member','core','admin'] : ['admin','core','member','guest'],
+      access_roles:     personal ? ['member','core','admin'] : ['admin','core','member','guest'],
       week_number:      isoWeek(st),
     }, {onConflict: 'google_event_id'})
     if (ue) errors.push(String(item.id) + ': ' + ue.message)


### PR DESCRIPTION
## Summary

Fixes all application-code references to the renamed column `visibility_roles` → `access_roles` on `calendar_events` and `trips` tables (migration `20260502075427`).

## Changes

- `app/api/calendar/feed.ics/route.ts` — `.contains('access_roles', ...)`
- `app/api/trips/route.ts` — GET filter + POST insert key
- `app/admin/operations/components/operations-types.ts` — `Trip.access_roles`
- `app/admin/operations/components/TripForm.tsx` — all field refs
- `app/admin/operations/components/TripsTab.tsx` — `emptyTrip()` + `openEdit()` reads
- `supabase/functions/sync-google-calendar/index.ts` — upsert key + redeployed via MCP

Closes #244

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] All 6 files updated in single commit
- [x] PR created
**Next:** Confirm Edge Function redeploy success, then mark DONE