### PR TITLE
[2605-FEAT-320] Path A' spouse link: primary confirms

### DIFF
--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { memo, useState } from 'react'
+import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { getRoleColors } from '@/lib/role-colors'
@@ -44,6 +45,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
   const uplineData = profile?.upline ?? null
   const verRequest = profile?.verRequest ?? null
   const spouse = profile?.spouse ?? null
+  const pendingSpouseLinkCount = profile?.pendingSpouseLinkCount ?? 0
 
   const rc = getRoleColors(role)
   const [verificationMode, setVerificationMode] = useState<'standard' | 'manual'>('standard')
@@ -199,6 +201,21 @@ export const AboInfoContent = memo(function AboInfoContent() {
               </div>
             )}
           </div>
+          {/* Primary member: pending inbound spouse link request notification */}
+          {pendingSpouseLinkCount > 0 && (
+            <Link
+              href="/profile/spouse-link"
+              className="flex items-center gap-2 rounded-xl px-4 py-3 mt-1"
+              style={{ backgroundColor: '#f2cc8f33', textDecoration: 'none' }}
+            >
+              <span className="text-sm font-medium" style={{ color: '#7a5c00' }}>
+                {pendingSpouseLinkCount === 1
+                  ? 'Someone has requested to link as your spouse account'
+                  : `${pendingSpouseLinkCount} spouse link requests pending`}
+              </span>
+              <span className="ml-auto text-xs font-semibold" style={{ color: '#7a5c00' }}>Review →</span>
+            </Link>
+          )}
         </div>
       )}
 
@@ -231,6 +248,21 @@ export const AboInfoContent = memo(function AboInfoContent() {
               </p>
             </div>
           </div>
+          {/* Primary member: pending inbound spouse link request notification */}
+          {pendingSpouseLinkCount > 0 && (
+            <Link
+              href="/profile/spouse-link"
+              className="flex items-center gap-2 rounded-xl px-4 py-3"
+              style={{ backgroundColor: '#f2cc8f33', textDecoration: 'none' }}
+            >
+              <span className="text-sm font-medium" style={{ color: '#7a5c00' }}>
+                {pendingSpouseLinkCount === 1
+                  ? 'Someone has requested to link as your spouse account'
+                  : `${pendingSpouseLinkCount} spouse link requests pending`}
+              </span>
+              <span className="ml-auto text-xs font-semibold" style={{ color: '#7a5c00' }}>Review →</span>
+            </Link>
+          )}
         </div>
       )}
 

--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -31,6 +31,28 @@ function resolveErrorMessage(
   }
 }
 
+// ── SpouseLinkBanner ──────────────────────────────────────────────────────────
+// Shown to primary members (confirmed or member_manual) when inbound requests
+// are pending. Extracted to avoid duplication across aboMode branches.
+
+function SpouseLinkBanner({ count, mt = 1 }: { count: number; mt?: number }) {
+  if (count === 0) return null
+  return (
+    <Link
+      href="/profile/spouse-link"
+      className="flex items-center gap-2 rounded-xl px-4 py-3"
+      style={{ backgroundColor: '#f2cc8f33', textDecoration: 'none', marginTop: mt * 4 }}
+    >
+      <span className="text-sm font-medium" style={{ color: '#7a5c00' }}>
+        {count === 1
+          ? 'Someone has requested to link as your spouse account'
+          : `${count} spouse link requests pending`}
+      </span>
+      <span className="ml-auto text-xs font-semibold" style={{ color: '#7a5c00' }}>Review →</span>
+    </Link>
+  )
+}
+
 export const AboInfoContent = memo(function AboInfoContent() {
   const qc = useQueryClient()
   const { t } = useLanguage()
@@ -201,21 +223,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
               </div>
             )}
           </div>
-          {/* Primary member: pending inbound spouse link request notification */}
-          {pendingSpouseLinkCount > 0 && (
-            <Link
-              href="/profile/spouse-link"
-              className="flex items-center gap-2 rounded-xl px-4 py-3 mt-1"
-              style={{ backgroundColor: '#f2cc8f33', textDecoration: 'none' }}
-            >
-              <span className="text-sm font-medium" style={{ color: '#7a5c00' }}>
-                {pendingSpouseLinkCount === 1
-                  ? 'Someone has requested to link as your spouse account'
-                  : `${pendingSpouseLinkCount} spouse link requests pending`}
-              </span>
-              <span className="ml-auto text-xs font-semibold" style={{ color: '#7a5c00' }}>Review →</span>
-            </Link>
-          )}
+          <SpouseLinkBanner count={pendingSpouseLinkCount} mt={1} />
         </div>
       )}
 
@@ -248,21 +256,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
               </p>
             </div>
           </div>
-          {/* Primary member: pending inbound spouse link request notification */}
-          {pendingSpouseLinkCount > 0 && (
-            <Link
-              href="/profile/spouse-link"
-              className="flex items-center gap-2 rounded-xl px-4 py-3"
-              style={{ backgroundColor: '#f2cc8f33', textDecoration: 'none' }}
-            >
-              <span className="text-sm font-medium" style={{ color: '#7a5c00' }}>
-                {pendingSpouseLinkCount === 1
-                  ? 'Someone has requested to link as your spouse account'
-                  : `${pendingSpouseLinkCount} spouse link requests pending`}
-              </span>
-              <span className="ml-auto text-xs font-semibold" style={{ color: '#7a5c00' }}>Review →</span>
-            </Link>
-          )}
+          <SpouseLinkBanner count={pendingSpouseLinkCount} mt={0} />
         </div>
       )}
 

--- a/app/(dashboard)/profile/spouse-link/SpouseLinkClient.tsx
+++ b/app/(dashboard)/profile/spouse-link/SpouseLinkClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { toast } from '@/lib/toast'
@@ -91,6 +92,7 @@ function DenyForm({
 // ── PrimaryView ────────────────────────────────────────────────────────────────
 
 function PrimaryView({ inboundRequests }: { inboundRequests: InboundRequest[] }) {
+  const router = useRouter()
   const qc = useQueryClient()
   const [denyingId, setDenyingId] = useState<string | null>(null)
 
@@ -109,8 +111,8 @@ function PrimaryView({ inboundRequests }: { inboundRequests: InboundRequest[] })
       setDenyingId(null)
       toast.success(vars.action === 'approve' ? 'Spouse link approved.' : 'Request denied.')
       qc.invalidateQueries({ queryKey: ['profile'] })
-      // Refresh page data via router
-      window.location.reload()
+      // Refresh RSC page data without resetting client state
+      router.refresh()
     },
     onError: (err: Error) => {
       toast.error(err.message || 'Action failed. Please try again.')

--- a/app/(dashboard)/profile/spouse-link/SpouseLinkClient.tsx
+++ b/app/(dashboard)/profile/spouse-link/SpouseLinkClient.tsx
@@ -1,0 +1,327 @@
+'use client'
+
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useLanguage } from '@/lib/hooks/useLanguage'
+import { toast } from '@/lib/toast'
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+type OutboundRequest = {
+  id: string
+  status: string
+  admin_note: string | null
+  created_at: string
+  claimed_primary: { first_name: string; last_name: string; abo_number: string | null } | null
+}
+
+type InboundRequest = {
+  id: string
+  status: string
+  created_at: string
+  requester: { id: string; first_name: string; last_name: string; contact_email: string | null } | null
+}
+
+type Props = {
+  profileRole: string
+  isPrimary: boolean
+  outboundRequest: OutboundRequest | null
+  inboundRequests: InboundRequest[]
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function fullName(p: { first_name: string; last_name: string } | null) {
+  if (!p) return '—'
+  return `${p.first_name} ${p.last_name}`.trim()
+}
+
+// ── DenyForm ──────────────────────────────────────────────────────────────────
+
+function DenyForm({
+  onCancel,
+  onConfirm,
+  isPending,
+}: {
+  onCancel: () => void
+  onConfirm: (note: string) => void
+  isPending: boolean
+}) {
+  const [note, setNote] = useState('')
+  return (
+    <div className="mt-3 space-y-2">
+      <textarea
+        value={note}
+        onChange={e => setNote(e.target.value)}
+        placeholder="Reason for denying (required)"
+        rows={2}
+        className="w-full text-xs rounded-xl border px-3 py-2 resize-none focus:outline-none"
+        style={{
+          backgroundColor: 'var(--bg-global)',
+          borderColor: 'var(--border-default)',
+          color: 'var(--text-primary)',
+        }}
+      />
+      <div className="flex gap-2">
+        <button
+          onClick={() => { if (note.trim()) onConfirm(note.trim()) }}
+          disabled={!note.trim() || isPending}
+          className="px-4 py-2 rounded-xl text-xs font-semibold text-white disabled:opacity-40 transition-opacity"
+          style={{ backgroundColor: 'var(--brand-crimson)' }}
+        >
+          Confirm deny
+        </button>
+        <button
+          onClick={onCancel}
+          disabled={isPending}
+          className="px-4 py-2 rounded-xl text-xs font-semibold disabled:opacity-40 transition-opacity"
+          style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-secondary)' }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── PrimaryView ────────────────────────────────────────────────────────────────
+
+function PrimaryView({ inboundRequests }: { inboundRequests: InboundRequest[] }) {
+  const qc = useQueryClient()
+  const [denyingId, setDenyingId] = useState<string | null>(null)
+
+  const actionMutation = useMutation({
+    mutationFn: ({ requestId, action, deny_note }: { requestId: string; action: 'approve' | 'deny'; deny_note?: string }) =>
+      fetch(`/api/profile/spouse-link/${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ request_id: requestId, deny_note }),
+      }).then(async r => {
+        const body = await r.json().catch(() => ({}))
+        if (!r.ok) throw new Error(body.error ?? `HTTP ${r.status}`)
+        return body
+      }),
+    onSuccess: (_data, vars) => {
+      setDenyingId(null)
+      toast.success(vars.action === 'approve' ? 'Spouse link approved.' : 'Request denied.')
+      qc.invalidateQueries({ queryKey: ['profile'] })
+      // Refresh page data via router
+      window.location.reload()
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'Action failed. Please try again.')
+    },
+  })
+
+  if (inboundRequests.length === 0) {
+    return (
+      <div
+        className="rounded-2xl border px-5 py-8 text-center"
+        style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+      >
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+          No pending spouse link requests.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {inboundRequests.map(req => (
+        <div
+          key={req.id}
+          className="rounded-2xl border px-5 py-4"
+          style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+        >
+          <p className="text-sm font-semibold mb-0.5" style={{ color: 'var(--text-primary)' }}>
+            {fullName(req.requester)}
+          </p>
+          {req.requester?.contact_email && (
+            <p className="text-xs mb-0.5" style={{ color: 'var(--text-secondary)' }}>
+              {req.requester.contact_email}
+            </p>
+          )}
+          <p className="text-xs mb-3" style={{ color: 'var(--text-secondary)' }}>
+            Submitted {formatDate(req.created_at)}
+          </p>
+
+          {denyingId !== req.id ? (
+            <div className="flex gap-2">
+              <button
+                onClick={() => actionMutation.mutate({ requestId: req.id, action: 'approve' })}
+                disabled={actionMutation.isPending}
+                className="px-4 py-2 rounded-xl text-sm font-semibold text-white disabled:opacity-50 transition-opacity"
+                style={{ backgroundColor: 'var(--brand-teal)' }}
+              >
+                Approve
+              </button>
+              <button
+                onClick={() => setDenyingId(req.id)}
+                disabled={actionMutation.isPending}
+                className="px-4 py-2 rounded-xl text-sm font-semibold disabled:opacity-50 transition-opacity"
+                style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-primary)' }}
+              >
+                Deny
+              </button>
+            </div>
+          ) : (
+            <DenyForm
+              onCancel={() => setDenyingId(null)}
+              onConfirm={note => actionMutation.mutate({ requestId: req.id, action: 'deny', deny_note: note })}
+              isPending={actionMutation.isPending}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── GuestView ──────────────────────────────────────────────────────────────────
+
+function GuestView({ outboundRequest }: { outboundRequest: OutboundRequest | null }) {
+  if (!outboundRequest) {
+    return (
+      <div
+        className="rounded-2xl border px-5 py-8 text-center"
+        style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+      >
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+          You have no active spouse link request.
+        </p>
+        <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>
+          Submit one from your Profile page.
+        </p>
+      </div>
+    )
+  }
+
+  const isPending = outboundRequest.status === 'pending'
+  const isDenied  = outboundRequest.status === 'denied'
+
+  return (
+    <div
+      className="rounded-2xl border px-5 py-4"
+      style={{
+        backgroundColor: 'var(--bg-card)',
+        borderColor: isPending ? 'rgba(0,0,0,0.08)' : isDenied ? 'var(--brand-crimson)' : 'var(--border-default)',
+      }}
+    >
+      <div
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold mb-3"
+        style={{
+          backgroundColor: isPending ? '#f2cc8f33' : isDenied ? '#bc474915' : '#1a3c2e18',
+          color: isPending ? '#7a5c00' : isDenied ? '#bc4749' : '#1a3c2e',
+        }}
+      >
+        {isPending ? 'Pending primary review' : isDenied ? 'Denied' : 'Approved'}
+      </div>
+      <p className="text-sm font-semibold mb-0.5" style={{ color: 'var(--text-primary)' }}>
+        {fullName(outboundRequest.claimed_primary)}
+        {outboundRequest.claimed_primary?.abo_number && (
+          <span className="font-normal text-xs ml-1.5" style={{ color: 'var(--text-secondary)' }}>
+            ABO {outboundRequest.claimed_primary.abo_number}
+          </span>
+        )}
+      </p>
+      <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+        Submitted {formatDate(outboundRequest.created_at)}
+      </p>
+      {isDenied && outboundRequest.admin_note && (
+        <p className="text-xs mt-2" style={{ color: 'var(--brand-crimson)' }}>
+          {outboundRequest.admin_note}
+        </p>
+      )}
+      {isPending && (
+        <p className="text-xs mt-2" style={{ color: 'var(--text-secondary)' }}>
+          Waiting for {fullName(outboundRequest.claimed_primary)} to review your request.
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ── Page component ─────────────────────────────────────────────────────────────
+
+export default function SpouseLinkClient({
+  profileRole,
+  isPrimary,
+  outboundRequest,
+  inboundRequests,
+}: Props) {
+  const { t } = useLanguage()
+  void t
+
+  const isGuest = profileRole === 'guest'
+  const title = isGuest ? 'Your spouse link request' : 'Spouse link requests'
+  const subtitle = isGuest
+    ? 'Track the status of your request to link as a spouse account.'
+    : 'Review and approve or deny requests from guests claiming to be your spouse.'
+
+  const content = (
+    <>
+      <div
+        style={{
+          borderRadius: 'var(--bento-radius)',
+          padding: 'var(--bento-padding)',
+          backgroundColor: 'var(--bg-card)',
+          border: '1px solid var(--border-default)',
+          marginBottom: 12,
+        }}
+      >
+        <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-1" style={{ color: 'var(--brand-crimson)' }}>
+          {title}
+        </p>
+        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+          {subtitle}
+        </p>
+      </div>
+
+      {isGuest ? (
+        <GuestView outboundRequest={outboundRequest} />
+      ) : isPrimary ? (
+        <PrimaryView inboundRequests={inboundRequests} />
+      ) : (
+        <div
+          className="rounded-2xl border px-5 py-8 text-center"
+          style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+        >
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            This page is not available for secondary accounts.
+          </p>
+        </div>
+      )}
+    </>
+  )
+
+  return (
+    <div className="py-8 pb-16">
+
+      {/* ── DESKTOP ─────────────────────────────────────────────────────────── */}
+      <div className="hidden md:block max-w-[860px] mx-auto px-4">
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
+            gap: '12px',
+          }}
+        >
+          <div style={{ gridColumn: '3 / span 8' }}>
+            {content}
+          </div>
+        </div>
+      </div>
+
+      {/* ── MOBILE ──────────────────────────────────────────────────────────── */}
+      <div className="md:hidden flex flex-col gap-3 px-4">
+        {content}
+      </div>
+
+    </div>
+  )
+}

--- a/app/(dashboard)/profile/spouse-link/page.tsx
+++ b/app/(dashboard)/profile/spouse-link/page.tsx
@@ -1,0 +1,69 @@
+import { auth } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+import { createServiceClient } from '@/lib/supabase/service'
+import SpouseLinkClient from './SpouseLinkClient'
+
+export default async function SpouseLinkPage() {
+  const { userId } = await auth()
+  if (!userId) redirect('/sign-in')
+
+  const supabase = createServiceClient()
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id, role, primary_profile_id')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (!profile) redirect('/profile')
+
+  // Guests: fetch their own outbound request
+  let outboundRequest: {
+    id: string
+    status: string
+    admin_note: string | null
+    created_at: string
+    claimed_primary: { first_name: string; last_name: string; abo_number: string | null } | null
+  } | null = null
+
+  if (profile.role === 'guest' && !profile.primary_profile_id) {
+    const { data } = await supabase
+      .from('spouse_link_requests')
+      .select(`
+        id, status, admin_note, created_at,
+        claimed_primary:profiles!spouse_link_requests_claimed_primary_id_fkey(first_name, last_name, abo_number)
+      `)
+      .eq('requester_id', profile.id)
+      .maybeSingle()
+    outboundRequest = data ?? null
+  }
+
+  // Primary members: fetch inbound pending requests
+  let inboundRequests: {
+    id: string
+    status: string
+    created_at: string
+    requester: { id: string; first_name: string; last_name: string; contact_email: string | null } | null
+  }[] = []
+
+  if (profile.role !== 'guest' && !profile.primary_profile_id) {
+    const { data } = await supabase
+      .from('spouse_link_requests')
+      .select(`
+        id, status, created_at,
+        requester:profiles!spouse_link_requests_requester_id_fkey(id, first_name, last_name, contact_email)
+      `)
+      .eq('claimed_primary_id', profile.id)
+      .eq('status', 'pending')
+    inboundRequests = data ?? []
+  }
+
+  return (
+    <SpouseLinkClient
+      profileRole={profile.role}
+      isPrimary={!profile.primary_profile_id}
+      outboundRequest={outboundRequest}
+      inboundRequests={inboundRequests}
+    />
+  )
+}

--- a/app/(dashboard)/profile/types.ts
+++ b/app/(dashboard)/profile/types.ts
@@ -73,6 +73,8 @@ export type Profile = {
   upline: UplineData | null
   verRequest: VerificationRequest | null
   spouse: SpouseData | null
+  // Number of pending inbound spouse link requests (primary members only, else 0)
+  pendingSpouseLinkCount: number
 }
 
 export type TripPayment = {

--- a/app/admin/approval-hub/components/SpouseLinkRequestsTab.tsx
+++ b/app/admin/approval-hub/components/SpouseLinkRequestsTab.tsx
@@ -1,8 +1,6 @@
 'use client'
 
-import { useState } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from '@/lib/toast'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 
 // ── Types ────────────────────────────────────────────────
@@ -31,54 +29,10 @@ function fullName(p: { first_name: string; last_name: string } | null) {
   return `${p.first_name} ${p.last_name}`.trim()
 }
 
-// ── Row: deny input state ──────────────────────────────────
-// Hoisted to module scope — avoids React remount anti-pattern.
-function DenyForm({
-  onCancel,
-  onConfirm,
-  isPending,
-  t,
-}: {
-  onCancel: () => void
-  onConfirm: (note: string) => void
-  isPending: boolean
-  t: (key: Parameters<ReturnType<typeof useLanguage>['t']>[0]) => string
-}) {
-  const [note, setNote] = useState('')
-  return (
-    <div className="mt-2 space-y-2">
-      <textarea
-        value={note}
-        onChange={e => setNote(e.target.value)}
-        placeholder={t('admin.approval.spouse.denyNotePlaceholder')}
-        rows={2}
-        className="w-full text-xs rounded-lg border px-3 py-2 resize-none focus:outline-none"
-        style={{
-          backgroundColor: 'var(--bg-global)',
-          borderColor: 'var(--border-default)',
-          color: 'var(--text-primary)',
-        }}
-      />
-      <div className="flex gap-2">
-        <button
-          onClick={() => { if (note.trim()) onConfirm(note.trim()) }}
-          disabled={!note.trim() || isPending}
-          className="px-3 py-1.5 rounded-lg text-xs font-medium text-white disabled:opacity-40 transition-opacity"
-          style={{ backgroundColor: 'var(--brand-crimson)' }}
-        >
-          {t('admin.approval.spouse.btn.confirmDeny')}
-        </button>
-        <button
-          onClick={onCancel}
-          disabled={isPending}
-          className="px-3 py-1.5 rounded-lg text-xs font-medium disabled:opacity-40 transition-opacity"
-          style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-secondary)' }}
-        >
-          {t('admin.approval.spouse.btn.cancel')}
-        </button>
-      </div>
-    </div>
-  )
+const STATUS_STYLE: Record<SpouseLinkRequest['status'], { bg: string; color: string; label: string }> = {
+  pending:  { bg: '#f2cc8f33', color: '#7a5c00', label: 'Pending primary review' },
+  approved: { bg: '#1a3c2e18', color: '#1a3c2e', label: 'Approved' },
+  denied:   { bg: '#bc474915', color: '#bc4749', label: 'Denied' },
 }
 
 // ── Component ────────────────────────────────────────────
@@ -86,7 +40,6 @@ function DenyForm({
 export function SpouseLinkRequestsTab() {
   const { t } = useLanguage()
   const qc = useQueryClient()
-  const [denyingId, setDenyingId] = useState<string | null>(null)
 
   const { data: requests = [], isLoading } = useQuery<SpouseLinkRequest[]>({
     queryKey: ['spouse-link-requests'],
@@ -96,38 +49,7 @@ export function SpouseLinkRequestsTab() {
     }),
   })
 
-  const actionMutation = useMutation({
-    mutationFn: ({ id, status, admin_note }: { id: string; status: 'approved' | 'denied'; admin_note?: string }) =>
-      fetch(`/api/admin/spouse-link-requests/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status, admin_note }),
-      }).then(async r => {
-        const body = await r.json().catch(() => ({}))
-        if (!r.ok) throw new Error(body.error ?? `HTTP ${r.status}`)
-        return body
-      }),
-    onMutate: async ({ id }) => {
-      await qc.cancelQueries({ queryKey: ['spouse-link-requests'] })
-      const prev = qc.getQueryData<SpouseLinkRequest[]>(['spouse-link-requests'])
-      qc.setQueryData<SpouseLinkRequest[]>(['spouse-link-requests'],
-        old => old?.filter(r => r.id !== id)
-      )
-      return { prev }
-    },
-    onError: (_e, _v, ctx) => {
-      if (ctx?.prev) qc.setQueryData(['spouse-link-requests'], ctx.prev)
-      toast.error('Action failed. Please try again.')
-    },
-    onSuccess: (_data, vars) => {
-      setDenyingId(null)
-      const msg = vars.status === 'approved' ? 'Request approved.' : 'Request denied.'
-      toast.success(msg)
-    },
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: ['spouse-link-requests'] })
-    },
-  })
+  void qc // retained to avoid unused import warning; may be used for future refresh triggers
 
   const pending = requests.filter(r => r.status === 'pending')
 
@@ -137,13 +59,17 @@ export function SpouseLinkRequestsTab() {
         {t('admin.approval.spouse.pendingTitle').replace('{{count}}', String(pending.length))}
       </p>
 
+      <p className="text-xs mb-4" style={{ color: 'var(--text-secondary)' }}>
+        Spouse link requests are now reviewed by the primary member, not admin. This view is read-only.
+      </p>
+
       {isLoading ? (
         <div className="space-y-2">
           {[...Array(3)].map((_, i) => (
             <div key={i} className="h-16 bg-black/5 rounded-xl animate-pulse" />
           ))}
         </div>
-      ) : pending.length === 0 ? (
+      ) : requests.length === 0 ? (
         <div
           className="rounded-xl border px-5 py-8 text-center"
           style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
@@ -154,66 +80,57 @@ export function SpouseLinkRequestsTab() {
         </div>
       ) : (
         <div className="space-y-2">
-          {pending.map(req => (
-            <div
-              key={req.id}
-              className="rounded-xl border px-4 py-3.5"
-              style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
-            >
-              <div className="flex items-start gap-3">
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                    {fullName(req.requester)}
-                    {req.requester?.contact_email && (
-                      <span className="font-normal text-xs ml-1.5" style={{ color: 'var(--text-secondary)' }}>
-                        {req.requester.contact_email}
+          {requests.map(req => {
+            const s = STATUS_STYLE[req.status]
+            return (
+              <div
+                key={req.id}
+                className="rounded-xl border px-4 py-3.5"
+                style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}
+              >
+                <div className="flex items-start gap-3">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-0.5">
+                      <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                        {fullName(req.requester)}
+                      </p>
+                      <span
+                        className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
+                        style={{ backgroundColor: s.bg, color: s.color }}
+                      >
+                        {s.label}
                       </span>
+                    </div>
+                    {req.requester?.contact_email && (
+                      <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                        {req.requester.contact_email}
+                      </p>
                     )}
-                  </p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
-                    {t('admin.approval.spouse.claimedPrimary')}:{' '}
-                    <span style={{ color: 'var(--text-primary)' }}>
-                      {fullName(req.claimed_primary)}
-                      {req.claimed_primary?.abo_number && ` · ABO ${req.claimed_primary.abo_number}`}
-                    </span>
-                  </p>
-                  <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
-                    {t('admin.approval.spouse.submitted')}: {formatDate(req.created_at)}
-                  </p>
-                </div>
-
-                {denyingId !== req.id && (
-                  <div className="flex gap-2 flex-shrink-0">
-                    <button
-                      onClick={() => actionMutation.mutate({ id: req.id, status: 'approved' })}
-                      disabled={actionMutation.isPending}
-                      className="px-4 py-1.5 rounded-lg text-sm font-medium text-white disabled:opacity-50 transition-opacity"
-                      style={{ backgroundColor: 'var(--brand-teal)' }}
-                    >
-                      {t('admin.approval.spouse.btn.approve')}
-                    </button>
-                    <button
-                      onClick={() => setDenyingId(req.id)}
-                      disabled={actionMutation.isPending}
-                      className="px-4 py-1.5 rounded-lg text-sm font-medium disabled:opacity-50 transition-opacity"
-                      style={{ backgroundColor: 'rgba(0,0,0,0.06)', color: 'var(--text-primary)' }}
-                    >
-                      {t('admin.approval.spouse.btn.deny')}
-                    </button>
+                    <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+                      {t('admin.approval.spouse.claimedPrimary')}:{' '}
+                      <span style={{ color: 'var(--text-primary)' }}>
+                        {fullName(req.claimed_primary)}
+                        {req.claimed_primary?.abo_number && ` · ABO ${req.claimed_primary.abo_number}`}
+                      </span>
+                    </p>
+                    <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+                      {t('admin.approval.spouse.submitted')}: {formatDate(req.created_at)}
+                    </p>
+                    {req.admin_note && (
+                      <p className="text-xs mt-1 italic" style={{ color: 'var(--text-secondary)' }}>
+                        Note: {req.admin_note}
+                      </p>
+                    )}
+                    {req.resolved_at && (
+                      <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+                        Resolved: {formatDate(req.resolved_at)}
+                      </p>
+                    )}
                   </div>
-                )}
+                </div>
               </div>
-
-              {denyingId === req.id && (
-                <DenyForm
-                  onCancel={() => setDenyingId(null)}
-                  onConfirm={note => actionMutation.mutate({ id: req.id, status: 'denied', admin_note: note })}
-                  isPending={actionMutation.isPending}
-                  t={t}
-                />
-              )}
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/app/api/admin/spouse-link-requests/[id]/route.ts
+++ b/app/api/admin/spouse-link-requests/[id]/route.ts
@@ -1,9 +1,15 @@
-import { auth, clerkClient } from '@clerk/nextjs/server'
+import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { requireAdmin } from '@/lib/supabase/guards'
 
-export async function PATCH(
-  req: Request,
+// PATCH removed — admin cannot act on spouse link requests.
+// Approval/denial is now performed by the primary member via
+// POST /api/profile/spouse-link/[action].
+//
+// GET remains for the read-only Approval Hub view.
+
+export async function GET(
+  _req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { userId } = await auth()
@@ -14,151 +20,18 @@ export async function PATCH(
   if (guard) return guard
 
   const { id: requestId } = await params
-  const body = await req.json()
-  const { status, admin_note } = body
 
-  if (!status || !['approved', 'denied'].includes(status)) {
-    return Response.json({ error: 'status must be approved or denied' }, { status: 400 })
-  }
-  if (status === 'denied' && !admin_note?.trim()) {
-    return Response.json({ error: 'admin_note is required when denying' }, { status: 400 })
-  }
-
-  // Fetch the request
-  const { data: request } = await supabase
+  const { data, error } = await supabase
     .from('spouse_link_requests')
-    .select('id, status, requester_id, claimed_primary_id')
+    .select(`
+      id, status, admin_note, created_at, resolved_at,
+      requester:profiles!spouse_link_requests_requester_id_fkey(id, first_name, last_name, contact_email, role),
+      claimed_primary:profiles!spouse_link_requests_claimed_primary_id_fkey(id, first_name, last_name, abo_number, role)
+    `)
     .eq('id', requestId)
     .single()
-  if (!request) return Response.json({ error: 'Request not found' }, { status: 404 })
-  if (request.status !== 'pending') {
-    return Response.json({ error: 'Request is no longer pending' }, { status: 409 })
-  }
 
-  if (status === 'denied') {
-    const { error } = await supabase
-      .from('spouse_link_requests')
-      .update({ status: 'denied', admin_note, resolved_at: new Date().toISOString() })
-      .eq('id', requestId)
-    if (error) return Response.json({ error: error.message }, { status: 500 })
-    return Response.json({ status: 'denied' })
-  }
-
-  // --- APPROVE path ---
-  // Re-verify all guards at approval time (not just submission time)
-
-  // Guard 1: requester must still be a guest with no primary_profile_id
-  const { data: requester } = await supabase
-    .from('profiles')
-    .select('id, role, primary_profile_id, clerk_id, first_name, contact_email')
-    .eq('id', request.requester_id)
-    .single()
-  if (!requester) return Response.json({ error: 'Requester profile not found' }, { status: 404 })
-  if (requester.role !== 'guest') {
-    return Response.json(
-      { error: 'Requester is no longer a guest. Cannot approve.', error_code: 'requester_not_guest' },
-      { status: 409 }
-    )
-  }
-  if (requester.primary_profile_id) {
-    return Response.json(
-      { error: 'Requester is already linked as a spouse.', error_code: 'requester_already_linked' },
-      { status: 409 }
-    )
-  }
-
-  // Guard 2: claimed_primary must be a verified member, with abo_number, and itself a primary
-  const { data: primary } = await supabase
-    .from('profiles')
-    .select('id, role, abo_number, primary_profile_id')
-    .eq('id', request.claimed_primary_id)
-    .single()
-  if (!primary) return Response.json({ error: 'Primary profile not found' }, { status: 404 })
-  if (primary.role === 'guest') {
-    return Response.json(
-      { error: 'Primary profile is not a verified member.', error_code: 'primary_not_member' },
-      { status: 409 }
-    )
-  }
-  if (!primary.abo_number) {
-    return Response.json(
-      { error: 'Primary profile has no ABO number.', error_code: 'primary_no_abo' },
-      { status: 409 }
-    )
-  }
-  if (primary.primary_profile_id) {
-    return Response.json(
-      { error: 'Primary profile is itself a secondary account.', error_code: 'primary_is_secondary' },
-      { status: 409 }
-    )
-  }
-
-  // Guard 3: primary must have no existing secondary
-  const { data: existingSecondary } = await supabase
-    .from('profiles')
-    .select('id')
-    .eq('primary_profile_id', primary.id)
-    .maybeSingle()
-  if (existingSecondary) {
-    return Response.json(
-      { error: 'Primary already has a linked spouse account.', error_code: 'primary_has_secondary' },
-      { status: 409 }
-    )
-  }
-
-  // Atomic writes
-  const { error: profileErr } = await supabase
-    .from('profiles')
-    .update({
-      primary_profile_id: primary.id,
-      abo_number: primary.abo_number,
-      role: 'member',
-    })
-    .eq('id', requester.id)
-  if (profileErr) return Response.json({ error: profileErr.message }, { status: 500 })
-
-  const { error: requestErr } = await supabase
-    .from('spouse_link_requests')
-    .update({ status: 'approved', admin_note: admin_note ?? null, resolved_at: new Date().toISOString() })
-    .eq('id', requestId)
-  if (requestErr) return Response.json({ error: requestErr.message }, { status: 500 })
-
-  // Audit log
-  await supabase.from('role_change_audit').insert({
-    profile_id: requester.id,
-    changed_by: userId,
-    old_role: 'guest',
-    new_role: 'member',
-    note: 'Spouse link approval',
-  })
-
-  // Sync Clerk metadata
-  if (requester.clerk_id) {
-    const clerk = await clerkClient()
-    await clerk.users.updateUserMetadata(requester.clerk_id, {
-      publicMetadata: { role: 'member' },
-    })
-  }
-
-  // Welcome email — best-effort
-  if (requester.contact_email) {
-    import('@/lib/email/send').then(({ sendNotificationEmail }) => {
-      import('@/lib/email/templates/render').then(({ renderEmailTemplate }) => {
-        import('@/lib/email/templates/WelcomeEmail').then(({ WelcomeEmail }) => {
-          renderEmailTemplate(WelcomeEmail({ firstName: requester.first_name || 'Member' }))
-            .then(html => {
-              sendNotificationEmail({
-                to: requester.contact_email!,
-                subject: 'Welcome to Team Enjoy VD!',
-                html,
-                template: 'abo_verification_result',
-                meta: { profile_id: requester.id },
-              }).catch(console.error)
-            }).catch(console.error)
-        }).catch(console.error)
-      }).catch(console.error)
-    }).catch(console.error)
-  }
-
-  return Response.json({ status: 'approved' }, { status: 200 })
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+  if (!data) return Response.json({ error: 'Not found' }, { status: 404 })
+  return Response.json(data)
 }

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -28,7 +28,7 @@ export async function GET() {
   const role: string = data.role
   const primaryProfileId: string | null = data.primary_profile_id ?? null
 
-  const [upline, verRequest, spouse] = await Promise.all([
+  const [upline, verRequest, spouse, pendingSpouseLinkCount] = await Promise.all([
     // Resolve upline for any verified member.
     // Standard path: abo_number set — look up sponsor via los_members tree.
     // Manual path: abo_number null but upline_abo_number set — resolve name directly.
@@ -101,9 +101,21 @@ export async function GET() {
         return secondary ?? null
       }
     })(),
+    // Pending inbound spouse link requests — only relevant for primary members
+    // (non-guest, no primary_profile_id). Guests and secondaries always get 0.
+    role !== 'guest' && !primaryProfileId
+      ? (async () => {
+          const { count } = await supabase
+            .from('spouse_link_requests')
+            .select('id', { count: 'exact', head: true })
+            .eq('claimed_primary_id', profileId)
+            .eq('status', 'pending')
+          return count ?? 0
+        })()
+      : Promise.resolve(0),
   ])
 
-  return Response.json({ ...data, upline, verRequest, spouse })
+  return Response.json({ ...data, upline, verRequest, spouse, pendingSpouseLinkCount })
 }
 
 export async function PATCH(req: Request): Promise<Response> {

--- a/app/api/profile/spouse-link/[action]/route.ts
+++ b/app/api/profile/spouse-link/[action]/route.ts
@@ -21,6 +21,9 @@ export async function POST(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
+  // member_event_log and role_change_audit are not yet in generated Supabase types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const db = supabase as any
 
   // Resolve caller profile
   const { data: caller } = await supabase
@@ -67,7 +70,7 @@ export async function POST(
       .eq('id', request_id)
     if (error) return Response.json({ error: error.message }, { status: 500 })
 
-    supabase.from('member_event_log').insert({
+    db.from('member_event_log').insert({
       actor_id: userId,
       subject_id: request.requester_id,
       event_type: 'spouse_link_denied',
@@ -157,7 +160,7 @@ export async function POST(
   if (requestErr) return Response.json({ error: requestErr.message }, { status: 500 })
 
   // Audit log
-  await supabase.from('role_change_audit').insert({
+  await db.from('role_change_audit').insert({
     profile_id: requester.id,
     changed_by: userId,
     old_role: 'guest',
@@ -166,7 +169,7 @@ export async function POST(
   })
 
   // Event log
-  supabase.from('member_event_log').insert([
+  db.from('member_event_log').insert([
     {
       actor_id: userId,
       subject_id: requester.id,
@@ -181,14 +184,14 @@ export async function POST(
     clerk.users.updateUserMetadata(requester.clerk_id, {
       publicMetadata: { role: 'member' },
     }).then(() => {
-      supabase.from('member_event_log').insert({
+      db.from('member_event_log').insert({
         actor_id: userId,
         subject_id: requester.id,
         event_type: 'clerk_sync_ok',
         payload: { context: 'spouse_link_approve' },
       }).then().catch(console.error)
     }).catch((err: unknown) => {
-      supabase.from('member_event_log').insert({
+      db.from('member_event_log').insert({
         actor_id: userId,
         subject_id: requester.id,
         event_type: 'clerk_sync_failed',

--- a/app/api/profile/spouse-link/[action]/route.ts
+++ b/app/api/profile/spouse-link/[action]/route.ts
@@ -1,0 +1,216 @@
+import { auth, clerkClient } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { sendNotificationEmail } from '@/lib/email/send'
+import { renderEmailTemplate } from '@/lib/email/templates/render'
+import { WelcomeEmail } from '@/lib/email/templates/WelcomeEmail'
+
+// POST /api/profile/spouse-link/approve
+// POST /api/profile/spouse-link/deny
+// Called by the primary member. Body: { request_id: string, deny_note?: string }
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ action: string }> }
+) {
+  const { action } = await params
+  if (action !== 'approve' && action !== 'deny') {
+    return Response.json({ error: 'Invalid action' }, { status: 404 })
+  }
+
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+
+  // Resolve caller profile
+  const { data: caller } = await supabase
+    .from('profiles')
+    .select('id, role, primary_profile_id')
+    .eq('clerk_id', userId)
+    .single()
+  if (!caller) return Response.json({ error: 'Profile not found' }, { status: 404 })
+
+  // Caller must be a primary member (member, no primary_profile_id)
+  if (caller.role === 'guest') {
+    return Response.json({ error: 'Only verified members can act on spouse link requests' }, { status: 403 })
+  }
+  if (caller.primary_profile_id) {
+    return Response.json({ error: 'Secondary accounts cannot act on spouse link requests' }, { status: 403 })
+  }
+
+  const body = await req.json()
+  const { request_id, deny_note } = body
+  if (!request_id) return Response.json({ error: 'request_id is required' }, { status: 400 })
+  if (action === 'deny' && !deny_note?.trim()) {
+    return Response.json({ error: 'deny_note is required when denying' }, { status: 400 })
+  }
+
+  // Fetch the request — verify claimed_primary_id matches caller
+  const { data: request } = await supabase
+    .from('spouse_link_requests')
+    .select('id, status, requester_id, claimed_primary_id')
+    .eq('id', request_id)
+    .single()
+  if (!request) return Response.json({ error: 'Request not found' }, { status: 404 })
+  if (request.claimed_primary_id !== caller.id) {
+    return Response.json({ error: 'You are not the primary for this request' }, { status: 403 })
+  }
+  if (request.status !== 'pending') {
+    return Response.json({ error: 'Request is no longer pending' }, { status: 409 })
+  }
+
+  // ── DENY ──────────────────────────────────────────────────────────────────
+  if (action === 'deny') {
+    const { error } = await supabase
+      .from('spouse_link_requests')
+      .update({ status: 'denied', admin_note: deny_note.trim(), resolved_at: new Date().toISOString() })
+      .eq('id', request_id)
+    if (error) return Response.json({ error: error.message }, { status: 500 })
+
+    supabase.from('member_event_log').insert({
+      actor_id: userId,
+      subject_id: request.requester_id,
+      event_type: 'spouse_link_denied',
+      payload: { request_id, denied_by: caller.id },
+    }).then().catch(console.error)
+
+    return Response.json({ status: 'denied' })
+  }
+
+  // ── APPROVE ───────────────────────────────────────────────────────────────
+  // Re-verify all guards at approval time
+
+  // Guard 1: requester must still be a guest with no primary_profile_id
+  const { data: requester } = await supabase
+    .from('profiles')
+    .select('id, role, primary_profile_id, clerk_id, first_name, contact_email')
+    .eq('id', request.requester_id)
+    .single()
+  if (!requester) return Response.json({ error: 'Requester profile not found' }, { status: 404 })
+  if (requester.role !== 'guest') {
+    return Response.json(
+      { error: 'Requester is no longer a guest. Cannot approve.', error_code: 'requester_not_guest' },
+      { status: 409 }
+    )
+  }
+  if (requester.primary_profile_id) {
+    return Response.json(
+      { error: 'Requester is already linked as a spouse.', error_code: 'requester_already_linked' },
+      { status: 409 }
+    )
+  }
+
+  // Guard 2: caller (primary) must still be a verified member with abo_number, itself a primary
+  const { data: primary } = await supabase
+    .from('profiles')
+    .select('id, role, abo_number, primary_profile_id')
+    .eq('id', caller.id)
+    .single()
+  if (!primary) return Response.json({ error: 'Primary profile not found' }, { status: 404 })
+  if (primary.role === 'guest') {
+    return Response.json(
+      { error: 'Your account is not a verified member.', error_code: 'primary_not_member' },
+      { status: 409 }
+    )
+  }
+  if (!primary.abo_number) {
+    return Response.json(
+      { error: 'Your account has no ABO number.', error_code: 'primary_no_abo' },
+      { status: 409 }
+    )
+  }
+  if (primary.primary_profile_id) {
+    return Response.json(
+      { error: 'Your account is itself a secondary account.', error_code: 'primary_is_secondary' },
+      { status: 409 }
+    )
+  }
+
+  // Guard 3: primary must have no existing secondary
+  const { data: existingSecondary } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('primary_profile_id', primary.id)
+    .maybeSingle()
+  if (existingSecondary) {
+    return Response.json(
+      { error: 'You already have a linked spouse account.', error_code: 'primary_has_secondary' },
+      { status: 409 }
+    )
+  }
+
+  // Atomic writes
+  const { error: profileErr } = await supabase
+    .from('profiles')
+    .update({
+      primary_profile_id: primary.id,
+      abo_number: primary.abo_number,
+      role: 'member',
+    })
+    .eq('id', requester.id)
+  if (profileErr) return Response.json({ error: profileErr.message }, { status: 500 })
+
+  const { error: requestErr } = await supabase
+    .from('spouse_link_requests')
+    .update({ status: 'approved', admin_note: null, resolved_at: new Date().toISOString() })
+    .eq('id', request_id)
+  if (requestErr) return Response.json({ error: requestErr.message }, { status: 500 })
+
+  // Audit log
+  await supabase.from('role_change_audit').insert({
+    profile_id: requester.id,
+    changed_by: userId,
+    old_role: 'guest',
+    new_role: 'member',
+    note: 'Spouse link approval by primary member',
+  })
+
+  // Event log
+  supabase.from('member_event_log').insert([
+    {
+      actor_id: userId,
+      subject_id: requester.id,
+      event_type: 'spouse_link_approved',
+      payload: { request_id, approved_by: caller.id },
+    },
+  ]).then().catch(console.error)
+
+  // Sync Clerk metadata
+  if (requester.clerk_id) {
+    const clerk = await clerkClient()
+    clerk.users.updateUserMetadata(requester.clerk_id, {
+      publicMetadata: { role: 'member' },
+    }).then(() => {
+      supabase.from('member_event_log').insert({
+        actor_id: userId,
+        subject_id: requester.id,
+        event_type: 'clerk_sync_ok',
+        payload: { context: 'spouse_link_approve' },
+      }).then().catch(console.error)
+    }).catch((err: unknown) => {
+      supabase.from('member_event_log').insert({
+        actor_id: userId,
+        subject_id: requester.id,
+        event_type: 'clerk_sync_failed',
+        payload: { context: 'spouse_link_approve', error: String(err) },
+      }).then().catch(console.error)
+    })
+  }
+
+  // Welcome email — best-effort
+  if (requester.contact_email) {
+    renderEmailTemplate(
+      WelcomeEmail({ firstName: requester.first_name || 'Member' })
+    ).then(html =>
+      sendNotificationEmail({
+        to: requester.contact_email!,
+        subject: 'Welcome to Team Enjoy VD!',
+        html,
+        template: 'abo_verification_result',
+        meta: { profile_id: requester.id },
+      })
+    ).catch(console.error)
+  }
+
+  return Response.json({ status: 'approved' })
+}

--- a/app/api/profile/spouse-link/[action]/route.ts
+++ b/app/api/profile/spouse-link/[action]/route.ts
@@ -70,12 +70,12 @@ export async function POST(
       .eq('id', request_id)
     if (error) return Response.json({ error: error.message }, { status: 500 })
 
-    db.from('member_event_log').insert({
+    await db.from('member_event_log').insert({
       actor_id: userId,
       subject_id: request.requester_id,
       event_type: 'spouse_link_denied',
       payload: { request_id, denied_by: caller.id },
-    }).then().catch(console.error)
+    })
 
     return Response.json({ status: 'denied' })
   }
@@ -169,38 +169,40 @@ export async function POST(
   })
 
   // Event log
-  db.from('member_event_log').insert([
+  await db.from('member_event_log').insert([
     {
       actor_id: userId,
       subject_id: requester.id,
       event_type: 'spouse_link_approved',
       payload: { request_id, approved_by: caller.id },
     },
-  ]).then().catch(console.error)
+  ])
 
-  // Sync Clerk metadata
+  // Sync Clerk metadata — awaited so the serverless function does not exit
+  // before the role is visible to the user's next session.
   if (requester.clerk_id) {
     const clerk = await clerkClient()
-    clerk.users.updateUserMetadata(requester.clerk_id, {
-      publicMetadata: { role: 'member' },
-    }).then(() => {
-      db.from('member_event_log').insert({
+    try {
+      await clerk.users.updateUserMetadata(requester.clerk_id, {
+        publicMetadata: { role: 'member' },
+      })
+      await db.from('member_event_log').insert({
         actor_id: userId,
         subject_id: requester.id,
         event_type: 'clerk_sync_ok',
         payload: { context: 'spouse_link_approve' },
-      }).then().catch(console.error)
-    }).catch((err: unknown) => {
-      db.from('member_event_log').insert({
+      })
+    } catch (err: unknown) {
+      await db.from('member_event_log').insert({
         actor_id: userId,
         subject_id: requester.id,
         event_type: 'clerk_sync_failed',
         payload: { context: 'spouse_link_approve', error: String(err) },
-      }).then().catch(console.error)
-    })
+      })
+    }
   }
 
-  // Welcome email — best-effort
+  // Welcome email — best-effort, non-blocking
   if (requester.contact_email) {
     renderEmailTemplate(
       WelcomeEmail({ firstName: requester.first_name || 'Member' })

--- a/app/api/profile/spouse-link/route.ts
+++ b/app/api/profile/spouse-link/route.ts
@@ -31,6 +31,7 @@ export async function POST(req: Request) {
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
+  // member_event_log is not in generated types; notifications uses PromiseLike (no .catch)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const db = supabase as any
 
@@ -126,7 +127,8 @@ export async function POST(req: Request) {
   const requesterName = `${profile.first_name ?? ''} ${profile.last_name ?? ''}`.trim() || 'Someone'
 
   // In-app notification for primary — best-effort
-  supabase.from('notifications').insert({
+  // Use db (any) to avoid PromiseLike.catch TS error on the typed supabase client
+  db.from('notifications').insert({
     profile_id: primary.id,
     type: 'spouse_link_request',
     title: 'Spouse link request',
@@ -154,7 +156,7 @@ export async function POST(req: Request) {
     ).catch(console.error)
   }
 
-  // Event log — member_event_log not yet in generated types; cast to any
+  // Event log — member_event_log not in generated types
   db.from('member_event_log').insert({
     actor_id: userId,
     subject_id: primary.id,

--- a/app/api/profile/spouse-link/route.ts
+++ b/app/api/profile/spouse-link/route.ts
@@ -1,5 +1,8 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { sendNotificationEmail } from '@/lib/email/send'
+import { renderEmailTemplate } from '@/lib/email/templates/render'
+import { SpouseLinkRequestEmail } from '@/lib/email/templates/SpouseLinkRequestEmail'
 
 // GET — return own pending/denied spouse_link_requests row, or null
 export async function GET() {
@@ -30,7 +33,7 @@ export async function POST(req: Request) {
   const supabase = createServiceClient()
   const { data: profile } = await supabase
     .from('profiles')
-    .select('id, role, primary_profile_id')
+    .select('id, role, primary_profile_id, first_name, last_name')
     .eq('clerk_id', userId)
     .single()
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
@@ -62,7 +65,7 @@ export async function POST(req: Request) {
   // Resolve the claimed primary by ABO number
   const { data: primary } = await supabase
     .from('profiles')
-    .select('id, role, abo_number, primary_profile_id')
+    .select('id, role, abo_number, primary_profile_id, first_name, contact_email')
     .eq('abo_number', claimed_primary_abo)
     .neq('id', profile.id)
     .maybeSingle()
@@ -116,6 +119,46 @@ export async function POST(req: Request) {
     .single()
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
+
+  const requesterName = `${profile.first_name ?? ''} ${profile.last_name ?? ''}`.trim() || 'Someone'
+
+  // In-app notification for primary — best-effort
+  supabase.from('notifications').insert({
+    profile_id: primary.id,
+    type: 'spouse_link_request',
+    title: 'Spouse link request',
+    message: `${requesterName} has requested to link as your spouse account.`,
+    action_url: '/profile/spouse-link',
+  }).then().catch(console.error)
+
+  // Email notification for primary — best-effort
+  if (primary.contact_email) {
+    renderEmailTemplate(
+      SpouseLinkRequestEmail({
+        primaryFirstName: primary.first_name ?? 'Member',
+        requesterFirstName: profile.first_name ?? '',
+        requesterLastName: profile.last_name ?? '',
+        actionUrl: `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://portal.teamenjoyvd.com'}/profile/spouse-link`,
+      })
+    ).then(html =>
+      sendNotificationEmail({
+        to: primary.contact_email!,
+        subject: `${requesterName} has requested to link as your spouse account`,
+        html,
+        template: 'spouse_link_request',
+        meta: { requester_id: profile.id, primary_id: primary.id },
+      })
+    ).catch(console.error)
+  }
+
+  // Event log
+  supabase.from('member_event_log').insert({
+    actor_id: userId,
+    subject_id: primary.id,
+    event_type: 'spouse_link_requested',
+    payload: { requester_id: profile.id, request_id: data.id },
+  }).then().catch(console.error)
+
   return Response.json(data, { status: 201 })
 }
 

--- a/app/api/profile/spouse-link/route.ts
+++ b/app/api/profile/spouse-link/route.ts
@@ -31,6 +31,9 @@ export async function POST(req: Request) {
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const db = supabase as any
+
   const { data: profile } = await supabase
     .from('profiles')
     .select('id, role, primary_profile_id, first_name, last_name')
@@ -151,8 +154,8 @@ export async function POST(req: Request) {
     ).catch(console.error)
   }
 
-  // Event log
-  supabase.from('member_event_log').insert({
+  // Event log — member_event_log not yet in generated types; cast to any
+  db.from('member_event_log').insert({
     actor_id: userId,
     subject_id: primary.id,
     event_type: 'spouse_link_requested',

--- a/lib/email/templates/SpouseLinkRequestEmail.tsx
+++ b/lib/email/templates/SpouseLinkRequestEmail.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable i18next/no-literal-string -- TODO: email i18n — static server-rendered copy, no lang context available */
+import { Section, Text } from '@react-email/components'
+import * as React from 'react'
+import { EmailShell, bodyPadding } from './_shell'
+
+export type SpouseLinkRequestEmailProps = {
+  primaryFirstName: string
+  requesterFirstName: string
+  requesterLastName: string
+  actionUrl: string
+}
+
+export function SpouseLinkRequestEmail({
+  primaryFirstName,
+  requesterFirstName,
+  requesterLastName,
+  actionUrl,
+}: SpouseLinkRequestEmailProps) {
+  return (
+    <EmailShell
+      preview={`${requesterFirstName} ${requesterLastName} has requested to link as your spouse account`}
+      title="Spouse Link Request"
+    >
+      <Section style={{ ...bodyPadding }}>
+        <Text style={{ margin: '0 0 16px', fontSize: 15, color: '#111827' }}>
+          Hi {primaryFirstName},
+        </Text>
+        <Text style={{ margin: '0 0 20px', fontSize: 15, color: '#374151' }}>
+          <strong>{requesterFirstName} {requesterLastName}</strong> has submitted a request to be linked as your spouse account on the TeamEnjoyVD portal.
+        </Text>
+        <Text style={{ margin: '0 0 20px', fontSize: 15, color: '#374151' }}>
+          You can review and approve or deny this request from your profile page.
+        </Text>
+
+        <Section
+          style={{
+            backgroundColor: '#1a3c2e18',
+            border: '1px solid #1a3c2e44',
+            borderRadius: 8,
+            padding: '12px 16px',
+            marginBottom: 20,
+          }}
+        >
+          <Text style={{ margin: 0, fontSize: 14, color: '#1a3c2e' }}>
+            <a
+              href={actionUrl}
+              style={{ color: '#1a3c2e', fontWeight: 700, textDecoration: 'underline' }}
+            >
+              Review request →
+            </a>
+          </Text>
+        </Section>
+
+        <Text style={{ margin: 0, fontSize: 14, color: '#6b7280' }}>
+          If you don't recognise this person, you can safely deny the request. No action is required from you if you wish to deny it — but approving it will link their account to yours.
+        </Text>
+      </Section>
+    </EmailShell>
+  )
+}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1605,6 +1605,7 @@ export type Database = {
         | "los_digest"
         | "trip_message"
         | "trip_attachment"
+        | "spouse_link_request"
       registration_status: "pending" | "approved" | "denied"
       user_role: "admin" | "core" | "member" | "guest"
     }
@@ -1747,6 +1748,7 @@ export const Constants = {
         "los_digest",
         "trip_message",
         "trip_attachment",
+        "spouse_link_request",
       ],
       registration_status: ["pending", "approved", "denied"],
       user_role: ["admin", "core", "member", "guest"],


### PR DESCRIPTION
## Summary

Spouse link flow shifted from admin-approves to primary-member-approves.

## Changes

- `POST /api/profile/spouse-link`: sends in-app notification + transactional email to primary on submission; logs `spouse_link_requested`
- `POST /api/profile/spouse-link/[action]` (new): approve/deny by primary member only; approve path does full atomic write, Clerk sync, welcome email, logs `spouse_link_approved` / `clerk_sync_ok` / `clerk_sync_failed`; deny path logs `spouse_link_denied`
- `GET /api/admin/spouse-link-requests/[id]`: PATCH removed; GET retained for read-only Approval Hub
- `app/(dashboard)/profile/spouse-link/page.tsx` (new): primary sees pending inbound requests; guest sees their own outbound status; dual layout law followed
- `GET /api/profile`: now returns `pendingSpouseLinkCount` for primary members
- `AboInfoContent.tsx`: primary sees amber banner → `/profile/spouse-link` when inbound requests are pending
- `SpouseLinkRequestsTab.tsx`: read-only; shows requester name, ABO claim, primary name, date, status

Closes #320

## Session State
**Status:** DONE
**Completed:**
- [x] `/api/profile/spouse-link` POST notification + event log
- [x] `/api/profile/spouse-link/[action]` approve + deny routes
- [x] Admin `[id]` route PATCH removed, GET read-only
- [x] `/profile/spouse-link` page (RSC shell + client)
- [x] `pendingSpouseLinkCount` in profile API
- [x] ABO bento primary notification banner
- [x] `SpouseLinkRequestsTab` read-only
**Next:** Vercel Preview ready → merge