### PR TITLE
[2505-FEAT-347] Roles table view — /roles page (Core+ member-facing)

### DIFF
--- a/app/(dashboard)/roles/components/RolesClient.tsx
+++ b/app/(dashboard)/roles/components/RolesClient.tsx
@@ -8,7 +8,16 @@ type Props = {
   events: RoleEvent[]
 }
 
-const SLOT_LABELS = ['HOST', 'SPEAKER', 'PRODUCTS'] as const
+type SlotLabel = 'HOST' | 'SPEAKER' | 'PRODUCTS'
+
+const SLOT_LABELS: SlotLabel[] = ['HOST', 'SPEAKER', 'PRODUCTS']
+
+// Maps the DB constant to its i18n key
+const SLOT_LABEL_KEY: Record<SlotLabel, 'event.roles.label.host' | 'event.roles.label.speaker' | 'event.roles.label.products'> = {
+  HOST:     'event.roles.label.host',
+  SPEAKER:  'event.roles.label.speaker',
+  PRODUCTS: 'event.roles.label.products',
+}
 
 // ── Shared helpers ───────────────────────────────────────────────────────────
 
@@ -25,7 +34,7 @@ function OccupantCell({ name }: { name: string | null }) {
 
 // ── Desktop table ────────────────────────────────────────────────────────────
 
-function RolesTable({ events }: { events: RoleEvent[] }) {
+function RolesTable({ events, headers }: { events: RoleEvent[]; headers: string[] }) {
   return (
     <div
       className="rounded-2xl overflow-hidden"
@@ -41,12 +50,7 @@ function RolesTable({ events }: { events: RoleEvent[] }) {
           backgroundColor: 'rgba(0,0,0,0.02)',
         }}
       >
-        <span>Event</span>
-        <span>Date</span>
-        <span>Time</span>
-        <span>Host</span>
-        <span>Speaker</span>
-        <span>Products</span>
+        {headers.map(h => <span key={h}>{h}</span>)}
       </div>
 
       {/* Data rows */}
@@ -82,7 +86,7 @@ function RolesTable({ events }: { events: RoleEvent[] }) {
 
 // ── Mobile cards ─────────────────────────────────────────────────────────────
 
-function RolesCards({ events }: { events: RoleEvent[] }) {
+function RolesCards({ events, slotLabels }: { events: RoleEvent[]; slotLabels: Record<SlotLabel, string> }) {
   return (
     <div className="flex flex-col gap-3">
       {events.map(event => (
@@ -113,7 +117,7 @@ function RolesCards({ events }: { events: RoleEvent[] }) {
                   className="text-[10px] font-semibold tracking-widest uppercase"
                   style={{ color: 'var(--text-secondary)', minWidth: 72 }}
                 >
-                  {label}
+                  {slotLabels[label]}
                 </span>
                 <span className="text-xs text-right">
                   <OccupantCell name={event.slots[label]} />
@@ -131,6 +135,21 @@ function RolesCards({ events }: { events: RoleEvent[] }) {
 
 export default function RolesClient({ events }: Props) {
   const { t } = useLanguage()
+
+  const headers = [
+    t('event.roles.col.event'),
+    t('event.roles.col.date'),
+    t('event.roles.col.time'),
+    t('event.roles.label.host'),
+    t('event.roles.label.speaker'),
+    t('event.roles.label.products'),
+  ]
+
+  const slotLabels: Record<SlotLabel, string> = {
+    HOST:     t(SLOT_LABEL_KEY.HOST),
+    SPEAKER:  t(SLOT_LABEL_KEY.SPEAKER),
+    PRODUCTS: t(SLOT_LABEL_KEY.PRODUCTS),
+  }
 
   return (
     <div className="py-8 pb-16">
@@ -152,7 +171,7 @@ export default function RolesClient({ events }: Props) {
             {t('event.rolesEmpty')}
           </p>
         ) : (
-          <RolesTable events={events} />
+          <RolesTable events={events} headers={headers} />
         )}
       </div>
 
@@ -173,7 +192,7 @@ export default function RolesClient({ events }: Props) {
             {t('event.rolesEmpty')}
           </p>
         ) : (
-          <RolesCards events={events} />
+          <RolesCards events={events} slotLabels={slotLabels} />
         )}
       </div>
 

--- a/app/(dashboard)/roles/components/RolesClient.tsx
+++ b/app/(dashboard)/roles/components/RolesClient.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useLanguage } from '@/lib/hooks/useLanguage'
+import { formatDate, formatTime } from '@/lib/format'
+import type { RoleEvent } from '@/app/api/roles/route'
+
+type Props = {
+  events: RoleEvent[]
+}
+
+const SLOT_LABELS = ['HOST', 'SPEAKER', 'PRODUCTS'] as const
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+function OccupantCell({ name }: { name: string | null }) {
+  if (!name) {
+    return (
+      <span style={{ color: 'var(--text-secondary)' }}>—</span>
+    )
+  }
+  return (
+    <span className="font-medium" style={{ color: 'var(--text-primary)' }}>{name}</span>
+  )
+}
+
+// ── Desktop table ────────────────────────────────────────────────────────────
+
+function RolesTable({ events }: { events: RoleEvent[] }) {
+  return (
+    <div
+      className="rounded-2xl overflow-hidden"
+      style={{ border: '1px solid rgba(0,0,0,0.07)', backgroundColor: 'var(--bg-card)' }}
+    >
+      {/* Header row */}
+      <div
+        className="grid text-[10px] font-semibold tracking-widest uppercase px-4 py-2.5"
+        style={{
+          gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr 1fr',
+          borderBottom: '1px solid rgba(0,0,0,0.06)',
+          color: 'var(--text-secondary)',
+          backgroundColor: 'rgba(0,0,0,0.02)',
+        }}
+      >
+        <span>Event</span>
+        <span>Date</span>
+        <span>Time</span>
+        <span>Host</span>
+        <span>Speaker</span>
+        <span>Products</span>
+      </div>
+
+      {/* Data rows */}
+      {events.map((event, i) => (
+        <div
+          key={event.id}
+          className="grid items-center px-4 py-3 text-sm"
+          style={{
+            gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr 1fr',
+            borderTop: i === 0 ? undefined : '1px solid rgba(0,0,0,0.04)',
+          }}
+        >
+          <span
+            className="font-semibold truncate pr-4"
+            style={{ color: 'var(--text-primary)' }}
+          >
+            {event.title}
+          </span>
+          <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+            {formatDate(event.start_time)}
+          </span>
+          <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+            {formatTime(event.start_time)}
+          </span>
+          <span className="text-xs"><OccupantCell name={event.slots.HOST} /></span>
+          <span className="text-xs"><OccupantCell name={event.slots.SPEAKER} /></span>
+          <span className="text-xs"><OccupantCell name={event.slots.PRODUCTS} /></span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Mobile cards ─────────────────────────────────────────────────────────────
+
+function RolesCards({ events }: { events: RoleEvent[] }) {
+  return (
+    <div className="flex flex-col gap-3">
+      {events.map(event => (
+        <div
+          key={event.id}
+          className="rounded-2xl p-4"
+          style={{
+            border: '1px solid rgba(0,0,0,0.07)',
+            backgroundColor: 'var(--bg-card)',
+          }}
+        >
+          {/* Event title + date/time */}
+          <p
+            className="text-sm font-semibold mb-1 leading-snug"
+            style={{ color: 'var(--text-primary)' }}
+          >
+            {event.title}
+          </p>
+          <p className="text-xs mb-3" style={{ color: 'var(--text-secondary)' }}>
+            {formatDate(event.start_time)} · {formatTime(event.start_time)}
+          </p>
+
+          {/* Role slots */}
+          <div className="flex flex-col gap-2">
+            {SLOT_LABELS.map(label => (
+              <div key={label} className="flex items-center justify-between gap-2">
+                <span
+                  className="text-[10px] font-semibold tracking-widest uppercase"
+                  style={{ color: 'var(--text-secondary)', minWidth: 72 }}
+                >
+                  {label}
+                </span>
+                <span className="text-xs text-right">
+                  <OccupantCell name={event.slots[label]} />
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
+
+export default function RolesClient({ events }: Props) {
+  const { t } = useLanguage()
+
+  return (
+    <div className="py-8 pb-16">
+
+      {/* ════════════════════════════════════════════════════════════════════
+          DESKTOP layout (lg+)
+          Full-width table with card container, max-w-5xl centred
+          ════════════════════════════════════════════════════════════════════ */}
+      <div className="hidden lg:block max-w-5xl mx-auto px-6">
+        <h1
+          className="font-display text-2xl font-bold mb-6"
+          style={{ color: 'var(--text-primary)' }}
+        >
+          {t('event.rolesPageTitle')}
+        </h1>
+
+        {events.length === 0 ? (
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            {t('event.rolesEmpty')}
+          </p>
+        ) : (
+          <RolesTable events={events} />
+        )}
+      </div>
+
+      {/* ════════════════════════════════════════════════════════════════════
+          MOBILE layout (< lg)
+          Stacked cards, full-width with px-4
+          ════════════════════════════════════════════════════════════════════ */}
+      <div className="lg:hidden px-4">
+        <h1
+          className="font-display text-xl font-bold mb-4"
+          style={{ color: 'var(--text-primary)' }}
+        >
+          {t('event.rolesPageTitle')}
+        </h1>
+
+        {events.length === 0 ? (
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            {t('event.rolesEmpty')}
+          </p>
+        ) : (
+          <RolesCards events={events} />
+        )}
+      </div>
+
+    </div>
+  )
+}

--- a/app/(dashboard)/roles/page.tsx
+++ b/app/(dashboard)/roles/page.tsx
@@ -1,0 +1,70 @@
+import { auth } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+import { createServiceClient } from '@/lib/supabase/service'
+import RolesClient from './components/RolesClient'
+import type { RoleEvent } from '@/app/api/roles/route'
+
+const ROLE_RANK: Record<string, number> = { guest: 0, member: 1, core: 2, admin: 3 }
+
+export default async function RolesPage() {
+  const { userId } = await auth()
+  if (!userId) redirect('/calendar')
+
+  const supabase = createServiceClient()
+
+  const { data: callerProfile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (!callerProfile || (ROLE_RANK[callerProfile.role] ?? -1) < ROLE_RANK.core) {
+    redirect('/calendar')
+  }
+
+  // Fetch upcoming events with slots
+  const { data: events } = await supabase
+    .from('calendar_events')
+    .select('id, title, start_time, end_time, event_role_slots ( role_label )')
+    .gte('start_time', new Date().toISOString())
+    .order('start_time', { ascending: true })
+
+  const eventsWithSlots = (events ?? []).filter(
+    e => e.event_role_slots && e.event_role_slots.length > 0
+  )
+
+  if (eventsWithSlots.length === 0) {
+    return <RolesClient events={[]} />
+  }
+
+  const eventIds = eventsWithSlots.map(e => e.id)
+
+  const { data: approvedRequests } = await supabase
+    .from('event_role_requests')
+    .select('event_id, role_label, profile:profiles!profile_id ( first_name, last_name )')
+    .in('event_id', eventIds)
+    .eq('status', 'approved')
+
+  // Build occupant lookup
+  const occupantMap: Record<string, Record<string, string>> = {}
+  for (const req of approvedRequests ?? []) {
+    if (!occupantMap[req.event_id]) occupantMap[req.event_id] = {}
+    const profile = req.profile as { first_name: string | null; last_name: string | null } | null
+    const name = [profile?.first_name, profile?.last_name].filter(Boolean).join(' ').trim()
+    if (name) occupantMap[req.event_id][req.role_label] = name
+  }
+
+  const roleEvents: RoleEvent[] = eventsWithSlots.map(event => ({
+    id: event.id,
+    title: event.title,
+    start_time: event.start_time,
+    end_time: event.end_time,
+    slots: {
+      HOST:     occupantMap[event.id]?.['HOST']     ?? null,
+      SPEAKER:  occupantMap[event.id]?.['SPEAKER']  ?? null,
+      PRODUCTS: occupantMap[event.id]?.['PRODUCTS'] ?? null,
+    },
+  }))
+
+  return <RolesClient events={roleEvents} />
+}

--- a/app/api/roles/route.ts
+++ b/app/api/roles/route.ts
@@ -1,16 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 
-type RoleSlotRow = {
-  role_label: string
-  event_role_requests: {
-    profile: {
-      first_name: string | null
-      last_name: string | null
-    } | null
-  }[] | null
-}
-
 export type RoleEvent = {
   id: string
   title: string
@@ -42,7 +32,9 @@ export async function GET(): Promise<Response> {
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  // Fetch events that have at least one slot, upcoming only
+  // Fetch upcoming events with their slot labels only.
+  // Approved occupants are fetched in a second query — PostgREST cannot filter
+  // nested rows by status without an RPC, so we never attempt the nested join.
   const { data: events, error } = await supabase
     .from('calendar_events')
     .select(`
@@ -50,63 +42,32 @@ export async function GET(): Promise<Response> {
       title,
       start_time,
       end_time,
-      event_role_slots (
-        role_label,
-        event_role_requests (
-          profile:profiles!profile_id ( first_name, last_name )
-        )
-      )
+      event_role_slots ( role_label )
     `)
     .gte('start_time', new Date().toISOString())
     .order('start_time', { ascending: true })
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
 
-  // Filter to only events that actually have slots configured
+  const SLOT_LABELS = ['HOST', 'SPEAKER', 'PRODUCTS'] as const
+
+  // Filter to events that have at least one configured slot
   const eventsWithSlots = (events ?? []).filter(
     e => e.event_role_slots && e.event_role_slots.length > 0
   )
 
-  const SLOT_LABELS = ['HOST', 'SPEAKER', 'PRODUCTS'] as const
+  if (eventsWithSlots.length === 0) return Response.json([])
 
-  const result: RoleEvent[] = eventsWithSlots.map(event => {
-    const slotMap: Record<string, string | null> = { HOST: null, SPEAKER: null, PRODUCTS: null }
+  const eventIds = eventsWithSlots.map(e => e.id)
 
-    for (const slot of (event.event_role_slots as RoleSlotRow[])) {
-      const label = slot.role_label as typeof SLOT_LABELS[number]
-      if (!SLOT_LABELS.includes(label)) continue
-
-      // event_role_slots -> event_role_requests is a nested array filtered to approved only
-      // by the join — but PostgREST returns all requests; we filter status client-side
-      // Note: the join here doesn't filter by status — we need to handle that.
-      // Since we only want approved, we take the first request in the array
-      // (the RPC/trigger enforces one approved per slot, so at most one exists).
-      // However PostgREST nested select returns ALL requests — we cannot filter
-      // nested rows in PostgREST without an RPC. Safe approach: fetch separately below.
-      slotMap[label] = null
-    }
-
-    return {
-      id: event.id,
-      title: event.title,
-      start_time: event.start_time,
-      end_time: event.end_time,
-      slots: slotMap as RoleEvent['slots'],
-    }
-  })
-
-  // PostgREST cannot filter nested rows — fetch approved requests separately
-  if (result.length === 0) return Response.json(result)
-
-  const eventIds = result.map(e => e.id)
-
+  // Fetch approved requests separately (correct approach — no nested filter needed)
   const { data: approvedRequests } = await supabase
     .from('event_role_requests')
     .select('event_id, role_label, profile:profiles!profile_id ( first_name, last_name )')
     .in('event_id', eventIds)
     .eq('status', 'approved')
 
-  // Build a lookup: eventId -> roleLabel -> occupant name
+  // Build lookup: eventId -> roleLabel -> occupant name
   const occupantMap: Record<string, Record<string, string>> = {}
   for (const req of approvedRequests ?? []) {
     if (!occupantMap[req.event_id]) occupantMap[req.event_id] = {}
@@ -115,13 +76,26 @@ export async function GET(): Promise<Response> {
     if (name) occupantMap[req.event_id][req.role_label] = name
   }
 
-  // Merge occupant data into result
-  for (const event of result) {
+  const result: RoleEvent[] = eventsWithSlots.map(event => {
     const eventOccupants = occupantMap[event.id] ?? {}
-    event.slots.HOST     = eventOccupants['HOST']     ?? null
-    event.slots.SPEAKER  = eventOccupants['SPEAKER']  ?? null
-    event.slots.PRODUCTS = eventOccupants['PRODUCTS'] ?? null
-  }
+
+    // Only expose slots that are configured on this event
+    const configuredLabels = new Set(
+      (event.event_role_slots ?? []).map(s => s.role_label)
+    )
+
+    return {
+      id: event.id,
+      title: event.title,
+      start_time: event.start_time,
+      end_time: event.end_time,
+      slots: {
+        HOST:     configuredLabels.has('HOST')     ? (eventOccupants['HOST']     ?? null) : null,
+        SPEAKER:  configuredLabels.has('SPEAKER')  ? (eventOccupants['SPEAKER']  ?? null) : null,
+        PRODUCTS: configuredLabels.has('PRODUCTS') ? (eventOccupants['PRODUCTS'] ?? null) : null,
+      },
+    }
+  })
 
   return Response.json(result)
 }

--- a/app/api/roles/route.ts
+++ b/app/api/roles/route.ts
@@ -1,0 +1,127 @@
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+
+type RoleSlotRow = {
+  role_label: string
+  event_role_requests: {
+    profile: {
+      first_name: string | null
+      last_name: string | null
+    } | null
+  }[] | null
+}
+
+export type RoleEvent = {
+  id: string
+  title: string
+  start_time: string
+  end_time: string
+  slots: {
+    HOST: string | null
+    SPEAKER: string | null
+    PRODUCTS: string | null
+  }
+}
+
+export async function GET(): Promise<Response> {
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+
+  const { data: callerProfile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (!callerProfile) return Response.json({ error: 'Profile not found' }, { status: 404 })
+
+  const rank: Record<string, number> = { guest: 0, member: 1, core: 2, admin: 3 }
+  if ((rank[callerProfile.role] ?? -1) < rank.core) {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  // Fetch events that have at least one slot, upcoming only
+  const { data: events, error } = await supabase
+    .from('calendar_events')
+    .select(`
+      id,
+      title,
+      start_time,
+      end_time,
+      event_role_slots (
+        role_label,
+        event_role_requests (
+          profile:profiles!profile_id ( first_name, last_name )
+        )
+      )
+    `)
+    .gte('start_time', new Date().toISOString())
+    .order('start_time', { ascending: true })
+
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+
+  // Filter to only events that actually have slots configured
+  const eventsWithSlots = (events ?? []).filter(
+    e => e.event_role_slots && e.event_role_slots.length > 0
+  )
+
+  const SLOT_LABELS = ['HOST', 'SPEAKER', 'PRODUCTS'] as const
+
+  const result: RoleEvent[] = eventsWithSlots.map(event => {
+    const slotMap: Record<string, string | null> = { HOST: null, SPEAKER: null, PRODUCTS: null }
+
+    for (const slot of (event.event_role_slots as RoleSlotRow[])) {
+      const label = slot.role_label as typeof SLOT_LABELS[number]
+      if (!SLOT_LABELS.includes(label)) continue
+
+      // event_role_slots -> event_role_requests is a nested array filtered to approved only
+      // by the join — but PostgREST returns all requests; we filter status client-side
+      // Note: the join here doesn't filter by status — we need to handle that.
+      // Since we only want approved, we take the first request in the array
+      // (the RPC/trigger enforces one approved per slot, so at most one exists).
+      // However PostgREST nested select returns ALL requests — we cannot filter
+      // nested rows in PostgREST without an RPC. Safe approach: fetch separately below.
+      slotMap[label] = null
+    }
+
+    return {
+      id: event.id,
+      title: event.title,
+      start_time: event.start_time,
+      end_time: event.end_time,
+      slots: slotMap as RoleEvent['slots'],
+    }
+  })
+
+  // PostgREST cannot filter nested rows — fetch approved requests separately
+  if (result.length === 0) return Response.json(result)
+
+  const eventIds = result.map(e => e.id)
+
+  const { data: approvedRequests } = await supabase
+    .from('event_role_requests')
+    .select('event_id, role_label, profile:profiles!profile_id ( first_name, last_name )')
+    .in('event_id', eventIds)
+    .eq('status', 'approved')
+
+  // Build a lookup: eventId -> roleLabel -> occupant name
+  const occupantMap: Record<string, Record<string, string>> = {}
+  for (const req of approvedRequests ?? []) {
+    if (!occupantMap[req.event_id]) occupantMap[req.event_id] = {}
+    const profile = req.profile as { first_name: string | null; last_name: string | null } | null
+    const name = [profile?.first_name, profile?.last_name].filter(Boolean).join(' ').trim()
+    if (name) occupantMap[req.event_id][req.role_label] = name
+  }
+
+  // Merge occupant data into result
+  for (const event of result) {
+    const eventOccupants = occupantMap[event.id] ?? {}
+    event.slots.HOST     = eventOccupants['HOST']     ?? null
+    event.slots.SPEAKER  = eventOccupants['SPEAKER']  ?? null
+    event.slots.PRODUCTS = eventOccupants['PRODUCTS'] ?? null
+  }
+
+  return Response.json(result)
+}

--- a/lib/i18n/domains/events.ts
+++ b/lib/i18n/domains/events.ts
@@ -17,6 +17,16 @@ export const events = {
   'event.rolesPageTitle':   { en: 'Roles',             bg: 'Роли'                            },
   'event.rolesEmpty':       { en: 'No upcoming events with roles configured.', bg: 'Няма предстоящи събития с конфигурирани роли.' },
 
+  // roles page — table headers
+  'event.roles.col.event':    { en: 'Event',    bg: 'Събитие'  },
+  'event.roles.col.date':     { en: 'Date',     bg: 'Дата'     },
+  'event.roles.col.time':     { en: 'Time',     bg: 'Час'      },
+
+  // roles page — slot role labels
+  'event.roles.label.host':     { en: 'Host',     bg: 'Домакин'   },
+  'event.roles.label.speaker':  { en: 'Speaker',  bg: 'Говорител' },
+  'event.roles.label.products': { en: 'Products', bg: 'Продукти'  },
+
   // join page
   'event.join.brandName':          { en: 'TeamEnjoyVD',                                              bg: 'TeamEnjoyVD'                                                    },
   'event.join.linkExpired':        { en: 'This link has expired.',                                   bg: 'Тази връзка е изтекла.'                                         },
@@ -42,8 +52,8 @@ export const events = {
   // register/components/RegisterForm
   'event.register.checkInbox':     { en: 'Check your inbox',                                         bg: 'Проверете пощата си'                                            },
   'event.register.sentLink':       { en: "We've sent your access link. The link expires in 72 hours.", bg: 'Изпратихме ви връзка за достъп. Тя е валидна 72 часа.'          },
-  'event.register.fullName':       { en: 'Full Name',                                                bg: 'Пълно ime'                                                      },
-  'event.register.yourName':       { en: 'Your name',                                                bg: 'Вашето ime'                                                     },
+  'event.register.fullName':       { en: 'Full Name',                                                bg: 'Пълно име'                                                      },
+  'event.register.yourName':       { en: 'Your name',                                                bg: 'Вашето име'                                                     },
   'event.register.emailAddress':   { en: 'Email Address',                                            bg: 'Имейл адрес'                                                    },
   'event.register.emailPlaceholder': { en: 'you@example.com',                                        bg: 'you@example.com'                                                },
   'event.register.sendingLink':    { en: 'Sending link…',                                            bg: 'Изпращане…'                                                     },

--- a/lib/i18n/domains/events.ts
+++ b/lib/i18n/domains/events.ts
@@ -13,6 +13,10 @@ export const events = {
   'event.slot.filled':      { en: 'Filled',            bg: 'Заета'                           },
   'event.slot.yourRequest': { en: 'Your request',      bg: 'Вашата заявка'                   },
 
+  // roles page
+  'event.rolesPageTitle':   { en: 'Roles',             bg: 'Роли'                            },
+  'event.rolesEmpty':       { en: 'No upcoming events with roles configured.', bg: 'Няма предстоящи събития с конфигурирани роли.' },
+
   // join page
   'event.join.brandName':          { en: 'TeamEnjoyVD',                                              bg: 'TeamEnjoyVD'                                                    },
   'event.join.linkExpired':        { en: 'This link has expired.',                                   bg: 'Тази връзка е изтекла.'                                         },
@@ -38,8 +42,8 @@ export const events = {
   // register/components/RegisterForm
   'event.register.checkInbox':     { en: 'Check your inbox',                                         bg: 'Проверете пощата си'                                            },
   'event.register.sentLink':       { en: "We've sent your access link. The link expires in 72 hours.", bg: 'Изпратихме ви връзка за достъп. Тя е валидна 72 часа.'          },
-  'event.register.fullName':       { en: 'Full Name',                                                bg: 'Пълно име'                                                      },
-  'event.register.yourName':       { en: 'Your name',                                                bg: 'Вашето име'                                                     },
+  'event.register.fullName':       { en: 'Full Name',                                                bg: 'Пълно ime'                                                      },
+  'event.register.yourName':       { en: 'Your name',                                                bg: 'Вашето ime'                                                     },
   'event.register.emailAddress':   { en: 'Email Address',                                            bg: 'Имейл адрес'                                                    },
   'event.register.emailPlaceholder': { en: 'you@example.com',                                        bg: 'you@example.com'                                                },
   'event.register.sendingLink':    { en: 'Sending link…',                                            bg: 'Изпращане…'                                                     },

--- a/lib/i18n/domains/nav.ts
+++ b/lib/i18n/domains/nav.ts
@@ -8,5 +8,6 @@ export const nav = {
   'nav.admin':         { en: 'Admin',         bg: 'Админ'        },
   'nav.network':       { en: 'My Network',    bg: 'Моята мрежа'  },
   'nav.howtos':        { en: 'Guides',        bg: 'Ръководства'  },
+  'nav.roles':         { en: 'Roles',         bg: 'Роли'         },
   'nav.signIn':        { en: 'Sign in',       bg: 'Вход'         },
 } as const

--- a/lib/nav.ts
+++ b/lib/nav.ts
@@ -2,8 +2,8 @@
 // Adding, removing, or renaming a route = one edit here, propagates everywhere.
 //
 // Consumer guide:
-//   Header    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + profile, no /los)
-//   Footer    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + profile, no /los)
+//   Header    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + profile, no /los, no /roles)
+//   Footer    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + profile + roles, no /los)
 //   AdminNav  — ADMIN_NAV
 
 export type NavItem = {
@@ -41,10 +41,11 @@ export const PUBLIC_NAV: NavItem[] = [
 export const MEMBER_NAV: NavItem[] = [
   { href: '/library', labels: { en: 'Library',    bg: 'Библиотека'  }, minRole: 'member' },
   { href: '/los',     labels: { en: 'My Network', bg: 'Моята мрежа' }, minRole: 'member' },
+  { href: '/roles',   labels: { en: 'Roles',      bg: 'Роли'        }, minRole: 'core'   },
   { href: '/profile', labels: { en: 'Profile',    bg: 'Профил'      }, minRole: 'guest'  },
 ]
 
-// Footer and Header both show library + profile but not /los
+// Footer and Header both show library + profile + roles but not /los
 export const FOOTER_MEMBER_NAV: NavItem[] = MEMBER_NAV.filter(
   item => item.href !== '/los'
 )


### PR DESCRIPTION
# [2505-FEAT-347] Roles table view — /roles page (Core+ member-facing)

New read-only `/roles` page for Core+ users. Upcoming events with configured role slots, showing approved occupant per slot. No interaction — no popup, no mutations.

## Changes

- `lib/nav.ts` — `/roles` added to `MEMBER_NAV` with `minRole: 'core'`; propagates to `FOOTER_MEMBER_NAV` automatically
- `lib/i18n/domains/nav.ts` — `nav.roles` key added
- `lib/i18n/domains/events.ts` — `event.rolesPageTitle`, `event.rolesEmpty` added
- `app/api/roles/route.ts` — GET endpoint, 403 for guest/member, two-query pattern (approved requests fetched separately to work around PostgREST nested row filter limitation)
- `app/(dashboard)/roles/page.tsx` — RSC, redirects guest/member to `/calendar`, fetches directly via service client
- `app/(dashboard)/roles/components/RolesClient.tsx` — dual layout: desktop table (`hidden lg:block`), mobile stacked cards (`lg:hidden`); zero interactivity

## Session State
**Status:** DONE
**Completed:**
- [x] `lib/nav.ts` — `/roles` nav entry, `minRole: core`
- [x] `lib/i18n/domains/nav.ts` — `nav.roles` key
- [x] `lib/i18n/domains/events.ts` — `event.rolesPageTitle`, `event.rolesEmpty`
- [x] `app/api/roles/route.ts` — GET, auth + role guard, approved occupant query
- [x] `app/(dashboard)/roles/page.tsx` — RSC with redirect gate
- [x] `app/(dashboard)/roles/components/RolesClient.tsx` — dual layout, no interaction
**Next:** User merges via GitHub UI; confirm Vercel production deployment READY after merge.

Closes #347