### PR TITLE
hotfix: exempt coming-soon from Clerk to prevent redirect loop

### DIFF
--- a/app/api/waiting-list/route.ts
+++ b/app/api/waiting-list/route.ts
@@ -1,11 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
 import { NextResponse } from 'next/server'
 import { Resend } from 'resend'
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-)
+import { createServiceClient } from '@/lib/supabase/service'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
@@ -16,6 +11,8 @@ export async function POST(req: Request) {
     if (!email || typeof email !== 'string' || !email.includes('@')) {
       return NextResponse.json({ error: 'Invalid email' }, { status: 400 })
     }
+
+    const supabase = createServiceClient()
 
     const { error } = await supabase
       .from('waiting_list')

--- a/proxy.ts
+++ b/proxy.ts
@@ -14,8 +14,6 @@ const isWebhookRoute = createRouteMatcher(['/api/webhooks/(.*)', '/api/waiting-l
 
 function comingSoonGate(req: NextRequest): NextResponse | null {
   if (!COMING_SOON_ENABLED) return null
-  if (isComingSoonRoute(req)) return null
-  if (isWebhookRoute(req)) return null
 
   // Grant access via query param — set cookie and redirect to homepage
   const url = req.nextUrl
@@ -38,6 +36,9 @@ function comingSoonGate(req: NextRequest): NextResponse | null {
 }
 
 export default clerkMiddleware(async (auth, req) => {
+  // Fully exempt from Clerk — must return before auth() to prevent redirect loops
+  if (isComingSoonRoute(req) || isWebhookRoute(req)) return NextResponse.next()
+
   const gate = comingSoonGate(req)
   if (gate) return gate
 

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -258,34 +258,85 @@ export type Database = {
           },
         ]
       }
+      event_share_links: {
+        Row: {
+          click_count: number
+          created_at: string
+          event_id: string
+          id: string
+          profile_id: string
+          share_method: string
+          token: string
+        }
+        Insert: {
+          click_count?: number
+          created_at?: string
+          event_id: string
+          id?: string
+          profile_id: string
+          share_method: string
+          token: string
+        }
+        Update: {
+          click_count?: number
+          created_at?: string
+          event_id?: string
+          id?: string
+          profile_id?: string
+          share_method?: string
+          token?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "event_share_links_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "calendar_events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "event_share_links_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       guest_registrations: {
         Row: {
+          attended_at: string | null
           created_at: string
           email: string
           event_id: string
           expires_at: string
           id: string
           name: string
+          share_link_id: string | null
           status: Database["public"]["Enums"]["guest_registration_status"]
           token: string
         }
         Insert: {
+          attended_at?: string | null
           created_at?: string
           email: string
           event_id: string
           expires_at: string
           id?: string
           name: string
+          share_link_id?: string | null
           status?: Database["public"]["Enums"]["guest_registration_status"]
           token: string
         }
         Update: {
+          attended_at?: string | null
           created_at?: string
           email?: string
           event_id?: string
           expires_at?: string
           id?: string
           name?: string
+          share_link_id?: string | null
           status?: Database["public"]["Enums"]["guest_registration_status"]
           token?: string
         }
@@ -295,6 +346,13 @@ export type Database = {
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "calendar_events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "guest_registrations_share_link_id_fkey"
+            columns: ["share_link_id"]
+            isOneToOne: false
+            referencedRelation: "event_share_links"
             referencedColumns: ["id"]
           },
         ]
@@ -1170,6 +1228,24 @@ export type Database = {
           is_active?: boolean
           label?: string | null
           sort_order?: number
+        }
+        Relationships: []
+      }
+      waiting_list: {
+        Row: {
+          created_at: string
+          email: string
+          id: string
+        }
+        Insert: {
+          created_at?: string
+          email: string
+          id?: string
+        }
+        Update: {
+          created_at?: string
+          email?: string
+          id?: string
         }
         Relationships: []
       }


### PR DESCRIPTION
Fixes redirect loop on `/coming-soon` introduced in #256.

`/coming-soon` and `/api/waiting-list` were being passed through the gate correctly but Clerk's auth check was then intercepting unauthenticated requests and redirecting to `/sign-in` — which the gate re-intercepted back to `/coming-soon`. Loop.

Fix: return `NextResponse.next()` for these routes before `auth()` is ever called.