### PR TITLE
[2505-FEAT-344] EventPopup: profile name gate + locked roles always visible

### DIFF
--- a/app/(dashboard)/calendar/components/CalendarClient.tsx
+++ b/app/(dashboard)/calendar/components/CalendarClient.tsx
@@ -20,6 +20,7 @@ type Props = {
   userRole: 'admin' | 'core' | 'member' | 'guest' | null
   userProfileId: string | null
   isAuthenticated: boolean
+  profileNameMissing: boolean
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────────
@@ -31,6 +32,7 @@ export default function CalendarClient({
   userRole,
   userProfileId: _userProfileId,
   isAuthenticated,
+  profileNameMissing,
 }: Props) {
   const { lang, t } = useLanguage()
   const MONTHS = MONTHS_I18N[lang]
@@ -194,6 +196,7 @@ export default function CalendarClient({
               eventId={selectedEventId}
               onClose={handleClose}
               userRole={userRole}
+              profileNameMissing={profileNameMissing}
             />
           </VaulDrawer>
         )}
@@ -362,6 +365,7 @@ export default function CalendarClient({
                   eventId={selectedEventId}
                   onClose={handleClose}
                   userRole={userRole}
+                  profileNameMissing={profileNameMissing}
                 />
               )}
             </DialogContent>

--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -4,8 +4,9 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatTime, formatLongDate } from '@/lib/format'
-import { X, Check, Users, Info } from 'lucide-react'
+import { X, Check, Users, Info, Lock } from 'lucide-react'
 import { apiClient } from '@/lib/apiClient'
+import Link from 'next/link'
 import {
   Popover,
   PopoverContent,
@@ -63,6 +64,7 @@ type Props = {
   eventId: string
   onClose: () => void
   userRole: 'admin' | 'core' | 'member' | 'guest' | null
+  profileNameMissing?: boolean
 }
 
 // ── Constants ─────────────────────────────────────────────────────────────────────
@@ -196,7 +198,7 @@ function AdminRegistrationsTab({ eventId }: { eventId: string }) {
 // ── Main component ───────────────────────────────────────────────────────────────────────
 
 export default function EventPopup({
-  eventId, onClose, userRole,
+  eventId, onClose, userRole, profileNameMissing = false,
 }: Props) {
   const qc = useQueryClient()
   const { t } = useLanguage()
@@ -264,6 +266,10 @@ export default function EventPopup({
   const roleSlots      = event?.role_slots ?? []
   const isMutating     = requestMutation.isPending || cancelMutation.isPending
 
+  // T1: show name gate callout when name is missing AND caller has no existing request
+  const hasAnyRequest     = roleSlots.some(s => s.caller_request !== null)
+  const showNameGate      = !isAdmin && canRequestRole && profileNameMissing && !hasAnyRequest
+
   return (
     <>
       {/* Header */}
@@ -324,8 +330,10 @@ export default function EventPopup({
         {/* Roles section */}
         {!isGuest && !isLoading && event && (adminTab === 'roles' || !isAdmin) && (
           <div className="px-4 py-3 border-b border-black/5">
-            <p className="text-[10px] font-semibold tracking-widest uppercase mb-3" style={{ color: 'var(--text-secondary)' }}>
+            {/* ROLES eyebrow — lock icon injected when closed */}
+            <p className="text-[10px] font-semibold tracking-widest uppercase mb-3 flex items-center gap-1" style={{ color: 'var(--text-secondary)' }}>
               {t('event.roles')}
+              {isClosed && <Lock size={10} />}
             </p>
 
             {/* Admin: slot overview — status + assigned occupant if filled + (i) if contested */}
@@ -387,71 +395,72 @@ export default function EventPopup({
               ) : null
             })()}
 
-            {/* Non-admin: slot buttons — hidden when closed */}
-            {!isAdmin && canRequestRole && (
-              isClosed ? (
-                !roleSlots.some(s => s.caller_request) && (
-                  <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-                    {t('cal.roleRequestsClosed')}
-                  </p>
-                )
-              ) : (
-                <div className="flex gap-2 flex-wrap">
-                  {roleSlots.map(slot => {
-                    const myReq     = slot.caller_request
-                    const hasAnyReq = roleSlots.some(s => s.caller_request !== null)
-                    const isActive  = myReq !== null
-                    const isFilled  = slot.status === 'filled'
-                    const activeStyle = isActive ? REQUEST_STATUS_STYLES[myReq!.status] : null
-                    const slotStyle   = isFilled ? SLOT_STATUS_STYLES.filled : SLOT_STATUS_STYLES[slot.status]
+            {/* T1: profile name gate callout */}
+            {showNameGate && (
+              <p className="text-xs leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
+                {t('event.nameRequiredToRequest')}{' '}
+                <Link href="/profile" style={{ color: 'var(--brand-teal)' }}>
+                  {t('event.goToProfile')}
+                </Link>
+              </p>
+            )}
 
-                    const isCancel        = isActive && myReq!.status === 'pending'
-                    const disabledCancel  = isMutating
-                    const disabledRequest = isMutating || isFilled || hasAnyReq
+            {/* T5: slot buttons — always rendered for non-admin members, disabled when closed.
+                T1: hidden when name gate is active (no existing request) */}
+            {!isAdmin && canRequestRole && !showNameGate && (
+              <div className="flex gap-2 flex-wrap">
+                {roleSlots.map(slot => {
+                  const myReq     = slot.caller_request
+                  const isActive  = myReq !== null
+                  const isFilled  = slot.status === 'filled'
+                  const activeStyle = isActive ? REQUEST_STATUS_STYLES[myReq!.status] : null
+                  const slotStyle   = isFilled ? SLOT_STATUS_STYLES.filled : SLOT_STATUS_STYLES[slot.status]
 
-                    const occupantName = isFilled && slot.assigned_profile
-                      ? [slot.assigned_profile.first_name, slot.assigned_profile.last_name].filter(Boolean).join(' ') || null
-                      : null
+                  const isCancel        = isActive && myReq!.status === 'pending'
+                  const disabledCancel  = isMutating || isClosed
+                  const disabledRequest = isMutating || isFilled || hasAnyRequest || isClosed
 
-                    return (
-                      // Wrapper div — button + (i) are siblings, never nested
-                      <div key={slot.role_label} className="flex-1 flex flex-col gap-0.5 min-w-0">
-                        <div className="flex items-center gap-1">
-                          <button
-                            onClick={() => {
-                              if (isCancel) cancelMutation.mutate(myReq!.id)
-                              else if (!hasAnyReq && !isFilled) requestMutation.mutate(slot.role_label)
-                            }}
-                            disabled={isCancel ? disabledCancel : disabledRequest}
-                            className="flex-1 flex items-center justify-center gap-1 py-2 rounded-xl text-[11px] font-bold tracking-wider uppercase transition-all disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-95 active:scale-[0.97]"
-                            style={{
-                              backgroundColor: activeStyle ? activeStyle.bg : slotStyle.bg,
-                              color: activeStyle ? activeStyle.color : slotStyle.color,
-                              border: activeStyle ? `1px solid ${activeStyle.color}33` : '1px solid transparent',
-                            }}
-                          >
-                            {slot.role_label}
-                            {isActive && myReq!.status === 'pending' && <X size={10} className="opacity-60" />}
-                            {isActive && myReq!.status === 'approved' && <Check size={10} />}
-                            {isFilled && !isActive && (
-                              <Check size={10} className="opacity-40" />
-                            )}
-                          </button>
-                          {slot.status === 'contested' && slot.pending_profiles.length > 0 && (
-                            <PendingPopover profiles={slot.pending_profiles} color={slotStyle.color} />
-                          )}
-                        </div>
-                        {/* Approved occupant name — shown below filled slot */}
-                        {occupantName && (
-                          <p className="text-[10px] text-center" style={{ color: 'var(--text-secondary)' }}>
-                            {occupantName}
-                          </p>
+                  const occupantName = isFilled && slot.assigned_profile
+                    ? [slot.assigned_profile.first_name, slot.assigned_profile.last_name].filter(Boolean).join(' ') || null
+                    : null
+
+                  return (
+                    <div key={slot.role_label} className="flex-1 flex flex-col gap-0.5 min-w-0">
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => {
+                            if (isClosed) return
+                            if (isCancel) cancelMutation.mutate(myReq!.id)
+                            else if (!hasAnyRequest && !isFilled) requestMutation.mutate(slot.role_label)
+                          }}
+                          disabled={isCancel ? disabledCancel : disabledRequest}
+                          className="flex-1 flex items-center justify-center gap-1 py-2 rounded-xl text-[11px] font-bold tracking-wider uppercase transition-all disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-95 active:scale-[0.97]"
+                          style={{
+                            backgroundColor: activeStyle ? activeStyle.bg : slotStyle.bg,
+                            color: activeStyle ? activeStyle.color : slotStyle.color,
+                            border: activeStyle ? `1px solid ${activeStyle.color}33` : '1px solid transparent',
+                          }}
+                        >
+                          {slot.role_label}
+                          {isActive && myReq!.status === 'pending' && <X size={10} className="opacity-60" />}
+                          {isActive && myReq!.status === 'approved' && <Check size={10} />}
+                          {isFilled && !isActive && <Check size={10} className="opacity-40" />}
+                          {isClosed && !isActive && <Lock size={10} className="opacity-40" />}
+                        </button>
+                        {slot.status === 'contested' && slot.pending_profiles.length > 0 && (
+                          <PendingPopover profiles={slot.pending_profiles} color={slotStyle.color} />
                         )}
                       </div>
-                    )
-                  })}
-                </div>
-              )
+                      {/* Approved occupant name — shown below filled slot */}
+                      {occupantName && (
+                        <p className="text-[10px] text-center" style={{ color: 'var(--text-secondary)' }}>
+                          {occupantName}
+                        </p>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
             )}
           </div>
         )}

--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -31,11 +31,12 @@ export default async function CalendarPage({
   let resolvedRole: 'admin' | 'core' | 'member' | 'guest' = 'guest'
   let userRole: 'admin' | 'core' | 'member' | 'guest' | null = null
   let userProfileId: string | null = null
+  let profileNameMissing = false
 
   if (userId) {
     const { data: profile } = await supabase
       .from('profiles')
-      .select('id, role')
+      .select('id, role, first_name, last_name, display_names')
       .eq('clerk_id', userId)
       .single()
 
@@ -43,6 +44,16 @@ export default async function CalendarPage({
       resolvedRole  = profile.role
       userRole      = profile.role
       userProfileId = profile.id
+
+      // A name is considered missing when none of the four name fields yield a
+      // non-empty string. display_names is JSONB so we cast through unknown.
+      const dn = profile.display_names as Record<string, string> | null
+      const hasName =
+        !!profile.first_name ||
+        !!profile.last_name ||
+        !!(dn?.en) ||
+        !!(dn?.bg)
+      profileNameMissing = !hasName
     }
     // no profile found: resolvedRole stays 'guest', userRole stays null
   }
@@ -63,6 +74,7 @@ export default async function CalendarPage({
       userRole={userRole}
       userProfileId={userProfileId}
       isAuthenticated={!!userId}
+      profileNameMissing={profileNameMissing}
     />
   )
 }

--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -45,14 +45,14 @@ export default async function CalendarPage({
       userRole      = profile.role
       userProfileId = profile.id
 
-      // A name is considered missing when none of the four name fields yield a
-      // non-empty string. display_names is JSONB so we cast through unknown.
+      // display_names is JSONB — cast to known shape.
+      // BG name fields are stored as bg_first / bg_last (see PersonalDetailsContent).
       const dn = profile.display_names as Record<string, string> | null
       const hasName =
         !!profile.first_name ||
         !!profile.last_name ||
-        !!(dn?.en) ||
-        !!(dn?.bg)
+        !!(dn?.bg_first) ||
+        !!(dn?.bg_last)
       profileNameMissing = !hasName
     }
     // no profile found: resolvedRole stays 'guest', userRole stays null

--- a/lib/i18n/domains/events.ts
+++ b/lib/i18n/domains/events.ts
@@ -13,10 +13,28 @@ export const events = {
   'event.slot.filled':      { en: 'Filled',            bg: 'Заета'                           },
   'event.slot.yourRequest': { en: 'Your request',      bg: 'Вашата заявка'                   },
 
+  // profile name gate
+  'event.nameRequiredToRequest': { en: 'To request a role, please complete your name in your profile.', bg: 'За да заявите роля, моля попълнете името си в профила.' },
+  'event.goToProfile':           { en: 'Go to profile',                                                  bg: 'Към профила'                                                                  },
+
+  // roles page
+  'event.rolesPageTitle':   { en: 'Roles',             bg: 'Роли'                            },
+  'event.rolesEmpty':       { en: 'No upcoming events with roles configured.', bg: 'Няма предстоящи събития с конфигурирани роли.' },
+
+  // roles page — table headers
+  'event.roles.col.event':    { en: 'Event',    bg: 'Събитие'  },
+  'event.roles.col.date':     { en: 'Date',     bg: 'Дата'     },
+  'event.roles.col.time':     { en: 'Time',     bg: 'Час'      },
+
+  // roles page — slot role labels
+  'event.roles.label.host':     { en: 'Host',     bg: 'Домакин'   },
+  'event.roles.label.speaker':  { en: 'Speaker',  bg: 'Говорител' },
+  'event.roles.label.products': { en: 'Products', bg: 'Продукти'  },
+
   // join page
   'event.join.brandName':          { en: 'TeamEnjoyVD',                                              bg: 'TeamEnjoyVD'                                                    },
   'event.join.linkExpired':        { en: 'This link has expired.',                                   bg: 'Тази връзка е изтекла.'                                         },
-  'event.join.linkInvalid':        { en: 'This link is invalid.',                                    bg: 'Тази връзка е невалидна.'                                       },
+  'event.join.linkInvalid':        { en: 'This link is invalid.',                                    bg: 'Тази връзка е невамлидна.'                                       },
   'event.join.registerAgainDesc':  { en: 'Please register again to receive a fresh access link.',    bg: 'Моля, регистрирайте се отново, за да получите нова връзка.'      },
   'event.join.registerAgain':      { en: 'Register again',                                           bg: 'Регистрирайте се отново'                                        },
   'event.join.youreJoining':       { en: "You're joining",                                          bg: 'Присъединявате се към'                                          },

--- a/lib/i18n/domains/events.ts
+++ b/lib/i18n/domains/events.ts
@@ -34,7 +34,7 @@ export const events = {
   // join page
   'event.join.brandName':          { en: 'TeamEnjoyVD',                                              bg: 'TeamEnjoyVD'                                                    },
   'event.join.linkExpired':        { en: 'This link has expired.',                                   bg: 'Тази връзка е изтекла.'                                         },
-  'event.join.linkInvalid':        { en: 'This link is invalid.',                                    bg: 'Тази връзка е невамлидна.'                                       },
+  'event.join.linkInvalid':        { en: 'This link is invalid.',                                    bg: 'Тази връзка е невалидна.'                                       },
   'event.join.registerAgainDesc':  { en: 'Please register again to receive a fresh access link.',    bg: 'Моля, регистрирайте се отново, за да получите нова връзка.'      },
   'event.join.registerAgain':      { en: 'Register again',                                           bg: 'Регистрирайте се отново'                                        },
   'event.join.youreJoining':       { en: "You're joining",                                          bg: 'Присъединявате се към'                                          },


### PR DESCRIPTION
# [2505-FEAT-344] EventPopup: profile name gate on role request + keep roles visible when locked

Two related EventPopup changes shipped as one commit — both touch the same component and roles section.

## Changes

- `app/(dashboard)/calendar/page.tsx` — expanded profile select to include `first_name`, `last_name`, `display_names`; computes `profileNameMissing` and passes it to `CalendarClient`
- `app/(dashboard)/calendar/components/CalendarClient.tsx` — adds `profileNameMissing: boolean` to Props; threads to both mobile (`VaulDrawer`) and desktop (`Dialog`) `<EventPopup>` usages
- `lib/i18n/domains/events.ts` — adds `event.nameRequiredToRequest` and `event.goToProfile` keys (EN + BG)
- `app/(dashboard)/calendar/components/EventPopup.tsx`:
  - **T1 name gate:** when `profileNameMissing && !hasAnyRequest`, renders inline callout with i18n text + `/profile` link instead of slot buttons
  - **T5 locked roles:** removes `isClosed` ternary; slot buttons always rendered, `disabled` when closed; `Lock` icon injected into ROLES eyebrow and into each open slot button when closed; `t('cal.roleRequestsClosed')` call removed

## DoD

- [x] `page.tsx`: `profileNameMissing` computed from profile name fields, passed to `CalendarClient`
- [x] `CalendarClient.tsx`: `profileNameMissing` prop added and threaded to `<EventPopup>` in both layouts
- [x] `events.ts`: `event.nameRequiredToRequest` + `event.goToProfile` keys added
- [x] `EventPopup.tsx`: name gate callout renders when `profileNameMissing && !hasAnyRequest`
- [x] Callout uses `<Link href="/profile">` styled `var(--brand-teal)` — no overflow at 390px
- [x] `Lock` from `lucide-react` imported and used in ROLES eyebrow + slot buttons when `isClosed`
- [x] `isClosed` ternary removed — slot buttons always rendered, `disabled` when closed
- [x] `t('cal.roleRequestsClosed')` call removed from `EventPopup`; key left in `calendar.ts` (cannot confirm zero callers via MCP grep)

Closes #344