### PR TITLE
[2505-BUG-248] Fix iCal feed timezone — events imported 3 hours early

### DIFF
--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -42,11 +42,11 @@ export async function GET(req: Request) {
     .contains('access_roles', [payload.role])
     .order('start_time')
 
-  // Build iCal
+  // Build iCal — no timezone set so dates are emitted as UTC (DTSTART:...Z)
+  // start_time/end_time from Supabase are +00 UTC strings; new Date() preserves that.
   const calendar = ical({
     name: 'teamenjoyVD',
     prodId: { company: 'teamenjoyVD', product: 'tevd-portal' },
-    timezone: 'Europe/Sofia',
   })
 
   for (const event of events ?? []) {


### PR DESCRIPTION
## Summary

Removes `timezone: 'Europe/Sofia'` from the `ical-generator` calendar constructor in `feed.ics/route.ts`.

**Root cause:** `ical-generator` was emitting `DTSTART;TZID=Europe/Sofia:<utc-numeric-time>`. The UTC hour value was labelled as Sofia local time, so calendar clients interpreted e.g. 09:00 UTC as 09:00 Sofia — 3 hours early.

**Fix:** No timezone on the calendar or events. `ical-generator` then emits `DTSTART:...Z` (UTC, RFC 5545 Form 2). `new Date(event.start_time)` from Supabase `+00` timestamps is already UTC-correct — no conversion needed.

Closes #248

## Session State

**Status:** DONE
**Completed:**
- [x] Removed `timezone: 'Europe/Sofia'` from `ical()` constructor
- [x] Confirmed no `timezone` on individual `createEvent()` calls
- [x] PR open, Vercel preview deploying
**Next:** Verify preview URL returns `DTSTART:...Z` and test import in calendar client
