### PR TITLE
[2605-CHORE-272] ABO bento: consolidate to single profile query, remove redundant downstream fetches

### DIFF
--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -4,7 +4,7 @@ import { memo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { getRoleColors } from '@/lib/role-colors'
-import { type VerificationRequest, type UplineData, type Profile } from '../types'
+import { type Profile } from '../types'
 import { apiClient } from '@/lib/apiClient'
 
 type AboInfoMode = 'form' | 'pending' | 'confirmed' | 'member_manual'
@@ -17,30 +17,21 @@ export const AboInfoContent = memo(function AboInfoContent() {
   const qc = useQueryClient()
   const { t } = useLanguage()
 
-  const { data: profile } = useQuery<Profile>({
+  const { data: profile, isPending: profileIsPending } = useQuery<Profile>({
     queryKey: ['profile'],
     queryFn: () => apiClient('/api/profile'),
   })
+
   const role = profile?.role ?? 'guest'
   const aboNumber = profile?.abo_number ?? null
+  // upline and verRequest are eagerly joined by GET /api/profile
+  const uplineData = profile?.upline ?? null
+  const verRequest = profile?.verRequest ?? null
 
   const rc = getRoleColors(role)
   const [verificationMode, setVerificationMode] = useState<'standard' | 'manual'>('standard')
   const [aboInput, setAboInput] = useState('')
   const [uplineInput, setUplineInput] = useState('')
-
-  const { data: verRequest, isPending: isVerPending } = useQuery<VerificationRequest | null>({
-    queryKey: ['verify-abo'],
-    queryFn: () => apiClient('/api/profile/verify-abo'),
-    enabled: role === 'guest',
-  })
-
-  const { data: uplineData } = useQuery<UplineData>({
-    queryKey: ['profile-upline'],
-    queryFn: () => apiClient('/api/profile/upline'),
-    enabled: role !== 'guest',
-    staleTime: 10 * 60 * 1000,
-  })
 
   const submitVerification = useMutation({
     mutationFn: (params: { claimed_abo?: string; claimed_upline_abo: string; request_type: 'standard' | 'manual' }) =>
@@ -52,17 +43,19 @@ export const AboInfoContent = memo(function AboInfoContent() {
             : { claimed_abo: params.claimed_abo, claimed_upline_abo: params.claimed_upline_abo }
         ),
       }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['verify-abo'] }),
+    // ['profile'] is the single source of truth — invalidating it refetches
+    // role, abo_number, upline, and verRequest in one round-trip.
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['profile'] }),
   })
 
   const cancelVerification = useMutation({
     mutationFn: () => apiClient('/api/profile/verify-abo', { method: 'DELETE' }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['verify-abo'] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['profile'] }),
   })
 
-  // While the verify-abo query is in flight for a guest, defer mode resolution
+  // While the profile query is in flight for a guest, defer mode resolution
   // to avoid the form flashing before the pending/denied state is known.
-  if (role === 'guest' && isVerPending) {
+  if (role === 'guest' && profileIsPending) {
     return (
       <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
         <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-5 pr-16" style={{ color: 'var(--brand-crimson)' }}>

--- a/app/(dashboard)/profile/types.ts
+++ b/app/(dashboard)/profile/types.ts
@@ -22,25 +22,6 @@ export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
   document_expiring_soon: true,
 }
 
-export type Profile = {
-  id: string
-  clerk_id: string
-  first_name: string
-  last_name: string
-  abo_number: string | null
-  role: 'admin' | 'core' | 'member' | 'guest'
-  document_active_type: 'id' | 'passport'
-  id_number: string | null
-  passport_number: string | null
-  valid_through: string | null
-  display_names: Record<string, string>
-  created_at: string
-  phone: string | null
-  contact_email: string | null
-  ui_prefs: UiPrefs | null
-  notification_prefs: NotificationPrefs | null
-}
-
 export type VerificationRequest = {
   id: string
   claimed_abo: string | null
@@ -54,6 +35,29 @@ export type VerificationRequest = {
 export type UplineData = {
   upline_name: string | null
   upline_abo_number: string | null
+}
+
+export type Profile = {
+  id: string
+  clerk_id: string
+  first_name: string
+  last_name: string
+  abo_number: string | null
+  upline_abo_number: string | null
+  role: 'admin' | 'core' | 'member' | 'guest'
+  document_active_type: 'id' | 'passport'
+  id_number: string | null
+  passport_number: string | null
+  valid_through: string | null
+  display_names: Record<string, string>
+  created_at: string
+  phone: string | null
+  contact_email: string | null
+  ui_prefs: UiPrefs | null
+  notification_prefs: NotificationPrefs | null
+  // Eagerly joined by GET /api/profile — null when not applicable
+  upline: UplineData | null
+  verRequest: VerificationRequest | null
 }
 
 export type TripPayment = {

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -23,10 +23,14 @@ export async function GET() {
   // Extract scalars before Promise.all — TS cannot narrow property accesses
   // through IIFE closure boundaries, so we capture as typed consts here.
   const aboNumber: string | null = data.abo_number
+  const uplineAboNumber: string | null = data.upline_abo_number ?? null
   const profileId: string = data.id
   const role: string = data.role
 
   const [upline, verRequest] = await Promise.all([
+    // Resolve upline for any verified member.
+    // Standard path: abo_number set — look up sponsor via los_members tree.
+    // Manual path: abo_number null but upline_abo_number set — resolve name directly.
     aboNumber
       ? (async () => {
           const { data: losMember } = await supabase
@@ -50,7 +54,21 @@ export async function GET() {
             upline_abo_number: uplineMember?.abo_number ?? null,
           }
         })()
-      : Promise.resolve(null),
+      : uplineAboNumber
+        ? (async () => {
+            // Manual path: upline ABO already known, just resolve the name
+            const { data: uplineMember } = await supabase
+              .from('los_members')
+              .select('abo_number, name')
+              .eq('abo_number', uplineAboNumber)
+              .single()
+
+            return {
+              upline_name: uplineMember?.name ?? null,
+              upline_abo_number: uplineMember?.abo_number ?? uplineAboNumber,
+            }
+          })()
+        : Promise.resolve(null),
     role === 'guest'
       ? (async () => {
           const { data: req } = await supabase


### PR DESCRIPTION
## Summary

`AboInfoContent` was firing three separate React Query fetches (`['profile']`, `['verify-abo']`, `['profile-upline']`) for data that `GET /api/profile` already returns in a single response. Any mutation had to invalidate all three cache keys in sync — it didn't, causing stale ABO/upline display after verification actions.

This PR collapses to a single cache key. The profile route is also extended to cover the manual-path upline resolution (previously null for members with `abo_number: null` but `upline_abo_number` set).

## Changes

**`app/api/profile/route.ts`**
- Extended inline `upline` fetch: if `abo_number` is null but `upline_abo_number` is set, resolve upline name directly from `los_members` (manual path, mirrors `/api/profile/upline`)

**`app/(dashboard)/profile/components/AboInfoContent.tsx`**
- Removed `['verify-abo']` and `['profile-upline']` queries entirely
- `verRequest` and `uplineData` now read from `profile.verRequest` and `profile.upline`
- `submitVerification.onSuccess` and `cancelVerification.onSuccess` invalidate `['profile']` only
- `isVerPending` guard replaced with `profileIsPending` from the `['profile']` query

**`app/(dashboard)/profile/types.ts`**
- `Profile` type extended with `upline: UplineData | null` and `verRequest: VerificationRequest | null`
- `upline_abo_number: string | null` added to `Profile` (was missing)

## Verification

- [x] Standard-path member (`abo_number` set): confirmed view renders ABO + upline correctly
- [x] Manual-path member (`abo_number` null, `upline_abo_number` set): upline now resolves via profile route manual path
- [x] Guest flows (form / pending / denied / cancel / resubmit): all read from `profile.verRequest`, invalidate `['profile']` on mutation
- [x] Loading guard uses `profileIsPending` — no flash of form before pending state known
- [x] No new translation keys required
- [x] No migrations — pure app-layer change

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] All three files committed to branch
- [x] PR opened
**Next:** CI green + Vercel preview READY → GCR → mark DONE

Closes #272
