### PR TITLE
[2605-FEAT-332] Event role slots — DB foundation

### DIFF
--- a/app/api/admin/calendar/[id]/route.ts
+++ b/app/api/admin/calendar/[id]/route.ts
@@ -35,10 +35,12 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     const newRoles = (update.available_roles as string[]) ?? []
 
     // Fetch current slots for this event
-    const { data: currentSlots } = await supabase
+    const { data: currentSlots, error: fetchSlotsError } = await supabase
       .from('event_role_slots')
       .select('role_label')
       .eq('event_id', id)
+
+    if (fetchSlotsError) return Response.json({ error: fetchSlotsError.message }, { status: 500 })
 
     const existingLabels = new Set((currentSlots ?? []).map(s => s.role_label))
     const newLabels = new Set(newRoles)
@@ -48,12 +50,14 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 
     if (removedLabels.length > 0) {
       // Check for active (pending or approved) requests on removed labels
-      const { data: activeRequests } = await supabase
+      const { data: activeRequests, error: fetchRequestsError } = await supabase
         .from('event_role_requests')
         .select('role_label')
         .eq('event_id', id)
         .in('role_label', removedLabels)
         .in('status', ['pending', 'approved'])
+
+      if (fetchRequestsError) return Response.json({ error: fetchRequestsError.message }, { status: 500 })
 
       if (activeRequests && activeRequests.length > 0) {
         const blocked = [...new Set(activeRequests.map(r => r.role_label))]
@@ -64,20 +68,23 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
       }
 
       // Safe to delete open slots for removed labels
-      await supabase
+      const { error: deleteError } = await supabase
         .from('event_role_slots')
         .delete()
         .eq('event_id', id)
         .in('role_label', removedLabels)
+
+      if (deleteError) return Response.json({ error: deleteError.message }, { status: 500 })
     }
 
     // Upsert slots for new labels
     const addedLabels = newRoles.filter(l => !existingLabels.has(l))
     if (addedLabels.length > 0) {
-      await supabase.from('event_role_slots').upsert(
+      const { error: upsertError } = await supabase.from('event_role_slots').upsert(
         addedLabels.map(role_label => ({ event_id: id, role_label })),
         { onConflict: 'event_id,role_label', ignoreDuplicates: true }
       )
+      if (upsertError) return Response.json({ error: upsertError.message }, { status: 500 })
     }
   }
 

--- a/app/api/admin/calendar/[id]/route.ts
+++ b/app/api/admin/calendar/[id]/route.ts
@@ -29,6 +29,58 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     return Response.json({ error: 'No valid fields provided for update' }, { status: 400 })
   }
 
+  // If available_roles is changing, guard against removing labels that have
+  // filled or contested slots, then sync the slot registry.
+  if ('available_roles' in update) {
+    const newRoles = (update.available_roles as string[]) ?? []
+
+    // Fetch current slots for this event
+    const { data: currentSlots } = await supabase
+      .from('event_role_slots')
+      .select('role_label')
+      .eq('event_id', id)
+
+    const existingLabels = new Set((currentSlots ?? []).map(s => s.role_label))
+    const newLabels = new Set(newRoles)
+
+    // Identify labels being removed
+    const removedLabels = [...existingLabels].filter(l => !newLabels.has(l))
+
+    if (removedLabels.length > 0) {
+      // Check for active (pending or approved) requests on removed labels
+      const { data: activeRequests } = await supabase
+        .from('event_role_requests')
+        .select('role_label')
+        .eq('event_id', id)
+        .in('role_label', removedLabels)
+        .in('status', ['pending', 'approved'])
+
+      if (activeRequests && activeRequests.length > 0) {
+        const blocked = [...new Set(activeRequests.map(r => r.role_label))]
+        return Response.json(
+          { error: `Cannot remove role(s) with active requests: ${blocked.join(', ')}` },
+          { status: 409 }
+        )
+      }
+
+      // Safe to delete open slots for removed labels
+      await supabase
+        .from('event_role_slots')
+        .delete()
+        .eq('event_id', id)
+        .in('role_label', removedLabels)
+    }
+
+    // Upsert slots for new labels
+    const addedLabels = newRoles.filter(l => !existingLabels.has(l))
+    if (addedLabels.length > 0) {
+      await supabase.from('event_role_slots').upsert(
+        addedLabels.map(role_label => ({ event_id: id, role_label })),
+        { onConflict: 'event_id,role_label', ignoreDuplicates: true }
+      )
+    }
+  }
+
   const { data, error } = await supabase.from('calendar_events').update(update).eq('id', id).select().single()
   if (error) return Response.json({ error: error.message }, { status: 500 })
   return Response.json(data)

--- a/app/api/admin/calendar/route.ts
+++ b/app/api/admin/calendar/route.ts
@@ -35,5 +35,15 @@ export async function POST(req: Request): Promise<Response> {
 
   const { data, error } = await supabase.from('calendar_events').insert(body).select().single()
   if (error) return Response.json({ error: error.message }, { status: 500 })
+
+  // Seed role slots for the new event
+  const roles: string[] = data.available_roles ?? []
+  if (roles.length > 0) {
+    await supabase.from('event_role_slots').upsert(
+      roles.map(role_label => ({ event_id: data.id, role_label })),
+      { onConflict: 'event_id,role_label', ignoreDuplicates: true }
+    )
+  }
+
   return Response.json(data, { status: 201 })
 }

--- a/app/api/admin/calendar/route.ts
+++ b/app/api/admin/calendar/route.ts
@@ -39,10 +39,11 @@ export async function POST(req: Request): Promise<Response> {
   // Seed role slots for the new event
   const roles: string[] = data.available_roles ?? []
   if (roles.length > 0) {
-    await supabase.from('event_role_slots').upsert(
+    const { error: upsertError } = await supabase.from('event_role_slots').upsert(
       roles.map(role_label => ({ event_id: data.id, role_label })),
       { onConflict: 'event_id,role_label', ignoreDuplicates: true }
     )
+    if (upsertError) return Response.json({ error: upsertError.message }, { status: 500 })
   }
 
   return Response.json(data, { status: 201 })

--- a/supabase/migrations/20260512_002_event_role_slots.sql
+++ b/supabase/migrations/20260512_002_event_role_slots.sql
@@ -1,0 +1,28 @@
+-- 2605-FEAT-332: Event role slots — label registry
+-- Slot state (open/contested/filled) is always derived at read time
+-- from event_role_requests. Nothing stored here except the label.
+
+CREATE TABLE IF NOT EXISTS event_role_slots (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id    uuid        NOT NULL REFERENCES calendar_events(id) ON DELETE CASCADE,
+  role_label  text        NOT NULL CHECK (char_length(role_label) > 0),
+  created_at  timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (event_id, role_label)
+);
+
+CREATE INDEX IF NOT EXISTS event_role_slots_event_id_idx ON event_role_slots (event_id);
+
+-- RLS
+ALTER TABLE event_role_slots ENABLE ROW LEVEL SECURITY;
+
+-- Members and above can read slots (to display available roles on an event)
+CREATE POLICY "member_read_event_role_slots"
+  ON event_role_slots FOR SELECT
+  USING (get_my_role() IN ('member', 'core', 'admin'));
+
+-- Admins have full write access
+CREATE POLICY "admin_all_event_role_slots"
+  ON event_role_slots FOR ALL
+  USING (is_admin())
+  WITH CHECK (is_admin());

--- a/supabase/migrations/20260512_003_approve_event_role_request_rpc.sql
+++ b/supabase/migrations/20260512_003_approve_event_role_request_rpc.sql
@@ -1,0 +1,84 @@
+-- 2605-FEAT-332: approve_event_role_request RPC
+-- Atomically approves one role request and denies all competing pending
+-- requests for the same (event_id, role_label) slot.
+-- SECURITY DEFINER — only callable with service role or admin JWT.
+
+CREATE OR REPLACE FUNCTION approve_event_role_request(p_request_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_id    uuid;
+  v_role_label  text;
+  v_profile_id  uuid;
+  v_result      jsonb;
+BEGIN
+  -- Service-role / admin guard
+  IF auth.role() <> 'service_role' AND NOT is_admin() THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  -- Load target request
+  SELECT event_id, role_label, profile_id
+    INTO v_event_id, v_role_label, v_profile_id
+    FROM event_role_requests
+   WHERE id = p_request_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Request not found: %', p_request_id;
+  END IF;
+
+  -- Guard: slot must not already be filled
+  IF EXISTS (
+    SELECT 1 FROM event_role_requests
+     WHERE event_id   = v_event_id
+       AND role_label = v_role_label
+       AND status     = 'approved'
+       AND id         <> p_request_id
+  ) THEN
+    RAISE EXCEPTION 'Slot already filled for role "%" on event %', v_role_label, v_event_id;
+  END IF;
+
+  -- Approve the target request
+  UPDATE event_role_requests
+     SET status     = 'approved',
+         updated_at = now()
+   WHERE id = p_request_id;
+
+  -- Deny all other pending requests for the same slot
+  UPDATE event_role_requests
+     SET status     = 'denied',
+         updated_at = now()
+   WHERE event_id   = v_event_id
+     AND role_label = v_role_label
+     AND id         <> p_request_id
+     AND status     = 'pending';
+
+  -- Return the approved request + profile for email dispatch
+  SELECT jsonb_build_object(
+    'id',          r.id,
+    'role_label',  r.role_label,
+    'profile_id',  r.profile_id,
+    'event_id',    r.event_id,
+    'status',      r.status,
+    'profile',     jsonb_build_object(
+                     'first_name',    p.first_name,
+                     'last_name',     p.last_name,
+                     'contact_email', p.contact_email
+                   ),
+    'event',       jsonb_build_object(
+                     'title',      e.title,
+                     'start_time', e.start_time
+                   )
+  )
+    INTO v_result
+    FROM event_role_requests r
+    JOIN profiles           p ON p.id = r.profile_id
+    JOIN calendar_events    e ON e.id = r.event_id
+   WHERE r.id = p_request_id;
+
+  RETURN v_result;
+END;
+$$;

--- a/supabase/migrations/20260512_004_backfill_event_role_slots.sql
+++ b/supabase/migrations/20260512_004_backfill_event_role_slots.sql
@@ -1,0 +1,16 @@
+-- 2605-FEAT-332: Backfill event_role_slots from existing event_role_requests
+-- Creates one slot per distinct (event_id, role_label) pair.
+-- Safe to re-run — ON CONFLICT DO NOTHING.
+
+INSERT INTO event_role_slots (event_id, role_label)
+SELECT DISTINCT event_id, role_label
+  FROM event_role_requests
+ON CONFLICT (event_id, role_label) DO NOTHING;
+
+-- Also seed slots from calendar_events.available_roles for events
+-- that have no requests yet (so the popup can display empty slots).
+INSERT INTO event_role_slots (event_id, role_label)
+SELECT e.id, unnest(e.available_roles)
+  FROM calendar_events e
+ WHERE array_length(e.available_roles, 1) > 0
+ON CONFLICT (event_id, role_label) DO NOTHING;

--- a/supabase/migrations/20260512_005_event_role_requests_one_approved_per_slot.sql
+++ b/supabase/migrations/20260512_005_event_role_requests_one_approved_per_slot.sql
@@ -1,0 +1,5 @@
+-- 2605-FEAT-332 GCR: enforce at most one approved request per (event_id, role_label)
+-- Prevents race conditions where two concurrent approve calls could both succeed.
+CREATE UNIQUE INDEX idx_event_role_requests_one_approved_per_slot
+  ON event_role_requests (event_id, role_label)
+  WHERE (status = 'approved');

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -302,6 +302,35 @@ export type Database = {
           },
         ]
       }
+      event_role_slots: {
+        Row: {
+          created_at: string
+          event_id: string
+          id: string
+          role_label: string
+        }
+        Insert: {
+          created_at?: string
+          event_id: string
+          id?: string
+          role_label: string
+        }
+        Update: {
+          created_at?: string
+          event_id?: string
+          id?: string
+          role_label?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "event_role_slots_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "calendar_events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       event_share_links: {
         Row: {
           click_count: number
@@ -677,7 +706,7 @@ export type Database = {
           ppv?: number | null
           qualified_legs?: number | null
           renewal_date?: string | null
-          ruby_pv?: string | null
+          ruby_pv?: number | null
           sponsor_abo_number?: string | null
           sponsoring?: number | null
         }
@@ -1510,6 +1539,10 @@ export type Database = {
     }
     Functions: {
       abo_to_ltree_label: { Args: { abo: string }; Returns: string }
+      approve_event_role_request: {
+        Args: { p_request_id: string }
+        Returns: Json
+      }
       approve_member_verification: {
         Args: { p_admin_note?: string; p_request_id: string }
         Returns: {


### PR DESCRIPTION
## Summary

Introduces `event_role_slots` as a first-class label registry for calendar events. Slot state (open/contested/filled) is computed at read time from `event_role_requests` — never stored. The approved request row IS the assignment record.

No UI changes. No breaking API changes. Safe to merge independently before #333 and #334.

## Changes

**Migrations:**
- `20260512_002_event_role_slots.sql` — creates `event_role_slots(id, event_id, role_label, created_at)` with `UNIQUE(event_id, role_label)`, FK to `calendar_events ON DELETE CASCADE`, RLS via Pattern A helpers
- `20260512_003_approve_event_role_request_rpc.sql` — `approve_event_role_request(p_request_id)` SECURITY DEFINER RPC: approves target, denies all other pending for same `(event_id, role_label)`, returns approved row + profile + event for email dispatch
- `20260512_004_backfill_event_role_slots.sql` — backfills slots from existing `event_role_requests` via `INSERT … ON CONFLICT DO NOTHING`

**Routes:**
- `app/api/admin/calendar/route.ts` — POST: seeds slots via upsert after event INSERT
- `app/api/admin/calendar/[id]/route.ts` — PATCH: guards removed labels with active requests (409), deletes open slots for clean removals, upserts slots for added labels

**Types:**
- `types/supabase.ts` — regenerated; includes `event_role_slots` table and `approve_event_role_request` RPC

## Session State
**Status:** DONE
**Completed:**
- [x] Migration `_002`: `event_role_slots` table with RLS
- [x] Migration `_003`: `approve_event_role_request` SECURITY DEFINER RPC
- [x] Migration `_004`: backfill from existing requests
- [x] `calendar/route.ts` POST: slot seeding
- [x] `calendar/[id]/route.ts` PATCH: slot sync with 409 guard
- [x] `types/supabase.ts` regenerated

**Next:** Merge, then unblock #333 and proceed with API contract changes.

Closes #332