### PR TITLE
[2605-FEAT-319] Path A auto-approve on LOS match

### DIFF
--- a/app/api/profile/verify-abo/route.ts
+++ b/app/api/profile/verify-abo/route.ts
@@ -5,6 +5,7 @@ import { sendTransactionalEmail } from '@/lib/email/send'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { AboVerificationEmail } from '@/lib/email/templates/AboVerificationEmail'
 import { WelcomeEmail } from '@/lib/email/templates/WelcomeEmail'
+import type { Json } from '@/types/supabase'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -24,7 +25,7 @@ async function logEvent(
     actor_id: opts.actor_id,
     subject_id: opts.subject_id,
     event_type: opts.event_type,
-    payload: opts.payload ?? {},
+    payload: (opts.payload ?? {}) as Json,
     status: opts.status ?? 'ok',
   })
 }

--- a/app/api/profile/verify-abo/route.ts
+++ b/app/api/profile/verify-abo/route.ts
@@ -1,5 +1,37 @@
 import { auth } from '@clerk/nextjs/server'
+import { clerkClient } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { sendTransactionalEmail } from '@/lib/email/send'
+import { renderEmailTemplate } from '@/lib/email/templates/render'
+import { AboVerificationEmail } from '@/lib/email/templates/AboVerificationEmail'
+import { WelcomeEmail } from '@/lib/email/templates/WelcomeEmail'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function logEvent(
+  supabase: ReturnType<typeof createServiceClient>,
+  opts: {
+    actor_id: string
+    subject_id: string | null
+    event_type: string
+    payload?: Record<string, unknown>
+    status?: string
+  }
+) {
+  await supabase.from('member_event_log').insert({
+    actor_id: opts.actor_id,
+    subject_id: opts.subject_id,
+    event_type: opts.event_type,
+    payload: opts.payload ?? {},
+    status: opts.status ?? 'ok',
+  })
+}
+
+// ---------------------------------------------------------------------------
+// POST — submit ABO verification
+// ---------------------------------------------------------------------------
 
 export async function POST(req: Request) {
   const { userId } = await auth()
@@ -7,122 +39,242 @@ export async function POST(req: Request) {
 
   const supabase = createServiceClient()
   const { data: profile } = await supabase
-    .from('profiles').select('id, role, abo_number').eq('clerk_id', userId).single()
+    .from('profiles')
+    .select('id, role, abo_number, first_name, contact_email')
+    .eq('clerk_id', userId)
+    .single()
+
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
   if (profile.abo_number) return Response.json({ error: 'ABO already verified' }, { status: 409 })
   if (profile.role !== 'guest') return Response.json({ error: 'Already verified' }, { status: 409 })
 
   const body = await req.json()
-  const request_type: 'standard' | 'manual' = body.request_type === 'manual' ? 'manual' : 'standard'
+
+  // Manual path removed — 400 if submitted
+  if (body.request_type === 'manual') {
+    return Response.json(
+      { error: 'Manual verification requests are no longer accepted via this endpoint.' },
+      { status: 400 }
+    )
+  }
+
   const { claimed_abo, claimed_upline_abo } = body
 
-  if (request_type === 'standard') {
-    if (!claimed_abo || !claimed_upline_abo) {
-      return Response.json({ error: 'claimed_abo and claimed_upline_abo are required' }, { status: 400 })
-    }
+  if (!claimed_abo || !claimed_upline_abo) {
+    return Response.json(
+      { error: 'claimed_abo and claimed_upline_abo are required' },
+      { status: 400 }
+    )
+  }
 
-    // LOS existence check
-    const { data: losMember } = await supabase
+  // LOS existence check
+  const { data: losMember } = await supabase
+    .from('los_members')
+    .select('abo_number, sponsor_abo_number, last_synced_at')
+    .eq('abo_number', claimed_abo)
+    .maybeSingle()
+
+  if (!losMember) {
+    const { data: anyLos } = await supabase
       .from('los_members')
-      .select('abo_number, sponsor_abo_number, last_synced_at')
-      .eq('abo_number', claimed_abo)
+      .select('last_synced_at')
+      .order('last_synced_at', { ascending: false })
+      .limit(1)
       .maybeSingle()
+    const losAge = anyLos?.last_synced_at
+      ? Math.floor((Date.now() - new Date(anyLos.last_synced_at).getTime()) / 86_400_000)
+      : null
 
-    if (!losMember) {
-      const { data: anyLos } = await supabase
-        .from('los_members')
-        .select('last_synced_at')
-        .order('last_synced_at', { ascending: false })
-        .limit(1)
-        .maybeSingle()
-      const losAge = anyLos?.last_synced_at
-        ? Math.floor((Date.now() - new Date(anyLos.last_synced_at).getTime()) / 86_400_000)
-        : null
+    await logEvent(supabase, {
+      actor_id: userId,
+      subject_id: profile.id,
+      event_type: 'abo_verify_failed',
+      payload: { claimed_abo, claimed_upline_abo, error_code: 'abo_not_in_los', los_age_days: losAge },
+      status: 'failed',
+    })
+
+    return Response.json(
+      {
+        error: losAge !== null
+          ? `ABO ${claimed_abo} not found in LOS data (${losAge} days old). Check your number or ask your admin to re-import the LOS.`
+          : `ABO ${claimed_abo} not found in LOS data. Ask your admin to import the LOS.`,
+        error_code: 'abo_not_in_los',
+      },
+      { status: 422 }
+    )
+  }
+
+  // Sponsor mismatch check
+  if (losMember.sponsor_abo_number !== claimed_upline_abo) {
+    await logEvent(supabase, {
+      actor_id: userId,
+      subject_id: profile.id,
+      event_type: 'abo_verify_failed',
+      payload: {
+        claimed_abo,
+        claimed_upline_abo,
+        los_sponsor: losMember.sponsor_abo_number,
+        error_code: 'upline_mismatch',
+      },
+      status: 'failed',
+    })
+    return Response.json(
+      { error: `Your sponsor ABO does not match the LOS record for ${claimed_abo}.`, error_code: 'upline_mismatch' },
+      { status: 422 }
+    )
+  }
+
+  // Duplicate ABO check
+  const { data: existingHolder } = await supabase
+    .from('profiles')
+    .select('id, primary_profile_id')
+    .eq('abo_number', claimed_abo)
+    .neq('id', profile.id)
+    .maybeSingle()
+
+  if (existingHolder) {
+    if (existingHolder.primary_profile_id === null) {
+      // Primary holder — route to spouse link flow
       return Response.json(
         {
-          error: losAge !== null
-            ? `ABO ${claimed_abo} not found in LOS data (${losAge} days old). Check your number or ask your admin to re-import the LOS.`
-            : `ABO ${claimed_abo} not found in LOS data. Ask your admin to import the LOS.`,
-          error_code: 'abo_not_in_los',
+          error: 'This ABO is already registered. If you are the co-owner, use the Spouse Link option on your profile.',
+          error_code: 'abo_has_primary',
+          primary_profile_id: existingHolder.id,
         },
-        { status: 422 }
-      )
-    }
-
-    // Sponsor mismatch check
-    if (losMember.sponsor_abo_number !== claimed_upline_abo) {
-      return Response.json(
-        { error: `Your sponsor ABO does not match the LOS record for ${claimed_abo}.`, error_code: 'upline_mismatch' },
-        { status: 422 }
-      )
-    }
-
-    // Duplicate ABO check
-    // ADR-016: if the existing holder is a primary (primary_profile_id IS NULL),
-    // surface a specific error_code so the UI can offer the spouse link flow.
-    const { data: existingHolder } = await supabase
-      .from('profiles')
-      .select('id, primary_profile_id')
-      .eq('abo_number', claimed_abo)
-      .neq('id', profile.id)
-      .maybeSingle()
-
-    if (existingHolder) {
-      if (existingHolder.primary_profile_id === null) {
-        // The holder is a primary — this guest may be their spouse
-        return Response.json(
-          {
-            error: `This ABO is already registered. If you are the co-owner, use the Spouse Link option on your profile.`,
-            error_code: 'abo_has_primary',
-            primary_profile_id: existingHolder.id,
-          },
-          { status: 409 }
-        )
-      }
-      // The holder is a secondary — generic already-claimed error
-      return Response.json(
-        { error: `ABO ${claimed_abo} is already registered to another account.`, error_code: 'abo_already_claimed' },
         { status: 409 }
       )
     }
-  } else {
-    // Manual path
-    if (!claimed_upline_abo) {
-      return Response.json({ error: 'claimed_upline_abo is required' }, { status: 400 })
-    }
-
-    const { data: uplineLos } = await supabase
-      .from('los_members')
-      .select('abo_number')
-      .eq('abo_number', claimed_upline_abo)
-      .maybeSingle()
-
-    if (!uplineLos) {
-      return Response.json(
-        { error: `Upline ABO ${claimed_upline_abo} not found in LOS data. Check the number or contact your admin.`, error_code: 'upline_not_in_los' },
-        { status: 422 }
-      )
-    }
+    return Response.json(
+      { error: `ABO ${claimed_abo} is already registered to another account.`, error_code: 'abo_already_claimed' },
+      { status: 409 }
+    )
   }
 
-  const { data, error } = await supabase
+  // ---------------------------------------------------------------------------
+  // LOS match confirmed — insert request row then auto-approve
+  // ---------------------------------------------------------------------------
+
+  const { data: requestRow, error: insertError } = await supabase
     .from('abo_verification_requests')
     .upsert(
       {
         profile_id: profile.id,
-        claimed_abo: request_type === 'manual' ? null : claimed_abo,
+        claimed_abo,
         claimed_upline_abo,
-        request_type,
+        request_type: 'standard',
         status: 'pending',
         resolved_at: null,
       },
       { onConflict: 'profile_id' }
     )
-    .select().single()
+    .select()
+    .single()
 
-  if (error) return Response.json({ error: error.message }, { status: 500 })
-  return Response.json(data, { status: 201 })
+  if (insertError || !requestRow) {
+    return Response.json({ error: insertError?.message ?? 'Failed to create request' }, { status: 500 })
+  }
+
+  // Call RPC — DB transaction commits here
+  const { data: rpcRows, error: rpcError } = await supabase.rpc(
+    'approve_member_verification',
+    { p_request_id: requestRow.id, p_admin_note: null }
+  )
+
+  if (rpcError) {
+    await logEvent(supabase, {
+      actor_id: 'system',
+      subject_id: profile.id,
+      event_type: 'abo_verify_failed',
+      payload: { claimed_abo, claimed_upline_abo, rpc_error: rpcError.message, error_code: rpcError.code },
+      status: 'failed',
+    })
+    return Response.json({ error: rpcError.message }, { status: 500 })
+  }
+
+  const result = Array.isArray(rpcRows) ? rpcRows[0] : rpcRows
+
+  // Log success
+  await logEvent(supabase, {
+    actor_id: 'system',
+    subject_id: profile.id,
+    event_type: 'abo_verified',
+    payload: { claimed_abo, claimed_upline_abo, request_id: requestRow.id },
+    status: 'ok',
+  })
+
+  // Post-commit: Clerk sync + emails (try/catch — DB already committed)
+  try {
+    const clerk = await clerkClient()
+    await clerk.users.updateUserMetadata(userId, {
+      publicMetadata: { role: 'member' },
+    })
+
+    await logEvent(supabase, {
+      actor_id: 'system',
+      subject_id: profile.id,
+      event_type: 'clerk_sync_ok',
+      payload: { clerk_id: userId },
+    })
+  } catch (clerkErr) {
+    console.error('[verify-abo] Clerk sync failed:', clerkErr)
+    await logEvent(supabase, {
+      actor_id: 'system',
+      subject_id: profile.id,
+      event_type: 'clerk_sync_failed',
+      payload: { clerk_id: userId, error: String(clerkErr) },
+      status: 'failed',
+    })
+  }
+
+  if (profile.contact_email) {
+    try {
+      const approvalHtml = await renderEmailTemplate(
+        AboVerificationEmail({
+          firstName: profile.first_name || 'Member',
+          claimedAbo: claimed_abo,
+          status: 'approved',
+          adminNote: null,
+        })
+      )
+      await sendTransactionalEmail({
+        to: profile.contact_email,
+        subject: 'ABO Verification Approved ✓',
+        html: approvalHtml,
+        template: 'abo_verification_result',
+        meta: { request_id: requestRow.id, profile_id: profile.id },
+      })
+
+      // Welcome email — always a guest-to-member promotion on this path
+      const welcomeHtml = await renderEmailTemplate(
+        WelcomeEmail({ firstName: profile.first_name || 'Member' })
+      )
+      await sendTransactionalEmail({
+        to: profile.contact_email,
+        subject: 'Welcome to Team Enjoy VD!',
+        html: welcomeHtml,
+        template: 'abo_verification_result',
+        meta: { request_id: requestRow.id, profile_id: profile.id },
+      })
+    } catch (emailErr) {
+      console.error('[verify-abo] email failed:', emailErr)
+    }
+  }
+
+  // In-app notification
+  await supabase.from('notifications').insert({
+    profile_id: profile.id,
+    type: 'role_request',
+    title: 'ABO Verification Approved',
+    message: `Your ABO number ${claimed_abo} has been verified. You are now a Member.`,
+    action_url: '/profile',
+  })
+
+  return Response.json({ status: 'approved', result })
 }
+
+// ---------------------------------------------------------------------------
+// DELETE — cancel a pending request
+// ---------------------------------------------------------------------------
 
 export async function DELETE() {
   const { userId } = await auth()
@@ -130,7 +282,10 @@ export async function DELETE() {
 
   const supabase = createServiceClient()
   const { data: profile } = await supabase
-    .from('profiles').select('id').eq('clerk_id', userId).single()
+    .from('profiles')
+    .select('id')
+    .eq('clerk_id', userId)
+    .single()
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
   const { error } = await supabase
@@ -143,13 +298,20 @@ export async function DELETE() {
   return Response.json({ cancelled: true })
 }
 
+// ---------------------------------------------------------------------------
+// GET — fetch current request status
+// ---------------------------------------------------------------------------
+
 export async function GET() {
   const { userId } = await auth()
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
   const { data: profile } = await supabase
-    .from('profiles').select('id').eq('clerk_id', userId).single()
+    .from('profiles')
+    .select('id')
+    .eq('clerk_id', userId)
+    .single()
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
   const { data, error } = await supabase

--- a/app/api/profile/verify-abo/route.ts
+++ b/app/api/profile/verify-abo/route.ts
@@ -135,6 +135,13 @@ export async function POST(req: Request) {
 
   if (existingHolder) {
     if (existingHolder.primary_profile_id === null) {
+      await logEvent(supabase, {
+        actor_id: userId,
+        subject_id: profile.id,
+        event_type: 'abo_verify_failed',
+        payload: { claimed_abo, claimed_upline_abo, error_code: 'abo_has_primary', existing_profile_id: existingHolder.id },
+        status: 'failed',
+      })
       return Response.json(
         {
           error: 'This ABO is already registered. If you are the co-owner, use the Spouse Link option on your profile.',
@@ -144,6 +151,13 @@ export async function POST(req: Request) {
         { status: 409 }
       )
     }
+    await logEvent(supabase, {
+      actor_id: userId,
+      subject_id: profile.id,
+      event_type: 'abo_verify_failed',
+      payload: { claimed_abo, claimed_upline_abo, error_code: 'abo_already_claimed', existing_profile_id: existingHolder.id },
+      status: 'failed',
+    })
     return Response.json(
       { error: `ABO ${claimed_abo} is already registered to another account.`, error_code: 'abo_already_claimed' },
       { status: 409 }
@@ -244,6 +258,7 @@ export async function POST(req: Request) {
         meta: { request_id: requestRow.id, profile_id: profile.id },
       })
 
+      // Welcome email — always a guest-to-member promotion on this path
       const welcomeHtml = await renderEmailTemplate(
         WelcomeEmail({ firstName: profile.first_name || 'Member' })
       )
@@ -251,7 +266,7 @@ export async function POST(req: Request) {
         to: profile.contact_email,
         subject: 'Welcome to Team Enjoy VD!',
         html: welcomeHtml,
-        template: 'abo_verification_result',
+        template: 'welcome_email',
         meta: { request_id: requestRow.id, profile_id: profile.id },
       })
     } catch (emailErr) {
@@ -260,13 +275,14 @@ export async function POST(req: Request) {
   }
 
   // In-app notification
-  await supabase.from('notifications').insert({
+  const { error: notifyError } = await supabase.from('notifications').insert({
     profile_id: profile.id,
     type: 'role_request',
     title: 'ABO Verification Approved',
     message: `Your ABO number ${claimed_abo} has been verified. You are now a Member.`,
     action_url: '/profile',
   })
+  if (notifyError) console.error('[verify-abo] notification failed:', notifyError)
 
   return Response.json({ status: 'approved', result })
 }

--- a/app/api/profile/verify-abo/route.ts
+++ b/app/api/profile/verify-abo/route.ts
@@ -135,7 +135,6 @@ export async function POST(req: Request) {
 
   if (existingHolder) {
     if (existingHolder.primary_profile_id === null) {
-      // Primary holder — route to spouse link flow
       return Response.json(
         {
           error: 'This ABO is already registered. If you are the co-owner, use the Spouse Link option on your profile.',
@@ -178,7 +177,7 @@ export async function POST(req: Request) {
   // Call RPC — DB transaction commits here
   const { data: rpcRows, error: rpcError } = await supabase.rpc(
     'approve_member_verification',
-    { p_request_id: requestRow.id, p_admin_note: null }
+    { p_request_id: requestRow.id }
   )
 
   if (rpcError) {
@@ -245,7 +244,6 @@ export async function POST(req: Request) {
         meta: { request_id: requestRow.id, profile_id: profile.id },
       })
 
-      // Welcome email — always a guest-to-member promotion on this path
       const welcomeHtml = await renderEmailTemplate(
         WelcomeEmail({ firstName: profile.first_name || 'Member' })
       )

--- a/supabase/migrations/20260510_002_member_event_log.sql
+++ b/supabase/migrations/20260510_002_member_event_log.sql
@@ -1,0 +1,16 @@
+CREATE TABLE public.member_event_log (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  actor_id    text        NOT NULL, -- 'system' or a Clerk user ID
+  subject_id  uuid        REFERENCES public.profiles(id) ON DELETE SET NULL,
+  event_type  text        NOT NULL,
+  payload     jsonb       NOT NULL DEFAULT '{}'::jsonb,
+  status      text        NOT NULL DEFAULT 'ok'
+);
+
+-- No RLS — service role only. Never exposed to client directly.
+ALTER TABLE public.member_event_log DISABLE ROW LEVEL SECURITY;
+
+CREATE INDEX member_event_log_subject_idx ON public.member_event_log (subject_id);
+CREATE INDEX member_event_log_event_type_idx ON public.member_event_log (event_type);
+CREATE INDEX member_event_log_created_at_idx ON public.member_event_log (created_at DESC);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -680,6 +680,44 @@ export type Database = {
         }
         Relationships: []
       }
+      member_event_log: {
+        Row: {
+          actor_id: string
+          created_at: string
+          event_type: string
+          id: string
+          payload: Json
+          status: string
+          subject_id: string | null
+        }
+        Insert: {
+          actor_id: string
+          created_at?: string
+          event_type: string
+          id?: string
+          payload?: Json
+          status?: string
+          subject_id?: string | null
+        }
+        Update: {
+          actor_id?: string
+          created_at?: string
+          event_type?: string
+          id?: string
+          payload?: Json
+          status?: string
+          subject_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "member_event_log_subject_id_fkey"
+            columns: ["subject_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       member_vital_signs: {
         Row: {
           created_at: string


### PR DESCRIPTION
Closes #319

## Summary

`POST /api/profile/verify-abo` now auto-approves immediately when ABO + upline match the LOS exactly. No admin action required on the standard path. Manual path removed (400). All outcomes logged to `member_event_log`.

## What changed

**`supabase/migrations/20260510_002_member_event_log.sql`** — new `member_event_log` table: `id, created_at, actor_id (text — 'system' or Clerk ID), subject_id (uuid → profiles), event_type, payload (jsonb), status`. RLS disabled, service role only. Indexes on `subject_id`, `event_type`, `created_at DESC`.

**`app/api/profile/verify-abo/route.ts`** — POST rewritten:
- `request_type === 'manual'` → 400 immediately.
- LOS check → failure logs `abo_verify_failed` to event log, returns 422 with `error_code`.
- Sponsor mismatch → same.
- `abo_has_primary` → returns existing `error_code` + `primary_profile_id` for spouse link UI routing (unchanged behaviour).
- On match: upsert `abo_verification_requests` as `pending`, call `approve_member_verification` RPC (DB commits), log `abo_verified`.
- Clerk sync in try/catch → logs `clerk_sync_ok` or `clerk_sync_failed`.
- Approval + welcome emails (always sent — this path is always guest→member).
- In-app notification inserted.
- Returns `{ status: 'approved', result }` 200.
- DELETE and GET handlers unchanged.

## Session State
**Status:** DONE
**Completed:**
- [x] `member_event_log` migration applied to prod DB
- [x] Route rewritten — auto-approve on LOS match
- [x] Manual path removed (400)
- [x] All outcomes logged to `member_event_log`
- [x] Clerk sync + emails post-commit try/catch
**Next:** User merges via GitHub UI. Unblock #320.