### PR TITLE
[2605-FEAT-280] fix: address Gemini PR#294 review comments

### DIFF
--- a/app/(dashboard)/components/tiles/ProfileTile.tsx
+++ b/app/(dashboard)/components/tiles/ProfileTile.tsx
@@ -12,7 +12,7 @@ type VerifRequest = { status: 'pending' | 'approved' | 'denied' } | null
 type Upline = { upline_name: string | null; upline_abo_number: string | null } | null
 type Profile = {
   role: string
-  first_name: string
+  first_name: string | null
   last_name: string | null
   display_names: Record<string, string> | null
   abo_number: string | null
@@ -66,8 +66,8 @@ export default function ProfileTile({
   // Guard empty strings from DB with || null (not ??) — DB defaults to '' not null.
   const enFirst = user?.firstName || profile?.first_name || null
   const enLast  = user?.lastName  || profile?.last_name  || null
-  const bgFirst = (profile?.display_names?.['bg_first'] || null) as string | null
-  const bgLast  = (profile?.display_names?.['bg_last']  || null) as string | null
+  const bgFirst = profile?.display_names?.['bg_first'] || null
+  const bgLast  = profile?.display_names?.['bg_last']  || null
 
   const displayName: string | null = lang === 'bg'
     ? (bgFirst ?? bgLast ?? enFirst ?? enLast)


### PR DESCRIPTION
# GCR follow-up — PR #294\n\n## Changes\n\nTwo MEDIUM Gemini comments applied. One skipped.\n\n## GCR Report\n\n| # | Comment | Verdict |\n|---|---|---|\n| 1 | `first_name: string` → `string \| null` for type consistency with `last_name` and actual DB behaviour | ✅ Applied |\n| 2 | Remove redundant `as string \| null` casts and parens from `bgFirst`/`bgLast` derivation | ✅ Applied |\n| 3 | Localise hardcoded `\"Hey, \"` greeting prefix | ⚠️ Skipped — requires new i18n keys, out of scope per #280 DoD constraint. Belongs in a dedicated i18n ticket. |\n\n## Session State\n**Status:** DONE\n**Completed:**\n- [x] GCR findings reported\n- [x] Comments 1 + 2 applied\n- [x] Comment 3 skipped with justification\n- [x] PR opened\n**Next:** CI green → merge.">