### PR TITLE
[2505-FEAT-264] Admin calendar sync button

### DIFF
--- a/app/admin/calendar/components/AdminCalendarClient.tsx
+++ b/app/admin/calendar/components/AdminCalendarClient.tsx
@@ -28,7 +28,6 @@ type CalEvent = {
 
 type TimeScope = 'upcoming' | 'past' | 'all'
 type CategoryFilter = 'All' | 'N21' | 'Personal'
-type SyncStatus = 'idle' | 'pending' | 'success' | 'error'
 
 export default function AdminCalendarClient() {
   const qc = useQueryClient()
@@ -37,7 +36,6 @@ export default function AdminCalendarClient() {
   const [editing, setEditing] = useState<CalEvent | null>(null)
   const [form, setForm] = useState<EventFormState>(emptyForm())
   const [formError, setFormError] = useState<string | null>(null)
-  const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle')
 
   // ── Filter state ─────────────────────────────────────────────────────────────────────
   const [search, setSearch] = useState('')
@@ -91,19 +89,20 @@ export default function AdminCalendarClient() {
     })
   }, [events, search, categoryFilter, timeScope, monthFilter])
 
-  async function handleSync() {
-    setSyncStatus('pending')
-    try {
+  const syncMutation = useMutation({
+    mutationFn: async () => {
       const res = await fetch('/api/admin/calendar-sync', { method: 'POST' })
-      if (!res.ok) throw new Error('sync failed')
-      await qc.invalidateQueries({ queryKey: ['admin-calendar'] })
-      setSyncStatus('success')
-      setTimeout(() => setSyncStatus('idle'), 2000)
-    } catch {
-      setSyncStatus('error')
-      setTimeout(() => setSyncStatus('idle'), 2000)
-    }
-  }
+      if (!res.ok) throw new Error('Failed to sync calendar')
+      return res.json()
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin-calendar'] })
+      setTimeout(() => syncMutation.reset(), 2000)
+    },
+    onError: () => {
+      setTimeout(() => syncMutation.reset(), 2000)
+    },
+  })
 
   const createMutation = useMutation({
     mutationFn: (body: EventFormState) =>
@@ -188,19 +187,19 @@ export default function AdminCalendarClient() {
         </div>
         <div className="flex items-center gap-2">
           <button
-            onClick={handleSync}
-            disabled={syncStatus === 'pending'}
+            onClick={() => syncMutation.mutate()}
+            disabled={syncMutation.status !== 'idle'}
             aria-label="Sync calendar"
             className="p-2 rounded-xl border transition-colors disabled:opacity-40"
             style={{
-              borderColor: syncStatus === 'error' ? 'var(--brand-crimson)' : 'var(--border-default)',
-              color: syncStatus === 'error' ? 'var(--brand-crimson)' : syncStatus === 'success' ? 'var(--brand-forest)' : 'var(--text-secondary)',
+              borderColor: syncMutation.isError ? 'var(--brand-crimson)' : 'var(--border-default)',
+              color: syncMutation.isError ? 'var(--brand-crimson)' : syncMutation.isSuccess ? 'var(--brand-forest)' : 'var(--text-secondary)',
               backgroundColor: 'var(--bg-card)',
             }}
           >
             <RefreshCw
               size={15}
-              className={syncStatus === 'pending' ? 'animate-spin' : ''}
+              className={syncMutation.isPending ? 'animate-spin' : ''}
             />
           </button>
           <button onClick={openCreate}

--- a/app/admin/calendar/components/AdminCalendarClient.tsx
+++ b/app/admin/calendar/components/AdminCalendarClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useMemo } from 'react'
+import { RefreshCw } from 'lucide-react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { formatDateTime, toSofiaLocalInput } from '@/lib/format'
 import { Drawer } from '@/components/ui/drawer'
@@ -27,6 +28,7 @@ type CalEvent = {
 
 type TimeScope = 'upcoming' | 'past' | 'all'
 type CategoryFilter = 'All' | 'N21' | 'Personal'
+type SyncStatus = 'idle' | 'pending' | 'success' | 'error'
 
 export default function AdminCalendarClient() {
   const qc = useQueryClient()
@@ -35,6 +37,7 @@ export default function AdminCalendarClient() {
   const [editing, setEditing] = useState<CalEvent | null>(null)
   const [form, setForm] = useState<EventFormState>(emptyForm())
   const [formError, setFormError] = useState<string | null>(null)
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle')
 
   // ── Filter state ─────────────────────────────────────────────────────────────────────
   const [search, setSearch] = useState('')
@@ -87,6 +90,20 @@ export default function AdminCalendarClient() {
       return true
     })
   }, [events, search, categoryFilter, timeScope, monthFilter])
+
+  async function handleSync() {
+    setSyncStatus('pending')
+    try {
+      const res = await fetch('/api/admin/calendar-sync', { method: 'POST' })
+      if (!res.ok) throw new Error('sync failed')
+      await qc.invalidateQueries({ queryKey: ['admin-calendar'] })
+      setSyncStatus('success')
+      setTimeout(() => setSyncStatus('idle'), 2000)
+    } catch {
+      setSyncStatus('error')
+      setTimeout(() => setSyncStatus('idle'), 2000)
+    }
+  }
 
   const createMutation = useMutation({
     mutationFn: (body: EventFormState) =>
@@ -169,11 +186,29 @@ export default function AdminCalendarClient() {
             {t('admin.calendar.pageDesc')}
           </p>
         </div>
-        <button onClick={openCreate}
-          className="px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
-          style={{ backgroundColor: 'var(--brand-crimson)' }}>
-          {t('admin.calendar.btn.new')}
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleSync}
+            disabled={syncStatus === 'pending'}
+            aria-label="Sync calendar"
+            className="p-2 rounded-xl border transition-colors disabled:opacity-40"
+            style={{
+              borderColor: syncStatus === 'error' ? 'var(--brand-crimson)' : 'var(--border-default)',
+              color: syncStatus === 'error' ? 'var(--brand-crimson)' : syncStatus === 'success' ? 'var(--brand-forest)' : 'var(--text-secondary)',
+              backgroundColor: 'var(--bg-card)',
+            }}
+          >
+            <RefreshCw
+              size={15}
+              className={syncStatus === 'pending' ? 'animate-spin' : ''}
+            />
+          </button>
+          <button onClick={openCreate}
+            className="px-4 py-2 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
+            style={{ backgroundColor: 'var(--brand-crimson)' }}>
+            {t('admin.calendar.btn.new')}
+          </button>
+        </div>
       </div>
 
       {/* ── Filter bar ──────────────────────────────────────────────────────────────────── */}


### PR DESCRIPTION
## Summary
Adds a `RefreshCw` icon button next to the "New event" button in the admin calendar header. Clicking it POSTs to `/api/admin/calendar-sync`, spins while pending, invalidates the `['admin-calendar']` query on success, and briefly tints red on error. No translation key needed — icon only.

Closes #264

## Session State
**Status:** DONE
**Completed:**
- [x] `RefreshCw` imported from `lucide-react`
- [x] `syncStatus` state added (`'idle' | 'pending' | 'success' | 'error'`)
- [x] Icon button placed next to "New event", wired to `handleSync`
- [x] On success: query invalidated, status resets to idle after 2s
- [x] On error: icon tints crimson, resets to idle after 2s
- [x] Button disabled during pending to prevent double-fire
**Next:** Verify Vercel Preview READY, CI green