### PR TITLE
[2505-BUG-359] Collapse two-column layout, fix mobile hierarchy, and UX polish

### DIFF
--- a/app/(dashboard)/trips/[id]/TripDetailClient.tsx
+++ b/app/(dashboard)/trips/[id]/TripDetailClient.tsx
@@ -5,7 +5,6 @@ import { AvailableView } from './components/AvailableView'
 import { PendingView } from './components/PendingView'
 import { AttendeeView } from './components/AttendeeView'
 import { ArchivedView } from './components/ArchivedView'
-import { BackButton, TripHero } from './components/shared'
 import type { Tables } from '@/types/supabase'
 import type { TripState, TripProfile, TripPayment, TeamAttendee } from './page'
 
@@ -24,7 +23,6 @@ interface TripDetailClientProps {
 export function TripDetailClient(props: TripDetailClientProps) {
   const { trip, state, registration, payments, profile, teamAttendees } = props
 
-  // ── States that use single-column on both breakpoints ──────────────────
   if (state === 'locked') {
     return <LockedView trip={trip} profile={profile} />
   }
@@ -34,83 +32,24 @@ export function TripDetailClient(props: TripDetailClientProps) {
   if (state === 'archived') {
     return <ArchivedView trip={trip} profile={profile} payments={payments} />
   }
-
-  // ── attendee: two-column desktop / single-column mobile ──────────────
   if (state === 'attendee') {
     return (
-      <>
-        {/* Desktop: two-column grid */}
-        <div className="hidden md:block py-8 pb-16">
-          <div
-            className="mx-auto px-4"
-            style={{ maxWidth: 1024, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}
-          >
-            <BackButton />
-            <div />
-            {/* Left column */}
-            <div className="space-y-4">
-              <TripHero trip={trip} profile={profile} />
-            </div>
-            {/* Right column */}
-            <div className="space-y-4">
-              <AttendeeView
-                trip={trip}
-                profile={profile}
-                payments={payments}
-                teamAttendees={teamAttendees}
-                desktopActionSlot
-              />
-            </div>
-          </div>
-        </div>
-        {/* Mobile: single-column stack */}
-        <div className="md:hidden">
-          <AttendeeView
-            trip={trip}
-            profile={profile}
-            payments={payments}
-            teamAttendees={teamAttendees}
-          />
-        </div>
-      </>
+      <AttendeeView
+        trip={trip}
+        profile={profile}
+        payments={payments}
+        teamAttendees={teamAttendees}
+      />
     )
   }
-
-  // ── available: two-column desktop / single-column mobile ────────────
   if (state === 'available') {
-    return (
-      <>
-        {/* Desktop: two-column grid */}
-        <div className="hidden md:block py-8 pb-16">
-          <div
-            className="mx-auto px-4"
-            style={{ maxWidth: 1024, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}
-          >
-            <BackButton />
-            <div />
-            {/* Left column */}
-            <div className="space-y-4">
-              <TripHero trip={trip} profile={profile} />
-            </div>
-            {/* Right column */}
-            <div className="space-y-4">
-              <AvailableView trip={trip} profile={profile} desktopActionSlot />
-            </div>
-          </div>
-        </div>
-        {/* Mobile: single-column stack */}
-        <div className="md:hidden">
-          <AvailableView trip={trip} profile={profile} />
-        </div>
-      </>
-    )
+    return <AvailableView trip={trip} profile={profile} />
   }
 
   // Fallback
   return (
     <div className="py-8 pb-16">
-      <div className="max-w-[720px] mx-auto px-4">
-        <BackButton />
+      <div className="max-w-4xl mx-auto px-4">
         <div className="rounded-2xl overflow-hidden"
           style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
           <div className="px-6 py-8">

--- a/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
@@ -302,9 +302,9 @@ export function AttendeeView({
         <TripDocumentsTile tripId={trip.id} />
       </div>
 
-      {/* Sticky footer CTA — slimmed */}
+      {/* Sticky footer CTA — slimmed, mobile only */}
       <div
-        className="fixed bottom-0 left-0 right-0 px-4 pb-4 pt-2"
+        className="fixed bottom-0 left-0 right-0 px-4 pb-4 pt-2 md:hidden"
         style={{ backgroundColor: 'var(--bg-base)', borderTop: '1px solid var(--border-default)' }}
       >
         <SubmitPaymentCTA onOpen={() => setDrawerOpen(true)} />

--- a/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
@@ -42,7 +42,7 @@ function WhosGoingTile({ attendees }: { attendees: TeamAttendee[] }) {
       <div className="px-6 pt-5 pb-2">
         <p className="text-xs font-semibold tracking-widest uppercase"
           style={{ color: 'var(--text-secondary)' }}>
-          {t('trips.whosGoing')}
+          {t('trips.whosGoing')} · {attendees.length}
         </p>
       </div>
       <div className="px-6 pb-5">
@@ -76,13 +76,9 @@ function WhosGoingTile({ attendees }: { attendees: TeamAttendee[] }) {
   )
 }
 
-// ── SubmitPaymentCTA (shared between mobile sticky and desktop panel) ───
-
 function SubmitPaymentCTA({
-  remaining,
   onOpen,
 }: {
-  remaining: number
   onOpen: () => void
 }) {
   const { t } = useLanguage()
@@ -98,14 +94,12 @@ function SubmitPaymentCTA({
 }
 
 export function AttendeeView({
-  trip, profile, payments, teamAttendees, desktopActionSlot,
+  trip, profile, payments, teamAttendees,
 }: {
   trip: Trip
   profile: TripProfile
   payments: TripPayment[]
   teamAttendees: TeamAttendee[]
-  /** When true the Submit Payment CTA is rendered as a sticky footer (mobile). Desktop panel injects via this prop. */
-  desktopActionSlot?: boolean
 }) {
   const { t } = useLanguage()
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -133,7 +127,6 @@ export function AttendeeView({
     return acc
   }, [])
 
-  // CSS background-image countdown — degrades silently on load failure
   const countdownBg = trip.image_url
     ? {
         backgroundImage: `linear-gradient(rgba(0,0,0,0.55), rgba(0,0,0,0.55)), url(${JSON.stringify(trip.image_url)})`,
@@ -143,13 +136,13 @@ export function AttendeeView({
     : { backgroundColor: 'var(--brand-forest)' }
 
   return (
-    <div className="py-8 pb-20 md:pb-16">
-      <div className="max-w-[720px] mx-auto px-4 space-y-4">
+    <div className="py-8 pb-16">
+      <div className="max-w-4xl mx-auto px-4 space-y-4">
         <BackButton />
 
         {/* Countdown header */}
         <div
-          className="rounded-2xl px-6 py-7 flex items-center justify-between gap-4"
+          className="rounded-2xl px-6 py-5 flex items-center justify-between gap-4"
           style={{ ...countdownBg, color: 'rgba(255,255,255,0.92)' }}
         >
           <div>
@@ -172,8 +165,8 @@ export function AttendeeView({
           )}
         </div>
 
-        {/* Trip Messages — immediately below countdown */}
-        <TripMessagesTile tripId={trip.id} />
+        {/* Trip identity card */}
+        <TripHero trip={trip} profile={profile} />
 
         {/* Payment ledger */}
         <div className="rounded-2xl overflow-hidden"
@@ -295,32 +288,27 @@ export function AttendeeView({
                 {remaining === 0 ? t('payment.paidInFull') : formatCurrency(remaining)}
               </p>
             </div>
-            {/* Desktop: CTA inline in ledger tile */}
-            {desktopActionSlot && (
-              <SubmitPaymentCTA remaining={remaining} onOpen={() => setDrawerOpen(true)} />
-            )}
+            <SubmitPaymentCTA onOpen={() => setDrawerOpen(true)} />
           </div>
         </div>
 
         {/* Who's Going */}
         <WhosGoingTile attendees={teamAttendees} />
 
-        {/* Trip Documents */}
-        <TripDocumentsTile tripId={trip.id} />
+        {/* Trip Messages — secondary content */}
+        <TripMessagesTile tripId={trip.id} />
 
-        {/* Trip info (read-only) */}
-        <TripHero trip={trip} profile={profile} />
+        {/* Trip Documents — secondary content */}
+        <TripDocumentsTile tripId={trip.id} />
       </div>
 
-      {/* Mobile: sticky CTA */}
-      {!desktopActionSlot && (
-        <div
-          className="fixed bottom-0 left-0 right-0 px-4 pb-6 pt-3 md:hidden"
-          style={{ backgroundColor: 'var(--bg-base)', borderTop: '1px solid var(--border-default)' }}
-        >
-          <SubmitPaymentCTA remaining={remaining} onOpen={() => setDrawerOpen(true)} />
-        </div>
-      )}
+      {/* Sticky footer CTA — slimmed */}
+      <div
+        className="fixed bottom-0 left-0 right-0 px-4 pb-4 pt-2"
+        style={{ backgroundColor: 'var(--bg-base)', borderTop: '1px solid var(--border-default)' }}
+      >
+        <SubmitPaymentCTA onOpen={() => setDrawerOpen(true)} />
+      </div>
 
       <SubmitPaymentDrawer
         tripId={trip.id}

--- a/app/(dashboard)/trips/[id]/components/AvailableView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AvailableView.tsx
@@ -10,35 +10,16 @@ type Trip = Tables<'trips'>
 export function AvailableView({
   trip,
   profile,
-  desktopActionSlot,
 }: {
   trip: Trip
   profile: TripProfile
-  desktopActionSlot?: boolean
 }) {
-  // Desktop: action panel only (TripHero rendered in left column by TripDetailClient)
-  if (desktopActionSlot) {
-    return (
-      <div className="rounded-2xl px-6 py-6 space-y-4"
-        style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
-        <p className="text-xs font-semibold tracking-widest uppercase"
-          style={{ color: 'var(--text-secondary)' }}>
-          Register
-        </p>
-        <RegisterButton tripId={trip.id} profileId={profile.id} />
-      </div>
-    )
-  }
-
-  // Mobile: full single-column layout
   return (
     <div className="py-8 pb-16">
-      <div className="max-w-[720px] mx-auto px-4">
+      <div className="max-w-4xl mx-auto px-4 space-y-4">
         <BackButton />
         <TripHero trip={trip} profile={profile} />
-        <div className="mt-4">
-          <RegisterButton tripId={trip.id} profileId={profile.id} />
-        </div>
+        <RegisterButton tripId={trip.id} profileId={profile.id} />
       </div>
     </div>
   )

--- a/app/(dashboard)/trips/[id]/components/shared.tsx
+++ b/app/(dashboard)/trips/[id]/components/shared.tsx
@@ -149,13 +149,19 @@ export function TripHero({
         )}
 
         {trip.inclusions.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {trip.inclusions.map((inc, i) => (
-              <span key={i} className="text-xs px-2 py-0.5 rounded-full"
-                style={{ backgroundColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>
-                {inc}
-              </span>
-            ))}
+          <div>
+            <p className="text-xs font-semibold tracking-widest uppercase mb-2"
+              style={{ color: 'var(--text-secondary)' }}>
+              {t('trips.inclusions')}
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {trip.inclusions.map((inc, i) => (
+                <span key={i} className="text-xs px-2 py-0.5 rounded-full"
+                  style={{ backgroundColor: 'rgba(129,178,154,0.15)', color: 'var(--text-primary)' }}>
+                  {inc}
+                </span>
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/lib/i18n/domains/trips.ts
+++ b/lib/i18n/domains/trips.ts
@@ -41,4 +41,5 @@ export const trips = {
   'trips.upload':             { en: 'Upload',                  bg: 'Качи'                               },
   'trips.uploading':          { en: 'Uploading…',              bg: 'Качва се…'                          },
   'trips.delete':             { en: 'Delete',                  bg: 'Изтрий'                             },
+  'trips.inclusions':         { en: "What's Included",         bg: 'Включено в цената'                  },
 } as const


### PR DESCRIPTION
Closes #359

## Changes

- `TripDetailClient`: collapsed `attendee` and `available` blocks to single component returns — no more grid, no `hidden md:block` splits
- `AttendeeView`: removed `desktopActionSlot` prop; single `max-w-4xl` layout; new stack order (BackButton → Countdown → TripHero → Ledger → Who's Going → Messages → Documents); countdown trimmed to `py-5`; sticky footer slimmed to `py-2 pb-4`; Who's Going header shows attendee count
- `AvailableView`: removed `desktopActionSlot` prop and conditional branch; single layout at `max-w-4xl`
- `shared.tsx` (TripHero): inclusions section gets "What's Included" label; chips styled with `rgba(129,178,154,0.15)` background and `--text-primary` colour
- `lib/i18n/domains/trips.ts`: added `trips.inclusions` key (en/bg)

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] All five files committed to feature branch
**Next:** Verify Vercel Preview READY and CI green, then run DoD checklist
