### PR TITLE
[2505-CHORE-258] fix: read role from profile query not Clerk publicMetadata

### DIFF
--- a/components/layout/UserDropdown.tsx
+++ b/components/layout/UserDropdown.tsx
@@ -21,12 +21,24 @@ const ROLE_LABELS: Record<string, string> = {
   guest:  'Guest',
 }
 
+type VerRequest = {
+  id: string
+  claimed_abo: string
+  claimed_upline_abo: string
+  status: string
+  admin_note: string | null
+  created_at: string
+  request_type: string
+} | null
+
 type ProfileData = {
   id: string
   first_name: string
   last_name: string
   role: string
   abo_number: string | null
+  upline: { upline_name: string | null; upline_abo_number: string | null } | null
+  verRequest: VerRequest
 }
 
 export default function UserDropdown() {
@@ -51,19 +63,9 @@ export default function UserDropdown() {
   const initials  = `${firstName[0] ?? ''}${lastName[0] ?? ''}`.toUpperCase() || '?'
   const fullName  = `${firstName} ${lastName}`.trim() || 'Member'
 
-  const { data: uplineData } = useQuery<{ upline_name: string | null }>({
-    queryKey: ['profile-upline'],
-    queryFn: () => fetch('/api/profile/upline').then(r => r.json()),
-    staleTime: 5 * 60 * 1000,
-  })
+  const uplineName = profileData?.upline?.upline_name ?? null
 
-  const { data: verRequest } = useQuery<{ status: string } | null>({
-    queryKey: ['verify-abo'],
-    queryFn: () => fetch('/api/profile/verify-abo').then(r => r.json()),
-    enabled: role === 'guest',
-    staleTime: 5 * 60 * 1000,
-  })
-
+  const verRequest = profileData?.verRequest ?? null
   const isUnverified = role === 'guest' &&
     !!verRequest &&
     (verRequest.status === 'pending' || verRequest.status === 'denied')
@@ -104,10 +106,10 @@ export default function UserDropdown() {
               </span>
             </div>
           </div>
-          {uplineData?.upline_name && (
+          {uplineName && (
             <p className="text-xs mt-3" style={{ color: 'var(--text-secondary)' }}>
               <span className="font-medium">Upline</span>{' '}
-              {uplineData.upline_name}
+              {uplineName}
             </p>
           )}
         </div>

--- a/components/layout/UserDropdown.tsx
+++ b/components/layout/UserDropdown.tsx
@@ -36,14 +36,15 @@ export default function UserDropdown() {
   const { theme, mounted: themeMounted, toggle: toggleTheme } = useTheme()
   const [open, setOpen] = useState(false)
 
-  const role = (user?.publicMetadata?.role as string) ?? 'guest'
-  const isAdmin = role === 'admin'
-
   const { data: profileData } = useQuery<ProfileData>({
     queryKey: ['profile'],
     queryFn: () => fetch('/api/profile').then(r => r.json()),
     staleTime: 5 * 60 * 1000,
   })
+
+  // Role sourced from DB via profile query — single source of truth
+  const role = profileData?.role ?? 'guest'
+  const isAdmin = role === 'admin'
 
   const firstName = profileData?.first_name || user?.firstName || ''
   const lastName  = profileData?.last_name  || user?.lastName  || ''


### PR DESCRIPTION
Closes #258

## What
Single line change: `role` now derived from `profileData?.role` (DB via existing React Query fetch) instead of `user?.publicMetadata?.role` (Clerk).

## Why
Clerk `publicMetadata` is not kept in sync when role changes in the DB. The profile query is already in flight — using it eliminates the second source of truth entirely. No Clerk sync logic needed anywhere.
