### PR TITLE
[2605-FEAT-275] Invites bento preview + full-page detail

### DIFF
--- a/app/(dashboard)/profile/components/InvitesBento.tsx
+++ b/app/(dashboard)/profile/components/InvitesBento.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { apiClient } from '@/lib/apiClient'
 
@@ -24,20 +24,28 @@ type ApiResponse = { links: ShareLink[]; total: number }
 
 export function InvitesBento() {
   const { t } = useLanguage()
-  const router = useRouter()
 
   const { data, isLoading } = useQuery<ApiResponse>({
     queryKey: ['invites'],
     queryFn:  () => apiClient('/api/profile/event-shares'),
   })
 
-  const totalLinks  = data?.links.length ?? 0
-  const totalGuests = data?.links.reduce((acc, l) => acc + l.guests.length, 0) ?? 0
-  const confirmed   = data?.links.reduce((acc, l) => acc + l.guests.filter(g => g.status === 'confirmed' || !!g.attended_at).length, 0) ?? 0
-  const attended    = data?.links.reduce((acc, l) => acc + l.guests.filter(g => !!g.attended_at).length, 0) ?? 0
+  const totalLinks = data?.links?.length ?? 0
+  const { totalGuests, confirmed, attended } = (data?.links ?? []).reduce(
+    (acc, link) => {
+      acc.totalGuests += link.guests.length
+      link.guests.forEach((g) => {
+        const isAttended = !!g.attended_at
+        if (isAttended) acc.attended++
+        if (isAttended || g.status === 'confirmed') acc.confirmed++
+      })
+      return acc
+    },
+    { totalGuests: 0, confirmed: 0, attended: 0 },
+  )
 
   const stats: { label: string; value: number }[] = [
-    { label: t('profile.invites.statLinks'),    value: totalLinks  },
+    { label: t('profile.invites.statLinks'),     value: totalLinks  },
     { label: t('profile.invites.registrations'), value: totalGuests },
     { label: t('profile.invites.confirmed'),     value: confirmed   },
     { label: t('profile.invites.attended'),      value: attended    },
@@ -81,13 +89,13 @@ export function InvitesBento() {
       )}
 
       {/* CTA */}
-      <button
-        onClick={() => router.push('/profile/invites')}
-        className="mt-auto text-xs font-semibold px-3 py-2 rounded-xl transition-opacity hover:opacity-70 text-left"
+      <Link
+        href="/profile/invites"
+        className="mt-auto text-xs font-semibold px-3 py-2 rounded-xl transition-opacity hover:opacity-70 text-left block"
         style={{ backgroundColor: 'rgba(0,0,0,0.05)', color: 'var(--text-primary)' }}
       >
         {t('profile.invites.viewAll')} →
-      </button>
+      </Link>
     </div>
   )
 }

--- a/app/(dashboard)/profile/components/InvitesBento.tsx
+++ b/app/(dashboard)/profile/components/InvitesBento.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { useLanguage } from '@/lib/hooks/useLanguage'
+import { apiClient } from '@/lib/apiClient'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type GuestRow = {
+  id:          string
+  attended_at: string | null
+  status:      string
+}
+
+type ShareLink = {
+  id:     string
+  guests: GuestRow[]
+}
+
+type ApiResponse = { links: ShareLink[]; total: number }
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function InvitesBento() {
+  const { t } = useLanguage()
+  const router = useRouter()
+
+  const { data, isLoading } = useQuery<ApiResponse>({
+    queryKey: ['invites'],
+    queryFn:  () => apiClient('/api/profile/event-shares'),
+  })
+
+  const totalLinks  = data?.links.length ?? 0
+  const totalGuests = data?.links.reduce((acc, l) => acc + l.guests.length, 0) ?? 0
+  const confirmed   = data?.links.reduce((acc, l) => acc + l.guests.filter(g => g.status === 'confirmed' || !!g.attended_at).length, 0) ?? 0
+  const attended    = data?.links.reduce((acc, l) => acc + l.guests.filter(g => !!g.attended_at).length, 0) ?? 0
+
+  const stats: { label: string; value: number }[] = [
+    { label: t('profile.invites.statLinks'),    value: totalLinks  },
+    { label: t('profile.invites.registrations'), value: totalGuests },
+    { label: t('profile.invites.confirmed'),     value: confirmed   },
+    { label: t('profile.invites.attended'),      value: attended    },
+  ]
+
+  return (
+    <div className="p-4 flex flex-col gap-4 h-full">
+      {/* Header */}
+      <p className="text-[10px] font-semibold tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>
+        {t('profile.bento.invites')}
+      </p>
+
+      {/* Stat chips */}
+      {isLoading ? (
+        <div className="grid grid-cols-2 gap-2">
+          {[...Array(4)].map((_, i) => (
+            <div
+              key={i}
+              className="h-14 rounded-xl animate-pulse"
+              style={{ backgroundColor: 'rgba(0,0,0,0.06)' }}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-2">
+          {stats.map(({ label, value }) => (
+            <div
+              key={label}
+              className="rounded-xl px-3 py-2 flex flex-col gap-0.5"
+              style={{ backgroundColor: 'rgba(0,0,0,0.04)' }}
+            >
+              <span className="text-xl font-bold tabular-nums" style={{ color: 'var(--text-primary)' }}>
+                {value}
+              </span>
+              <span className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>
+                {label}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* CTA */}
+      <button
+        onClick={() => router.push('/profile/invites')}
+        className="mt-auto text-xs font-semibold px-3 py-2 rounded-xl transition-opacity hover:opacity-70 text-left"
+        style={{ backgroundColor: 'rgba(0,0,0,0.05)', color: 'var(--text-primary)' }}
+      >
+        {t('profile.invites.viewAll')} →
+      </button>
+    </div>
+  )
+}

--- a/app/(dashboard)/profile/components/ProfileClient.tsx
+++ b/app/(dashboard)/profile/components/ProfileClient.tsx
@@ -30,7 +30,7 @@ import { CalendarSection, CALENDAR_MIN_HEIGHT } from './CalendarSection'
 import { StatsSection, STATS_MIN_HEIGHT } from './StatsSection'
 import { AdminSection } from './AdminSection'
 import { EmailPrefsSection, EMAIL_PREFS_MIN_HEIGHT } from './EmailPrefsSection'
-import { InvitesSection, INVITES_MIN_HEIGHT } from './InvitesSection'
+import { InvitesBento } from './InvitesBento'
 import { type Profile } from '../types'
 import { apiClient } from '@/lib/apiClient'
 
@@ -225,8 +225,8 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
       node: <StatsSection role={role} aboNumber={aboNumber} />,
     } : null,
     [BENTO_IDS.INVITES]: hasInvites ? {
-      colSpan: 12, minHeight: INVITES_MIN_HEIGHT,
-      node: <InvitesSection />,
+      colSpan: 6, minHeight: BENTO_HEIGHT.M,
+      node: <InvitesBento />,
     } : null,
     [BENTO_IDS.ADMIN]: isAdmin ? {
       colSpan: 6, minHeight: BENTO_HEIGHT.S,

--- a/app/(dashboard)/profile/invites/page.tsx
+++ b/app/(dashboard)/profile/invites/page.tsx
@@ -1,0 +1,67 @@
+import { auth } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { InvitesSection } from '../components/InvitesSection'
+
+export default async function ProfileInvitesPage() {
+  const { userId } = await auth()
+  if (!userId) redirect('/sign-in')
+
+  return (
+    <div className="py-8 pb-16">
+
+      {/* ════════════════════════════════════════════════════════════════════
+          DESKTOP layout (md+)
+          Single centred column, max-w-[1280px]
+          ════════════════════════════════════════════════════════════════════ */}
+      <div className="hidden md:block max-w-[1280px] mx-auto px-6 xl:px-8">
+        {/* Back link */}
+        <Link
+          href="/profile"
+          className="inline-flex items-center gap-1 text-xs font-semibold mb-5 hover:opacity-70 transition-opacity"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          ← Back to Profile
+        </Link>
+
+        {/* Full invites section — no bento wrapper */}
+        <div
+          className="rounded-2xl"
+          style={{
+            backgroundColor: 'var(--bg-card)',
+            border: '1px solid var(--border-default)',
+          }}
+        >
+          <InvitesSection />
+        </div>
+      </div>
+
+      {/* ════════════════════════════════════════════════════════════════════
+          MOBILE layout (< md)
+          Full-width, no horizontal padding on the card
+          ════════════════════════════════════════════════════════════════════ */}
+      <div className="md:hidden flex flex-col gap-3 px-4">
+        {/* Back link */}
+        <Link
+          href="/profile"
+          className="inline-flex items-center gap-1 text-xs font-semibold hover:opacity-70 transition-opacity"
+          style={{ color: 'var(--text-secondary)' }}
+        >
+          ← Back to Profile
+        </Link>
+
+        {/* Full invites section */}
+        <div
+          className="rounded-2xl overflow-hidden"
+          style={{
+            backgroundColor: 'var(--bg-card)',
+            border: '1px solid var(--border-default)',
+          }}
+        >
+          <InvitesSection />
+        </div>
+      </div>
+
+    </div>
+  )
+}

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -150,4 +150,7 @@ export const profile = {
   'profile.invites.via':                  { en: 'via',                        bg: 'чрез'                                 },
   'profile.invites.direct':               { en: 'Direct',                     bg: 'Директно'                             },
   'profile.invites.registrations.tab':    { en: 'Registrations',              bg: 'Регистрации'                          },
+  // InvitesBento
+  'profile.invites.statLinks':            { en: 'invite links',               bg: 'покани'                               },
+  'profile.invites.viewAll':              { en: 'View all invites',           bg: 'Виж всички покани'                    },
 } as const


### PR DESCRIPTION
## Summary

Splits the My Invites surface into two: a compact bento preview tile on `/profile` and a dedicated full-page view at `/profile/invites`.

**Root cause:** `InvitesSection` had `colSpan: 12`, breaking the 12-col bento grid. All other tiles are `colSpan: 6`. The full filter controls were also crammed into a bento tile — a content-in-container mismatch.

## Changes

- **`InvitesBento`** (new) — `colSpan: 6` preview tile. Reads from the shared `['invites']` React Query key. Derives 4 aggregate stats client-side (links, registrations, confirmed, attended). "View all invites →" navigates to `/profile/invites`. Loading state: 4 skeleton chips.
- **`ProfileClient`** — swaps `InvitesSection` → `InvitesBento`, changes `colSpan: 12` → `colSpan: 6`.
- **`/profile/invites/page.tsx`** (new) — RSC auth guard + redirect. Two explicit layouts (desktop / mobile). Renders `InvitesSection` directly — no new wrapper, no logic changes to the section itself.
- **`lib/i18n/domains/profile.ts`** — adds `profile.invites.statLinks` and `profile.invites.viewAll` (EN + BG).

No new API route. No new React Query key. `InvitesSection` is unchanged.

## Session State

**Status:** DONE
**Completed:**
- [x] `InvitesBento.tsx` created, `colSpan: 6`, shared query key
- [x] `ProfileClient.tsx` swapped, `colSpan: 12` → `6`
- [x] `/profile/invites/page.tsx` created, dual layout, auth guard
- [x] Two new i18n keys added (EN + BG)
**Next:** CI green + Vercel preview READY → merge

Closes #275