### PR TITLE
[2505-FEAT-301] ABO co-ownership: member-facing UI (Ticket 2 of 3)

### DIFF
--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -57,8 +57,9 @@ export const AboInfoContent = memo(function AboInfoContent() {
   const { data: spouseLinkRequest } = useQuery<SpouseLinkRequest | null>({
     queryKey: ['spouseLinkRequest'],
     queryFn: () => apiClient('/api/profile/spouse-link'),
-    // Only fetch for guests with no existing primary link
-    enabled: role === 'guest' && !profile?.primary_profile_id,
+    // Guard on !!profile to avoid firing before profile loads — role defaults to
+    // 'guest' so without this the query would execute for every user on mount.
+    enabled: !!profile && role === 'guest' && !profile.primary_profile_id,
   })
 
   const submitVerification = useMutation({
@@ -339,7 +340,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
               className="mt-4 text-xs font-medium hover:underline"
               style={{ color: 'var(--text-secondary)' }}
             >
-              {t('profile.spouseLinkDesc').split('.')[0] + '?'}
+              {t('profile.spouseLinkEntryPoint')}
             </button>
           )}
         </>

--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -4,7 +4,7 @@ import { memo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { getRoleColors } from '@/lib/role-colors'
-import { type Profile } from '../types'
+import { type Profile, type SpouseLinkRequest } from '../types'
 import { apiClient } from '@/lib/apiClient'
 
 type AboInfoMode = 'form' | 'pending' | 'confirmed' | 'member_manual'
@@ -25,6 +25,7 @@ function resolveErrorMessage(
     case 'upline_mismatch':    return t('profile.error.uplineMismatch')
     case 'abo_already_claimed': return t('profile.error.aboAlreadyClaimed')
     case 'upline_not_in_los':  return t('profile.error.uplineNotInLos')
+    case 'abo_has_primary':    return t('profile.error.aboHasPrimary')
     default:                   return error
   }
 }
@@ -42,15 +43,27 @@ export const AboInfoContent = memo(function AboInfoContent() {
   const aboNumber = profile?.abo_number ?? null
   const uplineData = profile?.upline ?? null
   const verRequest = profile?.verRequest ?? null
+  const spouse = profile?.spouse ?? null
 
   const rc = getRoleColors(role)
   const [verificationMode, setVerificationMode] = useState<'standard' | 'manual'>('standard')
   const [aboInput, setAboInput] = useState('')
   const [uplineInput, setUplineInput] = useState('')
 
+  // Spouse link flow state
+  const [showSpouseLink, setShowSpouseLink] = useState(false)
+  const [spouseAboInput, setSpouseAboInput] = useState('')
+
+  const { data: spouseLinkRequest } = useQuery<SpouseLinkRequest | null>({
+    queryKey: ['spouseLinkRequest'],
+    queryFn: () => apiClient('/api/profile/spouse-link'),
+    // Only fetch for guests with no existing primary link
+    enabled: role === 'guest' && !profile?.primary_profile_id,
+  })
+
   const submitVerification = useMutation({
     mutationFn: async (params: { claimed_abo?: string; claimed_upline_abo: string; request_type: 'standard' | 'manual' }) => {
-      // Intentionally using raw fetch instead of apiClient because apiClient 
+      // Intentionally using raw fetch instead of apiClient because apiClient
       // discards the custom 'error_code' needed for i18n translation mapping.
       const res = await fetch('/api/profile/verify-abo', {
         method: 'POST',
@@ -75,6 +88,29 @@ export const AboInfoContent = memo(function AboInfoContent() {
   const cancelVerification = useMutation({
     mutationFn: () => apiClient('/api/profile/verify-abo', { method: 'DELETE' }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['profile'] }),
+  })
+
+  const submitSpouseLink = useMutation({
+    mutationFn: async (claimed_primary_abo: string) => {
+      const res = await fetch('/api/profile/spouse-link', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ claimed_primary_abo }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Request failed')
+      return data
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['spouseLinkRequest'] })
+      setShowSpouseLink(false)
+      setSpouseAboInput('')
+    },
+  })
+
+  const cancelSpouseLink = useMutation({
+    mutationFn: () => apiClient('/api/profile/spouse-link', { method: 'DELETE' }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['spouseLinkRequest'] }),
   })
 
   if (role === 'guest' && profileIsPending) {
@@ -107,6 +143,9 @@ export const AboInfoContent = memo(function AboInfoContent() {
     mutationError?.error_code,
     t
   )
+
+  // When verify-abo returns abo_has_primary, surface the spouse link flow inline
+  const showSpouseLinkCta = mutationError?.error_code === 'abo_has_primary'
 
   // Stale-LOS hint for denied requests (admin_note signals stale LOS)
   const showStaleHint =
@@ -150,6 +189,14 @@ export const AboInfoContent = memo(function AboInfoContent() {
                 {uplineData?.upline_abo_number ?? '—'}
               </p>
             </div>
+            {spouse && (
+              <div className="grid grid-cols-2 gap-3 mt-2">
+                <p className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>{t('profile.coOwner')}</p>
+                <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                  {spouse.first_name} {spouse.last_name}
+                </p>
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -243,6 +290,8 @@ export const AboInfoContent = memo(function AboInfoContent() {
               )}
               submitPending={submitVerification.isPending}
               submitError={submitErrorMessage}
+              showSpouseLinkCta={showSpouseLinkCta}
+              onSpouseLinkCtaClick={() => setShowSpouseLink(true)}
               t={t}
             />
           )}
@@ -250,22 +299,50 @@ export const AboInfoContent = memo(function AboInfoContent() {
       )}
 
       {aboMode === 'form' && (
-        <VerificationForm
-          verificationMode={verificationMode}
-          aboInput={aboInput}
-          uplineInput={uplineInput}
-          onModeChange={setVerificationMode}
-          onAboChange={setAboInput}
-          onUplineChange={setUplineInput}
-          onSubmit={() => submitVerification.mutate(
-            verificationMode === 'manual'
-              ? { request_type: 'manual', claimed_upline_abo: uplineInput.trim() }
-              : { request_type: 'standard', claimed_abo: aboInput.trim(), claimed_upline_abo: uplineInput.trim() }
+        <>
+          <VerificationForm
+            verificationMode={verificationMode}
+            aboInput={aboInput}
+            uplineInput={uplineInput}
+            onModeChange={setVerificationMode}
+            onAboChange={setAboInput}
+            onUplineChange={setUplineInput}
+            onSubmit={() => submitVerification.mutate(
+              verificationMode === 'manual'
+                ? { request_type: 'manual', claimed_upline_abo: uplineInput.trim() }
+                : { request_type: 'standard', claimed_abo: aboInput.trim(), claimed_upline_abo: uplineInput.trim() }
+            )}
+            submitPending={submitVerification.isPending}
+            submitError={submitErrorMessage}
+            showSpouseLinkCta={showSpouseLinkCta}
+            onSpouseLinkCtaClick={() => setShowSpouseLink(true)}
+            t={t}
+          />
+          {/* Spouse link flow — shown when abo_has_primary error or user taps the entry point */}
+          {(showSpouseLink || spouseLinkRequest) && (
+            <SpouseLinkSection
+              spouseLinkRequest={spouseLinkRequest ?? null}
+              spouseAboInput={spouseAboInput}
+              onAboChange={setSpouseAboInput}
+              onSubmit={() => submitSpouseLink.mutate(spouseAboInput.trim())}
+              onCancel={() => cancelSpouseLink.mutate()}
+              submitPending={submitSpouseLink.isPending}
+              submitError={submitSpouseLink.isError ? (submitSpouseLink.error as Error).message : null}
+              cancelPending={cancelSpouseLink.isPending}
+              t={t}
+            />
           )}
-          submitPending={submitVerification.isPending}
-          submitError={submitErrorMessage}
-          t={t}
-        />
+          {/* Entry point for guests with no active flow and no abo_has_primary error */}
+          {!showSpouseLink && !spouseLinkRequest && !showSpouseLinkCta && (
+            <button
+              onClick={() => setShowSpouseLink(true)}
+              className="mt-4 text-xs font-medium hover:underline"
+              style={{ color: 'var(--text-secondary)' }}
+            >
+              {t('profile.spouseLinkDesc').split('.')[0] + '?'}
+            </button>
+          )}
+        </>
       )}
     </div>
   )
@@ -281,6 +358,8 @@ function VerificationForm({
   onSubmit,
   submitPending,
   submitError,
+  showSpouseLinkCta,
+  onSpouseLinkCtaClick,
   t,
 }: {
   verificationMode: 'standard' | 'manual'
@@ -292,6 +371,8 @@ function VerificationForm({
   onSubmit: () => void
   submitPending: boolean
   submitError: string | null
+  showSpouseLinkCta: boolean
+  onSpouseLinkCtaClick: () => void
   t: (key: import('@/lib/i18n/translations').TranslationKey) => string
 }) {
   return (
@@ -352,6 +433,15 @@ function VerificationForm({
       {submitError && (
         <p className="text-xs" style={{ color: 'var(--brand-crimson)' }}>{submitError}</p>
       )}
+      {showSpouseLinkCta && (
+        <button
+          onClick={onSpouseLinkCtaClick}
+          className="w-full py-2 rounded-xl text-xs font-semibold border transition-colors hover:opacity-80"
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+        >
+          {t('profile.spouseLinkSubmit')}
+        </button>
+      )}
       <button
         onClick={onSubmit}
         disabled={submitPending || (verificationMode === 'standard' ? (!aboInput || !uplineInput) : !uplineInput)}
@@ -359,6 +449,89 @@ function VerificationForm({
         style={{ backgroundColor: 'var(--text-primary)' }}
       >
         {submitPending ? t('profile.submitting') : t('profile.submitVerif')}
+      </button>
+    </div>
+  )
+}
+
+function SpouseLinkSection({
+  spouseLinkRequest,
+  spouseAboInput,
+  onAboChange,
+  onSubmit,
+  onCancel,
+  submitPending,
+  submitError,
+  cancelPending,
+  t,
+}: {
+  spouseLinkRequest: SpouseLinkRequest | null
+  spouseAboInput: string
+  onAboChange: (v: string) => void
+  onSubmit: () => void
+  onCancel: () => void
+  submitPending: boolean
+  submitError: string | null
+  cancelPending: boolean
+  t: (key: import('@/lib/i18n/translations').TranslationKey) => string
+}) {
+  if (spouseLinkRequest?.status === 'pending') {
+    return (
+      <div className="mt-4 rounded-xl px-4 py-3" style={{ backgroundColor: '#f2cc8f33' }}>
+        <p className="text-sm font-medium" style={{ color: '#7a5c00' }}>
+          {t('profile.spouseLinkPending')}
+        </p>
+        <button
+          onClick={onCancel}
+          disabled={cancelPending}
+          className="text-xs mt-2 font-medium hover:underline disabled:opacity-50"
+          style={{ color: 'var(--brand-crimson)' }}
+        >
+          {t('profile.spouseLinkCancelRequest')}
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-4 space-y-3" style={{ borderTop: '1px solid var(--border-default)', paddingTop: 16 }}>
+      {spouseLinkRequest?.status === 'denied' && (
+        <div className="rounded-xl px-4 py-3" style={{ backgroundColor: '#bc474915' }}>
+          <p className="text-sm font-medium" style={{ color: 'var(--brand-crimson)' }}>
+            {t('profile.spouseLinkDenied')}
+          </p>
+          {spouseLinkRequest.admin_note && (
+            <p className="text-xs mt-0.5" style={{ color: 'var(--brand-crimson)' }}>
+              {spouseLinkRequest.admin_note}
+            </p>
+          )}
+        </div>
+      )}
+      <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+        {t('profile.spouseLinkDesc')}
+      </p>
+      <div>
+        <label className="text-xs mb-1 block" style={{ color: 'var(--text-secondary)' }}>
+          {t('profile.spouseLinkAboLabel')}
+        </label>
+        <input
+          value={spouseAboInput}
+          onChange={e => onAboChange(e.target.value)}
+          placeholder="e.g. 7023040472"
+          className="w-full border border-black/10 rounded-xl px-3 py-2.5 text-sm font-mono"
+          style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-global)' }}
+        />
+      </div>
+      {submitError && (
+        <p className="text-xs" style={{ color: 'var(--brand-crimson)' }}>{submitError}</p>
+      )}
+      <button
+        onClick={onSubmit}
+        disabled={submitPending || !spouseAboInput}
+        className="w-full py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
+        style={{ backgroundColor: 'var(--text-primary)' }}
+      >
+        {submitPending ? t('profile.submitting') : (spouseLinkRequest?.status === 'denied' ? t('profile.spouseLinkResubmit') : t('profile.spouseLinkSubmit'))}
       </button>
     </div>
   )

--- a/app/(dashboard)/profile/types.ts
+++ b/app/(dashboard)/profile/types.ts
@@ -32,6 +32,19 @@ export type VerificationRequest = {
   request_type: string
 }
 
+export type SpouseLinkRequest = {
+  id: string
+  status: 'pending' | 'approved' | 'denied'
+  admin_note: string | null
+  created_at: string
+}
+
+export type SpouseData = {
+  id: string
+  first_name: string
+  last_name: string
+}
+
 export type UplineData = {
   upline_name: string | null
   upline_abo_number: string | null
@@ -44,6 +57,7 @@ export type Profile = {
   last_name: string
   abo_number: string | null
   upline_abo_number: string | null
+  primary_profile_id: string | null
   role: 'admin' | 'core' | 'member' | 'guest'
   document_active_type: 'id' | 'passport'
   id_number: string | null
@@ -58,6 +72,7 @@ export type Profile = {
   // Eagerly joined by GET /api/profile — null when not applicable
   upline: UplineData | null
   verRequest: VerificationRequest | null
+  spouse: SpouseData | null
 }
 
 export type TripPayment = {

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -26,8 +26,9 @@ export async function GET() {
   const uplineAboNumber: string | null = data.upline_abo_number ?? null
   const profileId: string = data.id
   const role: string = data.role
+  const primaryProfileId: string | null = data.primary_profile_id ?? null
 
-  const [upline, verRequest] = await Promise.all([
+  const [upline, verRequest, spouse] = await Promise.all([
     // Resolve upline for any verified member.
     // Standard path: abo_number set — look up sponsor via los_members tree.
     // Manual path: abo_number null but upline_abo_number set — resolve name directly.
@@ -79,9 +80,30 @@ export async function GET() {
           return req ?? null
         })()
       : Promise.resolve(null),
+    // Spouse: primary fetches their secondary; secondary fetches their primary.
+    // Returns null for unlinked profiles.
+    (async () => {
+      if (primaryProfileId) {
+        // This profile is a secondary — fetch the primary
+        const { data: primary } = await supabase
+          .from('profiles')
+          .select('id, first_name, last_name')
+          .eq('id', primaryProfileId)
+          .maybeSingle()
+        return primary ?? null
+      } else {
+        // This profile may be a primary — fetch any secondary linked to it
+        const { data: secondary } = await supabase
+          .from('profiles')
+          .select('id, first_name, last_name')
+          .eq('primary_profile_id', profileId)
+          .maybeSingle()
+        return secondary ?? null
+      }
+    })(),
   ])
 
-  return Response.json({ ...data, upline, verRequest })
+  return Response.json({ ...data, upline, verRequest, spouse })
 }
 
 export async function PATCH(req: Request): Promise<Response> {

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -91,6 +91,7 @@ export const profile = {
   'profile.error.aboAlreadyClaimed':  { en: 'This ABO number is already registered to another account. Contact support if you believe this is an error.', bg: 'Този ABO номер вече е регистриран към друг акаунт. Свържете се с поддръжката, ако смятате, че е грешка.' },
   'profile.error.uplineNotInLos':     { en: 'The upline ABO number was not found in the LOS. Check the number or ask your admin to re-import the LOS.', bg: 'ABO номерът на ъплайна не е намерен в LOS. Проверете номера или помолете администратора да импортира отново LOS.' },
   'profile.error.losStaleNote':       { en: 'Your numbers may be correct — the admin\'s LOS data may be outdated.', bg: 'Вашите номера може да са верни — LOS данните на администратора може да са остарели.' },
+  'profile.error.aboHasPrimary':      { en: 'This ABO is already registered by a co-owner. If you are their spouse, request a spouse link below.', bg: 'Този ABO вече е регистриран от съсобственик. Ако сте съпруг/а, заявете свързване по-долу.' },
   'profile.emailOnlyNote':            { en: 'Emails are sent only to your contact email address.', bg: 'Имейлите се изпращат само на вашия контактен адрес.' },
   'profile.pref.tripReg':             { en: 'Trip registration updates',                        bg: 'Промени по регистрация за пътуване'              },
   'profile.pref.paymentStatus':       { en: 'Payment status updates',                           bg: 'Промени по статус на плащане'                    },
@@ -158,4 +159,13 @@ export const profile = {
   // InvitesBento
   'profile.invites.statLinks':            { en: 'invite links',               bg: 'покани'                               },
   'profile.invites.viewAll':              { en: 'View all invites',           bg: 'Виж всички покани'                    },
+  // ABO co-ownership / spouse link
+  'profile.coOwner':                      { en: 'Co-owner',                   bg: 'Съсобственик'                         },
+  'profile.spouseLinkDesc':               { en: 'Are you a co-owner on a shared ABO? Enter the primary account holder\'s ABO number to request a spouse link.', bg: 'Съсобственик ли сте на споделен ABO? Въведете ABO номера на основния титуляр, за да заявите свързване.' },
+  'profile.spouseLinkAboLabel':           { en: 'Primary account holder\'s ABO number', bg: 'ABO номер на основния титуляр'  },
+  'profile.spouseLinkSubmit':             { en: 'Request spouse link',        bg: 'Заяви свързване на съпруг/а'          },
+  'profile.spouseLinkPending':            { en: 'Spouse link request pending admin approval.', bg: 'Заявката за свързване на съпруг/а очаква одобрение от администратор.' },
+  'profile.spouseLinkCancelRequest':      { en: 'Cancel spouse link request', bg: 'Отмени заявката за свързване'         },
+  'profile.spouseLinkDenied':             { en: 'Spouse link request was not approved.', bg: 'Заявката за свързване на съпруг/а не беше одобрена.' },
+  'profile.spouseLinkResubmit':           { en: 'Submit again',               bg: 'Изпрати отново'                       },
 } as const

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -162,6 +162,7 @@ export const profile = {
   // ABO co-ownership / spouse link
   'profile.coOwner':                      { en: 'Co-owner',                   bg: 'Съсобственик'                         },
   'profile.spouseLinkDesc':               { en: 'Are you a co-owner on a shared ABO? Enter the primary account holder\'s ABO number to request a spouse link.', bg: 'Съсобственик ли сте на споделен ABO? Въведете ABO номера на основния титуляр, за да заявите свързване.' },
+  'profile.spouseLinkEntryPoint':         { en: 'Are you a co-owner on a shared ABO?', bg: 'Съсобственик ли сте на споделен ABO?'  },
   'profile.spouseLinkAboLabel':           { en: 'Primary account holder\'s ABO number', bg: 'ABO номер на основния титуляр'  },
   'profile.spouseLinkSubmit':             { en: 'Request spouse link',        bg: 'Заяви свързване на съпруг/а'          },
   'profile.spouseLinkPending':            { en: 'Spouse link request pending admin approval.', bg: 'Заявката за свързване на съпруг/а очаква одобрение от администратор.' },


### PR DESCRIPTION
# [2505-FEAT-301] ABO co-ownership: member-facing UI (Ticket 2 of 3)

Closes #301

## What

Member-facing surface for ABO co-ownership:

- `/api/profile` extended to return `spouse: { id, first_name, last_name } | null` (parallel fetch, handles primary→secondary and secondary→primary lookup)
- `verify-abo` 409 `abo_has_primary` response includes `primary_profile_id`
- `AboInfoContent` confirmed mode: co-owner row below upline when `spouse` present
- `AboInfoContent` `abo_has_primary` error: distinct state with "Request spouse link" CTA
- Guest spouse link flow: ABO number input → `POST /api/profile/spouse-link` → pending/denied/resubmit states
- `SpouseLinkSection` sub-component: pending (with cancel), denied (with admin note + resubmit), form
- `/api/profile/spouse-link` GET/POST/DELETE route with full validation
- All strings i18n'd (EN + BG), `profile.coOwner`, `profile.spouseLink*`, `profile.error.aboHasPrimary`

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] `/api/profile` spouse field
- [x] `verify-abo` `primary_profile_id` in 409 body
- [x] `AboInfoContent` co-owner badge (confirmed mode)
- [x] `AboInfoContent` `abo_has_primary` CTA
- [x] `SpouseLinkSection` component (pending / denied / form)
- [x] `/api/profile/spouse-link` route (GET / POST / DELETE)
- [x] i18n keys (BG + EN)
**Next:** Verify CI green + Vercel preview ready → FINALIZE
