### PR TITLE
[2605-FEAT-339] Expose pending requesters and approved occupant names in event role slots

### DIFF
--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -21,6 +21,7 @@ type CallerRequest = {
 }
 
 type PendingProfile = {
+  profile_id: string
   first_name: string | null
   last_name: string | null
 }
@@ -110,10 +111,10 @@ function PendingPopover({ profiles, color }: { profiles: PendingProfile[]; color
           Requested by
         </p>
         <div className="space-y-0.5">
-          {profiles.map((p, i) => {
+          {profiles.map((p) => {
             const name = [p.first_name, p.last_name].filter(Boolean).join(' ') || '—'
             return (
-              <p key={i} className="text-xs font-medium" style={{ color: 'var(--text-primary)' }}>
+              <p key={p.profile_id} className="text-xs font-medium" style={{ color: 'var(--text-primary)' }}>
                 {name}
               </p>
             )

--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -4,10 +4,15 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatTime, formatLongDate } from '@/lib/format'
-import { X, Check, Users } from 'lucide-react'
+import { X, Check, Users, Info } from 'lucide-react'
 import { apiClient } from '@/lib/apiClient'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
 
-// ── Types ───────────────────────────────────────────────────────────────────
+// ── Types ───────────────────────────────────────────────────────────────────────────
 
 type CallerRequest = {
   id: string
@@ -15,10 +20,16 @@ type CallerRequest = {
   status: 'pending' | 'approved' | 'denied'
 }
 
+type PendingProfile = {
+  first_name: string | null
+  last_name: string | null
+}
+
 type RoleSlot = {
   role_label: string
   status: 'open' | 'contested' | 'filled'
   assigned_profile: { first_name: string | null; last_name: string | null } | null
+  pending_profiles: PendingProfile[]
   caller_request: CallerRequest | null
 }
 
@@ -53,7 +64,7 @@ type Props = {
   userRole: 'admin' | 'core' | 'member' | 'guest' | null
 }
 
-// ── Constants ───────────────────────────────────────────────────────────────
+// ── Constants ─────────────────────────────────────────────────────────────────────
 
 const REQUEST_STATUS_STYLES = {
   pending:  { bg: '#f2cc8f33', color: '#7a5c00'  },
@@ -73,7 +84,47 @@ const EVENT_TYPE_STYLES: Record<string, { bg: string; color: string; label: stri
   'hybrid':    { bg: 'rgba(242,204,143,0.35)', color: '#7a5c00',  label: 'Hybrid'    },
 }
 
-// ── Admin: guest registration list ──────────────────────────────────────────
+// ── PendingPopover ──────────────────────────────────────────────────────────────────
+
+function PendingPopover({ profiles, color }: { profiles: PendingProfile[]; color: string }) {
+  if (profiles.length === 0) return null
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center justify-center w-5 h-5 rounded-full flex-shrink-0 hover:opacity-70 transition-opacity"
+          style={{ color }}
+          aria-label="View requesters"
+        >
+          <Info size={12} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        align="center"
+        className="p-2 min-w-0 w-auto max-w-[200px]"
+        style={{ backgroundColor: 'var(--bg-card)', border: '1px solid rgba(0,0,0,0.08)' }}
+      >
+        <p className="text-[10px] font-semibold tracking-wider uppercase mb-1.5" style={{ color: 'var(--text-secondary)' }}>
+          Requested by
+        </p>
+        <div className="space-y-0.5">
+          {profiles.map((p, i) => {
+            const name = [p.first_name, p.last_name].filter(Boolean).join(' ') || '—'
+            return (
+              <p key={i} className="text-xs font-medium" style={{ color: 'var(--text-primary)' }}>
+                {name}
+              </p>
+            )
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+// ── Admin: guest registration list ────────────────────────────────────────────────────────
 
 function AdminRegistrationsTab({ eventId }: { eventId: string }) {
   const { data, isLoading } = useQuery<{ registrations: GuestRegistration[] }>({
@@ -141,7 +192,7 @@ function AdminRegistrationsTab({ eventId }: { eventId: string }) {
   )
 }
 
-// ── Main component ───────────────────────────────────────────────────────────
+// ── Main component ───────────────────────────────────────────────────────────────────────
 
 export default function EventPopup({
   eventId, onClose, userRole,
@@ -276,7 +327,7 @@ export default function EventPopup({
               {t('event.roles')}
             </p>
 
-            {/* Admin: slot overview — status + assigned occupant if filled */}
+            {/* Admin: slot overview — status + assigned occupant if filled + (i) if contested */}
             {isAdmin && (
               roleSlots.length > 0 ? (
                 <div className="space-y-2">
@@ -294,10 +345,15 @@ export default function EventPopup({
                               <p className="text-[10px] mt-0.5" style={{ color: 'var(--text-secondary)' }}>{occupantName}</p>
                             )}
                           </div>
-                          <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
-                            style={{ backgroundColor: 'rgba(255,255,255,0.55)', color: slotStyle.color }}>
-                            {t(`event.slot.${slot.status}` as `event.slot.${'open'|'contested'|'filled'}`)}
-                          </span>
+                          <div className="flex items-center gap-1.5 flex-shrink-0">
+                            {slot.status === 'contested' && (
+                              <PendingPopover profiles={slot.pending_profiles} color={slotStyle.color} />
+                            )}
+                            <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
+                              style={{ backgroundColor: 'rgba(255,255,255,0.55)', color: slotStyle.color }}>
+                              {t(`event.slot.${slot.status}` as `event.slot.${'open'|'contested'|'filled'}`)}
+                            </span>
+                          </div>
                         </div>
                       </div>
                     )
@@ -348,35 +404,49 @@ export default function EventPopup({
                     const activeStyle = isActive ? REQUEST_STATUS_STYLES[myReq!.status] : null
                     const slotStyle   = isFilled ? SLOT_STATUS_STYLES.filled : SLOT_STATUS_STYLES[slot.status]
 
-                    // Explicit per-intent disabled logic:
-                    // cancel: only block while mutating
-                    // request: block while mutating, if filled, or if user already has a request elsewhere
-                    const isCancel         = isActive && myReq!.status === 'pending'
-                    const disabledCancel   = isMutating
-                    const disabledRequest  = isMutating || isFilled || hasAnyReq
+                    const isCancel        = isActive && myReq!.status === 'pending'
+                    const disabledCancel  = isMutating
+                    const disabledRequest = isMutating || isFilled || hasAnyReq
+
+                    const occupantName = isFilled && slot.assigned_profile
+                      ? [slot.assigned_profile.first_name, slot.assigned_profile.last_name].filter(Boolean).join(' ') || null
+                      : null
 
                     return (
-                      <button
-                        key={slot.role_label}
-                        onClick={() => {
-                          if (isCancel) cancelMutation.mutate(myReq!.id)
-                          else if (!hasAnyReq && !isFilled) requestMutation.mutate(slot.role_label)
-                        }}
-                        disabled={isCancel ? disabledCancel : disabledRequest}
-                        className="flex-1 flex items-center justify-center gap-1 py-2 rounded-xl text-[11px] font-bold tracking-wider uppercase transition-all disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-95 active:scale-[0.97]"
-                        style={{
-                          backgroundColor: activeStyle ? activeStyle.bg : slotStyle.bg,
-                          color: activeStyle ? activeStyle.color : slotStyle.color,
-                          border: activeStyle ? `1px solid ${activeStyle.color}33` : '1px solid transparent',
-                        }}
-                      >
-                        {slot.role_label}
-                        {isActive && myReq!.status === 'pending' && <X size={10} className="opacity-60" />}
-                        {isActive && myReq!.status === 'approved' && <Check size={10} />}
-                        {isFilled && !isActive && (
-                          <Check size={10} className="opacity-40" />
+                      // Wrapper div — button + (i) are siblings, never nested
+                      <div key={slot.role_label} className="flex-1 flex flex-col gap-0.5 min-w-0">
+                        <div className="flex items-center gap-1">
+                          <button
+                            onClick={() => {
+                              if (isCancel) cancelMutation.mutate(myReq!.id)
+                              else if (!hasAnyReq && !isFilled) requestMutation.mutate(slot.role_label)
+                            }}
+                            disabled={isCancel ? disabledCancel : disabledRequest}
+                            className="flex-1 flex items-center justify-center gap-1 py-2 rounded-xl text-[11px] font-bold tracking-wider uppercase transition-all disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-95 active:scale-[0.97]"
+                            style={{
+                              backgroundColor: activeStyle ? activeStyle.bg : slotStyle.bg,
+                              color: activeStyle ? activeStyle.color : slotStyle.color,
+                              border: activeStyle ? `1px solid ${activeStyle.color}33` : '1px solid transparent',
+                            }}
+                          >
+                            {slot.role_label}
+                            {isActive && myReq!.status === 'pending' && <X size={10} className="opacity-60" />}
+                            {isActive && myReq!.status === 'approved' && <Check size={10} />}
+                            {isFilled && !isActive && (
+                              <Check size={10} className="opacity-40" />
+                            )}
+                          </button>
+                          {slot.status === 'contested' && slot.pending_profiles.length > 0 && (
+                            <PendingPopover profiles={slot.pending_profiles} color={slotStyle.color} />
+                          )}
+                        </div>
+                        {/* Approved occupant name — shown below filled slot */}
+                        {occupantName && (
+                          <p className="text-[10px] text-center" style={{ color: 'var(--text-secondary)' }}>
+                            {occupantName}
+                          </p>
                         )}
-                      </button>
+                      </div>
                     )
                   })}
                 </div>

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -44,14 +44,14 @@ export async function GET(
     .select('role_label')
     .eq('event_id', id)
 
-  // Fetch all requests for this event
+  // Fetch all requests for this event — chronological order required for pending_profiles
   const { data: allRequests } = await supabase
     .from('event_role_requests')
     .select('id, role_label, status, profile_id, profile:profiles!profile_id(first_name, last_name)')
     .eq('event_id', id)
+    .order('created_at', { ascending: true })
 
   const requests = allRequests ?? []
-  const isAdminOrCore = callerProfile.role === 'admin' || callerProfile.role === 'core'
 
   // Group requests by role_label once — O(R) — to avoid O(S×R) filter-inside-map
   const requestsByRole = requests.reduce((acc, r) => {
@@ -75,17 +75,21 @@ export async function GET(
       status = 'open'
     }
 
-    // Non-admin/core: omit other profiles' identity
+    // All authenticated non-guest callers see the approved occupant name
     const assigned_profile = approvedReq
-      ? isAdminOrCore
-        ? (approvedReq.profile as { first_name: string | null; last_name: string | null } | null)
-        : { first_name: null, last_name: null }
+      ? (approvedReq.profile as { first_name: string | null; last_name: string | null } | null)
       : null
+
+    // Pending requesters in chronological order — visible to all authenticated non-guest callers
+    const pending_profiles = pendingReqs.map(
+      r => r.profile as { first_name: string | null; last_name: string | null } | null
+    ).filter((p): p is { first_name: string | null; last_name: string | null } => p !== null)
 
     return {
       role_label: slot.role_label,
       status,
       assigned_profile,
+      pending_profiles,
       caller_request: callerReq
         ? { id: callerReq.id, status: callerReq.status, role_label: callerReq.role_label }
         : null,

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -80,10 +80,11 @@ export async function GET(
       ? (approvedReq.profile as { first_name: string | null; last_name: string | null } | null)
       : null
 
-    // Pending requesters in chronological order — visible to all authenticated non-guest callers
-    const pending_profiles = pendingReqs.map(
-      r => r.profile as { first_name: string | null; last_name: string | null } | null
-    ).filter((p): p is { first_name: string | null; last_name: string | null } => p !== null)
+    // Pending requesters in chronological order — profile_id included for stable React key
+    const pending_profiles = pendingReqs.map(r => {
+      const profile = r.profile as { first_name: string | null; last_name: string | null } | null
+      return profile ? { profile_id: r.profile_id, ...profile } : null
+    }).filter((p): p is { profile_id: string; first_name: string | null; last_name: string | null } => p !== null)
 
     return {
       role_label: slot.role_label,


### PR DESCRIPTION
## Summary

Exposes pending requester names and approved occupant names in event role slots for all authenticated non-guest callers. Adds an `(i)` popover for contested slots and occupant name display below filled slots.

Closes #339

## Changes

### `app/api/events/[id]/route.ts`
- Added `pending_profiles: { first_name, last_name }[]` to each slot — chronological pending requests (`ORDER BY created_at ASC`), all authenticated non-guest callers (no role gate)
- Removed `assigned_profile` redaction for non-admin/core — all non-guest callers now see the approved occupant name
- Zero extra DB queries — `pending_profiles` derived from `allRequests` already in memory

### `app/(dashboard)/calendar/components/EventPopup.tsx`
- Added `PendingProfile` type and `pending_profiles: PendingProfile[]` to `RoleSlot` type
- Extracted `PendingPopover` sub-component using shadcn `Popover` — renders `InfoIcon` trigger listing requesters chronologically
- **Admin slot card**: renders `PendingPopover` on `InfoIcon` when `status === 'contested'`
- **Non-admin filled slot**: occupant name rendered below the slot button (not inside it)
- **Non-admin contested slot**: `PendingPopover` rendered as sibling to the slot button via flex wrapper — no nested interactives

## DoD Checklist

- [x] `app/api/events/[id]/route.ts`: `pending_profiles` added to each slot, chronological order
- [x] `app/api/events/[id]/route.ts`: `assigned_profile` redaction removed for non-admin/core
- [x] `app/(dashboard)/calendar/components/EventPopup.tsx`: `RoleSlot` type updated with `pending_profiles`
- [x] `app/(dashboard)/calendar/components/EventPopup.tsx`: admin slot card — shadcn `Popover` on `InfoIcon` when `status === 'contested'`
- [x] `app/(dashboard)/calendar/components/EventPopup.tsx`: non-admin `filled` slot — occupant name below button
- [x] `app/(dashboard)/calendar/components/EventPopup.tsx`: non-admin `contested` slot — `InfoIcon` Popover as sibling, not nested in button
- [ ] 390px: slot row + `(i)` popover renders without overflow — verify on Vercel Preview

## Gotchas Applied

- `(i)` trigger is a standalone `<button>` as sibling to slot button — no nested interactives
- `pending_profiles` sorted via `order('created_at', { ascending: true })` on the single `event_role_requests` fetch
- No new migrations, no schema changes, no env var changes, no new translation keys