### PR TITLE
[2505-BUG-268] Calendar event visibility: fix cron overwrite and access control

### DIFF
--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -26,19 +26,9 @@ export default async function CalendarPage({
 
   const supabase = createServiceClient()
 
-  let query = supabase
-    .from('calendar_events')
-    .select('*')
-    .gte('start_time', start)
-    .lt('start_time', end)
-    .order('start_time')
-
-  if (!userId) {
-    query = query.eq('category', 'N21')
-  }
-
-  const { data: initialEvents } = await query
-
+  // Resolve the role for access_roles filtering.
+  // Unauthenticated and authenticated-but-no-profile both resolve to 'guest'.
+  let resolvedRole: string = 'guest'
   let userRole: 'admin' | 'core' | 'member' | 'guest' | null = null
   let userProfileId: string | null = null
 
@@ -49,9 +39,21 @@ export default async function CalendarPage({
       .eq('clerk_id', userId)
       .single()
 
-    userRole = (profile?.role ?? 'member') as 'admin' | 'core' | 'member' | 'guest'
-    userProfileId = profile?.id ?? null
+    if (profile) {
+      resolvedRole  = profile.role
+      userRole      = profile.role as 'admin' | 'core' | 'member' | 'guest'
+      userProfileId = profile.id
+    }
+    // no profile found: resolvedRole stays 'guest', userRole stays null
   }
+
+  const { data: initialEvents } = await supabase
+    .from('calendar_events')
+    .select('*')
+    .gte('start_time', start)
+    .lt('start_time', end)
+    .contains('access_roles', [resolvedRole])
+    .order('start_time')
 
   return (
     <CalendarClient

--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -28,7 +28,7 @@ export default async function CalendarPage({
 
   // Resolve the role for access_roles filtering.
   // Unauthenticated and authenticated-but-no-profile both resolve to 'guest'.
-  let resolvedRole: string = 'guest'
+  let resolvedRole: 'admin' | 'core' | 'member' | 'guest' = 'guest'
   let userRole: 'admin' | 'core' | 'member' | 'guest' | null = null
   let userProfileId: string | null = null
 
@@ -41,7 +41,7 @@ export default async function CalendarPage({
 
     if (profile) {
       resolvedRole  = profile.role
-      userRole      = profile.role as 'admin' | 'core' | 'member' | 'guest'
+      userRole      = profile.role
       userProfileId = profile.id
     }
     // no profile found: resolvedRole stays 'guest', userRole stays null

--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -6,7 +6,8 @@ export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const month = searchParams.get('month')
 
-  // Resolve role for filtering
+  // Resolve role for access_roles filtering.
+  // Unauthenticated and authenticated-but-no-profile both resolve to 'guest'.
   let role = 'guest'
   try {
     const { userId } = await auth()
@@ -20,9 +21,7 @@ export async function GET(req: Request) {
   let query = supabase
     .from('calendar_events')
     .select('*')
-    // Include events where access_roles contains the user's role,
-    // OR where access_roles is null (safe fallback for manually created events).
-    .or(`access_roles.cs.{${role}},access_roles.is.null`)
+    .contains('access_roles', [role])
     .order('start_time')
 
   if (month) {

--- a/supabase/functions/sync-google-calendar/index.ts
+++ b/supabase/functions/sync-google-calendar/index.ts
@@ -129,20 +129,37 @@ Deno.serve(async (req: Request) => {
     const location   = typeof item.location === 'string' && item.location ? item.location : null
 
     const {data:ex} = await sb.from('calendar_events').select('id').eq('google_event_id', item.id).maybeSingle()
-    const {error:ue} = await sb.from('calendar_events').upsert({
-      google_event_id:  item.id,
-      title:            String(item.summary ?? 'Untitled'),
-      description:      cleanDesc,
-      meeting_url:      meetingUrl,
-      location:         location,
-      start_time:       st.toISOString(),
-      end_time:         et.toISOString(),
-      category:         personal ? 'Personal' : 'N21',
-      access_roles:     personal ? ['member','core','admin'] : ['admin','core','member','guest'],
-      week_number:      isoWeek(st),
-    }, {onConflict: 'google_event_id'})
-    if (ue) errors.push(String(item.id) + ': ' + ue.message)
-    else { upserted++; if (!ex) newEvents++ }
+
+    if (!ex) {
+      // New event: full insert including category and access_roles
+      const {error:ie} = await sb.from('calendar_events').insert({
+        google_event_id:  item.id,
+        title:            String(item.summary ?? 'Untitled'),
+        description:      cleanDesc,
+        meeting_url:      meetingUrl,
+        location:         location,
+        start_time:       st.toISOString(),
+        end_time:         et.toISOString(),
+        category:         personal ? 'Personal' : 'N21',
+        access_roles:     personal ? ['member','core','admin'] : ['admin','core','member','guest'],
+        week_number:      isoWeek(st),
+      })
+      if (ie) errors.push(String(item.id) + ': ' + ie.message)
+      else { upserted++; newEvents++ }
+    } else {
+      // Existing event: update scheduling and content only — never touch category or access_roles
+      const {error:ue} = await sb.from('calendar_events').update({
+        title:       String(item.summary ?? 'Untitled'),
+        description: cleanDesc,
+        meeting_url: meetingUrl,
+        location:    location,
+        start_time:  st.toISOString(),
+        end_time:    et.toISOString(),
+        week_number: isoWeek(st),
+      }).eq('google_event_id', item.id)
+      if (ue) errors.push(String(item.id) + ': ' + ue.message)
+      else upserted++
+    }
   }
 
   if (newEvents > 0) {

--- a/supabase/functions/sync-google-calendar/index.ts
+++ b/supabase/functions/sync-google-calendar/index.ts
@@ -130,33 +130,31 @@ Deno.serve(async (req: Request) => {
 
     const {data:ex} = await sb.from('calendar_events').select('id').eq('google_event_id', item.id).maybeSingle()
 
+    const eventPayload = {
+      title:       String(item.summary ?? 'Untitled'),
+      description: cleanDesc,
+      meeting_url: meetingUrl,
+      location:    location,
+      start_time:  st.toISOString(),
+      end_time:    et.toISOString(),
+      week_number: isoWeek(st),
+    }
+
     if (!ex) {
       // New event: full insert including category and access_roles
       const {error:ie} = await sb.from('calendar_events').insert({
-        google_event_id:  item.id,
-        title:            String(item.summary ?? 'Untitled'),
-        description:      cleanDesc,
-        meeting_url:      meetingUrl,
-        location:         location,
-        start_time:       st.toISOString(),
-        end_time:         et.toISOString(),
-        category:         personal ? 'Personal' : 'N21',
-        access_roles:     personal ? ['member','core','admin'] : ['admin','core','member','guest'],
-        week_number:      isoWeek(st),
+        ...eventPayload,
+        google_event_id: item.id,
+        category:        personal ? 'Personal' : 'N21',
+        access_roles:    personal ? ['member','core','admin'] : ['admin','core','member','guest'],
       })
       if (ie) errors.push(String(item.id) + ': ' + ie.message)
       else { upserted++; newEvents++ }
     } else {
       // Existing event: update scheduling and content only — never touch category or access_roles
-      const {error:ue} = await sb.from('calendar_events').update({
-        title:       String(item.summary ?? 'Untitled'),
-        description: cleanDesc,
-        meeting_url: meetingUrl,
-        location:    location,
-        start_time:  st.toISOString(),
-        end_time:    et.toISOString(),
-        week_number: isoWeek(st),
-      }).eq('google_event_id', item.id)
+      const {error:ue} = await sb.from('calendar_events')
+        .update(eventPayload)
+        .eq('google_event_id', item.id)
       if (ue) errors.push(String(item.id) + ': ' + ue.message)
       else upserted++
     }


### PR DESCRIPTION
Closes #268

## Summary

Three independent bugs combined to leak Personal calendar events to guests/unauthenticated users, and allowed the sync cron to destroy manually-set access settings. All three are fixed.

### Fix A — Cron no longer overwrites `category` / `access_roles`
`sync-google-calendar/index.ts` now branches on the `ex` (existing record) check:
- **New event:** full insert including `category` and `access_roles`
- **Existing event:** updates only `title`, `description`, `meeting_url`, `location`, `start_time`, `end_time`, `week_number` — `category` and `access_roles` are never touched

### Fix B — SSR query uses `access_roles` containment filter
`app/(dashboard)/calendar/page.tsx` now resolves role first:
- Unauthenticated → `'guest'`
- Authenticated, no profile → `'guest'` (was incorrectly `'member'`)
- Authenticated, profile found → `profile.role`
- Filters with `.contains('access_roles', [resolvedRole])` — `category`-based filter removed

### Fix C — API route removes null-access hole
`app/api/calendar/route.ts` no longer includes `access_roles.is.null` in any OR clause. Filter is `.contains('access_roles', [role])` only. Safe since `seq343` backfilled all nulls and set a NOT NULL default.

## Files Changed
- `supabase/functions/sync-google-calendar/index.ts`
- `app/(dashboard)/calendar/page.tsx`
- `app/api/calendar/route.ts`

## Session State
**Status:** DONE
**Completed:**
- [x] Fix A: cron branches on `ex`, preserves `category`/`access_roles` on existing events
- [x] Fix B: SSR uses `access_roles` containment filter, guest fallback correct
- [x] Fix C: API route `access_roles.is.null` removed
- [x] PR #270 opened
- [x] Edge function deployed (version 22, ACTIVE)
**Next:** Verify Vercel Preview READY + CI green, then merge
