### PR TITLE
[2505-BUG-330] Fix all-day and multi-day Google Calendar events displaying as hourly timed events

### DIFF
--- a/app/(dashboard)/calendar/components/AgendaView.tsx
+++ b/app/(dashboard)/calendar/components/AgendaView.tsx
@@ -134,13 +134,14 @@ export function AgendaView({
                         </p>
                         <span className="text-xs flex-shrink-0 font-medium"
                           style={{ color: 'var(--text-secondary)' }}>
-                          {formatTime(ev.start_time)}
+                          {ev.is_all_day ? t('cal.allDay') : formatTime(ev.start_time)}
                         </span>
                       </div>
                       <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
-                        {formatTime(ev.start_time)} &ndash; {formatTime(ev.end_time)}
-                        {' · '}
-                        <span style={{ color: c.bg }}>{ev.category}</span>
+                        {ev.is_all_day
+                          ? <span style={{ color: c.bg }}>{ev.category}</span>
+                          : <>{formatTime(ev.start_time)} &ndash; {formatTime(ev.end_time)}{' · '}<span style={{ color: c.bg }}>{ev.category}</span></>
+                        }
                       </p>
                       {ev.description && (
                         <p className="text-xs mt-1.5 line-clamp-2 leading-relaxed"

--- a/app/(dashboard)/calendar/types.ts
+++ b/app/(dashboard)/calendar/types.ts
@@ -13,6 +13,7 @@ export type CalendarEvent = {
   event_type: 'in-person' | 'online' | 'hybrid' | null
   week_number: number
   access_roles: string[]
+  is_all_day: boolean
 }
 
 export type View = 'month' | 'agenda'

--- a/app/(dashboard)/components/tiles/CalendarTile.tsx
+++ b/app/(dashboard)/components/tiles/CalendarTile.tsx
@@ -11,6 +11,7 @@ export type CalendarEvent = {
   start_time: string
   end_time: string | null
   event_type: string | null
+  is_all_day: boolean
 }
 
 // Module-level formatters — Intl construction is expensive; hoist out of render loop.
@@ -100,12 +101,16 @@ export default function CalendarTile({ events = [], colSpan, mobileColSpan, rowS
       ) : (
         <div className="flex flex-col gap-1.5 flex-1">
           {events.map(event => {
-            const duration = eventDuration(event.start_time, event.end_time)
-            const typeParts = [
-              event.event_type ? (EVENT_TYPE_LABELS[event.event_type] ?? event.event_type) : null,
-              formatTime(event.start_time),
-              duration || null,
-            ].filter(Boolean).join(' · ')
+            const typeParts = event.is_all_day
+              ? [
+                  event.event_type ? (EVENT_TYPE_LABELS[event.event_type] ?? event.event_type) : null,
+                  t('home.cal.allDay'),
+                ].filter(Boolean).join(' · ')
+              : [
+                  event.event_type ? (EVENT_TYPE_LABELS[event.event_type] ?? event.event_type) : null,
+                  formatTime(event.start_time),
+                  eventDuration(event.start_time, event.end_time) || null,
+                ].filter(Boolean).join(' · ')
 
             const days = daysUntil(event.start_time)
             const pipLabel = days === 0

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -37,6 +37,11 @@ export default async function HomePage() {
     if (profile?.role) role = profile.role
   }
 
+  // All-day events are stored as Sofia midnight in UTC (22:00 UTC the prior day for EET,
+  // 21:00 UTC for EEST). To avoid filtering them out the moment Sofia midnight passes,
+  // subtract 3h from UTC midnight — covers both EET (+02:00) and EEST (+03:00) offsets.
+  const calendarFrom = new Date(new Date().setUTCHours(0, 0, 0, 0) - 3 * 3600 * 1000).toISOString()
+
   const [announcementsRes, linksRes, tripsRes, guidesRes, eventsRes] = await Promise.all([
     supabase.from('announcements').select('id, titles, contents, is_active, slug').eq('is_active', true)
       .contains('access_roles', [role]).order('created_at', { ascending: false }).limit(5),
@@ -49,7 +54,7 @@ export default async function HomePage() {
     supabase.from('calendar_events')
       .select('id, title, start_time, end_time, event_type, is_all_day')
       .contains('access_roles', [role])
-      .gte('start_time', new Date().toISOString())
+      .gte('start_time', calendarFrom)
       .order('start_time')
       .limit(5),
   ])

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -24,7 +24,7 @@ type Announcement = {
 type SiteLink = { id: string; label: { en: string; bg: string }; url: string }
 type Guide = { id: string; slug: string; title: { en: string; bg: string }; emoji: string | null }
 type Trip = { id: string; title: string; destination: string; start_date: string; image_url: string | null }
-type CalendarEvent = { id: string; title: string; start_time: string; end_time: string | null; event_type: string | null }
+type CalendarEvent = { id: string; title: string; start_time: string; end_time: string | null; event_type: string | null; is_all_day: boolean }
 
 export default async function HomePage() {
   let userId: string | null = null
@@ -47,7 +47,7 @@ export default async function HomePage() {
       .eq('is_published', true).contains('access_roles', [role])
       .order('created_at', { ascending: false }).limit(6),
     supabase.from('calendar_events')
-      .select('id, title, start_time, end_time, event_type')
+      .select('id, title, start_time, end_time, event_type, is_all_day')
       .contains('access_roles', [role])
       .gte('start_time', new Date().toISOString())
       .order('start_time')

--- a/lib/i18n/domains/calendar.ts
+++ b/lib/i18n/domains/calendar.ts
@@ -17,4 +17,5 @@ export const calendar = {
   'cal.shareEvent':         { en: 'Share event',              bg: 'Сподели събитие'               },
   'cal.linkCopied':         { en: 'Link copied!',             bg: 'Линкът е копиран!'             },
   'cal.roleRequestsClosed': { en: 'Role requests closed.',    bg: 'Заявките за роли са затворени.' },
+  'cal.allDay':             { en: 'All day',                  bg: 'Целодневно'                    },
 } as const

--- a/lib/i18n/domains/home.ts
+++ b/lib/i18n/domains/home.ts
@@ -7,6 +7,7 @@ export const home = {
   'home.cal.typeHybrid':     { en: 'Hybrid',               bg: 'Хибридно'                },
   'home.cal.today':          { en: 'TODAY',                bg: 'ДНЕС'                    },
   'home.cal.tomorrow':       { en: 'TOMORROW',             bg: 'УТРЕ'                    },
+  'home.cal.allDay':         { en: 'All day',              bg: 'Целодневно'              },
   // AnnouncementTile
   'home.ann.moreLink':       { en: 'More →',               bg: 'Още →'                   },
   // GuidesTile / LinksGuidesTile

--- a/supabase/functions/sync-google-calendar/index.ts
+++ b/supabase/functions/sync-google-calendar/index.ts
@@ -32,12 +32,27 @@ async function getGoogleAccessToken(sa: Record<string,string>): Promise<string> 
   return d.access_token
 }
 
+/**
+ * Return a Date whose UTC year/month/day matches the Sofia calendar date of `date`.
+ * Used to compute ISO week numbers in Sofia local time rather than UTC.
+ * Intl.DateTimeFormat with numeric parts is specified behaviour — safe in Deno/V8.
+ */
+function sofiaDateFor(date: Date): Date {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Europe/Sofia',
+    year: 'numeric', month: 'numeric', day: 'numeric',
+  }).formatToParts(date)
+  const get = (type: string) => parseInt(parts.find(p => p.type === type)!.value, 10)
+  // Date.UTC month is 0-indexed
+  return new Date(Date.UTC(get('year'), get('month') - 1, get('day')))
+}
+
 function isoWeek(date: Date): number {
   const d = new Date(date)
-  d.setHours(0,0,0,0)
-  d.setDate(d.getDate()+3-((d.getDay()+6)%7))
-  const w1 = new Date(d.getFullYear(),0,4)
-  return 1+Math.round(((d.getTime()-w1.getTime())/86400000-3+((w1.getDay()+6)%7))/7)
+  d.setUTCHours(0,0,0,0)
+  d.setUTCDate(d.getUTCDate()+3-((d.getUTCDay()+6)%7))
+  const w1 = new Date(Date.UTC(d.getUTCFullYear(),0,4))
+  return 1+Math.round(((d.getTime()-w1.getTime())/86400000-3+((w1.getUTCDay()+6)%7))/7)
 }
 
 /**
@@ -137,7 +152,7 @@ function resolveTimes(item: Record<string, unknown>): {
     return { startIso, endIso, isAllDay: true }
   }
 
-  // Malformed item — fall back to current time so the caller can skip it.
+  // Malformed item — fall back to empty strings so the caller can skip it.
   return { startIso: '', endIso: '', isAllDay: false }
 }
 
@@ -199,7 +214,7 @@ Deno.serve(async (req: Request) => {
       location:    location,
       start_time:  startIso,
       end_time:    endIso,
-      week_number: isoWeek(st),
+      week_number: isoWeek(sofiaDateFor(st)),
       is_all_day:  isAllDay,
     }
 

--- a/supabase/functions/sync-google-calendar/index.ts
+++ b/supabase/functions/sync-google-calendar/index.ts
@@ -80,6 +80,73 @@ function stripHtml(html: string): string {
     .trim()
 }
 
+/**
+ * Resolve start/end times for a GCal event item.
+ *
+ * Google returns two distinct shapes:
+ *   - Timed events:   { start: { dateTime: '2026-06-15T10:00:00+02:00' }, end: { dateTime: ... } }
+ *   - All-day events: { start: { date: '2026-06-15' }, end: { date: '2026-06-16' } }
+ *
+ * The `date` form is a bare YYYY-MM-DD string. Passing it directly to
+ * new Date(...) parses it as UTC midnight, which in Sofia (UTC+2) shifts
+ * the event to the previous day at 22:00.
+ *
+ * Fix: detect all-day by absence of dateTime, then build an explicit
+ * Sofia-midnight ISO string using the +02:00 offset. This produces the
+ * correct UTC instant (e.g. 2026-06-14T22:00:00.000Z) while preserving
+ * the correct calendar date when rendered in the Sofia timezone.
+ *
+ * Google's end.date is EXCLUSIVE (the day after the last day of the event).
+ * We subtract one day so a single-day event stores start=Jun 15, end=Jun 15
+ * and a two-day event stores start=Jun 15, end=Jun 16.
+ */
+function resolveTimes(item: Record<string, unknown>): {
+  startIso: string
+  endIso: string
+  isAllDay: boolean
+} {
+  const start = item.start as Record<string, string> | undefined
+  const end   = item.end   as Record<string, string> | undefined
+
+  if (start?.dateTime && end?.dateTime) {
+    // Timed event — dateTime already carries timezone offset, safe to use as-is.
+    return {
+      startIso: new Date(start.dateTime).toISOString(),
+      endIso:   new Date(end.dateTime).toISOString(),
+      isAllDay: false,
+    }
+  }
+
+  if (start?.date && end?.date) {
+    // All-day event — construct explicit Sofia midnight strings.
+    // +02:00 is Sofia standard time (EET). EEST (+03:00) applies May–Oct;
+    // using +02:00 year-round is a deliberate simplification: the stored
+    // UTC instant may be off by 1h during summer but the rendered Sofia
+    // calendar date will always be correct because the display layer reads
+    // back through the Europe/Sofia TZ (which applies DST automatically).
+    const startIso = new Date(`${start.date}T00:00:00+02:00`).toISOString()
+
+    // Subtract one day from Google's exclusive end date.
+    const exclusiveEnd = new Date(`${end.date}T00:00:00+02:00`)
+    exclusiveEnd.setDate(exclusiveEnd.getDate() - 1)
+    // Re-build as midnight Sofia on the corrected date.
+    const [endDateStr] = exclusiveEnd.toISOString().split('T') // YYYY-MM-DD in UTC
+    // The UTC date may differ from Sofia date for the last ~2h of the day;
+    // use Sofia date formatter to be safe.
+    const sofiaDate = new Intl.DateTimeFormat('sv-SE', {
+      timeZone: 'Europe/Sofia',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(exclusiveEnd)
+    const endIso = new Date(`${sofiaDate}T00:00:00+02:00`).toISOString()
+    void endDateStr // suppress unused-var lint (kept for documentation)
+
+    return { startIso, endIso, isAllDay: true }
+  }
+
+  // Malformed item — fall back to current time so the caller can skip it.
+  return { startIso: '', endIso: '', isAllDay: false }
+}
+
 Deno.serve(async (req: Request) => {
   const secret = Deno.env.get('SYNC_SECRET')
   if (secret && req.headers.get('x-sync-secret') !== secret) {
@@ -117,10 +184,11 @@ Deno.serve(async (req: Request) => {
 
   for (const item of items) {
     if (item.status === 'cancelled') continue
-    const startRaw = (item.start as Record<string,string>)?.dateTime ?? (item.start as Record<string,string>)?.date
-    const endRaw   = (item.end   as Record<string,string>)?.dateTime ?? (item.end   as Record<string,string>)?.date
-    if (!startRaw || !endRaw) continue
-    const st = new Date(startRaw), et = new Date(endRaw)
+
+    const { startIso, endIso, isAllDay } = resolveTimes(item)
+    if (!startIso || !endIso) continue
+
+    const st = new Date(startIso)
     const personal = String(item.summary??'').includes('[Personal]') || String(item.description??'').includes('[Personal]')
 
     const rawDesc    = item.description ? String(item.description) : null
@@ -135,9 +203,10 @@ Deno.serve(async (req: Request) => {
       description: cleanDesc,
       meeting_url: meetingUrl,
       location:    location,
-      start_time:  st.toISOString(),
-      end_time:    et.toISOString(),
+      start_time:  startIso,
+      end_time:    endIso,
       week_number: isoWeek(st),
+      is_all_day:  isAllDay,
     }
 
     if (!ex) {
@@ -151,7 +220,9 @@ Deno.serve(async (req: Request) => {
       if (ie) errors.push(String(item.id) + ': ' + ie.message)
       else { upserted++; newEvents++ }
     } else {
-      // Existing event: update scheduling and content only — never touch category or access_roles
+      // Existing event: update scheduling, content, and is_all_day.
+      // category and access_roles are intentionally not touched here
+      // (admins may have customised them after the initial sync).
       const {error:ue} = await sb.from('calendar_events')
         .update(eventPayload)
         .eq('google_event_id', item.id)

--- a/supabase/functions/sync-google-calendar/index.ts
+++ b/supabase/functions/sync-google-calendar/index.ts
@@ -127,18 +127,12 @@ function resolveTimes(item: Record<string, unknown>): {
     const startIso = new Date(`${start.date}T00:00:00+02:00`).toISOString()
 
     // Subtract one day from Google's exclusive end date.
+    // exclusiveEnd is initialised as Sofia midnight (22:00 UTC); setDate adjusts
+    // the UTC date by -1, yielding the correct Sofia midnight for the inclusive
+    // end day. toISOString() on the resulting Date is the correct UTC instant.
     const exclusiveEnd = new Date(`${end.date}T00:00:00+02:00`)
     exclusiveEnd.setDate(exclusiveEnd.getDate() - 1)
-    // Re-build as midnight Sofia on the corrected date.
-    const [endDateStr] = exclusiveEnd.toISOString().split('T') // YYYY-MM-DD in UTC
-    // The UTC date may differ from Sofia date for the last ~2h of the day;
-    // use Sofia date formatter to be safe.
-    const sofiaDate = new Intl.DateTimeFormat('sv-SE', {
-      timeZone: 'Europe/Sofia',
-      year: 'numeric', month: '2-digit', day: '2-digit',
-    }).format(exclusiveEnd)
-    const endIso = new Date(`${sofiaDate}T00:00:00+02:00`).toISOString()
-    void endDateStr // suppress unused-var lint (kept for documentation)
+    const endIso = exclusiveEnd.toISOString()
 
     return { startIso, endIso, isAllDay: true }
   }

--- a/supabase/migrations/20260512_001_add_is_all_day_to_calendar_events.sql
+++ b/supabase/migrations/20260512_001_add_is_all_day_to_calendar_events.sql
@@ -1,0 +1,9 @@
+-- Migration: add is_all_day column to calendar_events
+-- All-day events synced from Google Calendar need a flag so the client
+-- can suppress time-grid positioning and show "All day" labels instead.
+-- Existing rows default to false (correct — all previously stored events
+-- are timed events; all-day events were being stored incorrectly and will
+-- be corrected on the next sync run after the edge function is deployed).
+
+ALTER TABLE calendar_events
+  ADD COLUMN is_all_day boolean NOT NULL DEFAULT false;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -163,6 +163,7 @@ export type Database = {
           event_type: Database["public"]["Enums"]["event_type"] | null
           google_event_id: string | null
           id: string
+          is_all_day: boolean
           location: string | null
           meeting_url: string | null
           start_time: string
@@ -181,6 +182,7 @@ export type Database = {
           event_type?: Database["public"]["Enums"]["event_type"] | null
           google_event_id?: string | null
           id?: string
+          is_all_day?: boolean
           location?: string | null
           meeting_url?: string | null
           start_time: string
@@ -199,6 +201,7 @@ export type Database = {
           event_type?: Database["public"]["Enums"]["event_type"] | null
           google_event_id?: string | null
           id?: string
+          is_all_day?: boolean
           location?: string | null
           meeting_url?: string | null
           start_time?: string
@@ -674,7 +677,7 @@ export type Database = {
           ppv?: number | null
           qualified_legs?: number | null
           renewal_date?: string | null
-          ruby_pv?: number | null
+          ruby_pv?: string | null
           sponsor_abo_number?: string | null
           sponsoring?: number | null
         }


### PR DESCRIPTION
## Summary

All-day and multi-day events synced from Google Calendar were stored with incorrect timestamps and rendered as hourly timed events.

**Root cause:** Google Calendar returns all-day events with `start.date` / `end.date` (bare `YYYY-MM-DD` strings) rather than `start.dateTime`. Passing a bare date string to `new Date(...)` parses it as UTC midnight, which in Sofia (UTC+2) shifts the event to the previous day at 22:00. Additionally, Google's `end.date` is exclusive (one day past the last day of the event), causing multi-day events to be stored one day too long.

**Fix:**
- Introduced `resolveTimes()` helper in the edge function that detects all-day events by absence of `dateTime`, constructs explicit Sofia-midnight ISO strings using `+02:00` offset, and subtracts one day from Google's exclusive `end.date` before storing
- Added `is_all_day boolean NOT NULL DEFAULT false` column to `calendar_events`
- `AgendaView` and `CalendarTile` suppress time display for all-day events and show "All day" / "Цялодневно" instead
- All existing all-day events will be corrected on the next sync run (the update payload now includes `is_all_day`)

## Changes

- `supabase/migrations/20260512_001_add_is_all_day_to_calendar_events.sql` — new column
- `supabase/functions/sync-google-calendar/index.ts` — `resolveTimes()` helper, `is_all_day` in insert + update payloads
- `types/supabase.ts` — regenerated
- `app/(dashboard)/calendar/types.ts` — `is_all_day: boolean` added to `CalendarEvent`
- `app/(dashboard)/calendar/components/AgendaView.tsx` — "All day" label when `is_all_day`
- `app/(dashboard)/components/tiles/CalendarTile.tsx` — suppress time, show "All day" when `is_all_day`
- `app/(dashboard)/page.tsx` — `is_all_day` added to local `CalendarEvent` type + select query
- `lib/i18n/domains/calendar.ts` — `cal.allDay` key
- `lib/i18n/domains/home.ts` — `home.cal.allDay` key

Edge function deployed to production (version 23).

Closes #330

## Session State
**Status:** DONE
**Completed:**
- [x] Migration applied — `is_all_day boolean NOT NULL DEFAULT false`
- [x] Edge function fixed and deployed (v23)
- [x] Types updated — `CalendarEvent`, `types/supabase.ts`, local page type
- [x] UI updated — AgendaView + CalendarTile suppress times for all-day events
- [x] i18n keys added — `cal.allDay`, `home.cal.allDay`
**Next:** Verify Vercel preview is green, then merge