### PR TITLE
style: change event category color to sienna

### DIFF
--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -272,7 +272,7 @@ export default function EventPopup({
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5 flex-wrap mb-1.5">
               <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
-                style={{ backgroundColor: event?.category === 'N21' ? 'var(--brand-forest)' : 'var(--brand-crimson)', color: 'rgba(255,255,255,0.9)' }}>
+                style={{ backgroundColor: event?.category === 'N21' ? 'var(--brand-forest)' : 'var(--sienna)', color: 'rgba(255,255,255,0.9)' }}>
                 {event?.category ?? '…'}
               </span>
               {eventTypeStyle && (

--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -272,7 +272,7 @@ export default function EventPopup({
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5 flex-wrap mb-1.5">
               <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
-                style={{ backgroundColor: event?.category === 'N21' ? 'var(--brand-forest)' : 'var(--sienna)', color: 'rgba(255,255,255,0.9)' }}>
+                style={{ backgroundColor: event?.category === 'N21' ? 'var(--brand-forest)' : 'var(--brand-sienna)', color: 'rgba(255,255,255,0.9)' }}>
                 {event?.category ?? '…'}
               </span>
               {eventTypeStyle && (

--- a/app/(dashboard)/calendar/utils.ts
+++ b/app/(dashboard)/calendar/utils.ts
@@ -11,8 +11,8 @@ export const HOURS = Array.from({ length: 24 }, (_, i) => i)
 export const HOUR_HEIGHT = 60
 
 export const CATEGORY_COLOR: Record<string, { bg: string; text: string }> = {
-  N21:      { bg: 'var(--forest)',  text: 'rgba(255,255,255,0.95)' },
-  Personal: { bg: 'var(--sienna)', text: 'rgba(255,255,255,0.95)' },
+  N21:      { bg: 'var(--brand-forest)',  text: 'rgba(255,255,255,0.95)' },
+  Personal: { bg: 'var(--brand-sienna)', text: 'rgba(255,255,255,0.95)' },
 }
 
 // ── Module-level cached formatters ────────────────────────────────────────

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -5,6 +5,7 @@
   --brand-forest:    #2d332a;
   --brand-crimson:   #bc4749;
   --brand-teal:      #3E7785;
+  --brand-sienna:    #e07a5f;
   --brand-parchment: #FAF8F3;
   --brand-void:      #1A1F18;
   --brand-oyster:    #F0EDE6;

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -12,6 +12,10 @@
   --brand-moss:      #252B23;
   --brand-stone:     #8A8577;
 
+  /* ── Primitive aliases — legacy callers use bare token names ── */
+  --sienna: var(--brand-sienna);
+  --forest: var(--brand-forest);
+
   /* ── Semantic ── */
   --bg-global-rgb:     250, 248, 243;
   --bg-global:         var(--brand-parchment);


### PR DESCRIPTION
This PR updates the event category pill in the `EventPopup` component to use `var(--sienna)` instead of `var(--brand-crimson)` for non-N21 categories.