### PR TITLE
[2505-FEAT-255] Coming soon gate with waiting list

### DIFF
--- a/app/api/waiting-list/route.ts
+++ b/app/api/waiting-list/route.ts
@@ -1,0 +1,53 @@
+import { createClient } from '@supabase/supabase-js'
+import { NextResponse } from 'next/server'
+import { Resend } from 'resend'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+export async function POST(req: Request) {
+  try {
+    const { email } = await req.json()
+
+    if (!email || typeof email !== 'string' || !email.includes('@')) {
+      return NextResponse.json({ error: 'Invalid email' }, { status: 400 })
+    }
+
+    const { error } = await supabase
+      .from('waiting_list')
+      .insert({ email: email.toLowerCase().trim() })
+
+    if (error) {
+      if (error.code === '23505') {
+        // Already signed up — treat as success, don't leak info
+        return NextResponse.json({ ok: true })
+      }
+      console.error('[waiting-list] insert error:', error)
+      return NextResponse.json({ error: 'Server error' }, { status: 500 })
+    }
+
+    // Fire-and-forget confirmation email
+    resend.emails.send({
+      from: 'teamenjoyVD <noreply@teamenjoyvd.com>',
+      to: email,
+      subject: "You're on the list",
+      html: `
+        <div style="font-family: Georgia, serif; max-width: 480px; margin: 0 auto; padding: 40px 24px; color: #1A1F18;">
+          <img src="https://www.teamenjoyvd.com/logo.png" alt="teamenjoyVD" style="height: 48px; margin-bottom: 32px;" />
+          <h1 style="font-size: 24px; font-weight: normal; margin: 0 0 16px;">You're on the list.</h1>
+          <p style="font-size: 16px; line-height: 1.6; color: #5C5950; margin: 0;">
+            We'll let you know the moment teamenjoyVD launches. Stay close.
+          </p>
+        </div>
+      `,
+    }).catch(() => { /* swallow — not critical */ })
+
+    return NextResponse.json({ ok: true })
+  } catch {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}

--- a/app/coming-soon/page.tsx
+++ b/app/coming-soon/page.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import Image from 'next/image'
+import { useState } from 'react'
+
+export default function ComingSoonPage() {
+  const [email, setEmail] = useState('')
+  const [state, setState] = useState<'idle' | 'loading' | 'done' | 'error'>('idle')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!email || state === 'loading' || state === 'done') return
+    setState('loading')
+    try {
+      const res = await fetch('/api/waiting-list', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      })
+      setState(res.ok ? 'done' : 'error')
+    } catch {
+      setState('error')
+    }
+  }
+
+  return (
+    <main
+      style={{
+        minHeight: '100dvh',
+        background: 'var(--brand-forest)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '40px 24px',
+        fontFamily: 'Georgia, serif',
+      }}
+    >
+      {/* Logo */}
+      <Image
+        src="/logo.png"
+        alt="teamenjoyVD"
+        width={120}
+        height={120}
+        style={{ objectFit: 'contain', marginBottom: '48px' }}
+        priority
+      />
+
+      {/* Heading */}
+      <div style={{ textAlign: 'center', marginBottom: '48px' }}>
+        <p
+          style={{
+            fontSize: '11px',
+            letterSpacing: '0.2em',
+            textTransform: 'uppercase',
+            color: 'var(--brand-crimson)',
+            margin: '0 0 16px',
+          }}
+        >
+          teamenjoyVD
+        </p>
+        <h1
+          style={{
+            fontSize: 'clamp(36px, 8vw, 72px)',
+            fontWeight: 'normal',
+            color: 'var(--brand-parchment)',
+            margin: '0 0 16px',
+            lineHeight: 1.1,
+            letterSpacing: '-0.02em',
+          }}
+        >
+          Coming Soon
+        </h1>
+        <p
+          style={{
+            fontSize: '16px',
+            color: 'rgba(250,248,243,0.5)',
+            margin: 0,
+            lineHeight: 1.6,
+          }}
+        >
+          Something is being built. Leave your email and we&apos;ll let you know.
+        </p>
+      </div>
+
+      {/* Email capture */}
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          width: '100%',
+          maxWidth: '400px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '12px',
+        }}
+      >
+        {state !== 'done' ? (
+          <>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="your@email.com"
+              required
+              disabled={state === 'loading'}
+              style={{
+                width: '100%',
+                padding: '14px 16px',
+                background: 'rgba(250,248,243,0.06)',
+                border: '1px solid rgba(250,248,243,0.15)',
+                borderRadius: '4px',
+                color: 'var(--brand-parchment)',
+                fontSize: '16px',
+                fontFamily: 'inherit',
+                outline: 'none',
+                boxSizing: 'border-box',
+              }}
+            />
+            <button
+              type="submit"
+              disabled={state === 'loading'}
+              style={{
+                width: '100%',
+                padding: '14px 16px',
+                background: 'var(--brand-crimson)',
+                border: 'none',
+                borderRadius: '4px',
+                color: 'var(--brand-parchment)',
+                fontSize: '14px',
+                letterSpacing: '0.1em',
+                textTransform: 'uppercase',
+                fontFamily: 'inherit',
+                cursor: state === 'loading' ? 'wait' : 'pointer',
+                opacity: state === 'loading' ? 0.7 : 1,
+              }}
+            >
+              {state === 'loading' ? 'Saving...' : 'Notify me'}
+            </button>
+            {state === 'error' && (
+              <p style={{ color: 'var(--brand-crimson)', fontSize: '14px', margin: 0, textAlign: 'center' }}>
+                Something went wrong. Try again.
+              </p>
+            )}
+          </>
+        ) : (
+          <p
+            style={{
+              color: 'var(--brand-parchment)',
+              fontSize: '16px',
+              textAlign: 'center',
+              margin: 0,
+              padding: '14px 0',
+              borderTop: '1px solid rgba(250,248,243,0.15)',
+            }}
+          >
+            You&apos;re on the list. We&apos;ll be in touch.
+          </p>
+        )}
+      </form>
+    </main>
+  )
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,11 +1,46 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
 import { isPublicRoute } from '@/lib/public-routes'
+
+const PREVIEW_TOKEN = 'itypoonpurpoise'
+const PREVIEW_COOKIE = 'tevd_preview'
+const COMING_SOON_ENABLED = true
 
 const isAdminApiRoute = createRouteMatcher(['/api/admin/(.*)'])
 const isAdminPageRoute = createRouteMatcher(['/admin/(.*)'])
+const isComingSoonRoute = createRouteMatcher(['/coming-soon'])
+const isWebhookRoute = createRouteMatcher(['/api/webhooks/(.*)', '/api/waiting-list'])
+
+function comingSoonGate(req: NextRequest): NextResponse | null {
+  if (!COMING_SOON_ENABLED) return null
+  if (isComingSoonRoute(req)) return null
+  if (isWebhookRoute(req)) return null
+
+  // Grant access via query param — set cookie and redirect to homepage
+  const url = req.nextUrl
+  if (url.searchParams.get('preview') === PREVIEW_TOKEN) {
+    const res = NextResponse.redirect(new URL('/', req.url))
+    res.cookies.set(PREVIEW_COOKIE, PREVIEW_TOKEN, {
+      httpOnly: true,
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 24 * 30, // 30 days
+      path: '/',
+    })
+    return res
+  }
+
+  // Valid cookie — pass through
+  if (req.cookies.get(PREVIEW_COOKIE)?.value === PREVIEW_TOKEN) return null
+
+  // No access — redirect to coming soon
+  return NextResponse.redirect(new URL('/coming-soon', req.url))
+}
 
 export default clerkMiddleware(async (auth, req) => {
+  const gate = comingSoonGate(req)
+  if (gate) return gate
+
   if (isPublicRoute(req)) return
 
   const { userId } = await auth()
@@ -19,12 +54,7 @@ export default clerkMiddleware(async (auth, req) => {
     return NextResponse.redirect(new URL('/sign-in', req.url))
   }
 
-  // Admin API routes: authN confirmed above. AuthZ (role check) is handled
-  // per-handler via requireAdmin() in lib/supabase/guards.ts.
   if (isAdminApiRoute(req)) return
-
-  // Admin page routes: authN confirmed above. AuthZ (role check + redirect)
-  // is handled by app/(dashboard)/admin/layout.tsx.
   if (isAdminPageRoute(req)) return
 })
 

--- a/supabase/migrations/20260504000000_waiting_list.sql
+++ b/supabase/migrations/20260504000000_waiting_list.sql
@@ -1,0 +1,11 @@
+-- waiting_list: email capture for launch notifications
+CREATE TABLE public.waiting_list (
+  id         uuid        NOT NULL DEFAULT gen_random_uuid(),
+  email      text        NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT waiting_list_pkey PRIMARY KEY (id),
+  CONSTRAINT waiting_list_email_key UNIQUE (email)
+);
+
+-- No RLS — only accessible via service role from the API route
+ALTER TABLE public.waiting_list DISABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Closes #255

## What
- Coming soon gate in `proxy.ts` — all traffic redirected to `/coming-soon` until preview cookie is set
- Preview bypass: `www.teamenjoyvd.com?preview=itypoonpurpoise` sets a 30-day cookie
- `/coming-soon` page — logo, heading, email capture form
- `POST /api/waiting-list` — inserts email to Supabase, fires confirmation via Resend
- `waiting_list` table on prod DB (migration applied)

## To launch
Remove the gate by setting `COMING_SOON_ENABLED = false` in `proxy.ts`, or revert this PR entirely.

## Session State
**Status:** DONE
**Completed:**
- [x] Migration applied to prod
- [x] All four files pushed to branch
- [x] PR opened
**Next:** Merge to main to activate the gate
