### PR TITLE
[2605-BUG-291] fix: fall back to LOS name when profile first/last name is empty

### DIFF
--- a/app/admin/members/components/MembersTable.tsx
+++ b/app/admin/members/components/MembersTable.tsx
@@ -33,6 +33,18 @@ function formatNum(n: number) {
   return numberFormatter.format(n)
 }
 
+/**
+ * Resolves the display name for a LOS member.
+ * Priority: profile name (if non-empty) → los_members.name → abo_number
+ * LOS is the single source of truth when the user has not filled in their profile.
+ */
+function resolveDisplayName(m: LOSMember): string {
+  const profileName = m.profile
+    ? `${m.profile.first_name} ${m.profile.last_name}`.trim()
+    : ''
+  return profileName || m.name || m.abo_number
+}
+
 const LEVEL_BG: Record<string, { bg: string; color: string }> = {
   '1': { bg: 'var(--brand-forest)', color: 'white' },
   '2': { bg: 'var(--brand-crimson)', color: 'white' },
@@ -72,9 +84,7 @@ export function MembersTable({
   }, [])
 
   const columns = useMemo(() => [
-    colHelper.accessor(row => row.profile
-      ? `${row.profile.first_name} ${row.profile.last_name}`
-      : (row.name ?? row.abo_number), {
+    colHelper.accessor(row => resolveDisplayName(row), {
       id: 'name',
       header: t('admin.members.table.name'),
       enableSorting: true,
@@ -89,7 +99,7 @@ export function MembersTable({
               style={{ backgroundColor: lc.bg, color: lc.color }}>{lvl}</span>
             <div className="min-w-0">
               <p className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
-                {m.profile ? `${m.profile.first_name} ${m.profile.last_name}` : (m.name ?? '—')}
+                {resolveDisplayName(m)}
               </p>
             </div>
             {m.profile && profileRc && (
@@ -205,9 +215,7 @@ export function MembersTable({
     globalFilterFn: (row, _colId, filterValue: unknown) => {
       const q = typeof filterValue === 'string' ? filterValue.toLowerCase() : ''
       const m = row.original
-      const name = m.profile
-        ? `${m.profile.first_name} ${m.profile.last_name}`.toLowerCase()
-        : (m.name ?? '').toLowerCase()
+      const name = resolveDisplayName(m).toLowerCase()
       return name.includes(q) || m.abo_number.toLowerCase().includes(q)
     },
     initialState: { pagination: { pageSize: 25 } },

--- a/app/admin/members/components/MembersTable.tsx
+++ b/app/admin/members/components/MembersTable.tsx
@@ -35,14 +35,14 @@ function formatNum(n: number) {
 
 /**
  * Resolves the display name for a LOS member.
- * Priority: profile name (if non-empty) → los_members.name → abo_number
+ * Priority: profile name (if non-empty) → los_members.name → —
  * LOS is the single source of truth when the user has not filled in their profile.
  */
 function resolveDisplayName(m: LOSMember): string {
   const profileName = m.profile
     ? `${m.profile.first_name} ${m.profile.last_name}`.trim()
     : ''
-  return profileName || m.name || m.abo_number
+  return profileName || m.name || '—'
 }
 
 const LEVEL_BG: Record<string, { bg: string; color: string }> = {
@@ -88,7 +88,7 @@ export function MembersTable({
       id: 'name',
       header: t('admin.members.table.name'),
       enableSorting: true,
-      cell: ({ row }) => {
+      cell: ({ row, getValue }) => {
         const m = row.original
         const lvl = m.abo_level ?? '?'
         const lc = LEVEL_BG[lvl] ?? LEVEL_BG['3']
@@ -99,7 +99,7 @@ export function MembersTable({
               style={{ backgroundColor: lc.bg, color: lc.color }}>{lvl}</span>
             <div className="min-w-0">
               <p className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
-                {resolveDisplayName(m)}
+                {getValue()}
               </p>
             </div>
             {m.profile && profileRc && (


### PR DESCRIPTION
## Summary\n\nFixes #291\n\nMembers with a portal profile but empty `first_name`/`last_name` showed a blank name in `/admin/members?tab=members`. LOS is the single source of truth for name data until the user fills in their profile.\n\n## Change\n\nIntroduced `resolveDisplayName(m: LOSMember)` helper:\n\n```ts\nfunction resolveDisplayName(m: LOSMember): string {\n  const profileName = m.profile\n    ? `${m.profile.first_name} ${m.profile.last_name}`.trim()\n    : ''\n  return profileName || m.name || m.abo_number\n}\n```\n\nApplied in 3 places in `MembersTable.tsx`:\n- Column accessor (sort key)\n- Cell render\n- `globalFilterFn` (search)\n\n## Files Changed\n\n- `app/admin/members/components/MembersTable.tsx`\n\nNo migration. No API change. No new i18n keys.