### PR TITLE
[2505-FEAT-361] Trip hero redesign — split image/detail, dynamic accent countdown strip

### DIFF
--- a/app/(dashboard)/trips/[id]/components/ArchivedView.tsx
+++ b/app/(dashboard)/trips/[id]/components/ArchivedView.tsx
@@ -1,16 +1,21 @@
 'use client'
 
+import { useState } from 'react'
 import { formatDate, formatCurrency } from '@/lib/format'
-import { BackButton, TripHero } from './shared'
+import { BackButton, TripHeroImage, TripDetail } from './shared'
 import { TripMessagesTile } from './TripMessagesTile'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile, TripPayment } from '../page'
 
 type Trip = Tables<'trips'>
 
+const FALLBACK_ACCENT = '#2d6a4f'
+
 export function ArchivedView({
   trip, profile, payments,
 }: { trip: Trip; profile: TripProfile; payments: TripPayment[] }) {
+  const [accentColor, setAccentColor] = useState(FALLBACK_ACCENT)
+
   const approvedTotal = payments
     .filter(p => p.admin_status === 'approved')
     .reduce((sum, p) => sum + p.amount, 0)
@@ -20,7 +25,10 @@ export function ArchivedView({
       <div className="max-w-[720px] mx-auto px-4 space-y-4">
         <BackButton />
 
-        <TripHero trip={trip} profile={profile} muted />
+        <div className="rounded-2xl overflow-hidden" style={{ border: '1px solid var(--border-default)' }}>
+          <TripHeroImage trip={trip} muted onAccentColor={setAccentColor} />
+          <TripDetail trip={trip} profile={profile} accentColor={accentColor} />
+        </div>
 
         {/* Trip Messages — between hero card and Final Ledger */}
         <TripMessagesTile tripId={trip.id} />

--- a/app/(dashboard)/trips/[id]/components/ArchivedView.tsx
+++ b/app/(dashboard)/trips/[id]/components/ArchivedView.tsx
@@ -2,14 +2,12 @@
 
 import { useState } from 'react'
 import { formatDate, formatCurrency } from '@/lib/format'
-import { BackButton, TripHeroImage, TripDetail } from './shared'
+import { BackButton, TripHeroImage, TripDetail, FALLBACK_ACCENT } from './shared'
 import { TripMessagesTile } from './TripMessagesTile'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile, TripPayment } from '../page'
 
 type Trip = Tables<'trips'>
-
-const FALLBACK_ACCENT = '#2d6a4f'
 
 export function ArchivedView({
   trip, profile, payments,

--- a/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
@@ -8,12 +8,14 @@ import { Drawer } from '@/components/ui/drawer'
 import { PaymentForm } from '@/components/payment/PaymentForm'
 import { TripDocumentsTile } from './TripDocumentsTile'
 import { TripMessagesTile } from './TripMessagesTile'
-import { BackButton, TripHero } from './shared'
+import { BackButton, TripHeroImage, TripDetail } from './shared'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile, TripPayment, TeamAttendee } from '../page'
 
 type Trip = Tables<'trips'>
 type Milestone = { label: string; amount: number; due_date: string }
+
+const FALLBACK_ACCENT = '#2d6a4f'
 
 function SubmitPaymentDrawer({
   tripId,
@@ -103,6 +105,7 @@ export function AttendeeView({
 }) {
   const { t } = useLanguage()
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [accentColor, setAccentColor] = useState(FALLBACK_ACCENT)
 
   const milestones: Milestone[] = Array.isArray(trip.milestones)
     ? (trip.milestones as Milestone[])
@@ -127,46 +130,16 @@ export function AttendeeView({
     return acc
   }, [])
 
-  const countdownBg = trip.image_url
-    ? {
-        backgroundImage: `linear-gradient(rgba(0,0,0,0.55), rgba(0,0,0,0.55)), url(${JSON.stringify(trip.image_url)})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-      }
-    : { backgroundColor: 'var(--brand-forest)' }
-
   return (
     <div className="py-8 pb-16">
       <div className="max-w-4xl mx-auto px-4 space-y-4">
         <BackButton />
 
-        {/* Countdown header */}
-        <div
-          className="rounded-2xl px-6 py-5 flex items-center justify-between gap-4"
-          style={{ ...countdownBg, color: 'rgba(255,255,255,0.92)' }}
-        >
-          <div>
-            <p className="text-xs font-semibold tracking-widest uppercase opacity-70 mb-1">
-              {trip.destination} · {trip.title}
-            </p>
-            <div className="flex items-baseline gap-2">
-              <span className="font-display text-5xl font-bold leading-none">{daysToGo}</span>
-              <span className="text-lg font-medium opacity-80">{t('trips.daysToGo')}</span>
-            </div>
-            <p className="text-sm opacity-60 mt-1">
-              {formatDate(trip.start_date)} – {formatDate(trip.end_date)}
-            </p>
-          </div>
-          {daysToGo === 0 && (
-            <span className="text-xs font-semibold px-3 py-1 rounded-full"
-              style={{ backgroundColor: 'rgba(255,255,255,0.2)' }}>
-              {t('trips.todayBadge')}
-            </span>
-          )}
+        {/* Trip hero — image pane + detail pane as a unified card */}
+        <div className="rounded-2xl overflow-hidden" style={{ border: '1px solid var(--border-default)' }}>
+          <TripHeroImage trip={trip} onAccentColor={setAccentColor} />
+          <TripDetail trip={trip} profile={profile} accentColor={accentColor} countdown={daysToGo} />
         </div>
-
-        {/* Trip identity card */}
-        <TripHero trip={trip} profile={profile} />
 
         {/* Payment ledger */}
         <div className="rounded-2xl overflow-hidden"

--- a/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
@@ -8,14 +8,12 @@ import { Drawer } from '@/components/ui/drawer'
 import { PaymentForm } from '@/components/payment/PaymentForm'
 import { TripDocumentsTile } from './TripDocumentsTile'
 import { TripMessagesTile } from './TripMessagesTile'
-import { BackButton, TripHeroImage, TripDetail } from './shared'
+import { BackButton, TripHeroImage, TripDetail, FALLBACK_ACCENT } from './shared'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile, TripPayment, TeamAttendee } from '../page'
 
 type Trip = Tables<'trips'>
 type Milestone = { label: string; amount: number; due_date: string }
-
-const FALLBACK_ACCENT = '#2d6a4f'
 
 function SubmitPaymentDrawer({
   tripId,

--- a/app/(dashboard)/trips/[id]/components/AvailableView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AvailableView.tsx
@@ -2,13 +2,11 @@
 
 import { useState } from 'react'
 import RegisterButton from '@/components/trips/RegisterButton'
-import { BackButton, TripHeroImage, TripDetail } from './shared'
+import { BackButton, TripHeroImage, TripDetail, FALLBACK_ACCENT } from './shared'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile } from '../page'
 
 type Trip = Tables<'trips'>
-
-const FALLBACK_ACCENT = '#2d6a4f'
 
 export function AvailableView({
   trip,

--- a/app/(dashboard)/trips/[id]/components/AvailableView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AvailableView.tsx
@@ -1,11 +1,14 @@
 'use client'
 
+import { useState } from 'react'
 import RegisterButton from '@/components/trips/RegisterButton'
-import { BackButton, TripHero } from './shared'
+import { BackButton, TripHeroImage, TripDetail } from './shared'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile } from '../page'
 
 type Trip = Tables<'trips'>
+
+const FALLBACK_ACCENT = '#2d6a4f'
 
 export function AvailableView({
   trip,
@@ -14,11 +17,16 @@ export function AvailableView({
   trip: Trip
   profile: TripProfile
 }) {
+  const [accentColor, setAccentColor] = useState(FALLBACK_ACCENT)
+
   return (
     <div className="py-8 pb-16">
       <div className="max-w-4xl mx-auto px-4 space-y-4">
         <BackButton />
-        <TripHero trip={trip} profile={profile} />
+        <div className="rounded-2xl overflow-hidden" style={{ border: '1px solid var(--border-default)' }}>
+          <TripHeroImage trip={trip} onAccentColor={setAccentColor} />
+          <TripDetail trip={trip} profile={profile} accentColor={accentColor} />
+        </div>
         <RegisterButton tripId={trip.id} profileId={profile.id} />
       </div>
     </div>

--- a/app/(dashboard)/trips/[id]/components/PendingView.tsx
+++ b/app/(dashboard)/trips/[id]/components/PendingView.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useMutation } from '@tanstack/react-query'
 import { useState } from 'react'
 import { formatDate } from '@/lib/format'
-import { BackButton, TripHero } from './shared'
+import { BackButton, TripHeroImage, TripDetail } from './shared'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile } from '../page'
 import { apiClient } from '@/lib/apiClient'
@@ -22,11 +22,14 @@ import {
 type Trip = Tables<'trips'>
 type Registration = Tables<'trip_registrations'>
 
+const FALLBACK_ACCENT = '#2d6a4f'
+
 export function PendingView({
   trip, profile, registration,
 }: { trip: Trip; profile: TripProfile; registration: Registration }) {
   const router = useRouter()
   const [alertOpen, setAlertOpen] = useState(false)
+  const [accentColor, setAccentColor] = useState(FALLBACK_ACCENT)
 
   const cancelMutation = useMutation({
     mutationFn: () =>
@@ -39,7 +42,10 @@ export function PendingView({
       <div className="py-8 pb-16">
         <div className="max-w-[720px] mx-auto px-4">
           <BackButton />
-          <TripHero trip={trip} profile={profile} />
+          <div className="rounded-2xl overflow-hidden" style={{ border: '1px solid var(--border-default)' }}>
+            <TripHeroImage trip={trip} onAccentColor={setAccentColor} />
+            <TripDetail trip={trip} profile={profile} accentColor={accentColor} />
+          </div>
           <div className="mt-4 rounded-2xl px-6 py-5"
             style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
             <p className="text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>
@@ -55,7 +61,10 @@ export function PendingView({
     <div className="py-8 pb-16">
       <div className="max-w-[720px] mx-auto px-4">
         <BackButton />
-        <TripHero trip={trip} profile={profile} />
+        <div className="rounded-2xl overflow-hidden" style={{ border: '1px solid var(--border-default)' }}>
+          <TripHeroImage trip={trip} onAccentColor={setAccentColor} />
+          <TripDetail trip={trip} profile={profile} accentColor={accentColor} />
+        </div>
         <div className="mt-4 rounded-2xl px-6 py-6"
           style={{ backgroundColor: 'rgba(180,138,60,0.08)', border: '1px solid rgba(180,138,60,0.25)' }}>
           <div className="flex items-start gap-4">

--- a/app/(dashboard)/trips/[id]/components/PendingView.tsx
+++ b/app/(dashboard)/trips/[id]/components/PendingView.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useMutation } from '@tanstack/react-query'
 import { useState } from 'react'
 import { formatDate } from '@/lib/format'
-import { BackButton, TripHeroImage, TripDetail } from './shared'
+import { BackButton, TripHeroImage, TripDetail, FALLBACK_ACCENT } from './shared'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile } from '../page'
 import { apiClient } from '@/lib/apiClient'
@@ -21,8 +21,6 @@ import {
 
 type Trip = Tables<'trips'>
 type Registration = Tables<'trip_registrations'>
-
-const FALLBACK_ACCENT = '#2d6a4f'
 
 export function PendingView({
   trip, profile, registration,

--- a/app/(dashboard)/trips/[id]/components/shared.tsx
+++ b/app/(dashboard)/trips/[id]/components/shared.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef } from 'react'
+import { useRef, useEffect } from 'react'
 import Link from 'next/link'
 import { formatDate, formatCurrency } from '@/lib/format'
 import type { Tables } from '@/types/supabase'
@@ -9,7 +9,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 
 type Trip = Tables<'trips'>
 
-const FALLBACK_ACCENT = '#2d6a4f'
+export const FALLBACK_ACCENT = '#2d6a4f'
 
 // ---------------------------------------------------------------------------
 // BackButton
@@ -46,6 +46,13 @@ export function TripHeroImage({
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
+  // Fallback when no image — must be in useEffect to avoid render-phase state update
+  useEffect(() => {
+    if (!trip.image_url) {
+      onAccentColor(FALLBACK_ACCENT)
+    }
+  }, [trip.image_url, onAccentColor])
+
   const imageFilter = muted ? 'opacity(0.5) grayscale(1)' : undefined
   const badgeBg = muted ? 'rgba(0,0,0,0.15)' : 'var(--brand-forest)'
   const badgeColor = muted ? 'rgba(255,255,255,0.6)' : 'rgba(255,255,255,0.85)'
@@ -60,17 +67,20 @@ export function TripHeroImage({
       const img = e.currentTarget
       const canvas = canvasRef.current
       if (!canvas) { onAccentColor(FALLBACK_ACCENT); return }
-      canvas.width = img.naturalWidth
-      canvas.height = img.naturalHeight
-      const ctx = canvas.getContext('2d')
-      if (!ctx) { onAccentColor(FALLBACK_ACCENT); return }
-      ctx.drawImage(img, 0, 0)
-      // Sample a 50x50 block from the bottom-left (where gradient overlay is darkest)
+
       const sampleX = 0
       const sampleY = Math.max(0, img.naturalHeight - 60)
       const sampleW = Math.min(50, img.naturalWidth)
-      const sampleH = Math.min(50, 60)
-      const data = ctx.getImageData(sampleX, sampleY, sampleW, sampleH).data
+      const sampleH = Math.min(50, img.naturalHeight - sampleY)
+
+      canvas.width = sampleW
+      canvas.height = sampleH
+      const ctx = canvas.getContext('2d')
+      if (!ctx) { onAccentColor(FALLBACK_ACCENT); return }
+
+      ctx.drawImage(img, sampleX, sampleY, sampleW, sampleH, 0, 0, sampleW, sampleH)
+      const data = ctx.getImageData(0, 0, sampleW, sampleH).data
+
       let r = 0, g = 0, b = 0, count = 0
       for (let i = 0; i < data.length; i += 4) {
         r += data[i]; g += data[i + 1]; b += data[i + 2]; count++
@@ -97,9 +107,7 @@ export function TripHeroImage({
   }
 
   return (
-    <div
-      style={{ backgroundColor: 'var(--brand-forest)', borderRadius: '16px 16px 0 0', overflow: 'hidden' }}
-    >
+    <div style={{ backgroundColor: 'var(--brand-forest)' }}>
       {/* Hidden canvas for pixel sampling — never rendered visually */}
       <canvas ref={canvasRef} style={{ display: 'none' }} aria-hidden="true" />
 
@@ -114,10 +122,12 @@ export function TripHeroImage({
             className="w-full h-full object-cover"
             style={imageFilter ? { filter: imageFilter } : undefined}
             onLoad={handleImageLoad}
-            onError={() => onAccentColor(FALLBACK_ACCENT)}
+            onError={e => {
+              onAccentColor(FALLBACK_ACCENT)
+              e.currentTarget.style.display = 'none'
+            }}
           />
         ) : null}
-        {!trip.image_url && (() => { onAccentColor(FALLBACK_ACCENT); return null })()}
         {/* Gradient overlay */}
         <div
           className="absolute inset-0 pointer-events-none"
@@ -175,13 +185,7 @@ export function TripDetail({
   const { t } = useLanguage()
 
   return (
-    <div
-      style={{
-        backgroundColor: 'var(--bg-card)',
-        border: '1px solid var(--border-default)',
-        borderRadius: '0 0 16px 16px',
-      }}
-    >
+    <div style={{ backgroundColor: 'var(--bg-card)' }}>
       {/* Countdown strip — only when countdown prop is provided */}
       {countdown !== undefined && (
         <div

--- a/app/(dashboard)/trips/[id]/components/shared.tsx
+++ b/app/(dashboard)/trips/[id]/components/shared.tsx
@@ -44,6 +44,7 @@ export function TripHeroImage({
   muted?: boolean
   onAccentColor: (hex: string) => void
 }) {
+  const { t } = useLanguage()
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   // Fallback when no image — must be in useEffect to avoid render-phase state update
@@ -151,7 +152,7 @@ export function TripHeroImage({
               </span>
             )}
             <span className="text-xs" style={{ color: 'rgba(255,255,255,0.65)' }}>
-              {days} day{days !== 1 ? 's' : ''}
+              {days} {t(days !== 1 ? 'trips.dayPlural' : 'trips.daySingular')}
             </span>
           </div>
           <h1

--- a/app/(dashboard)/trips/[id]/components/shared.tsx
+++ b/app/(dashboard)/trips/[id]/components/shared.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRef } from 'react'
 import Link from 'next/link'
 import { formatDate, formatCurrency } from '@/lib/format'
 import type { Tables } from '@/types/supabase'
@@ -8,6 +9,11 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 
 type Trip = Tables<'trips'>
 
+const FALLBACK_ACCENT = '#2d6a4f'
+
+// ---------------------------------------------------------------------------
+// BackButton
+// ---------------------------------------------------------------------------
 export function BackButton() {
   return (
     <Link
@@ -23,49 +29,95 @@ export function BackButton() {
   )
 }
 
-export function TripHero({
+// ---------------------------------------------------------------------------
+// TripHeroImage
+// Renders the 280px image pane. Samples canvas to derive accent colour,
+// calls onAccentColor with blended hex. Falls back to FALLBACK_ACCENT on
+// cross-origin SecurityError or missing image.
+// ---------------------------------------------------------------------------
+export function TripHeroImage({
   trip,
-  profile,
   muted = false,
+  onAccentColor,
 }: {
   trip: Trip
-  profile: TripProfile
   muted?: boolean
+  onAccentColor: (hex: string) => void
 }) {
-  const { t } = useLanguage()
-  const days = Math.round(
-    (new Date(trip.end_date).getTime() - new Date(trip.start_date).getTime()) / 86400000
-  )
+  const canvasRef = useRef<HTMLCanvasElement>(null)
 
   const imageFilter = muted ? 'opacity(0.5) grayscale(1)' : undefined
   const badgeBg = muted ? 'rgba(0,0,0,0.15)' : 'var(--brand-forest)'
   const badgeColor = muted ? 'rgba(255,255,255,0.6)' : 'rgba(255,255,255,0.85)'
   const tealBadgeBg = muted ? 'rgba(0,0,0,0.12)' : 'var(--brand-teal)'
 
+  const days = Math.round(
+    (new Date(trip.end_date).getTime() - new Date(trip.start_date).getTime()) / 86400000
+  )
+
+  function handleImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
+    try {
+      const img = e.currentTarget
+      const canvas = canvasRef.current
+      if (!canvas) { onAccentColor(FALLBACK_ACCENT); return }
+      canvas.width = img.naturalWidth
+      canvas.height = img.naturalHeight
+      const ctx = canvas.getContext('2d')
+      if (!ctx) { onAccentColor(FALLBACK_ACCENT); return }
+      ctx.drawImage(img, 0, 0)
+      // Sample a 50x50 block from the bottom-left (where gradient overlay is darkest)
+      const sampleX = 0
+      const sampleY = Math.max(0, img.naturalHeight - 60)
+      const sampleW = Math.min(50, img.naturalWidth)
+      const sampleH = Math.min(50, 60)
+      const data = ctx.getImageData(sampleX, sampleY, sampleW, sampleH).data
+      let r = 0, g = 0, b = 0, count = 0
+      for (let i = 0; i < data.length; i += 4) {
+        r += data[i]; g += data[i + 1]; b += data[i + 2]; count++
+      }
+      if (count === 0) { onAccentColor(FALLBACK_ACCENT); return }
+      r = Math.round(r / count)
+      g = Math.round(g / count)
+      b = Math.round(b / count)
+      // Blend toward forest to keep it on-brand
+      const blendR = Math.round(r * 0.6 + 0x2d * 0.4)
+      const blendG = Math.round(g * 0.6 + 0x6a * 0.4)
+      const blendB = Math.round(b * 0.6 + 0x4f * 0.4)
+      // Clamp HSL luminance to [30, 55] range
+      const hex = clampLuminance(blendR, blendG, blendB, 30, 55)
+      onAccentColor(hex)
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'SecurityError') {
+        // cross-origin canvas taint — silent fallback
+        onAccentColor(FALLBACK_ACCENT)
+      } else {
+        onAccentColor(FALLBACK_ACCENT)
+      }
+    }
+  }
+
   return (
     <div
-      className="rounded-2xl overflow-hidden"
-      style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+      style={{ backgroundColor: 'var(--brand-forest)', borderRadius: '16px 16px 0 0', overflow: 'hidden' }}
     >
-      {/* Hero image area — 280px with gradient overlay */}
-      <div
-        className="relative w-full"
-        style={{ height: 280, backgroundColor: 'var(--brand-forest)' }}
-      >
-        {trip.image_url && (
+      {/* Hidden canvas for pixel sampling — never rendered visually */}
+      <canvas ref={canvasRef} style={{ display: 'none' }} aria-hidden="true" />
+
+      <div className="relative w-full" style={{ height: 280 }}>
+        {trip.image_url ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={trip.image_url}
             alt=""
             aria-hidden="true"
+            crossOrigin="anonymous"
             className="w-full h-full object-cover"
             style={imageFilter ? { filter: imageFilter } : undefined}
-            onError={e => {
-              const el = e.currentTarget
-              el.style.display = 'none'
-            }}
+            onLoad={handleImageLoad}
+            onError={() => onAccentColor(FALLBACK_ACCENT)}
           />
-        )}
+        ) : null}
+        {!trip.image_url && (() => { onAccentColor(FALLBACK_ACCENT); return null })()}
         {/* Gradient overlay */}
         <div
           className="absolute inset-0 pointer-events-none"
@@ -100,8 +152,68 @@ export function TripHero({
           </h1>
         </div>
       </div>
+    </div>
+  )
+}
 
-      {/* Content below image */}
+// ---------------------------------------------------------------------------
+// TripDetail
+// Renders optional countdown strip + body content (dates, cost, description,
+// location, inclusions). accentColor drives the strip bg.
+// ---------------------------------------------------------------------------
+export function TripDetail({
+  trip,
+  profile,
+  accentColor,
+  countdown,
+}: {
+  trip: Trip
+  profile: TripProfile
+  accentColor: string
+  countdown?: number
+}) {
+  const { t } = useLanguage()
+
+  return (
+    <div
+      style={{
+        backgroundColor: 'var(--bg-card)',
+        border: '1px solid var(--border-default)',
+        borderRadius: '0 0 16px 16px',
+      }}
+    >
+      {/* Countdown strip — only when countdown prop is provided */}
+      {countdown !== undefined && (
+        <div
+          className="w-full px-6 py-3 flex items-center justify-between gap-3"
+          style={{ backgroundColor: accentColor }}
+        >
+          <div className="flex items-baseline gap-2 min-w-0">
+            <span
+              className="font-display font-bold leading-none flex-shrink-0"
+              style={{ fontSize: 'clamp(2rem, 8vw, 3rem)', color: '#fff' }}
+            >
+              {countdown}
+            </span>
+            <span
+              className="text-sm font-medium"
+              style={{ color: 'rgba(255,255,255,0.85)', whiteSpace: 'nowrap' }}
+            >
+              {t('trips.daysToGo')}
+            </span>
+          </div>
+          {countdown === 0 && (
+            <span
+              className="text-xs font-semibold px-3 py-1 rounded-full flex-shrink-0"
+              style={{ backgroundColor: 'rgba(255,255,255,0.2)', color: '#fff' }}
+            >
+              {t('trips.todayBadge')}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Body content */}
       <div className="px-6 pt-5 pb-8">
         {profile.role !== 'guest' && (
           <div className="flex items-center justify-between mb-4">
@@ -167,4 +279,38 @@ export function TripHero({
       </div>
     </div>
   )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convert RGB to HSL, clamp L to [lMin, lMax], return hex. */
+function clampLuminance(r: number, g: number, b: number, lMin: number, lMax: number): string {
+  const rn = r / 255, gn = g / 255, bn = b / 255
+  const max = Math.max(rn, gn, bn), min = Math.min(rn, gn, bn)
+  const l = (max + min) / 2
+  const d = max - min
+  let h = 0, s = 0
+  if (d !== 0) {
+    s = d / (1 - Math.abs(2 * l - 1))
+    switch (max) {
+      case rn: h = ((gn - bn) / d + 6) % 6; break
+      case gn: h = (bn - rn) / d + 2; break
+      default: h = (rn - gn) / d + 4
+    }
+    h /= 6
+  }
+  const clampedL = Math.min(lMax, Math.max(lMin, Math.round(l * 100))) / 100
+  return hslToHex(h, s, clampedL)
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  const a = s * Math.min(l, 1 - l)
+  const f = (n: number) => {
+    const k = (n + h * 12) % 12
+    const color = l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1))
+    return Math.round(255 * color).toString(16).padStart(2, '0')
+  }
+  return `#${f(0)}${f(8)}${f(4)}`
 }

--- a/lib/i18n/domains/trips.ts
+++ b/lib/i18n/domains/trips.ts
@@ -42,4 +42,6 @@ export const trips = {
   'trips.uploading':          { en: 'Uploading…',              bg: 'Качва се…'                          },
   'trips.delete':             { en: 'Delete',                  bg: 'Изтрий'                             },
   'trips.inclusions':         { en: "What's Included",         bg: 'Включено в цената'                  },
+  'trips.daySingular':        { en: 'day',                     bg: 'ден'                                },
+  'trips.dayPlural':          { en: 'days',                    bg: 'дни'                                },
 } as const


### PR DESCRIPTION
# [2505-FEAT-361] Trip hero redesign — split image/detail, dynamic accent countdown strip

## Summary

Replaces the old monolithic `TripHero` with two composable components:

- **`TripHeroImage`** — 280px image pane with canvas pixel sampling. Blends sampled colour 60/40 toward `#2d6a4f`, clamps HSL luminance to [30, 55], calls `onAccentColor` after load. Silent fallback on cross-origin `SecurityError` or missing image.
- **`TripDetail`** — detail pane (dates, cost, description, location, inclusions) with an optional full-width countdown strip driven by `accentColor`. Strip only renders when `countdown` prop is provided.

`AttendeeView` threads `accentColor` state from image → detail and passes `daysToGo` as `countdown`. Separate countdown card removed. `PendingView` and `ArchivedView` use the new split without countdown.

## DoD

- [x] `shared.tsx`: `TripHeroImage` and `TripDetail` exported; old `TripHero` deleted
- [x] Canvas sampling with HSL luminance clamp + `SecurityError` silent catch
- [x] Countdown strip renders only when `countdown` prop provided
- [x] `AttendeeView`: separate countdown card removed, accent threaded, `daysToGo` passed as prop
- [x] `PendingView`: migrated, no countdown
- [x] `ArchivedView`: migrated, no countdown
- [x] Countdown strip uses `clamp(2rem, 8vw, 3rem)` font — no overflow at 390px
- [x] No image / cross-origin → fallback `#2d6a4f`, no console error

## Affected Files

- `app/(dashboard)/trips/[id]/components/shared.tsx`
- `app/(dashboard)/trips/[id]/components/AttendeeView.tsx`
- `app/(dashboard)/trips/[id]/components/PendingView.tsx`
- `app/(dashboard)/trips/[id]/components/ArchivedView.tsx`

Closes #361

## Session State
**Status:** DONE
**Completed:**
- [x] All four files implemented on branch
- [x] DoD verified point-by-point
- [x] PR opened
**Next:** Vercel Preview → CI green → merge
