### PR TITLE
[2505-FEAT-302] ABO co-ownership: admin UI (Ticket 3 of 3)

### DIFF
--- a/app/admin/approval-hub/components/SpouseLinkRequestsTab.tsx
+++ b/app/admin/approval-hub/components/SpouseLinkRequestsTab.tsx
@@ -5,7 +5,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from '@/lib/toast'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 
-// ── Types ────────────────────────────────────────────────────────
+// ── Types ────────────────────────────────────────────────
 
 type Profile = { id: string; first_name: string; last_name: string; contact_email?: string; role?: string }
 type ClaimedPrimary = { id: string; first_name: string; last_name: string; abo_number: string | null; role?: string }
@@ -20,7 +20,7 @@ export type SpouseLinkRequest = {
   claimed_primary: ClaimedPrimary | null
 }
 
-// ── Helpers ──────────────────────────────────────────────────────
+// ── Helpers ──────────────────────────────────────────────
 
 function formatDate(iso: string) {
   return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
@@ -31,7 +31,7 @@ function fullName(p: { first_name: string; last_name: string } | null) {
   return `${p.first_name} ${p.last_name}`.trim()
 }
 
-// ── Row: deny input state ────────────────────────────────────────
+// ── Row: deny input state ──────────────────────────────────
 // Hoisted to module scope — avoids React remount anti-pattern.
 function DenyForm({
   onCancel,
@@ -81,7 +81,7 @@ function DenyForm({
   )
 }
 
-// ── Component ────────────────────────────────────────────────────
+// ── Component ────────────────────────────────────────────
 
 export function SpouseLinkRequestsTab() {
   const { t } = useLanguage()
@@ -90,7 +90,10 @@ export function SpouseLinkRequestsTab() {
 
   const { data: requests = [], isLoading } = useQuery<SpouseLinkRequest[]>({
     queryKey: ['spouse-link-requests'],
-    queryFn: () => fetch('/api/admin/spouse-link-requests').then(r => r.json()),
+    queryFn: () => fetch('/api/admin/spouse-link-requests').then(async r => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      return r.json()
+    }),
   })
 
   const actionMutation = useMutation({
@@ -107,7 +110,6 @@ export function SpouseLinkRequestsTab() {
     onMutate: async ({ id }) => {
       await qc.cancelQueries({ queryKey: ['spouse-link-requests'] })
       const prev = qc.getQueryData<SpouseLinkRequest[]>(['spouse-link-requests'])
-      // Optimistic: remove the row from pending view immediately
       qc.setQueryData<SpouseLinkRequest[]>(['spouse-link-requests'],
         old => old?.filter(r => r.id !== id)
       )

--- a/app/admin/approval-hub/components/SpouseLinkRequestsTab.tsx
+++ b/app/admin/approval-hub/components/SpouseLinkRequestsTab.tsx
@@ -1,0 +1,219 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from '@/lib/toast'
+import { useLanguage } from '@/lib/hooks/useLanguage'
+
+// ── Types ────────────────────────────────────────────────────────
+
+type Profile = { id: string; first_name: string; last_name: string; contact_email?: string; role?: string }
+type ClaimedPrimary = { id: string; first_name: string; last_name: string; abo_number: string | null; role?: string }
+
+export type SpouseLinkRequest = {
+  id: string
+  status: 'pending' | 'approved' | 'denied'
+  admin_note: string | null
+  created_at: string
+  resolved_at: string | null
+  requester: Profile | null
+  claimed_primary: ClaimedPrimary | null
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function fullName(p: { first_name: string; last_name: string } | null) {
+  if (!p) return '—'
+  return `${p.first_name} ${p.last_name}`.trim()
+}
+
+// ── Row: deny input state ────────────────────────────────────────
+// Hoisted to module scope — avoids React remount anti-pattern.
+function DenyForm({
+  onCancel,
+  onConfirm,
+  isPending,
+  t,
+}: {
+  onCancel: () => void
+  onConfirm: (note: string) => void
+  isPending: boolean
+  t: (key: Parameters<ReturnType<typeof useLanguage>['t']>[0]) => string
+}) {
+  const [note, setNote] = useState('')
+  return (
+    <div className="mt-2 space-y-2">
+      <textarea
+        value={note}
+        onChange={e => setNote(e.target.value)}
+        placeholder={t('admin.approval.spouse.denyNotePlaceholder')}
+        rows={2}
+        className="w-full text-xs rounded-lg border px-3 py-2 resize-none focus:outline-none"
+        style={{
+          backgroundColor: 'var(--bg-global)',
+          borderColor: 'var(--border-default)',
+          color: 'var(--text-primary)',
+        }}
+      />
+      <div className="flex gap-2">
+        <button
+          onClick={() => { if (note.trim()) onConfirm(note.trim()) }}
+          disabled={!note.trim() || isPending}
+          className="px-3 py-1.5 rounded-lg text-xs font-medium text-white disabled:opacity-40 transition-opacity"
+          style={{ backgroundColor: 'var(--brand-crimson)' }}
+        >
+          {t('admin.approval.spouse.btn.confirmDeny')}
+        </button>
+        <button
+          onClick={onCancel}
+          disabled={isPending}
+          className="px-3 py-1.5 rounded-lg text-xs font-medium disabled:opacity-40 transition-opacity"
+          style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-secondary)' }}
+        >
+          {t('admin.approval.spouse.btn.cancel')}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export function SpouseLinkRequestsTab() {
+  const { t } = useLanguage()
+  const qc = useQueryClient()
+  const [denyingId, setDenyingId] = useState<string | null>(null)
+
+  const { data: requests = [], isLoading } = useQuery<SpouseLinkRequest[]>({
+    queryKey: ['spouse-link-requests'],
+    queryFn: () => fetch('/api/admin/spouse-link-requests').then(r => r.json()),
+  })
+
+  const actionMutation = useMutation({
+    mutationFn: ({ id, status, admin_note }: { id: string; status: 'approved' | 'denied'; admin_note?: string }) =>
+      fetch(`/api/admin/spouse-link-requests/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status, admin_note }),
+      }).then(async r => {
+        const body = await r.json().catch(() => ({}))
+        if (!r.ok) throw new Error(body.error ?? `HTTP ${r.status}`)
+        return body
+      }),
+    onMutate: async ({ id }) => {
+      await qc.cancelQueries({ queryKey: ['spouse-link-requests'] })
+      const prev = qc.getQueryData<SpouseLinkRequest[]>(['spouse-link-requests'])
+      // Optimistic: remove the row from pending view immediately
+      qc.setQueryData<SpouseLinkRequest[]>(['spouse-link-requests'],
+        old => old?.filter(r => r.id !== id)
+      )
+      return { prev }
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.prev) qc.setQueryData(['spouse-link-requests'], ctx.prev)
+      toast.error('Action failed. Please try again.')
+    },
+    onSuccess: (_data, vars) => {
+      setDenyingId(null)
+      const msg = vars.status === 'approved' ? 'Request approved.' : 'Request denied.'
+      toast.success(msg)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['spouse-link-requests'] })
+    },
+  })
+
+  const pending = requests.filter(r => r.status === 'pending')
+
+  return (
+    <div>
+      <p className="text-xs font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
+        {t('admin.approval.spouse.pendingTitle').replace('{{count}}', String(pending.length))}
+      </p>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="h-16 bg-black/5 rounded-xl animate-pulse" />
+          ))}
+        </div>
+      ) : pending.length === 0 ? (
+        <div
+          className="rounded-xl border px-5 py-8 text-center"
+          style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+        >
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            {t('admin.approval.spouse.noPending')}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {pending.map(req => (
+            <div
+              key={req.id}
+              className="rounded-xl border px-4 py-3.5"
+              style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+            >
+              <div className="flex items-start gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                    {fullName(req.requester)}
+                    {req.requester?.contact_email && (
+                      <span className="font-normal text-xs ml-1.5" style={{ color: 'var(--text-secondary)' }}>
+                        {req.requester.contact_email}
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+                    {t('admin.approval.spouse.claimedPrimary')}:{' '}
+                    <span style={{ color: 'var(--text-primary)' }}>
+                      {fullName(req.claimed_primary)}
+                      {req.claimed_primary?.abo_number && ` · ABO ${req.claimed_primary.abo_number}`}
+                    </span>
+                  </p>
+                  <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+                    {t('admin.approval.spouse.submitted')}: {formatDate(req.created_at)}
+                  </p>
+                </div>
+
+                {denyingId !== req.id && (
+                  <div className="flex gap-2 flex-shrink-0">
+                    <button
+                      onClick={() => actionMutation.mutate({ id: req.id, status: 'approved' })}
+                      disabled={actionMutation.isPending}
+                      className="px-4 py-1.5 rounded-lg text-sm font-medium text-white disabled:opacity-50 transition-opacity"
+                      style={{ backgroundColor: 'var(--brand-teal)' }}
+                    >
+                      {t('admin.approval.spouse.btn.approve')}
+                    </button>
+                    <button
+                      onClick={() => setDenyingId(req.id)}
+                      disabled={actionMutation.isPending}
+                      className="px-4 py-1.5 rounded-lg text-sm font-medium disabled:opacity-50 transition-opacity"
+                      style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-primary)' }}
+                    >
+                      {t('admin.approval.spouse.btn.deny')}
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              {denyingId === req.id && (
+                <DenyForm
+                  onCancel={() => setDenyingId(null)}
+                  onConfirm={note => actionMutation.mutate({ id: req.id, status: 'denied', admin_note: note })}
+                  isPending={actionMutation.isPending}
+                  t={t}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/approval-hub/page.tsx
+++ b/app/admin/approval-hub/page.tsx
@@ -7,8 +7,10 @@ import AdminTabs, { TabsContent } from '@/app/admin/components/AdminTabs'
 import { TripRegistrationsTab } from './components/TripRegistrationsTab'
 import { AboVerificationTab } from './components/VerificationsTab'
 import { EventRolesTab } from './components/EventRolesTab'
+import { SpouseLinkRequestsTab } from './components/SpouseLinkRequestsTab'
 import type { TripRegistration } from './components/TripRegistrationsTab'
 import type { AdminMembersResponse } from './components/VerificationsTab'
+import type { SpouseLinkRequest } from './components/SpouseLinkRequestsTab'
 
 // ── Types ─────────────────────────────────────────────────────
 
@@ -25,7 +27,7 @@ type RoleRequest = {
 function ApprovalHubInner() {
   const searchParams = useSearchParams()
   const router = useRouter()
-  const tab = (searchParams.get('tab') ?? 'trips') as 'trips' | 'roles' | 'abo'
+  const tab = (searchParams.get('tab') ?? 'trips') as 'trips' | 'roles' | 'abo' | 'spouse'
 
   // Same queryKey + queryFn as TripRegistrationsTab — single cache entry, no conflict.
   const { data: registrations = [] } = useQuery<TripRegistration[]>({
@@ -54,14 +56,21 @@ function ApprovalHubInner() {
     queryFn: () => fetch('/api/admin/members').then(r => r.json()),
   })
 
-  const pendingTrips = registrations.filter(r => r.status === 'pending').length
-  const pendingRoles = roleRequests.filter(r => r.status === 'pending').length
-  const pendingAbo   = (membersData?.pending_verifications ?? []).length
+  const { data: spouseRequests = [] } = useQuery<SpouseLinkRequest[]>({
+    queryKey: ['spouse-link-requests'],
+    queryFn: () => fetch('/api/admin/spouse-link-requests').then(r => r.json()),
+  })
+
+  const pendingTrips  = registrations.filter(r => r.status === 'pending').length
+  const pendingRoles  = roleRequests.filter(r => r.status === 'pending').length
+  const pendingAbo    = (membersData?.pending_verifications ?? []).length
+  const pendingSpouse = spouseRequests.filter(r => r.status === 'pending').length
 
   const tabsWithBadges = [
-    { key: 'trips', label: 'Trip Registrations', badge: pendingTrips },
-    { key: 'roles', label: 'Event Roles',         badge: pendingRoles },
-    { key: 'abo',   label: 'ABO Verification',    badge: pendingAbo   },
+    { key: 'trips',  label: 'Trip Registrations',   badge: pendingTrips  },
+    { key: 'roles',  label: 'Event Roles',           badge: pendingRoles  },
+    { key: 'abo',    label: 'ABO Verification',      badge: pendingAbo    },
+    { key: 'spouse', label: 'Co-ownership Requests', badge: pendingSpouse },
   ]
 
   return (
@@ -81,6 +90,7 @@ function ApprovalHubInner() {
         <TabsContent value="trips"><TripRegistrationsTab /></TabsContent>
         <TabsContent value="roles"><EventRolesTab /></TabsContent>
         <TabsContent value="abo"><AboVerificationTab /></TabsContent>
+        <TabsContent value="spouse"><SpouseLinkRequestsTab /></TabsContent>
       </AdminTabs>
     </div>
   )

--- a/app/admin/members/[id]/page.tsx
+++ b/app/admin/members/[id]/page.tsx
@@ -82,7 +82,7 @@ const LOS_KEYS = [
   ['annual_ppv', 'Annual PPV'], ['sponsoring', 'Sponsoring'],
 ]
 
-// ── Partnership section ───────────────────────────────────────────
+// ── Partnership section ───────────────────────────────────────────────────
 // Hoisted to module scope — avoids React remount anti-pattern.
 function PartnershipSection({
   profile,
@@ -92,35 +92,29 @@ function PartnershipSection({
   t,
 }: {
   profile: MemberDetail['profile']
-  onDissolve: (secondaryId: string) => void
+  onDissolve: () => void
   onPromote: (primaryId: string, secondaryId: string) => void
   isPending: boolean
   t: ReturnType<typeof useLanguage>['t']
 }) {
   const isSecondary = Boolean(profile.primary_profile_id)
-
-  // If secondary: fetch the primary profile to show their name
-  // If primary: fetch the secondary profile (the one that has primary_profile_id = this profile's id)
   const partnerId = isSecondary ? profile.primary_profile_id! : null
 
   const { data: primaryData, isLoading: loadingPrimary } = useQuery<PartnerProfile>({
     queryKey: ['admin-member', partnerId],
-    queryFn: () => fetch(`/api/admin/members/${partnerId}`).then(r => r.json()),
+    queryFn: () => fetch(`/api/admin/members/${partnerId}`).then(async r => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      return r.json()
+    }),
     enabled: isSecondary && !!partnerId,
   })
 
-  // For a primary, we need to find their secondary. Query all members is too expensive;
-  // instead we use a separate endpoint that returns secondary profile for a given primary.
-  // The existing GET /api/admin/members?secondary_of=[id] isn't built — so we skip
-  // partner name display for primaries and just show the section with actions.
-  // The secondary's [id] page will show the primary link anyway.
   const partnerName = isSecondary
     ? primaryData
       ? `${primaryData.profile.first_name} ${primaryData.profile.last_name}`.trim()
       : loadingPrimary ? t('admin.members.partnership.loadingPartner') : '—'
     : null
 
-  // Secondary view: show primary name + dissolve action (dissolve targets this profile's id)
   if (isSecondary) {
     return (
       <div className="mt-4 pt-4 border-t border-black/5">
@@ -136,50 +130,73 @@ function PartnershipSection({
               {partnerName}
             </p>
           </div>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <button
-                disabled={isPending}
-                className="px-3 py-1.5 rounded-lg text-xs font-medium disabled:opacity-40 transition-opacity"
-                style={{ backgroundColor: '#bc474920', color: 'var(--brand-crimson)' }}
-              >
-                {t('admin.members.partnership.btn.dissolve')}
-              </button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>{t('admin.members.partnership.dissolveConfirmTitle')}</AlertDialogTitle>
-                <AlertDialogDescription>
-                  {t('admin.members.partnership.dissolveConfirmDesc').replace(
-                    '{{name}}',
-                    `${profile.first_name} ${profile.last_name}`.trim()
-                  )}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>{t('admin.members.partnership.btn.cancel')}</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={() => onDissolve(profile.id)}
-                  style={{ backgroundColor: 'var(--brand-crimson)' }}
+          <div className="flex gap-2">
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <button
+                  disabled={isPending}
+                  className="px-3 py-1.5 rounded-lg text-xs font-medium disabled:opacity-40 transition-opacity"
+                  style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-primary)' }}
                 >
-                  {t('admin.members.partnership.btn.confirmAction')}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+                  {t('admin.members.partnership.btn.promote')}
+                </button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{t('admin.members.partnership.promoteConfirmTitle')}</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {t('admin.members.partnership.promoteConfirmDesc')}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>{t('admin.members.partnership.btn.cancel')}</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => onPromote(partnerId!, profile.id)}
+                    style={{ backgroundColor: 'var(--brand-crimson)' }}
+                  >
+                    {t('admin.members.partnership.btn.confirmAction')}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <button
+                  disabled={isPending}
+                  className="px-3 py-1.5 rounded-lg text-xs font-medium disabled:opacity-40 transition-opacity"
+                  style={{ backgroundColor: '#bc474920', color: 'var(--brand-crimson)' }}
+                >
+                  {t('admin.members.partnership.btn.dissolve')}
+                </button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{t('admin.members.partnership.dissolveConfirmTitle')}</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {t('admin.members.partnership.dissolveConfirmDesc').replace(
+                      '{{name}}',
+                      `${profile.first_name} ${profile.last_name}`.trim()
+                    )}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>{t('admin.members.partnership.btn.cancel')}</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => onDissolve()}
+                    style={{ backgroundColor: 'var(--brand-crimson)' }}
+                  >
+                    {t('admin.members.partnership.btn.confirmAction')}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
         </div>
       </div>
     )
   }
 
-  // Primary view: show promote action.
-  // promote_to_primary route is called on the PRIMARY's id with secondary_id in body.
-  // We are on the secondary's page but the secondary is the one being promoted,
-  // so the route call is: PATCH /api/admin/members/[primaryId] { action, secondary_id: currentId }
-  // The primary's id is profile.primary_profile_id on the secondary.
-  // Since we're currently on a PRIMARY profile (isSecondary = false),
-  // we do NOT have a secondary_id here. The promote button only makes sense on the SECONDARY's page.
-  // Return null for primary — no Partnership section rendered for primaries.
   return null
 }
 
@@ -193,7 +210,10 @@ export default function MemberDetailPage() {
 
   const { data, isLoading } = useQuery<MemberDetail>({
     queryKey: ['admin-member', id],
-    queryFn: () => fetch(`/api/admin/members/${id}`).then(r => r.json()),
+    queryFn: () => fetch(`/api/admin/members/${id}`).then(async r => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      return r.json()
+    }),
   })
 
   const updateMutation = useMutation({
@@ -202,7 +222,10 @@ export default function MemberDetailPage() {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(patch),
-      }).then(r => r.json()),
+      }).then(async r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json()
+      }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['admin-member', id] })
       qc.invalidateQueries({ queryKey: ['admin-members'] })
@@ -210,29 +233,29 @@ export default function MemberDetailPage() {
     },
   })
 
-  // dissolve_partnership: PATCH on secondary's id (= current profile id)
-  const handleDissolve = (secondaryId: string) => {
-    updateMutation.mutate({ action: 'dissolve_partnership' }, {
-      // id is already the secondary's id (this profile)
-      // The mutationFn patches /api/admin/members/[id] — correct
-    })
-    void secondaryId // id already used via closure
+  const promoteMutation = useMutation({
+    mutationFn: ({ primaryId, secondaryId }: { primaryId: string; secondaryId: string }) =>
+      fetch(`/api/admin/members/${primaryId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'promote_to_primary', secondary_id: secondaryId }),
+      }).then(async r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json()
+      }),
+    onSuccess: (_data, { primaryId }) => {
+      qc.invalidateQueries({ queryKey: ['admin-member', id] })
+      qc.invalidateQueries({ queryKey: ['admin-member', primaryId] })
+      qc.invalidateQueries({ queryKey: ['admin-members'] })
+    },
+  })
+
+  const handleDissolve = () => {
+    updateMutation.mutate({ action: 'dissolve_partnership' })
   }
 
-  // promote_to_primary: PATCH on PRIMARY's id, body includes secondary_id = current profile
   const handlePromote = (primaryId: string, secondaryId: string) => {
-    fetch(`/api/admin/members/${primaryId}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'promote_to_primary', secondary_id: secondaryId }),
-    })
-      .then(r => r.json())
-      .then(() => {
-        qc.invalidateQueries({ queryKey: ['admin-member', id] })
-        qc.invalidateQueries({ queryKey: ['admin-member', primaryId] })
-        qc.invalidateQueries({ queryKey: ['admin-members'] })
-      })
-      .catch(() => {})
+    promoteMutation.mutate({ primaryId, secondaryId })
   }
 
   if (isLoading) {
@@ -259,6 +282,8 @@ export default function MemberDetailPage() {
   const totalPaid = payments
     .filter(p => p.status === 'completed')
     .reduce((sum, p) => sum + p.amount, 0)
+
+  const isPending = updateMutation.isPending || promoteMutation.isPending
 
   return (
     <div className="p-6">
@@ -373,7 +398,7 @@ export default function MemberDetailPage() {
             profile={profile}
             onDissolve={handleDissolve}
             onPromote={handlePromote}
-            isPending={updateMutation.isPending}
+            isPending={isPending}
             t={t}
           />
         )}

--- a/app/admin/members/[id]/page.tsx
+++ b/app/admin/members/[id]/page.tsx
@@ -3,6 +3,18 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useParams, useRouter } from 'next/navigation'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { useLanguage } from '@/lib/hooks/useLanguage'
 
 type MemberDetail = {
   profile: {
@@ -12,6 +24,7 @@ type MemberDetail = {
     id_number: string | null; passport_number: string | null
     valid_through: string | null; created_at: string
     tree_nodes: { path: string; depth: number }[] | null
+    primary_profile_id: string | null
   }
   los: Record<string, unknown> | null
   registrations: {
@@ -27,6 +40,13 @@ type MemberDetail = {
     id: string; role_label: string; status: string; created_at: string
     event: { title: string; start_time: string }
   }[]
+}
+
+type PartnerProfile = {
+  profile: {
+    id: string; first_name: string; last_name: string
+    primary_profile_id: string | null
+  }
 }
 
 function formatDate(iso: string) {
@@ -62,10 +82,112 @@ const LOS_KEYS = [
   ['annual_ppv', 'Annual PPV'], ['sponsoring', 'Sponsoring'],
 ]
 
+// ── Partnership section ───────────────────────────────────────────
+// Hoisted to module scope — avoids React remount anti-pattern.
+function PartnershipSection({
+  profile,
+  onDissolve,
+  onPromote,
+  isPending,
+  t,
+}: {
+  profile: MemberDetail['profile']
+  onDissolve: (secondaryId: string) => void
+  onPromote: (primaryId: string, secondaryId: string) => void
+  isPending: boolean
+  t: ReturnType<typeof useLanguage>['t']
+}) {
+  const isSecondary = Boolean(profile.primary_profile_id)
+
+  // If secondary: fetch the primary profile to show their name
+  // If primary: fetch the secondary profile (the one that has primary_profile_id = this profile's id)
+  const partnerId = isSecondary ? profile.primary_profile_id! : null
+
+  const { data: primaryData, isLoading: loadingPrimary } = useQuery<PartnerProfile>({
+    queryKey: ['admin-member', partnerId],
+    queryFn: () => fetch(`/api/admin/members/${partnerId}`).then(r => r.json()),
+    enabled: isSecondary && !!partnerId,
+  })
+
+  // For a primary, we need to find their secondary. Query all members is too expensive;
+  // instead we use a separate endpoint that returns secondary profile for a given primary.
+  // The existing GET /api/admin/members?secondary_of=[id] isn't built — so we skip
+  // partner name display for primaries and just show the section with actions.
+  // The secondary's [id] page will show the primary link anyway.
+  const partnerName = isSecondary
+    ? primaryData
+      ? `${primaryData.profile.first_name} ${primaryData.profile.last_name}`.trim()
+      : loadingPrimary ? t('admin.members.partnership.loadingPartner') : '—'
+    : null
+
+  // Secondary view: show primary name + dissolve action (dissolve targets this profile's id)
+  if (isSecondary) {
+    return (
+      <div className="mt-4 pt-4 border-t border-black/5">
+        <p className="text-xs font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
+          {t('admin.members.partnership.sectionTitle')}
+        </p>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+              {t('admin.members.partnership.primary')}
+            </p>
+            <p className="text-sm font-medium mt-0.5" style={{ color: 'var(--text-primary)' }}>
+              {partnerName}
+            </p>
+          </div>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <button
+                disabled={isPending}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium disabled:opacity-40 transition-opacity"
+                style={{ backgroundColor: '#bc474920', color: 'var(--brand-crimson)' }}
+              >
+                {t('admin.members.partnership.btn.dissolve')}
+              </button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>{t('admin.members.partnership.dissolveConfirmTitle')}</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {t('admin.members.partnership.dissolveConfirmDesc').replace(
+                    '{{name}}',
+                    `${profile.first_name} ${profile.last_name}`.trim()
+                  )}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>{t('admin.members.partnership.btn.cancel')}</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => onDissolve(profile.id)}
+                  style={{ backgroundColor: 'var(--brand-crimson)' }}
+                >
+                  {t('admin.members.partnership.btn.confirmAction')}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </div>
+    )
+  }
+
+  // Primary view: show promote action.
+  // promote_to_primary route is called on the PRIMARY's id with secondary_id in body.
+  // We are on the secondary's page but the secondary is the one being promoted,
+  // so the route call is: PATCH /api/admin/members/[primaryId] { action, secondary_id: currentId }
+  // The primary's id is profile.primary_profile_id on the secondary.
+  // Since we're currently on a PRIMARY profile (isSecondary = false),
+  // we do NOT have a secondary_id here. The promote button only makes sense on the SECONDARY's page.
+  // Return null for primary — no Partnership section rendered for primaries.
+  return null
+}
+
 export default function MemberDetailPage() {
   const { id } = useParams<{ id: string }>()
   const router = useRouter()
   const qc = useQueryClient()
+  const { t } = useLanguage()
   const [editRole, setEditRole] = useState(false)
   const [selectedRole, setSelectedRole] = useState<string>('')
 
@@ -88,6 +210,31 @@ export default function MemberDetailPage() {
     },
   })
 
+  // dissolve_partnership: PATCH on secondary's id (= current profile id)
+  const handleDissolve = (secondaryId: string) => {
+    updateMutation.mutate({ action: 'dissolve_partnership' }, {
+      // id is already the secondary's id (this profile)
+      // The mutationFn patches /api/admin/members/[id] — correct
+    })
+    void secondaryId // id already used via closure
+  }
+
+  // promote_to_primary: PATCH on PRIMARY's id, body includes secondary_id = current profile
+  const handlePromote = (primaryId: string, secondaryId: string) => {
+    fetch(`/api/admin/members/${primaryId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'promote_to_primary', secondary_id: secondaryId }),
+    })
+      .then(r => r.json())
+      .then(() => {
+        qc.invalidateQueries({ queryKey: ['admin-member', id] })
+        qc.invalidateQueries({ queryKey: ['admin-member', primaryId] })
+        qc.invalidateQueries({ queryKey: ['admin-members'] })
+      })
+      .catch(() => {})
+  }
+
   if (isLoading) {
     return (
       <div className="p-6 space-y-4">
@@ -101,6 +248,8 @@ export default function MemberDetailPage() {
 
   if (!data?.profile) return null
   const { profile, los, registrations, payments, roleRequests } = data
+
+  const isSecondary = Boolean(profile.primary_profile_id)
 
   const expiry = getExpiryState(profile.valid_through)
   const docNumber = profile.document_active_type === 'passport'
@@ -136,9 +285,19 @@ export default function MemberDetailPage() {
             {profile.first_name[0]}{profile.last_name[0]}
           </div>
           <div className="flex-1 min-w-0">
-            <h1 className="font-display text-2xl font-semibold" style={{ color: 'var(--text-primary)' }}>
-              {profile.first_name} {profile.last_name}
-            </h1>
+            <div className="flex items-center gap-2 flex-wrap">
+              <h1 className="font-display text-2xl font-semibold" style={{ color: 'var(--text-primary)' }}>
+                {profile.first_name} {profile.last_name}
+              </h1>
+              {isSecondary && (
+                <span
+                  className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-secondary)' }}
+                >
+                  {t('admin.members.table.coOwnerBadge')}
+                </span>
+              )}
+            </div>
             <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
               ABO: <span className="font-medium" style={{ color: 'var(--text-primary)' }}>
                 {profile.abo_number ?? '—'}
@@ -207,6 +366,17 @@ export default function MemberDetailPage() {
             </span>
           )}
         </div>
+
+        {/* Partnership section — only for secondary profiles */}
+        {isSecondary && (
+          <PartnershipSection
+            profile={profile}
+            onDissolve={handleDissolve}
+            onPromote={handlePromote}
+            isPending={updateMutation.isPending}
+            t={t}
+          />
+        )}
       </div>
 
       {/* Document */}

--- a/app/admin/members/components/MembersTab.tsx
+++ b/app/admin/members/components/MembersTab.tsx
@@ -25,6 +25,7 @@ export type LOSMember = {
     first_name: string
     last_name: string
     role: string
+    primary_profile_id: string | null
   } | null
 }
 

--- a/app/admin/members/components/MembersTable.tsx
+++ b/app/admin/members/components/MembersTable.tsx
@@ -93,6 +93,7 @@ export function MembersTable({
         const lvl = m.abo_level ?? '?'
         const lc = LEVEL_BG[lvl] ?? LEVEL_BG['3']
         const profileRc = m.profile ? getRoleColors(m.profile.role) : null
+        const isSecondary = Boolean(m.profile?.primary_profile_id)
         return (
           <div className="flex items-center gap-2 min-w-0">
             <span className="w-6 h-6 flex items-center justify-center rounded-full text-[10px] font-bold flex-shrink-0"
@@ -105,6 +106,14 @@ export function MembersTable({
             {m.profile && profileRc && (
               <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full flex-shrink-0"
                 style={{ backgroundColor: profileRc.bg, color: profileRc.font }}>{m.profile.role}</span>
+            )}
+            {isSecondary && (
+              <span
+                className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-secondary)' }}
+              >
+                {t('admin.members.table.coOwnerBadge')}
+              </span>
             )}
           </div>
         )

--- a/app/api/admin/members/route.ts
+++ b/app/api/admin/members/route.ts
@@ -34,7 +34,7 @@ export async function GET() {
   // Profiles linked by abo_number
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, abo_number, first_name, last_name, role, created_at')
+    .select('id, abo_number, first_name, last_name, role, primary_profile_id, created_at')
     .not('abo_number', 'is', null)
 
   // Pending verification requests with profile info and request_type

--- a/lib/i18n/domains/admin/core.ts
+++ b/lib/i18n/domains/admin/core.ts
@@ -97,4 +97,34 @@ export const adminCore = {
   'admin.notifications.pagination.info': { en: 'Page {{page}} of {{total}} — {{count}} total', bg: 'Страница {{page}} от {{total}} — {{count}} общо' },
   'admin.notifications.pagination.prev': { en: '← Prev', bg: '← Предишна' },
   'admin.notifications.pagination.next': { en: 'Next →', bg: 'Следваща →' },
+
+  // -- Spouse link requests (approval hub) --
+  'admin.approval.spouse.tabLabel': { en: 'Co-ownership Requests', bg: 'Заявки за съвместно членство' },
+  'admin.approval.spouse.pendingTitle': { en: 'Pending — {{count}}', bg: 'Чакащи — {{count}}' },
+  'admin.approval.spouse.noPending': { en: 'No pending co-ownership requests.', bg: 'Няма чакащи заявки за съвместно членство.' },
+  'admin.approval.spouse.requester': { en: 'Requester', bg: 'Заявител' },
+  'admin.approval.spouse.claimedPrimary': { en: 'Claimed primary', bg: 'Заявен основен акаунт' },
+  'admin.approval.spouse.submitted': { en: 'Submitted', bg: 'Подадено' },
+  'admin.approval.spouse.btn.approve': { en: 'Approve', bg: 'Одобри' },
+  'admin.approval.spouse.btn.deny': { en: 'Deny', bg: 'Откажи' },
+  'admin.approval.spouse.btn.confirmDeny': { en: 'Confirm deny', bg: 'Потвърди отказ' },
+  'admin.approval.spouse.btn.cancel': { en: 'Cancel', bg: 'Отмени' },
+  'admin.approval.spouse.denyNotePlaceholder': { en: 'Reason for denial (required)', bg: 'Причина за отказ (задължително)' },
+
+  // -- Partnership section (member detail panel) --
+  'admin.members.partnership.sectionTitle': { en: 'Partnership', bg: 'Партньорство' },
+  'admin.members.partnership.primary': { en: 'Primary account', bg: 'Основен акаунт' },
+  'admin.members.partnership.secondary': { en: 'Co-owner account', bg: 'Съвместен акаунт' },
+  'admin.members.partnership.btn.dissolve': { en: 'Dissolve partnership', bg: 'Прекрати партньорство' },
+  'admin.members.partnership.btn.promote': { en: 'Promote to primary', bg: 'Повиши до основен' },
+  'admin.members.partnership.dissolveConfirmTitle': { en: 'Dissolve partnership?', bg: 'Прекратяване на партньорство?' },
+  'admin.members.partnership.dissolveConfirmDesc': { en: 'This will demote {{name}} to Guest and remove their ABO number.', bg: 'Това ще понижи {{name}} до Гост и ще премахне техния СБА номер.' },
+  'admin.members.partnership.promoteConfirmTitle': { en: 'Promote to primary?', bg: 'Повишаване до основен акаунт?' },
+  'admin.members.partnership.promoteConfirmDesc': { en: 'This will restructure the LOS tree. Do not perform during active sessions.', bg: 'Това ще преструктурира дървото на LOS. Не изпълнявайте по време на активни сесии.' },
+  'admin.members.partnership.btn.confirmAction': { en: 'Confirm', bg: 'Потвърди' },
+  'admin.members.partnership.btn.cancel': { en: 'Cancel', bg: 'Отмени' },
+  'admin.members.partnership.loadingPartner': { en: 'Loading partner…', bg: 'Зареждане на партньор…' },
+
+  // -- Co-owner badge (members table) --
+  'admin.members.table.coOwnerBadge': { en: 'Co-owner', bg: 'Съвм.' },
 } as const


### PR DESCRIPTION
Closes #302

## Summary

Admin UI surface for ABO co-ownership. Builds on #298 (merged).

- Approval hub: spouse link requests queue with optimistic approve/deny (admin note required on deny)
- Member panel: Partnership section for primary/secondary profiles — dissolve (targets secondary id) + promote to primary (with `rebuild_tree_paths` warning dialog)
- Members list: Co-owner badge on secondary profile rows
- i18n: all new strings in `lib/i18n/domains/admin/core.ts` (EN + BG), `TranslationKey` union updated

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] SpouseLinkRequestsTab + approval hub wiring
- [x] Partnership section in member panel (dissolve + promote + confirmation dialogs)
- [x] Co-owner badge in MembersTable
- [x] i18n keys (EN + BG)
**Next:** Verify CI green + Vercel Preview READY, then tick DoD checkboxes and mark DONE