### PR TITLE
[2605-BUG-350] Profile data integrity hardening: field-level audit log + secondary profile invariant enforcement

### DIFF
--- a/app/api/profile/spouse-link/[action]/route.ts
+++ b/app/api/profile/spouse-link/[action]/route.ts
@@ -157,6 +157,14 @@ export async function POST(
     .eq('id', requester.id)
   if (profileErr) return Response.json({ error: profileErr.message }, { status: 500 })
 
+  // Defensive cleanup: remove any orphaned tree_nodes row for the secondary.
+  // A secondary must never have a standalone tree position (ADR-016 invariant).
+  // This is idempotent — safe to call even if no row exists.
+  await supabase
+    .from('tree_nodes')
+    .delete()
+    .eq('profile_id', requester.id)
+
   const { error: requestErr } = await supabase
     .from('spouse_link_requests')
     .update({ status: 'approved', admin_note: null, resolved_at: new Date().toISOString() })

--- a/app/api/profile/verify-abo/route.ts
+++ b/app/api/profile/verify-abo/route.ts
@@ -41,11 +41,23 @@ export async function POST(req: Request) {
   const supabase = createServiceClient()
   const { data: profile } = await supabase
     .from('profiles')
-    .select('id, role, abo_number, first_name, contact_email')
+    .select('id, role, abo_number, primary_profile_id, first_name, contact_email')
     .eq('clerk_id', userId)
     .single()
 
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
+
+  // Guard: secondary accounts cannot submit ABO verification
+  if (profile.primary_profile_id) {
+    return Response.json(
+      {
+        error: 'Secondary accounts cannot submit ABO verification',
+        error_code: 'secondary_cannot_verify',
+      },
+      { status: 400 }
+    )
+  }
+
   if (profile.abo_number) return Response.json({ error: 'ABO already verified' }, { status: 409 })
   if (profile.role !== 'guest') return Response.json({ error: 'Already verified' }, { status: 409 })
 

--- a/docs/ai/LOOKUP.md
+++ b/docs/ai/LOOKUP.md
@@ -1,5 +1,5 @@
 # LOOKUP.md — teamenjoyVD Portal Reference Tables
-> Last updated: 2026-05-09
+> Last updated: 2026-05-13
 > **Read on demand in GATHER only. Never read at SSU or at GATHER start.**
 > Pull only the sections the ticket needs. See section map in REF.md header.
 
@@ -90,7 +90,7 @@
     /profile/payments/route.ts
     /profile/route.ts
     /profile/spouse-link/route.ts  # ADR-016: GET own request, POST submit, DELETE cancel
-    /profile/verify-abo/route.ts   # ADR-016: abo_has_primary error_code when ABO holder is primary
+    /profile/verify-abo/route.ts   # ADR-016: abo_has_primary error_code; #350: secondary_cannot_verify guard
     /profile/vitals/route.ts
     /profile/event-roles/route.ts
     /profile/los-summary/route.ts  # ADR-016: resolves treeProfileId = primary_profile_id ?? id
@@ -169,6 +169,19 @@
 - `ui_prefs` JSONB NOT NULL default `{}` — shape: `{ bento_order: string[], bento_collapsed: Record<string, boolean> }`
 - `upline_abo_number`: written by `approve_member_verification` (both paths) and by `import_los_members` on sponsor change.
 - `primary_profile_id`: ADR-016. NULL = primary or standalone. NOT NULL = secondary/spouse. Self-referential FK ON DELETE SET NULL.
+
+**`profiles_audit`** — added #350 (migration `20260513_003`)
+`id, profile_id → profiles (ON DELETE CASCADE), changed_at, changed_by, old_abo_number, new_abo_number, old_upline_abo_number, new_upline_abo_number, old_primary_profile_id, new_primary_profile_id, old_role, new_role`
+- Written exclusively by `trg_profiles_field_audit` AFTER UPDATE trigger on `profiles`.
+- Only fires when at least one of the 4 tracked fields (`abo_number`, `upline_abo_number`, `primary_profile_id`, `role`) changes.
+- RLS: SELECT admin-only via `is_admin()`. No INSERT policy for authenticated users — trigger runs SECURITY DEFINER.
+- `changed_by`: `current_setting('app.current_user_id', true)` or `'service_role'` fallback.
+- Indexes: `(profile_id)`, `(changed_at DESC)`.
+
+**`v_member_history`** — view added #350 (migration `20260513_003`)
+Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `profile_id, changed_at, changed_by, event_type, field, old_value, new_value`.
+- `event_type` values: `abo_number_change`, `upline_abo_number_change`, `primary_profile_id_change`, `role_change`.
+- Admin-only access via underlying table RLS.
 
 **`spouse_link_requests`** — ADR-016
 `id, requester_id → profiles, claimed_primary_id → profiles, status (pending|approved|denied), admin_note, created_at, resolved_at`
@@ -307,7 +320,7 @@
 | Route | Method | Purpose |
 |---|---|---|
 | `/api/profile` | GET, PATCH | Read/update own profile |
-| `/api/profile/verify-abo` | POST | Submit ABO verification — LOS-validated at submit; `abo_has_primary` error_code when ABO holder is primary (ADR-016) |
+| `/api/profile/verify-abo` | POST | Submit ABO verification — LOS-validated at submit; `abo_has_primary` error_code when ABO holder is primary (ADR-016). Guard added #350: secondary accounts (`primary_profile_id IS NOT NULL`) receive 400 `secondary_cannot_verify`. |
 | `/api/profile/spouse-link` | GET, POST, DELETE | ADR-016: GET own request; POST submit (guest with no primary_profile_id, claiming a primary member with abo_number and no existing secondary); DELETE cancel own pending |
 | `/api/profile/vitals` | GET | Read own vital signs |
 | `/api/profile/event-roles` | GET | Read own event participation |
@@ -390,7 +403,7 @@
 | `get_core_ancestors(uuid)` | Returns Core-role profile UUIDs above a given node |
 | `rebuild_tree_paths` | Cascades ABO label rename down all descendants |
 | `upsert_tree_node(p_profile_id, p_abo_number, p_sponsor_abo_number?)` | Insert/update tree node; walks `los_members` sponsor chain (max 20 hops, cycle guard) if direct sponsor has no portal profile |
-| `approve_member_verification(p_request_id, p_admin_note?)` | **DEPRECATED** — retained for rollback only. Logic now in Inngest approve-verification Step 1. |
+| `approve_member_verification(p_request_id, p_admin_note?)` | **DEPRECATED** — retained for rollback only. Logic now in Inngest approve-verification Step 1. Guard added #350: raises `P0002` if `profile.primary_profile_id IS NOT NULL`. |
 | `patch_member_role(p_profile_id, p_new_role, p_changed_by, p_note?)` | Role update with audit trail — returns updated profile |
 | `get_trip_team_attendees(p_trip_id, p_viewer_profile)` | Returns Core/admin attendees for a trip |
 | `import_los_members(p_rows, p_imported_by?, p_expected_row_count?)` | Transactional LOS import: concurrency check → snapshot → upsert → server-side delete → rebuild_tree_paths → insert los_imports. Returns `{ inserted, removed, import_id, errors }`. |

--- a/docs/ai/REF.md
+++ b/docs/ai/REF.md
@@ -260,6 +260,19 @@ Operations payments tab: Log Payment Drawer with `<optgroup>` entity select; mem
 - `upline_abo_number`: written by `approve_member_verification` (both paths) and by `import_los_members` on sponsor change.
 - `primary_profile_id`: ADR-016. NULL = primary or standalone. NOT NULL = secondary/spouse profile pointing to its primary. Self-referential FK with ON DELETE SET NULL.
 
+**`profiles_audit`** — added #350 (migration `20260513_003`)
+`id, profile_id → profiles (ON DELETE CASCADE), changed_at, changed_by, old_abo_number, new_abo_number, old_upline_abo_number, new_upline_abo_number, old_primary_profile_id, new_primary_profile_id, old_role, new_role`
+- Written exclusively by `trg_profiles_field_audit` AFTER UPDATE trigger on `profiles`.
+- Only fires when at least one of the 4 tracked fields changes.
+- RLS: SELECT admin-only via `is_admin()`. No INSERT policy for authenticated users — trigger runs SECURITY DEFINER.
+- `changed_by`: `current_setting('app.current_user_id', true)` or `'service_role'` fallback.
+- Indexes: `(profile_id)`, `(changed_at DESC)`.
+
+**`v_member_history`** — view added #350 (migration `20260513_003`)
+Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `profile_id, changed_at, changed_by, event_type, field, old_value, new_value`.
+- `event_type` values: `abo_number_change`, `upline_abo_number_change`, `primary_profile_id_change`, `role_change`.
+- Admin-only access via underlying table RLS.
+
 **`spouse_link_requests`** — `id, requester_id → profiles, claimed_primary_id → profiles, status (pending|approved|denied), admin_note, created_at, resolved_at`
 - ADR-016. UNIQUE on `requester_id` (one active request per guest at a time). RLS: requester reads/inserts/deletes own pending; admin full access.
 
@@ -360,7 +373,7 @@ Operations payments tab: Log Payment Drawer with `<optgroup>` entity select; mem
 | Route | Method | Notes |
 |---|---|
 | `/api/profile` | GET, PATCH | |
-| `/api/profile/verify-abo` | POST | LOS-validated at submit: existence check + sponsor match + duplicate ABO check. Returns `abo_has_primary` error_code if the existing holder is a primary (ADR-016). |
+| `/api/profile/verify-abo` | POST | LOS-validated at submit: existence check + sponsor match + duplicate ABO check. Returns `abo_has_primary` error_code if the existing holder is a primary (ADR-016). Guard added #350: secondary accounts (`primary_profile_id IS NOT NULL`) receive 400 `secondary_cannot_verify`. |
 | `/api/profile/spouse-link` | GET, POST, DELETE | ADR-016: GET own request; POST submit (guest only, guards: requester is guest with no primary_profile_id, claimed_primary is member with abo_number and no existing secondary); DELETE cancel own pending |
 | `/api/profile/vitals` | GET | |
 | `/api/profile/event-roles` | GET | |
@@ -438,7 +451,7 @@ Operations payments tab: Log Payment Drawer with `<optgroup>` entity select; mem
 | `get_core_ancestors(uuid)` | Core-role UUIDs above a node |
 | `rebuild_tree_paths` | Cascade ABO label rename to descendants |
 | `upsert_tree_node(p_profile_id, p_abo_number, p_sponsor_abo_number?)` | Insert/update tree node; walks `los_members` sponsor chain (max 20 hops) if direct sponsor has no portal profile |
-| `approve_member_verification(p_request_id, p_admin_note?)` | **DEPRECATED** — retained as fallback only. Logic now lives in Inngest approve-verification Step 1. |
+| `approve_member_verification(p_request_id, p_admin_note?)` | **DEPRECATED** — retained as fallback only. Logic now lives in Inngest approve-verification Step 1. Guard added #350: raises `P0002` if `profile.primary_profile_id IS NOT NULL`. |
 | `patch_member_role(p_profile_id, p_new_role, p_changed_by, p_note?)` | Role update with audit trail — returns updated profile |
 | `get_trip_team_attendees(p_trip_id, p_viewer_profile)` | Returns Core/admin attendees for a trip |
 | `import_los_members(p_rows, p_imported_by?, p_expected_row_count?)` | Transactional LOS import: concurrency check → snapshot → upsert → server-side delete → rebuild_tree_paths → insert los_imports record. Returns `{ inserted, removed, import_id, errors }`. |

--- a/supabase/migrations/20260513_003_profiles_field_audit.sql
+++ b/supabase/migrations/20260513_003_profiles_field_audit.sql
@@ -1,0 +1,293 @@
+-- =============================================================================
+-- Migration: 20260513_003_profiles_field_audit.sql
+-- Purpose:
+--   A) Field-level forensic audit table + trigger for profiles
+--   B) Secondary profile invariant enforcement in approve_member_verification
+--   C) One-time cleanup of orphaned tree_nodes row for secondary cb703519
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- A1: profiles_audit table
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.profiles_audit (
+  id                       uuid        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  profile_id               uuid        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  changed_at               timestamptz NOT NULL DEFAULT now(),
+  changed_by               text,
+  old_abo_number           text,
+  new_abo_number           text,
+  old_upline_abo_number    text,
+  new_upline_abo_number    text,
+  old_primary_profile_id   uuid,
+  new_primary_profile_id   uuid,
+  old_role                 text,
+  new_role                 text
+);
+
+-- ---------------------------------------------------------------------------
+-- A2: Indexes
+-- ---------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS profiles_audit_profile_id_idx
+  ON public.profiles_audit (profile_id);
+
+CREATE INDEX IF NOT EXISTS profiles_audit_changed_at_idx
+  ON public.profiles_audit (changed_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- A3: RLS — SELECT admin-only; INSERT handled by trigger (service-role context
+--     bypasses RLS per ADR-002; no INSERT policy needed for authenticated users)
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.profiles_audit ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "profiles_audit_admin_select"
+  ON public.profiles_audit
+  FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+-- ---------------------------------------------------------------------------
+-- A4: Trigger function
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.fn_profiles_field_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Noop if none of the 4 tracked fields changed
+  IF (
+    NEW.abo_number           IS NOT DISTINCT FROM OLD.abo_number           AND
+    NEW.upline_abo_number    IS NOT DISTINCT FROM OLD.upline_abo_number    AND
+    NEW.primary_profile_id   IS NOT DISTINCT FROM OLD.primary_profile_id   AND
+    NEW.role                 IS NOT DISTINCT FROM OLD.role
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO public.profiles_audit (
+    profile_id,
+    changed_by,
+    old_abo_number,           new_abo_number,
+    old_upline_abo_number,    new_upline_abo_number,
+    old_primary_profile_id,   new_primary_profile_id,
+    old_role,                 new_role
+  ) VALUES (
+    NEW.id,
+    COALESCE(current_setting('app.current_user_id', true), 'service_role'),
+    OLD.abo_number,           NEW.abo_number,
+    OLD.upline_abo_number,    NEW.upline_abo_number,
+    OLD.primary_profile_id,   NEW.primary_profile_id,
+    OLD.role::text,           NEW.role::text
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- A5: Attach trigger to profiles
+-- ---------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS trg_profiles_field_audit ON public.profiles;
+
+CREATE TRIGGER trg_profiles_field_audit
+  AFTER UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.fn_profiles_field_audit();
+
+-- ---------------------------------------------------------------------------
+-- A6: v_member_history — normalised UNION ALL over profiles_audit + role_change_audit
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW public.v_member_history AS
+  SELECT
+    profile_id,
+    changed_at,
+    changed_by,
+    'abo_number_change'::text       AS event_type,
+    'abo_number'::text              AS field,
+    old_abo_number                  AS old_value,
+    new_abo_number                  AS new_value
+  FROM public.profiles_audit
+  WHERE old_abo_number IS DISTINCT FROM new_abo_number
+
+  UNION ALL
+
+  SELECT
+    profile_id,
+    changed_at,
+    changed_by,
+    'upline_abo_number_change'::text AS event_type,
+    'upline_abo_number'::text        AS field,
+    old_upline_abo_number            AS old_value,
+    new_upline_abo_number            AS new_value
+  FROM public.profiles_audit
+  WHERE old_upline_abo_number IS DISTINCT FROM new_upline_abo_number
+
+  UNION ALL
+
+  SELECT
+    profile_id,
+    changed_at,
+    changed_by,
+    'primary_profile_id_change'::text AS event_type,
+    'primary_profile_id'::text        AS field,
+    old_primary_profile_id::text      AS old_value,
+    new_primary_profile_id::text      AS new_value
+  FROM public.profiles_audit
+  WHERE old_primary_profile_id IS DISTINCT FROM new_primary_profile_id
+
+  UNION ALL
+
+  SELECT
+    profile_id,
+    changed_at,
+    changed_by,
+    'role_change'::text AS event_type,
+    'role'::text        AS field,
+    old_role            AS old_value,
+    new_role            AS new_value
+  FROM public.profiles_audit
+  WHERE old_role IS DISTINCT FROM new_role
+
+  UNION ALL
+
+  SELECT
+    profile_id,
+    changed_at,
+    changed_by,
+    'role_change'::text AS event_type,
+    'role'::text        AS field,
+    old_role::text      AS old_value,
+    new_role::text      AS new_value
+  FROM public.role_change_audit;
+
+-- ---------------------------------------------------------------------------
+-- B: approve_member_verification — add secondary profile guard
+--    Full CREATE OR REPLACE from 20260510_001 body + guard injected after
+--    the FOR UPDATE lock, before any writes.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.approve_member_verification(
+  p_request_id uuid,
+  p_admin_note text DEFAULT NULL::text
+)
+RETURNS TABLE(profile_id uuid, abo_number text, upline_abo_number text, role text, tree_path text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_req        public.abo_verification_requests%ROWTYPE;
+  v_los_sponsor text;
+BEGIN
+  -- Authorization: service_role (Path C) or admin users (Path B)
+  IF auth.role() <> 'service_role' AND NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  -- Lock the request row for the duration of the transaction
+  SELECT * INTO v_req
+  FROM public.abo_verification_requests
+  WHERE id = p_request_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'verification request % not found', p_request_id;
+  END IF;
+
+  -- Guard: secondary profiles cannot receive standalone verification
+  IF EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE id = v_req.profile_id
+      AND primary_profile_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'secondary profile % cannot receive standalone verification', v_req.profile_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Idempotency guard: re-running on an already-approved request
+  -- raises unique_violation (SQLSTATE 23505) so callers can 409.
+  IF v_req.status = 'approved' THEN
+    RAISE EXCEPTION 'request % is already approved', p_request_id
+      USING ERRCODE = '23505';
+  END IF;
+
+  -- Guard: standard path must have a non-null claimed_abo
+  IF v_req.request_type = 'standard' AND v_req.claimed_abo IS NULL THEN
+    RAISE EXCEPTION 'standard verification request % has null claimed_abo — cannot approve', p_request_id;
+  END IF;
+
+  IF v_req.request_type = 'standard' THEN
+    -- LOS existence guard — qualify abo_number to avoid ambiguity with RETURNS TABLE column
+    SELECT los_members.sponsor_abo_number INTO v_los_sponsor
+    FROM public.los_members
+    WHERE los_members.abo_number = v_req.claimed_abo;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'ABO % not found in los_members — re-import LOS before approving', v_req.claimed_abo;
+    END IF;
+
+    -- Sponsor mismatch guard
+    IF v_los_sponsor IS DISTINCT FROM v_req.claimed_upline_abo THEN
+      RAISE EXCEPTION 'ABO % sponsor in LOS is % but request claims % — data mismatch',
+        v_req.claimed_abo, v_los_sponsor, v_req.claimed_upline_abo;
+    END IF;
+
+    -- Duplicate guard: another profile already owns this ABO
+    IF EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.abo_number = v_req.claimed_abo
+        AND profiles.id <> v_req.profile_id
+    ) THEN
+      RAISE EXCEPTION 'ABO % is already claimed by another profile', v_req.claimed_abo;
+    END IF;
+  END IF;
+
+  IF v_req.request_type = 'manual' THEN
+    UPDATE public.profiles
+    SET role              = 'member',
+        upline_abo_number = v_req.claimed_upline_abo
+    WHERE id = v_req.profile_id;
+  ELSE
+    UPDATE public.profiles
+    SET role              = 'member',
+        abo_number        = v_req.claimed_abo,
+        upline_abo_number = v_req.claimed_upline_abo
+    WHERE id = v_req.profile_id;
+  END IF;
+
+  -- Mark approved
+  UPDATE public.abo_verification_requests
+  SET status      = 'approved',
+      resolved_at = now(),
+      admin_note  = p_admin_note
+  WHERE id = p_request_id;
+
+  -- Place in tree
+  PERFORM public.upsert_tree_node(
+    p_profile_id         => v_req.profile_id,
+    p_abo_number         => v_req.claimed_abo,
+    p_sponsor_abo_number => v_req.claimed_upline_abo
+  );
+
+  -- Return the promoted profile row for caller confirmation
+  RETURN QUERY
+  SELECT p.id,
+         p.abo_number,
+         p.upline_abo_number,
+         p.role::text,
+         t.path::text
+  FROM public.profiles p
+  LEFT JOIN public.tree_nodes t ON t.profile_id = p.id
+  WHERE p.id = v_req.profile_id;
+
+EXCEPTION
+  WHEN OTHERS THEN
+    RAISE;
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- C: One-time cleanup — orphaned tree_nodes row for secondary cb703519
+-- ---------------------------------------------------------------------------
+DELETE FROM public.tree_nodes
+WHERE profile_id = 'cb703519-866b-448c-959a-4945d9c21272';

--- a/supabase/migrations/20260514_001_fix_member_history_view.sql
+++ b/supabase/migrations/20260514_001_fix_member_history_view.sql
@@ -1,0 +1,187 @@
+-- =============================================================================
+-- Migration: 20260514_001_fix_member_history_view.sql
+-- Purpose:
+--   GCR fixes for PR #355:
+--   1) Remove duplicate role_change branch from v_member_history
+--      (profiles_audit role branch double-counted with role_change_audit)
+--   2) Fix misleading ERRCODE P0002 → P0001 in approve_member_verification
+--      secondary-profile guard
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Fix 1: v_member_history — drop profiles_audit role-change branch.
+--   role_change_audit is the authoritative source (has `note` field, written
+--   by patch_member_role RPC for every legitimate role change). The
+--   profiles_audit table still captures old_role/new_role for raw forensic
+--   queries on that table directly — it just must not be unioned here.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW public.v_member_history AS
+  SELECT
+    profile_id,
+    changed_at,
+    changed_by,
+    'abo_number_change'::text       AS event_type,
+    'abo_number'::text              AS field,
+    old_abo_number                  AS old_value,
+    new_abo_number                  AS new_value
+  FROM public.profiles_audit
+  WHERE old_abo_number IS DISTINCT FROM new_abo_number
+
+  UNION ALL
+
+  SELECT
+    profile_id,
+    changed_at,
+    changed_by,
+    'upline_abo_number_change'::text AS event_type,
+    'upline_abo_number'::text        AS field,
+    old_upline_abo_number            AS old_value,
+    new_upline_abo_number            AS new_value
+  FROM public.profiles_audit
+  WHERE old_upline_abo_number IS DISTINCT FROM new_upline_abo_number
+
+  UNION ALL
+
+  SELECT
+    profile_id,
+    changed_at,
+    changed_by,
+    'primary_profile_id_change'::text AS event_type,
+    'primary_profile_id'::text        AS field,
+    old_primary_profile_id::text      AS old_value,
+    new_primary_profile_id::text      AS new_value
+  FROM public.profiles_audit
+  WHERE old_primary_profile_id IS DISTINCT FROM new_primary_profile_id
+
+  UNION ALL
+
+  SELECT
+    profile_id,
+    changed_at,
+    changed_by,
+    'role_change'::text AS event_type,
+    'role'::text        AS field,
+    old_role::text      AS old_value,
+    new_role::text      AS new_value
+  FROM public.role_change_audit;
+
+-- ---------------------------------------------------------------------------
+-- Fix 2: approve_member_verification — change ERRCODE P0002 → P0001 on the
+--   secondary-profile guard. P0002 is `no_data_found` (standard SQLSTATE for
+--   a SELECT that returns no rows) — semantically wrong for a record that IS
+--   found but is ineligible. P0001 is the generic raise_exception code,
+--   correct for application-level validation failures.
+--   Full function body preserved; only ERRCODE changed.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.approve_member_verification(
+  p_request_id uuid,
+  p_admin_note text DEFAULT NULL::text
+)
+RETURNS TABLE(profile_id uuid, abo_number text, upline_abo_number text, role text, tree_path text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_req        public.abo_verification_requests%ROWTYPE;
+  v_los_sponsor text;
+BEGIN
+  -- Authorization: service_role (Path C) or admin users (Path B)
+  IF auth.role() <> 'service_role' AND NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  -- Lock the request row for the duration of the transaction
+  SELECT * INTO v_req
+  FROM public.abo_verification_requests
+  WHERE id = p_request_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'verification request % not found', p_request_id;
+  END IF;
+
+  -- Guard: secondary profiles cannot receive standalone verification
+  IF EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE id = v_req.profile_id
+      AND primary_profile_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'secondary profile % cannot receive standalone verification', v_req.profile_id
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Idempotency guard: re-running on an already-approved request
+  IF v_req.status = 'approved' THEN
+    RAISE EXCEPTION 'request % is already approved', p_request_id
+      USING ERRCODE = '23505';
+  END IF;
+
+  -- Guard: standard path must have a non-null claimed_abo
+  IF v_req.request_type = 'standard' AND v_req.claimed_abo IS NULL THEN
+    RAISE EXCEPTION 'standard verification request % has null claimed_abo — cannot approve', p_request_id;
+  END IF;
+
+  IF v_req.request_type = 'standard' THEN
+    SELECT los_members.sponsor_abo_number INTO v_los_sponsor
+    FROM public.los_members
+    WHERE los_members.abo_number = v_req.claimed_abo;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'ABO % not found in los_members — re-import LOS before approving', v_req.claimed_abo;
+    END IF;
+
+    IF v_los_sponsor IS DISTINCT FROM v_req.claimed_upline_abo THEN
+      RAISE EXCEPTION 'ABO % sponsor in LOS is % but request claims % — data mismatch',
+        v_req.claimed_abo, v_los_sponsor, v_req.claimed_upline_abo;
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.abo_number = v_req.claimed_abo
+        AND profiles.id <> v_req.profile_id
+    ) THEN
+      RAISE EXCEPTION 'ABO % is already claimed by another profile', v_req.claimed_abo;
+    END IF;
+  END IF;
+
+  IF v_req.request_type = 'manual' THEN
+    UPDATE public.profiles
+    SET role              = 'member',
+        upline_abo_number = v_req.claimed_upline_abo
+    WHERE id = v_req.profile_id;
+  ELSE
+    UPDATE public.profiles
+    SET role              = 'member',
+        abo_number        = v_req.claimed_abo,
+        upline_abo_number = v_req.claimed_upline_abo
+    WHERE id = v_req.profile_id;
+  END IF;
+
+  UPDATE public.abo_verification_requests
+  SET status      = 'approved',
+      resolved_at = now(),
+      admin_note  = p_admin_note
+  WHERE id = p_request_id;
+
+  PERFORM public.upsert_tree_node(
+    p_profile_id         => v_req.profile_id,
+    p_abo_number         => v_req.claimed_abo,
+    p_sponsor_abo_number => v_req.claimed_upline_abo
+  );
+
+  RETURN QUERY
+  SELECT p.id,
+         p.abo_number,
+         p.upline_abo_number,
+         p.role::text,
+         t.path::text
+  FROM public.profiles p
+  LEFT JOIN public.tree_nodes t ON t.profile_id = p.id
+  WHERE p.id = v_req.profile_id;
+
+EXCEPTION
+  WHEN OTHERS THEN
+    RAISE;
+END;
+$function$;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1072,6 +1072,59 @@ export type Database = {
           },
         ]
       }
+      profiles_audit: {
+        Row: {
+          changed_at: string
+          changed_by: string | null
+          id: string
+          new_abo_number: string | null
+          new_primary_profile_id: string | null
+          new_role: string | null
+          new_upline_abo_number: string | null
+          old_abo_number: string | null
+          old_primary_profile_id: string | null
+          old_role: string | null
+          old_upline_abo_number: string | null
+          profile_id: string
+        }
+        Insert: {
+          changed_at?: string
+          changed_by?: string | null
+          id?: string
+          new_abo_number?: string | null
+          new_primary_profile_id?: string | null
+          new_role?: string | null
+          new_upline_abo_number?: string | null
+          old_abo_number?: string | null
+          old_primary_profile_id?: string | null
+          old_role?: string | null
+          old_upline_abo_number?: string | null
+          profile_id: string
+        }
+        Update: {
+          changed_at?: string
+          changed_by?: string | null
+          id?: string
+          new_abo_number?: string | null
+          new_primary_profile_id?: string | null
+          new_role?: string | null
+          new_upline_abo_number?: string | null
+          old_abo_number?: string | null
+          old_primary_profile_id?: string | null
+          old_role?: string | null
+          old_upline_abo_number?: string | null
+          profile_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profiles_audit_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       role_change_audit: {
         Row: {
           changed_at: string
@@ -1106,6 +1159,48 @@ export type Database = {
             columns: ["profile_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      scheduled_reminders: {
+        Row: {
+          event_id: string
+          id: string
+          registration_id: string
+          reminder_type: Database["public"]["Enums"]["reminder_type"]
+          send_at: string
+          sent_at: string | null
+        }
+        Insert: {
+          event_id: string
+          id?: string
+          registration_id: string
+          reminder_type: Database["public"]["Enums"]["reminder_type"]
+          send_at: string
+          sent_at?: string | null
+        }
+        Update: {
+          event_id?: string
+          id?: string
+          registration_id?: string
+          reminder_type?: Database["public"]["Enums"]["reminder_type"]
+          send_at?: string
+          sent_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "scheduled_reminders_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "calendar_events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "scheduled_reminders_registration_id_fkey"
+            columns: ["registration_id"]
+            isOneToOne: false
+            referencedRelation: "guest_registrations"
             referencedColumns: ["id"]
           },
         ]
@@ -1535,7 +1630,18 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      v_member_history: {
+        Row: {
+          changed_at: string | null
+          changed_by: string | null
+          event_type: string | null
+          field: string | null
+          new_value: string | null
+          old_value: string | null
+          profile_id: string | null
+        }
+        Relationships: []
+      }
     }
     Functions: {
       abo_to_ltree_label: { Args: { abo: string }; Returns: string }
@@ -1681,6 +1787,7 @@ export type Database = {
         | "trip_attachment"
         | "spouse_link_request"
       registration_status: "pending" | "approved" | "denied"
+      reminder_type: "1_hour" | "15_min"
       user_role: "admin" | "core" | "member" | "guest"
     }
     CompositeTypes: {
@@ -1825,6 +1932,7 @@ export const Constants = {
         "spouse_link_request",
       ],
       registration_status: ["pending", "approved", "denied"],
+      reminder_type: ["1_hour", "15_min"],
       user_role: ["admin", "core", "member", "guest"],
     },
   },


### PR DESCRIPTION
# [2605-BUG-350] Profile data integrity hardening

Closes #350

## Summary

Production incident 2026-05-13: `abo_number`/`upline_abo_number` silently nulled on two profiles with no audit trail. Secondary profile `cb703519` had orphaned `tree_nodes` row violating ADR-016.

Two-pronged fix:
- **A** — `profiles_audit` table + AFTER UPDATE trigger + `v_member_history` view for forensic field-level audit
- **B** — Secondary profile guard in `approve_member_verification` RPC, `verify-abo` route, and `spouse-link` approve path

## Session State
**Status:** DONE
**Completed:**
- [x] Migration `20260513_003_profiles_field_audit.sql` applied + committed
- [x] Route changes pushed: `verify-abo` secondary guard, `spouse-link` orphan tree_node cleanup
- [x] `types/supabase.ts` regenerated
- [x] `docs/ai/REF.md` + `docs/ai/LOOKUP.md` updated
- [x] GCR: migration `20260514_001_fix_member_history_view.sql` — duplicate role_change branch removed from `v_member_history`; `P0002` → `P0001` ERRCODE on secondary-profile guard
**Next:** Merge via GitHub UI