### PR TITLE
[2505-FEAT-357] Modernise trips UI: hero images, card overlays, dual layout, view improvements

### DIFF
--- a/app/(dashboard)/trips/[id]/TripDetailClient.tsx
+++ b/app/(dashboard)/trips/[id]/TripDetailClient.tsx
@@ -5,7 +5,7 @@ import { AvailableView } from './components/AvailableView'
 import { PendingView } from './components/PendingView'
 import { AttendeeView } from './components/AttendeeView'
 import { ArchivedView } from './components/ArchivedView'
-import { BackButton } from './components/shared'
+import { BackButton, TripHero } from './components/shared'
 import type { Tables } from '@/types/supabase'
 import type { TripState, TripProfile, TripPayment, TeamAttendee } from './page'
 
@@ -21,18 +21,92 @@ interface TripDetailClientProps {
   teamAttendees: TeamAttendee[]
 }
 
-function TripDetailContent(props: TripDetailClientProps) {
+export function TripDetailClient(props: TripDetailClientProps) {
   const { trip, state, registration, payments, profile, teamAttendees } = props
 
-  if (state === 'locked') return <LockedView profile={profile} />
-  if (state === 'available') return <AvailableView trip={trip} profile={profile} />
-  if (state === 'pending' && registration)
+  // ── States that use single-column on both breakpoints ──────────────────
+  if (state === 'locked') {
+    return <LockedView trip={trip} profile={profile} />
+  }
+  if (state === 'pending' && registration) {
     return <PendingView trip={trip} profile={profile} registration={registration} />
-  if (state === 'attendee')
-    return <AttendeeView trip={trip} profile={profile} payments={payments} teamAttendees={teamAttendees} />
-  if (state === 'archived')
+  }
+  if (state === 'archived') {
     return <ArchivedView trip={trip} profile={profile} payments={payments} />
+  }
 
+  // ── attendee: two-column desktop / single-column mobile ──────────────
+  if (state === 'attendee') {
+    return (
+      <>
+        {/* Desktop: two-column grid */}
+        <div className="hidden md:block py-8 pb-16">
+          <div
+            className="mx-auto px-4"
+            style={{ maxWidth: 1024, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}
+          >
+            <BackButton />
+            <div />
+            {/* Left column */}
+            <div className="space-y-4">
+              <TripHero trip={trip} profile={profile} />
+            </div>
+            {/* Right column */}
+            <div className="space-y-4">
+              <AttendeeView
+                trip={trip}
+                profile={profile}
+                payments={payments}
+                teamAttendees={teamAttendees}
+                desktopActionSlot
+              />
+            </div>
+          </div>
+        </div>
+        {/* Mobile: single-column stack */}
+        <div className="md:hidden">
+          <AttendeeView
+            trip={trip}
+            profile={profile}
+            payments={payments}
+            teamAttendees={teamAttendees}
+          />
+        </div>
+      </>
+    )
+  }
+
+  // ── available: two-column desktop / single-column mobile ────────────
+  if (state === 'available') {
+    return (
+      <>
+        {/* Desktop: two-column grid */}
+        <div className="hidden md:block py-8 pb-16">
+          <div
+            className="mx-auto px-4"
+            style={{ maxWidth: 1024, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}
+          >
+            <BackButton />
+            <div />
+            {/* Left column */}
+            <div className="space-y-4">
+              <TripHero trip={trip} profile={profile} />
+            </div>
+            {/* Right column */}
+            <div className="space-y-4">
+              <AvailableView trip={trip} profile={profile} desktopActionSlot />
+            </div>
+          </div>
+        </div>
+        {/* Mobile: single-column stack */}
+        <div className="md:hidden">
+          <AvailableView trip={trip} profile={profile} />
+        </div>
+      </>
+    )
+  }
+
+  // Fallback
   return (
     <div className="py-8 pb-16">
       <div className="max-w-[720px] mx-auto px-4">
@@ -45,21 +119,5 @@ function TripDetailContent(props: TripDetailClientProps) {
         </div>
       </div>
     </div>
-  )
-}
-
-export function TripDetailClient(props: TripDetailClientProps) {
-  return (
-    <>
-      {/* Desktop */}
-      <div className="hidden md:block">
-        <TripDetailContent {...props} />
-      </div>
-
-      {/* Mobile */}
-      <div className="md:hidden">
-        <TripDetailContent {...props} />
-      </div>
-    </>
   )
 }

--- a/app/(dashboard)/trips/[id]/components/ArchivedView.tsx
+++ b/app/(dashboard)/trips/[id]/components/ArchivedView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { formatDate, formatCurrency } from '@/lib/format'
-import { BackButton } from './shared'
+import { BackButton, TripHero } from './shared'
 import { TripMessagesTile } from './TripMessagesTile'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile, TripPayment } from '../page'
@@ -20,36 +20,7 @@ export function ArchivedView({
       <div className="max-w-[720px] mx-auto px-4 space-y-4">
         <BackButton />
 
-        <div className="rounded-2xl overflow-hidden"
-          style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
-          {trip.image_url && (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={trip.image_url} alt="" aria-hidden="true"
-              className="w-full object-cover" style={{ height: 200, opacity: 0.55 }} />
-          )}
-          <div className="px-6 pt-5 pb-6">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex-1 min-w-0">
-                <div className="flex flex-wrap items-center gap-2 mb-2">
-                  <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
-                    style={{ backgroundColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>
-                    {trip.destination}
-                  </span>
-                  <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
-                    style={{ backgroundColor: 'rgba(129,178,154,0.15)', color: '#2d6a4f' }}>
-                    Completed
-                  </span>
-                </div>
-                <h1 className="font-display text-xl font-semibold" style={{ color: 'var(--text-primary)' }}>
-                  {trip.title}
-                </h1>
-                <p className="text-sm mt-1" style={{ color: 'var(--text-secondary)' }}>
-                  {formatDate(trip.start_date)} – {formatDate(trip.end_date)}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
+        <TripHero trip={trip} profile={profile} muted />
 
         {/* Trip Messages — between hero card and Final Ledger */}
         <TripMessagesTile tripId={trip.id} />

--- a/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
@@ -46,45 +46,67 @@ function WhosGoingTile({ attendees }: { attendees: TeamAttendee[] }) {
         </p>
       </div>
       <div className="px-6 pb-5">
-        {attendees.length === 0 ? (
-          <p className="text-sm pt-2" style={{ color: 'var(--text-secondary)' }}>
-            {t('trips.noTeamRegistered')}
-          </p>
-        ) : (
-          <div className="space-y-2 mt-1">
-            {attendees.map(a => {
-              const colors = getRoleColors(a.role)
-              return (
-                <div key={a.profile_id}
-                  className="flex items-center justify-between gap-3 py-2 border-b last:border-0"
-                  style={{ borderColor: 'var(--border-default)' }}>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                      {a.first_name} {a.last_name}
+        <div className="space-y-2 mt-1">
+          {attendees.map(a => {
+            const colors = getRoleColors(a.role)
+            return (
+              <div key={a.profile_id}
+                className="flex items-center justify-between gap-3 py-2 border-b last:border-0"
+                style={{ borderColor: 'var(--border-default)' }}>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                    {a.first_name} {a.last_name}
+                  </p>
+                  {a.abo_number && (
+                    <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                      {a.abo_number}
                     </p>
-                    {a.abo_number && (
-                      <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-                        {a.abo_number}
-                      </p>
-                    )}
-                  </div>
-                  <span className="text-xs font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: colors.bg, color: colors.font }}>
-                    {a.role}
-                  </span>
+                  )}
                 </div>
-              )
-            })}
-          </div>
-        )}
+                <span className="text-xs font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: colors.bg, color: colors.font }}>
+                  {a.role}
+                </span>
+              </div>
+            )
+          })}
+        </div>
       </div>
     </div>
   )
 }
 
+// ── SubmitPaymentCTA (shared between mobile sticky and desktop panel) ───
+
+function SubmitPaymentCTA({
+  remaining,
+  onOpen,
+}: {
+  remaining: number
+  onOpen: () => void
+}) {
+  const { t } = useLanguage()
+  return (
+    <button
+      onClick={onOpen}
+      className="w-full py-3 rounded-xl text-sm font-semibold text-white transition-opacity hover:opacity-90"
+      style={{ backgroundColor: 'var(--brand-forest)' }}
+    >
+      {t('payment.submit')}
+    </button>
+  )
+}
+
 export function AttendeeView({
-  trip, profile, payments, teamAttendees,
-}: { trip: Trip; profile: TripProfile; payments: TripPayment[]; teamAttendees: TeamAttendee[] }) {
+  trip, profile, payments, teamAttendees, desktopActionSlot,
+}: {
+  trip: Trip
+  profile: TripProfile
+  payments: TripPayment[]
+  teamAttendees: TeamAttendee[]
+  /** When true the Submit Payment CTA is rendered as a sticky footer (mobile). Desktop panel injects via this prop. */
+  desktopActionSlot?: boolean
+}) {
   const { t } = useLanguage()
   const [drawerOpen, setDrawerOpen] = useState(false)
 
@@ -102,20 +124,34 @@ export function AttendeeView({
     .filter(p => p.admin_status === 'approved')
     .reduce((sum, p) => sum + p.amount, 0)
   const remaining = Math.max(0, trip.total_cost - approvedTotal)
+  const progressPct = trip.total_cost > 0
+    ? Math.min(100, Math.round((approvedTotal / trip.total_cost) * 100))
+    : 0
 
   const cumulativeMilestones = milestones.reduce<number[]>((acc, m) => {
     acc.push((acc[acc.length - 1] ?? 0) + m.amount)
     return acc
   }, [])
 
+  // CSS background-image countdown — degrades silently on load failure
+  const countdownBg = trip.image_url
+    ? {
+        backgroundImage: `linear-gradient(rgba(0,0,0,0.55), rgba(0,0,0,0.55)), url(${JSON.stringify(trip.image_url)})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      }
+    : { backgroundColor: 'var(--brand-forest)' }
+
   return (
-    <div className="py-8 pb-16">
+    <div className="py-8 pb-20 md:pb-16">
       <div className="max-w-[720px] mx-auto px-4 space-y-4">
         <BackButton />
 
         {/* Countdown header */}
-        <div className="rounded-2xl px-6 py-7 flex items-center justify-between gap-4"
-          style={{ backgroundColor: 'var(--brand-forest)', color: 'rgba(255,255,255,0.92)' }}>
+        <div
+          className="rounded-2xl px-6 py-7 flex items-center justify-between gap-4"
+          style={{ ...countdownBg, color: 'rgba(255,255,255,0.92)' }}
+        >
           <div>
             <p className="text-xs font-semibold tracking-widest uppercase opacity-70 mb-1">
               {trip.destination} · {trip.title}
@@ -150,6 +186,19 @@ export function AttendeeView({
             <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
               {formatCurrency(approvedTotal)} / {formatCurrency(trip.total_cost)}
             </p>
+          </div>
+
+          {/* Progress bar */}
+          <div className="px-6 pb-3">
+            <div
+              className="w-full rounded-full overflow-hidden"
+              style={{ height: 4, backgroundColor: 'var(--border-default)' }}
+            >
+              <div
+                className="h-full rounded-full transition-all"
+                style={{ width: `${progressPct}%`, backgroundColor: '#2d6a4f' }}
+              />
+            </div>
           </div>
 
           {milestones.length > 0 && (
@@ -246,13 +295,10 @@ export function AttendeeView({
                 {remaining === 0 ? t('payment.paidInFull') : formatCurrency(remaining)}
               </p>
             </div>
-            <button
-              onClick={() => setDrawerOpen(true)}
-              className="w-full py-3 rounded-xl text-sm font-semibold text-white transition-opacity hover:opacity-90"
-              style={{ backgroundColor: 'var(--brand-forest)' }}
-            >
-              {t('payment.submit')}
-            </button>
+            {/* Desktop: CTA inline in ledger tile */}
+            {desktopActionSlot && (
+              <SubmitPaymentCTA remaining={remaining} onOpen={() => setDrawerOpen(true)} />
+            )}
           </div>
         </div>
 
@@ -265,6 +311,16 @@ export function AttendeeView({
         {/* Trip info (read-only) */}
         <TripHero trip={trip} profile={profile} />
       </div>
+
+      {/* Mobile: sticky CTA */}
+      {!desktopActionSlot && (
+        <div
+          className="fixed bottom-0 left-0 right-0 px-4 pb-6 pt-3 md:hidden"
+          style={{ backgroundColor: 'var(--bg-base)', borderTop: '1px solid var(--border-default)' }}
+        >
+          <SubmitPaymentCTA remaining={remaining} onOpen={() => setDrawerOpen(true)} />
+        </div>
+      )}
 
       <SubmitPaymentDrawer
         tripId={trip.id}

--- a/app/(dashboard)/trips/[id]/components/AvailableView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AvailableView.tsx
@@ -7,7 +7,30 @@ import type { TripProfile } from '../page'
 
 type Trip = Tables<'trips'>
 
-export function AvailableView({ trip, profile }: { trip: Trip; profile: TripProfile }) {
+export function AvailableView({
+  trip,
+  profile,
+  desktopActionSlot,
+}: {
+  trip: Trip
+  profile: TripProfile
+  desktopActionSlot?: boolean
+}) {
+  // Desktop: action panel only (TripHero rendered in left column by TripDetailClient)
+  if (desktopActionSlot) {
+    return (
+      <div className="rounded-2xl px-6 py-6 space-y-4"
+        style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+        <p className="text-xs font-semibold tracking-widest uppercase"
+          style={{ color: 'var(--text-secondary)' }}>
+          Register
+        </p>
+        <RegisterButton tripId={trip.id} profileId={profile.id} />
+      </div>
+    )
+  }
+
+  // Mobile: full single-column layout
   return (
     <div className="py-8 pb-16">
       <div className="max-w-[720px] mx-auto px-4">

--- a/app/(dashboard)/trips/[id]/components/LockedView.tsx
+++ b/app/(dashboard)/trips/[id]/components/LockedView.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { formatDate } from '@/lib/format'
-import { BackButton, TripHero } from './shared'
+import { BackButton } from './shared'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile } from '../page'
 

--- a/app/(dashboard)/trips/[id]/components/LockedView.tsx
+++ b/app/(dashboard)/trips/[id]/components/LockedView.tsx
@@ -2,10 +2,13 @@
 
 import { useRouter } from 'next/navigation'
 import { formatDate } from '@/lib/format'
-import { BackButton } from './shared'
+import { BackButton, TripHero } from './shared'
+import type { Tables } from '@/types/supabase'
 import type { TripProfile } from '../page'
 
-export function LockedView({ profile }: { profile: TripProfile }) {
+type Trip = Tables<'trips'>
+
+export function LockedView({ trip, profile }: { trip: Trip; profile: TripProfile }) {
   const router = useRouter()
   const docLabel = profile.document_active_type === 'passport' ? 'Passport' : 'ID Card'
   const expiryText = profile.valid_through
@@ -14,8 +17,23 @@ export function LockedView({ profile }: { profile: TripProfile }) {
 
   return (
     <div className="py-8 pb-16">
-      <div className="max-w-[720px] mx-auto px-4">
+      <div className="max-w-[720px] mx-auto px-4 space-y-4">
         <BackButton />
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
+            style={{ backgroundColor: 'var(--brand-forest)', color: 'rgba(255,255,255,0.85)' }}>
+            {trip.destination}
+          </span>
+          {trip.trip_type && (
+            <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
+              style={{ backgroundColor: 'var(--brand-teal)', color: 'rgba(255,255,255,0.85)' }}>
+              {trip.trip_type}
+            </span>
+          )}
+          <h1 className="text-base font-semibold" style={{ color: 'var(--text-primary)' }}>
+            {trip.title}
+          </h1>
+        </div>
         <div className="rounded-2xl px-6 py-8"
           style={{ backgroundColor: 'rgba(188,71,73,0.08)', border: '1px solid rgba(188,71,73,0.25)' }}>
           <div className="flex items-start gap-4">

--- a/app/(dashboard)/trips/[id]/components/PendingView.tsx
+++ b/app/(dashboard)/trips/[id]/components/PendingView.tsx
@@ -2,11 +2,22 @@
 
 import { useRouter } from 'next/navigation'
 import { useMutation } from '@tanstack/react-query'
+import { useState } from 'react'
 import { formatDate } from '@/lib/format'
 import { BackButton, TripHero } from './shared'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile } from '../page'
 import { apiClient } from '@/lib/apiClient'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '@/components/ui/alert-dialog'
 
 type Trip = Tables<'trips'>
 type Registration = Tables<'trip_registrations'>
@@ -15,6 +26,7 @@ export function PendingView({
   trip, profile, registration,
 }: { trip: Trip; profile: TripProfile; registration: Registration }) {
   const router = useRouter()
+  const [alertOpen, setAlertOpen] = useState(false)
 
   const cancelMutation = useMutation({
     mutationFn: () =>
@@ -62,12 +74,12 @@ export function PendingView({
                 Your registration request is awaiting admin approval.
               </p>
               <button
-                onClick={() => cancelMutation.mutate()}
+                onClick={() => setAlertOpen(true)}
                 disabled={cancelMutation.isPending}
                 className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium disabled:opacity-50 transition-opacity hover:opacity-80"
                 style={{ backgroundColor: 'var(--border-default)', color: 'var(--text-primary)' }}
               >
-                {cancelMutation.isPending ? 'Cancelling…' : 'Cancel Registration'}
+                Cancel Registration
               </button>
               {cancelMutation.isError && (
                 <p className="text-xs mt-2" style={{ color: '#bc4749' }}>
@@ -78,6 +90,26 @@ export function PendingView({
           </div>
         </div>
       </div>
+
+      <AlertDialog open={alertOpen} onOpenChange={open => { if (!open) setAlertOpen(false) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel registration?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will withdraw your registration for &ldquo;{trip.title}&rdquo;. You can re-register later if the trip is still open.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep registration</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => cancelMutation.mutate()}
+              disabled={cancelMutation.isPending}
+            >
+              {cancelMutation.isPending ? 'Cancelling…' : 'Yes, cancel'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/app/(dashboard)/trips/[id]/components/shared.tsx
+++ b/app/(dashboard)/trips/[id]/components/shared.tsx
@@ -7,7 +7,6 @@ import type { TripProfile } from '../page'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 
 type Trip = Tables<'trips'>
-type Milestone = { label: string; amount: number; due_date: string }
 
 export function BackButton() {
   return (
@@ -24,71 +23,106 @@ export function BackButton() {
   )
 }
 
-export function TripHero({ trip, profile }: { trip: Trip; profile: TripProfile }) {
+export function TripHero({
+  trip,
+  profile,
+  muted = false,
+}: {
+  trip: Trip
+  profile: TripProfile
+  muted?: boolean
+}) {
   const { t } = useLanguage()
-  const milestones: Milestone[] = Array.isArray(trip.milestones)
-    ? (trip.milestones as Milestone[])
-    : []
   const days = Math.round(
     (new Date(trip.end_date).getTime() - new Date(trip.start_date).getTime()) / 86400000
   )
 
+  const imageFilter = muted ? 'opacity(0.5) grayscale(1)' : undefined
+  const badgeBg = muted ? 'rgba(0,0,0,0.15)' : 'var(--brand-forest)'
+  const badgeColor = muted ? 'rgba(255,255,255,0.6)' : 'rgba(255,255,255,0.85)'
+  const tealBadgeBg = muted ? 'rgba(0,0,0,0.12)' : 'var(--brand-teal)'
+
   return (
-    <div className="rounded-2xl overflow-hidden"
-      style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
-      {trip.image_url && (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={trip.image_url}
-          alt=""
-          aria-hidden="true"
-          className="w-full object-cover"
-          style={{ height: 240 }}
+    <div
+      className="rounded-2xl overflow-hidden"
+      style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+    >
+      {/* Hero image area — 280px with gradient overlay */}
+      <div
+        className="relative w-full"
+        style={{ height: 280, backgroundColor: 'var(--brand-forest)' }}
+      >
+        {trip.image_url && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={trip.image_url}
+            alt=""
+            aria-hidden="true"
+            className="w-full h-full object-cover"
+            style={imageFilter ? { filter: imageFilter } : undefined}
+            onError={e => {
+              const el = e.currentTarget
+              el.style.display = 'none'
+            }}
+          />
+        )}
+        {/* Gradient overlay */}
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.62) 0%, transparent 55%)' }}
         />
-      )}
-      <div className="px-6 pt-6 pb-8">
-        <div className="flex items-start justify-between gap-4 mb-4">
-          <div className="flex-1 min-w-0">
-            <div className="flex flex-wrap items-center gap-2 mb-2">
-              <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
-                style={{ backgroundColor: 'var(--brand-forest)', color: 'rgba(255,255,255,0.85)' }}>
-                {trip.destination}
+        {/* Title + badges over image */}
+        <div className="absolute bottom-4 left-6 right-6">
+          <div className="flex flex-wrap items-center gap-1.5 mb-2">
+            <span
+              className="text-xs font-semibold px-2 py-0.5 rounded-full"
+              style={{ backgroundColor: badgeBg, color: badgeColor }}
+            >
+              {trip.destination}
+            </span>
+            {trip.trip_type && (
+              <span
+                className="text-xs font-semibold px-2 py-0.5 rounded-full"
+                style={{ backgroundColor: tealBadgeBg, color: badgeColor }}
+              >
+                {trip.trip_type}
               </span>
-              {trip.trip_type && (
-                <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
-                  style={{ backgroundColor: 'var(--brand-teal)', color: 'rgba(255,255,255,0.85)' }}>
-                  {trip.trip_type}
-                </span>
-              )}
-              <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-                {days} day{days !== 1 ? 's' : ''}
-              </span>
-            </div>
-            <h1 className="font-display text-2xl font-semibold leading-snug"
-              style={{ color: 'var(--text-primary)' }}>
-              {trip.title}
-            </h1>
+            )}
+            <span className="text-xs" style={{ color: 'rgba(255,255,255,0.65)' }}>
+              {days} day{days !== 1 ? 's' : ''}
+            </span>
           </div>
-          {profile.role !== 'guest' && (
-            <div className="text-right flex-shrink-0">
+          <h1
+            className="font-display text-2xl font-semibold leading-snug"
+            style={{ color: '#fff' }}
+          >
+            {trip.title}
+          </h1>
+        </div>
+      </div>
+
+      {/* Content below image */}
+      <div className="px-6 pt-5 pb-8">
+        {profile.role !== 'guest' && (
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-1.5 text-sm" style={{ color: 'var(--text-secondary)' }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect width="18" height="18" x="3" y="4" rx="2" />
+                <line x1="16" x2="16" y1="2" y2="6" />
+                <line x1="8" x2="8" y1="2" y2="6" />
+                <line x1="3" x2="21" y1="10" y2="10" />
+              </svg>
+              {formatDate(trip.start_date)} – {formatDate(trip.end_date)}
+            </div>
+            <div className="text-right">
               <p className="text-xl font-semibold" style={{ color: 'var(--text-primary)' }}>
                 {formatCurrency(trip.total_cost)}
               </p>
               <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('trips.totalCost')}</p>
             </div>
-          )}
-        </div>
-
-        <div className="flex items-center gap-1.5 text-sm mb-4" style={{ color: 'var(--text-secondary)' }}>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-            stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <rect width="18" height="18" x="3" y="4" rx="2" />
-            <line x1="16" x2="16" y1="2" y2="6" />
-            <line x1="8" x2="8" y1="2" y2="6" />
-            <line x1="3" x2="21" y1="10" y2="10" />
-          </svg>
-          {formatDate(trip.start_date)} – {formatDate(trip.end_date)}
-        </div>
+          </div>
+        )}
 
         {trip.description && (
           <p className="text-sm leading-relaxed mb-5" style={{ color: 'var(--text-secondary)' }}>
@@ -96,56 +130,32 @@ export function TripHero({ trip, profile }: { trip: Trip; profile: TripProfile }
           </p>
         )}
 
-        {trip.location && (
-          <div className="flex items-center gap-1.5 text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
-              stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-              <circle cx="12" cy="10" r="3" />
-            </svg>
-            {trip.location}
+        {(trip.location || trip.accommodation_type) && (
+          <div className="flex flex-wrap items-center gap-3 text-sm mb-4" style={{ color: 'var(--text-secondary)' }}>
+            {trip.location && (
+              <span className="flex items-center gap-1">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+                  <circle cx="12" cy="10" r="3" />
+                </svg>
+                {trip.location}
+              </span>
+            )}
+            {trip.accommodation_type && (
+              <span>{trip.accommodation_type}</span>
+            )}
           </div>
         )}
 
-        {trip.accommodation_type && (
-          <p className="text-sm mb-3" style={{ color: 'var(--text-secondary)' }}>
-            <span className="font-medium">Accommodation:</span>{' '}{trip.accommodation_type}
-          </p>
-        )}
-
         {trip.inclusions.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 mb-5">
+          <div className="flex flex-wrap gap-1.5">
             {trip.inclusions.map((inc, i) => (
               <span key={i} className="text-xs px-2 py-0.5 rounded-full"
                 style={{ backgroundColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>
                 {inc}
               </span>
             ))}
-          </div>
-        )}
-
-        {profile.role !== 'guest' && milestones.length > 0 && (
-          <div className="mt-4 pt-4 border-t" style={{ borderColor: 'var(--border-default)' }}>
-            <p className="text-xs font-semibold tracking-widest uppercase mb-3"
-              style={{ color: 'var(--text-secondary)' }}>
-              Payment milestones
-            </p>
-            <div className="space-y-2">
-              {milestones.map((m, i) => (
-                <div key={i} className="flex items-center justify-between py-2 border-b last:border-0"
-                  style={{ borderColor: 'var(--border-default)' }}>
-                  <div>
-                    <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{m.label}</p>
-                    <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-                      Due {formatDate(m.due_date)}
-                    </p>
-                  </div>
-                  <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-                    {formatCurrency(m.amount)}
-                  </p>
-                </div>
-              ))}
-            </div>
           </div>
         )}
       </div>

--- a/app/(dashboard)/trips/components/TripCardDesktop.tsx
+++ b/app/(dashboard)/trips/components/TripCardDesktop.tsx
@@ -9,15 +9,17 @@ export default function TripCardDesktop(props: CardProps) {
       className="rounded-2xl overflow-hidden flex flex-col h-full"
       style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)', minHeight: 300 }}
     >
-      <TripImage src={trip.image_url} height={180} />
+      <TripImage src={trip.image_url} height={220} overlay>
+        <div className="px-5 pb-4">
+          <TripBadges destination={trip.destination} tripType={trip.trip_type} />
+          <h3 className="font-display text-2xl font-semibold leading-snug text-white">
+            {trip.title}
+          </h3>
+        </div>
+      </TripImage>
       <div className="px-6 pt-5 pb-6 flex flex-col gap-3 flex-1">
         <div className="flex items-start justify-between gap-4">
-          <div className="flex-1 min-w-0">
-            <TripBadges destination={trip.destination} tripType={trip.trip_type} />
-            <h3 className="font-display text-2xl font-semibold leading-snug" style={{ color: 'var(--text-primary)' }}>
-              {trip.title}
-            </h3>
-          </div>
+          <DateBadge trip={trip} iconSize={14} textClassName="text-sm" />
           <PriceDisplay
             totalCost={trip.total_cost}
             label={props.t('trips.total')}
@@ -25,7 +27,6 @@ export default function TripCardDesktop(props: CardProps) {
             priceClassName="text-xl"
           />
         </div>
-        <DateBadge trip={trip} iconSize={14} textClassName="text-sm" />
         {trip.description && (
           <p className="text-sm leading-relaxed" style={{
             color: 'var(--text-secondary)',

--- a/app/(dashboard)/trips/components/TripCardMobile.tsx
+++ b/app/(dashboard)/trips/components/TripCardMobile.tsx
@@ -9,15 +9,17 @@ export default function TripCardMobile(props: CardProps) {
       className="rounded-2xl overflow-hidden flex flex-col"
       style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
     >
-      <TripImage src={trip.image_url} height={140} />
+      <TripImage src={trip.image_url} height={180} overlay>
+        <div className="px-4 pb-3">
+          <TripBadges destination={trip.destination} tripType={trip.trip_type} />
+          <h3 className="font-display text-xl font-semibold leading-snug text-white">
+            {trip.title}
+          </h3>
+        </div>
+      </TripImage>
       <div className="px-5 pt-4 pb-5 flex flex-col gap-3 flex-1">
         <div className="flex items-start justify-between gap-3">
-          <div className="flex-1 min-w-0">
-            <TripBadges destination={trip.destination} tripType={trip.trip_type} />
-            <h3 className="font-display text-xl font-semibold leading-snug" style={{ color: 'var(--text-primary)' }}>
-              {trip.title}
-            </h3>
-          </div>
+          <DateBadge trip={trip} iconSize={13} textClassName="text-xs" />
           <PriceDisplay
             totalCost={trip.total_cost}
             label={props.t('trips.total')}
@@ -25,7 +27,6 @@ export default function TripCardMobile(props: CardProps) {
             priceClassName="text-base"
           />
         </div>
-        <DateBadge trip={trip} iconSize={13} textClassName="text-xs" />
         <div className="mt-auto flex flex-col gap-2">
           {ctaNode}
         </div>

--- a/app/(dashboard)/trips/components/TripShared.tsx
+++ b/app/(dashboard)/trips/components/TripShared.tsx
@@ -17,10 +17,26 @@ export function PinIcon({ size }: { size: number }) {
   )
 }
 
-export function TripImage({ src, height }: { src: string | null | undefined; height: number }) {
+/**
+ * TripImage — image area with optional overlay and child slot.
+ *
+ * When overlay=true, renders a dark gradient over the image and accepts
+ * children positioned absolutely at the bottom of the container.
+ */
+export function TripImage({
+  src,
+  height,
+  overlay = false,
+  children,
+}: {
+  src: string | null | undefined
+  height: number
+  overlay?: boolean
+  children?: React.ReactNode
+}) {
   return (
     <div
-      className="w-full flex-shrink-0"
+      className="w-full flex-shrink-0 relative"
       style={{ height, backgroundColor: 'var(--brand-forest)' }}
     >
       {src && (
@@ -30,7 +46,22 @@ export function TripImage({ src, height }: { src: string | null | undefined; hei
           alt=""
           aria-hidden="true"
           className="w-full h-full object-cover"
+          onError={e => {
+            const el = e.currentTarget
+            el.style.display = 'none'
+          }}
         />
+      )}
+      {overlay && (
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.55) 0%, transparent 60%)' }}
+        />
+      )}
+      {children && (
+        <div className="absolute bottom-0 left-0 right-0">
+          {children}
+        </div>
       )}
     </div>
   )

--- a/app/admin/operations/components/TripForm.tsx
+++ b/app/admin/operations/components/TripForm.tsx
@@ -1,16 +1,162 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { formatCurrency } from '@/lib/format'
 import { ALL_ROLES, type Milestone, type Trip } from './operations-types'
 import { AttachmentsSection } from './AttachmentsSection'
 import { t } from '@/lib/i18n'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '@/components/ui/alert-dialog'
 
 // ── Types ────────────────────────────────────────────────────────
 
 export type TripFormState = Omit<Trip, 'id' | 'currency'>
 
 export type MilestoneInputState = { label: string; amount: string; due_date: string }
+
+// ── HeroImageField (module scope — never inside TripForm body) ───
+
+function HeroImageField({
+  tripId,
+  currentImageUrl,
+  onUploaded,
+}: {
+  tripId: string
+  currentImageUrl: string | null
+  onUploaded: (newUrl: string | null) => void
+}) {
+  const qc = useQueryClient()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [preview, setPreview] = useState<string | null>(currentImageUrl)
+  const [uploading, setUploading] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    if (file.size > 5 * 1024 * 1024) {
+      setError('Image must be under 5MB')
+      return
+    }
+    setError(null)
+    setUploading(true)
+    try {
+      const fd = new FormData()
+      fd.append('file', file)
+      const res = await fetch(`/api/admin/trips/${tripId}/hero`, { method: 'POST', body: fd })
+      if (!res.ok) throw new Error((await res.json()).error ?? 'Upload failed')
+      const trip = await res.json()
+      setPreview(trip.image_url)
+      onUploaded(trip.image_url)
+      qc.invalidateQueries({ queryKey: ['trips'] })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed')
+    } finally {
+      setUploading(false)
+      if (inputRef.current) inputRef.current.value = ''
+    }
+  }
+
+  async function handleDelete() {
+    setUploading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/admin/trips/${tripId}/hero`, { method: 'DELETE' })
+      if (!res.ok) throw new Error((await res.json()).error ?? 'Delete failed')
+      setPreview(null)
+      onUploaded(null)
+      qc.invalidateQueries({ queryKey: ['trips'] })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed')
+    } finally {
+      setUploading(false)
+      setDeleteOpen(false)
+    }
+  }
+
+  return (
+    <div className="pt-2 border-t" style={{ borderColor: 'var(--border-default)' }}>
+      <p className="text-xs font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>
+        Hero Image
+      </p>
+
+      {preview && (
+        <div className="relative mb-3 rounded-xl overflow-hidden" style={{ height: 120 }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={preview} alt="" aria-hidden="true" className="w-full h-full object-cover" />
+          <button
+            type="button"
+            onClick={() => setDeleteOpen(true)}
+            disabled={uploading}
+            className="absolute top-2 right-2 w-7 h-7 rounded-full flex items-center justify-center transition-opacity hover:opacity-80 disabled:opacity-40"
+            style={{ backgroundColor: 'rgba(0,0,0,0.55)', color: '#fff' }}
+            aria-label="Remove hero image"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="3 6 5 6 21 6" />
+              <path d="M19 6l-1 14H6L5 6" />
+              <path d="M10 11v6M14 11v6" />
+              <path d="M9 6V4h6v2" />
+            </svg>
+          </button>
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          disabled={uploading}
+          className="px-3 py-2 rounded-xl text-xs font-semibold border transition-colors hover:bg-black/5 disabled:opacity-40"
+          style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)' }}
+        >
+          {uploading ? 'Uploading…' : preview ? 'Replace image' : 'Upload image'}
+        </button>
+        {uploading && (
+          <svg className="animate-spin" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ color: 'var(--text-secondary)' }}>
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+          </svg>
+        )}
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/gif"
+        className="hidden"
+        disabled={uploading}
+        onChange={handleFileChange}
+      />
+
+      {error && <p className="text-xs mt-1" style={{ color: 'var(--brand-crimson)' }}>{error}</p>}
+
+      <AlertDialog open={deleteOpen} onOpenChange={open => { if (!open) setDeleteOpen(false) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove hero image?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the hero image for this trip.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete}>Remove</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}
 
 // ── TripForm ─────────────────────────────────────────────────────
 
@@ -165,9 +311,16 @@ export function TripForm({
       </div>
 
       {editing && (
-        <div className="pt-2 border-t" style={{ borderColor: 'var(--border-default)' }}>
-          <AttachmentsSection tripId={editing.id} />
-        </div>
+        <>
+          <div className="pt-2 border-t" style={{ borderColor: 'var(--border-default)' }}>
+            <AttachmentsSection tripId={editing.id} />
+          </div>
+          <HeroImageField
+            tripId={editing.id}
+            currentImageUrl={editing.image_url}
+            onUploaded={url => setForm(f => ({ ...f, image_url: url }))}
+          />
+        </>
       )}
 
       {error && <p className="text-sm" style={{ color: 'var(--brand-crimson)' }}>{error}</p>}

--- a/app/admin/operations/components/TripsTab.tsx
+++ b/app/admin/operations/components/TripsTab.tsx
@@ -27,6 +27,7 @@ const emptyTrip = (): TripFormState => ({
   location: null, accommodation_type: null,
   inclusions: [], trip_type: null,
   access_roles: [...ALL_ROLES],
+  image_url: null,
 })
 
 // ── Component ────────────────────────────────────────────
@@ -63,6 +64,7 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
       inclusions: Array.isArray(trip.inclusions) ? trip.inclusions : [],
       trip_type: trip.trip_type,
       access_roles: Array.isArray(trip.access_roles) ? trip.access_roles : [...ALL_ROLES],
+      image_url: trip.image_url,
     })
     setMilestoneInput({ label: '', amount: '', due_date: '' })
     setError(null)
@@ -76,7 +78,11 @@ export function TripsTab({ trips, isLoading }: { trips: Trip[]; isLoading: boole
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       }).then(async r => { if (!r.ok) throw new Error((await r.json()).error); return r.json() }),
-    onSuccess: () => { qc.invalidateQueries({ queryKey: ['trips'] }); setDrawerOpen(false); setError(null) },
+    onSuccess: (newTrip: Trip) => {
+      qc.invalidateQueries({ queryKey: ['trips'] })
+      setError(null)
+      openEdit(newTrip)
+    },
     onError: (e: Error) => setError(e.message),
   })
 

--- a/app/admin/operations/components/operations-types.ts
+++ b/app/admin/operations/components/operations-types.ts
@@ -11,6 +11,7 @@ export type Trip = {
   start_date: string; end_date: string
   total_cost: number; milestones: Milestone[]
   currency: string; description: string
+  image_url: string | null
   location: string | null; accommodation_type: string | null
   inclusions: string[]; trip_type: string | null
   access_roles: Role[]

--- a/app/api/admin/trips/[id]/hero/route.ts
+++ b/app/api/admin/trips/[id]/hero/route.ts
@@ -1,6 +1,17 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 
+// Helper: remove all objects under trips/{id}/ folder in storage
+async function purgeStorageFolder(supabase: ReturnType<typeof createServiceClient>, folder: string) {
+  const { data: objects } = await supabase.storage
+    .from('trip-hero-images')
+    .list(folder)
+  if (objects && objects.length > 0) {
+    const paths = objects.map(o => `${folder}/${o.name}`)
+    await supabase.storage.from('trip-hero-images').remove(paths)
+  }
+}
+
 export async function POST(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -23,6 +34,9 @@ export async function POST(
   const formData = await req.formData()
   const file = formData.get('file') as File | null
   if (!file) return Response.json({ error: 'No file provided' }, { status: 400 })
+
+  // Remove any existing hero images for this trip before uploading the new one
+  await purgeStorageFolder(supabase, id)
 
   const ext = file.name.split('.').pop() ?? 'jpg'
   const filename = `${id}/${Date.now()}.${ext}`
@@ -72,22 +86,8 @@ export async function DELETE(
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  // Fetch current image_url to derive storage path
-  const { data: trip } = await supabase
-    .from('trips')
-    .select('image_url')
-    .eq('id', id)
-    .single()
-
-  if (trip?.image_url) {
-    // Extract path after bucket name in the public URL
-    const url = new URL(trip.image_url)
-    const pathParts = url.pathname.split('/trip-hero-images/')
-    const storagePath = pathParts[1]
-    if (storagePath) {
-      await supabase.storage.from('trip-hero-images').remove([storagePath])
-    }
-  }
+  // Remove all storage objects under this trip's folder — deterministic, no URL parsing
+  await purgeStorageFolder(supabase, id)
 
   const { data: updated, error } = await supabase
     .from('trips')

--- a/app/api/admin/trips/[id]/hero/route.ts
+++ b/app/api/admin/trips/[id]/hero/route.ts
@@ -1,0 +1,101 @@
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (profile?.role !== 'admin') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const formData = await req.formData()
+  const file = formData.get('file') as File | null
+  if (!file) return Response.json({ error: 'No file provided' }, { status: 400 })
+
+  const ext = file.name.split('.').pop() ?? 'jpg'
+  const filename = `${id}/${Date.now()}.${ext}`
+
+  const { error: uploadError } = await supabase.storage
+    .from('trip-hero-images')
+    .upload(filename, file, { upsert: true, contentType: file.type })
+
+  if (uploadError) {
+    return Response.json({ error: uploadError.message }, { status: 500 })
+  }
+
+  const { data: urlData } = supabase.storage
+    .from('trip-hero-images')
+    .getPublicUrl(filename)
+
+  const { data: trip, error: updateError } = await supabase
+    .from('trips')
+    .update({ image_url: urlData.publicUrl })
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (updateError) {
+    return Response.json({ error: updateError.message }, { status: 500 })
+  }
+
+  return Response.json(trip)
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (profile?.role !== 'admin') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  // Fetch current image_url to derive storage path
+  const { data: trip } = await supabase
+    .from('trips')
+    .select('image_url')
+    .eq('id', id)
+    .single()
+
+  if (trip?.image_url) {
+    // Extract path after bucket name in the public URL
+    const url = new URL(trip.image_url)
+    const pathParts = url.pathname.split('/trip-hero-images/')
+    const storagePath = pathParts[1]
+    if (storagePath) {
+      await supabase.storage.from('trip-hero-images').remove([storagePath])
+    }
+  }
+
+  const { data: updated, error } = await supabase
+    .from('trips')
+    .update({ image_url: null })
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+  return Response.json(updated)
+}

--- a/supabase/migrations/20260514_003_trip_hero_images_bucket.sql
+++ b/supabase/migrations/20260514_003_trip_hero_images_bucket.sql
@@ -1,0 +1,34 @@
+-- Create trip-hero-images storage bucket (public)
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'trip-hero-images',
+  'trip-hero-images',
+  true,
+  5242880, -- 5MB
+  ARRAY['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Service role can insert
+CREATE POLICY "Service role can upload trip hero images"
+ON storage.objects FOR INSERT
+TO service_role
+WITH CHECK (bucket_id = 'trip-hero-images');
+
+-- Service role can update (overwrite)
+CREATE POLICY "Service role can update trip hero images"
+ON storage.objects FOR UPDATE
+TO service_role
+USING (bucket_id = 'trip-hero-images');
+
+-- Service role can delete
+CREATE POLICY "Service role can delete trip hero images"
+ON storage.objects FOR DELETE
+TO service_role
+USING (bucket_id = 'trip-hero-images');
+
+-- Public can read (bucket is public, but explicit policy for clarity)
+CREATE POLICY "Public can read trip hero images"
+ON storage.objects FOR SELECT
+TO public
+USING (bucket_id = 'trip-hero-images');


### PR DESCRIPTION
## Summary

Full design modernisation of the trips surface: hero image upload (admin), card overlays on list, genuine dual layout on detail page, view state improvements across all five states.

Closes #357

## Changes

**New**
- `supabase/migrations/20260514_003_trip_hero_images_bucket.sql` — public bucket + service role policies
- `app/api/admin/trips/[id]/hero/route.ts` — POST (upload) + DELETE (remove), admin-only, full row return

**Modified**
- `operations-types.ts` — `image_url: string | null` added to `Trip`
- `TripForm.tsx` — `HeroImageField` at module scope; upload loading state, 5MB guard, inline spinner, disabled input during upload, AlertDialog on delete
- `TripsTab.tsx` — `createMutation.onSuccess` calls `openEdit(newTrip)`; `emptyTrip()` includes `image_url: null`
- `TripShared.tsx` — `TripImage` gains `overlay` prop + child slot; `onerror` on img
- `TripCardMobile.tsx` — overlay treatment at 180px; title+badges over image; date+price in content area
- `TripCardDesktop.tsx` — overlay treatment at 220px; title+badges over image; description+location in content area
- `shared.tsx` — `TripHero` overlay + `muted` prop + `onerror` fallback; milestones section removed (was deleted, not migrated)
- `AttendeeView.tsx` — countdown banner via CSS `background-image` (silent degradation); progress bar; `desktopActionSlot` prop for desktop CTA; mobile sticky CTA
- `TripDetailClient.tsx` — two self-contained JSX trees for `attendee` and `available`; `locked`/`pending`/`archived` single-column both breakpoints; no shared wrapper
- `AvailableView.tsx` — `desktopActionSlot` prop renders register panel only; mobile renders full layout
- `PendingView.tsx` — cancel registration wrapped in `AlertDialog`
- `ArchivedView.tsx` — inline hero replaced with `<TripHero trip={trip} profile={profile} muted />`
- `LockedView.tsx` — `trip` prop added; title + destination badge rendered above error box
- `page.tsx` — `LockedView` receives `trip` prop (already passed via `TripDetailClient`)

## DoD checklist
- [x] Storage bucket + policies
- [x] Hero API route (POST + DELETE, admin-only, full row return)
- [x] `image_url` in `operations-types.ts`
- [x] `HeroImageField` at module scope with loading state
- [x] `createMutation.onSuccess` → `openEdit(newTrip)`
- [x] `TripImage` overlay prop + child slot
- [x] Card overlay treatment (mobile 180px, desktop 220px)
- [x] `TripHero` overlay + muted + onerror fallback, milestones deleted
- [x] Countdown via CSS `background-image`, progress bar
- [x] Genuine dual layout — two self-contained trees
- [x] `AvailableView` desktop slot
- [x] `PendingView` AlertDialog cancel
- [x] `ArchivedView` TripHero muted
- [x] `LockedView` trip prop + title/badge
