### PR TITLE
[2505-FEAT-375] Tiptap inline image upload — signed URL pattern, toolbar + drag + paste

### DIFF
--- a/app/admin/content/components/CoverImageUploader.tsx
+++ b/app/admin/content/components/CoverImageUploader.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { uploadToSignedUrl } from '@/lib/utils/uploadToSignedUrl'
+import { toast } from 'sonner'
 
 export function CoverImageUploader({
   value,
@@ -21,14 +23,14 @@ export function CoverImageUploader({
     setUploading(true)
     onUploading?.(true)
     try {
-      const fd = new FormData()
-      fd.append('file', file)
-      const res = await fetch('/api/admin/guides/upload', { method: 'POST', body: fd })
-      if (!res.ok) throw new Error((await res.json()).error ?? 'Upload failed')
-      const { url } = await res.json() as { url: string }
+      const url = await uploadToSignedUrl(
+        file,
+        '/api/admin/guides/upload-url/cover',
+        '/api/admin/guides/upload-url/cover-confirm',
+      )
       onChange(url)
     } catch (e) {
-      alert((e as Error).message)
+      toast.error((e as Error).message ?? 'Cover upload failed')
     } finally {
       setUploading(false)
       onUploading?.(false)
@@ -52,7 +54,7 @@ export function CoverImageUploader({
             type="file"
             accept="image/*"
             className="hidden"
-            onChange={e => { const f = e.target.files?.[0]; if (f) handleFileUpload(f) }}
+            onChange={e => { const f = e.target.files?.[0]; if (f) void handleFileUpload(f) }}
           />
         </label>
         {coverFile && !uploading && (

--- a/app/admin/content/components/ImageUploadExtension.ts
+++ b/app/admin/content/components/ImageUploadExtension.ts
@@ -1,0 +1,69 @@
+import { Extension } from '@tiptap/core'
+import { Plugin } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
+import { uploadToSignedUrl } from '@/lib/utils/uploadToSignedUrl'
+import { toast } from 'sonner'
+
+async function uploadAndInsert(file: File, view: EditorView, pos?: number): Promise<void> {
+  try {
+    const url = await uploadToSignedUrl(
+      file,
+      '/api/admin/guides/upload-url',
+      '/api/admin/guides/upload-url/confirm',
+    )
+    const { schema } = view.state
+    const node = schema.nodes.image.create({ src: url })
+    const tr = view.state.tr
+    if (pos !== undefined) {
+      tr.insert(pos, node)
+    } else {
+      tr.replaceSelectionWith(node)
+    }
+    view.dispatch(tr)
+  } catch (e) {
+    toast.error((e as Error).message ?? 'Image upload failed')
+  }
+}
+
+export const ImageUploadExtension = Extension.create({
+  name: 'imageUpload',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        props: {
+          handleDrop(view, event) {
+            const files = Array.from(event.dataTransfer?.files ?? [])
+            const images = files.filter(f => f.type.startsWith('image/'))
+            if (images.length === 0) return false
+
+            event.preventDefault()
+            const coords = view.posAtCoords({ left: event.clientX, top: event.clientY })
+            const pos = coords?.pos
+
+            for (const image of images) {
+              void uploadAndInsert(image, view, pos)
+            }
+            return true
+          },
+
+          handlePaste(view, event) {
+            const items = Array.from(event.clipboardData?.items ?? [])
+            const imageItems = items.filter(
+              item => item.kind === 'file' && item.type.startsWith('image/'),
+            )
+            if (imageItems.length === 0) return false
+
+            event.preventDefault()
+            for (const item of imageItems) {
+              const file = item.getAsFile()
+              if (!file) continue
+              void uploadAndInsert(file, view)
+            }
+            return true
+          },
+        },
+      }),
+    ]
+  },
+})

--- a/app/admin/content/components/ImageUploadExtension.ts
+++ b/app/admin/content/components/ImageUploadExtension.ts
@@ -4,7 +4,12 @@ import type { EditorView } from '@tiptap/pm/view'
 import { uploadToSignedUrl } from '@/lib/utils/uploadToSignedUrl'
 import { toast } from 'sonner'
 
-async function uploadAndInsert(file: File, view: EditorView, pos?: number): Promise<void> {
+/**
+ * Upload a file and insert an image node at the given position (or current
+ * selection if pos is undefined). Exported so TiptapEditor can reuse it
+ * for the toolbar file-picker path without duplicating the upload call.
+ */
+export async function uploadAndInsert(file: File, view: EditorView, pos?: number): Promise<void> {
   try {
     const url = await uploadToSignedUrl(
       file,

--- a/app/admin/content/components/TiptapEditor.tsx
+++ b/app/admin/content/components/TiptapEditor.tsx
@@ -8,8 +8,7 @@ import Placeholder from '@tiptap/extension-placeholder'
 import type { JSONContent } from '@tiptap/core'
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { uploadToSignedUrl } from '@/lib/utils/uploadToSignedUrl'
-import { ImageUploadExtension } from './ImageUploadExtension'
+import { ImageUploadExtension, uploadAndInsert } from './ImageUploadExtension'
 
 const TOOLBAR_BTN =
   'px-2 py-1 rounded text-xs font-semibold border transition-colors hover:bg-black/5 disabled:opacity-30'
@@ -177,14 +176,12 @@ export function TiptapEditor({
     if (!editor) return
     setImageUploading(true)
     try {
-      const url = await uploadToSignedUrl(
-        file,
-        '/api/admin/guides/upload-url',
-        '/api/admin/guides/upload-url/confirm',
-      )
-      editor.chain().focus().setImage({ src: url }).run()
-    } catch (e) {
-      toast.error((e as Error).message ?? 'Image upload failed')
+      // Reuse uploadAndInsert from the extension — same upload endpoints,
+      // same insertion logic, no duplication.
+      await uploadAndInsert(file, editor.view)
+    } catch {
+      // uploadAndInsert handles its own toast.error; catch here only to
+      // ensure setImageUploading(false) runs in the finally block.
     } finally {
       setImageUploading(false)
     }

--- a/app/admin/content/components/TiptapEditor.tsx
+++ b/app/admin/content/components/TiptapEditor.tsx
@@ -6,12 +6,23 @@ import Link from '@tiptap/extension-link'
 import Image from '@tiptap/extension-image'
 import Placeholder from '@tiptap/extension-placeholder'
 import type { JSONContent } from '@tiptap/core'
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { uploadToSignedUrl } from '@/lib/utils/uploadToSignedUrl'
+import { ImageUploadExtension } from './ImageUploadExtension'
 
 const TOOLBAR_BTN =
   'px-2 py-1 rounded text-xs font-semibold border transition-colors hover:bg-black/5 disabled:opacity-30'
 
-function Toolbar({ editor }: { editor: ReturnType<typeof useEditor> }) {
+function Toolbar({
+  editor,
+  onImageClick,
+  imageUploading,
+}: {
+  editor: ReturnType<typeof useEditor>
+  onImageClick: () => void
+  imageUploading: boolean
+}) {
   if (!editor) return null
   return (
     <div
@@ -51,7 +62,7 @@ function Toolbar({ editor }: { editor: ReturnType<typeof useEditor> }) {
           borderColor: 'var(--border-default)',
           color: editor.isActive('heading', { level: 2 }) ? 'var(--brand-crimson)' : 'var(--text-secondary)',
         }}
-        aria-label="Heading"
+        aria-label="Heading 2"
       >
         H2
       </button>
@@ -109,19 +120,16 @@ function Toolbar({ editor }: { editor: ReturnType<typeof useEditor> }) {
       </button>
       <button
         type="button"
-        onClick={() => {
-          const url = window.prompt('Image URL')
-          if (!url) return
-          editor.chain().focus().setImage({ src: url }).run()
-        }}
+        onClick={onImageClick}
+        disabled={imageUploading}
         className={TOOLBAR_BTN}
         style={{
           borderColor: 'var(--border-default)',
           color: 'var(--text-secondary)',
         }}
-        aria-label="Image"
+        aria-label="Upload image"
       >
-        Image
+        {imageUploading ? '↑' : 'Image'}
       </button>
     </div>
   )
@@ -138,12 +146,16 @@ export function TiptapEditor({
   placeholder?: string
   label?: string
 }): React.JSX.Element {
+  const [imageUploading, setImageUploading] = useState(false)
+  const imageInputRef = useRef<HTMLInputElement>(null)
+
   const editor = useEditor({
     extensions: [
       StarterKit,
       Link.configure({ openOnClick: false }),
-      Image,
+      Image.configure({ inline: false, allowBase64: false }),
       Placeholder.configure({ placeholder: placeholder ?? 'Write here…' }),
+      ImageUploadExtension,
     ],
     content: value ?? undefined,
     onUpdate: ({ editor: ed }) => {
@@ -161,6 +173,23 @@ export function TiptapEditor({
     }
   }, [editor, value])
 
+  async function handleImageFileSelected(file: File) {
+    if (!editor) return
+    setImageUploading(true)
+    try {
+      const url = await uploadToSignedUrl(
+        file,
+        '/api/admin/guides/upload-url',
+        '/api/admin/guides/upload-url/confirm',
+      )
+      editor.chain().focus().setImage({ src: url }).run()
+    } catch (e) {
+      toast.error((e as Error).message ?? 'Image upload failed')
+    } finally {
+      setImageUploading(false)
+    }
+  }
+
   return (
     <div
       className="rounded-xl overflow-hidden border"
@@ -174,11 +203,27 @@ export function TiptapEditor({
           {label}
         </div>
       )}
-      <Toolbar editor={editor} />
+      <Toolbar
+        editor={editor}
+        onImageClick={() => imageInputRef.current?.click()}
+        imageUploading={imageUploading}
+      />
       <EditorContent
         editor={editor}
         className="tiptap-editor min-h-[200px] px-4 py-3 text-sm"
         style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
+      />
+      <input
+        ref={imageInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={e => {
+          const file = e.target.files?.[0]
+          if (file) void handleImageFileSelected(file)
+          // reset so same file can be re-selected
+          e.target.value = ''
+        }}
       />
     </div>
   )

--- a/app/api/admin/guides/upload-url/confirm/route.ts
+++ b/app/api/admin/guides/upload-url/confirm/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { data: caller } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+  if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const body = await req.json() as { path?: string }
+  const { path } = body
+
+  if (!path || typeof path !== 'string') {
+    return NextResponse.json({ error: 'path is required' }, { status: 400 })
+  }
+
+  // Path ownership check — only images/ prefix is valid for body images
+  if (!path.startsWith('images/')) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+  }
+
+  const { data } = supabase.storage.from('guide-covers').getPublicUrl(path)
+
+  return NextResponse.json({ url: data.publicUrl })
+}

--- a/app/api/admin/guides/upload-url/cover-confirm/route.ts
+++ b/app/api/admin/guides/upload-url/cover-confirm/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { data: caller } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+  if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const body = await req.json() as { path?: string }
+  const { path } = body
+
+  if (!path || typeof path !== 'string') {
+    return NextResponse.json({ error: 'path is required' }, { status: 400 })
+  }
+
+  // Path ownership check — only covers/ prefix is valid for cover images
+  if (!path.startsWith('covers/')) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+  }
+
+  const { data } = supabase.storage.from('guide-covers').getPublicUrl(path)
+
+  return NextResponse.json({ url: data.publicUrl })
+}

--- a/app/api/admin/guides/upload-url/cover/route.ts
+++ b/app/api/admin/guides/upload-url/cover/route.ts
@@ -18,7 +18,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
 
   const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
-  const ext = filename.split('.').pop() ?? 'bin'
+  const parts = filename.split('.')
+  const ext = parts.length > 1 ? parts.pop()! : 'bin'
   const path = `covers/${randomUUID()}.${ext}`
 
   const { data, error } = await supabase.storage

--- a/app/api/admin/guides/upload-url/cover/route.ts
+++ b/app/api/admin/guides/upload-url/cover/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { randomUUID } from 'crypto'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { data: caller } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+  if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
+  const ext = filename.split('.').pop() ?? 'bin'
+  const path = `covers/${randomUUID()}.${ext}`
+
+  const { data, error } = await supabase.storage
+    .from('guide-covers')
+    .createSignedUploadUrl(path)
+
+  if (error || !data) {
+    return NextResponse.json({ error: error?.message ?? 'Failed to create signed URL' }, { status: 500 })
+  }
+
+  return NextResponse.json({ signedUrl: data.signedUrl, path })
+}

--- a/app/api/admin/guides/upload-url/route.ts
+++ b/app/api/admin/guides/upload-url/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { randomUUID } from 'crypto'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { data: caller } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+  if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
+  const ext = filename.split('.').pop() ?? 'bin'
+  const path = `images/${randomUUID()}.${ext}`
+
+  const { data, error } = await supabase.storage
+    .from('guide-covers')
+    .createSignedUploadUrl(path)
+
+  if (error || !data) {
+    return NextResponse.json({ error: error?.message ?? 'Failed to create signed URL' }, { status: 500 })
+  }
+
+  return NextResponse.json({ signedUrl: data.signedUrl, path })
+}

--- a/app/api/admin/guides/upload-url/route.ts
+++ b/app/api/admin/guides/upload-url/route.ts
@@ -18,7 +18,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
 
   const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
-  const ext = filename.split('.').pop() ?? 'bin'
+  const parts = filename.split('.')
+  const ext = parts.length > 1 ? parts.pop()! : 'bin'
   const path = `images/${randomUUID()}.${ext}`
 
   const { data, error } = await supabase.storage

--- a/app/api/admin/guides/upload/route.ts
+++ b/app/api/admin/guides/upload/route.ts
@@ -1,39 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@clerk/nextjs/server'
-import { createServiceClient } from '@/lib/supabase/service'
-
-export const dynamic = 'force-dynamic'
-
-export async function POST(req: NextRequest): Promise<NextResponse> {
-  const { userId } = await auth()
-  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-
-  const supabase = createServiceClient()
-  const { data: caller } = await supabase.from('profiles').select('role').eq('clerk_id', userId).single()
-  if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-
-  const formData = await req.formData()
-  const file = formData.get('file') as File | null
-  if (!file) return NextResponse.json({ error: 'No file provided' }, { status: 400 })
-
-  const ext = file.name.split('.').pop() ?? 'bin'
-  // ?type=image uploads go to images/ prefix; everything else is a cover
-  const type = req.nextUrl.searchParams.get('type')
-  const prefix = type === 'image' ? 'images' : 'covers'
-  const fileName = `${prefix}/${Date.now()}.${ext}`
-
-  const arrayBuffer = await file.arrayBuffer()
-  const buffer = Buffer.from(arrayBuffer)
-
-  const { error } = await supabase.storage
-    .from('guide-covers')
-    .upload(fileName, buffer, { contentType: file.type, upsert: true })
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
-
-  const { data: { publicUrl } } = supabase.storage
-    .from('guide-covers')
-    .getPublicUrl(fileName)
-
-  return NextResponse.json({ url: publicUrl })
-}
+// DELETED — replaced by signed URL pair:
+// GET  /api/admin/guides/upload-url         (body images)
+// POST /api/admin/guides/upload-url/confirm
+// GET  /api/admin/guides/upload-url/cover   (cover images)
+// POST /api/admin/guides/upload-url/cover-confirm
+//
+// This stub prevents a 404 build error if any stale import exists.
+// Safe to delete once Vercel confirms no remaining callers.
+export {}

--- a/lib/utils/uploadToSignedUrl.ts
+++ b/lib/utils/uploadToSignedUrl.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared signed-URL upload utility.
+ * Sequence: GET urlEndpoint?filename=X → { signedUrl, path } →
+ *           PUT file to signedUrl (raw bytes, no JSON) →
+ *           POST confirmEndpoint with { path } → { url }
+ *
+ * Returns the final public URL. Throws on any failure.
+ * No React state — callers manage their own loading state.
+ */
+export async function uploadToSignedUrl(
+  file: File,
+  urlEndpoint: string,
+  confirmEndpoint: string,
+): Promise<string> {
+  // Step 1: get signed upload URL
+  const urlRes = await fetch(
+    `${urlEndpoint}?filename=${encodeURIComponent(file.name)}`,
+  )
+  if (!urlRes.ok) {
+    const err = await urlRes.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error ?? 'Failed to get upload URL')
+  }
+  const { signedUrl, path } = await urlRes.json() as { signedUrl: string; path: string }
+
+  // Step 2: PUT file bytes directly to storage — server never touches the bytes
+  const putRes = await fetch(signedUrl, {
+    method: 'PUT',
+    body: file,
+    headers: { 'Content-Type': file.type },
+  })
+  if (!putRes.ok) throw new Error('Storage upload failed')
+
+  // Step 3: confirm and get public URL
+  const confirmRes = await fetch(confirmEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path }),
+  })
+  if (!confirmRes.ok) {
+    const err = await confirmRes.json().catch(() => ({}))
+    throw new Error((err as { error?: string }).error ?? 'Failed to confirm upload')
+  }
+  const { url } = await confirmRes.json() as { url: string }
+  if (!url) throw new Error('No URL returned from confirm')
+
+  return url
+}

--- a/supabase/migrations/20260515_002_guide_covers_admin_insert_policy.sql
+++ b/supabase/migrations/20260515_002_guide_covers_admin_insert_policy.sql
@@ -1,0 +1,13 @@
+-- Allow admins to upload to guide-covers bucket via signed URL (direct browser PUT).
+-- Mirrors the trip_attachments_admin_insert pattern.
+-- SELECT policy already exists ("Public read guide-covers").
+-- DELETE/UPDATE not needed — signed URL flow PUTs a new uuid-based path each time.
+
+CREATE POLICY "guide_covers_admin_insert"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'guide-covers'
+  AND is_admin()
+);


### PR DESCRIPTION
## Summary

Replaces the `window.prompt('Image URL')` stub and the FormData proxy route with a proper signed URL upload flow. File bytes go browser → Supabase Storage directly — Next.js server never holds image data in memory.

Covers three entry points in `TiptapEditor`: toolbar button, drag-and-drop into the editor, and paste from clipboard. Also migrates `CoverImageUploader` off the old proxy route to the same pattern.

Introduces `lib/utils/uploadToSignedUrl.ts` as the canonical shared upload utility for all future Tiptap/editor surfaces.

Closes #375

---

## What changed

**New routes**
- `GET /api/admin/guides/upload-url` — issues signed URL for body images (`images/` prefix)
- `POST /api/admin/guides/upload-url/confirm` — returns public URL, verifies `images/` prefix
- `GET /api/admin/guides/upload-url/cover` — issues signed URL for cover images (`covers/` prefix)
- `POST /api/admin/guides/upload-url/cover-confirm` — returns public URL, verifies `covers/` prefix

**New files**
- `lib/utils/uploadToSignedUrl.ts` — shared 3-step upload util (GET signed URL → PUT bytes → POST confirm)
- `app/admin/content/components/ImageUploadExtension.ts` — Tiptap ProseMirror plugin handling drop + paste

**Modified**
- `TiptapEditor.tsx` — toolbar Image button uses file picker + signed URL; `Image.configure({ allowBase64: false })`; `ImageUploadExtension` added
- `CoverImageUploader.tsx` — migrated from `fetch POST /api/admin/guides/upload` to `uploadToSignedUrl`

**Stubbed out**
- `app/api/admin/guides/upload/route.ts` — export stub with redirect comment; no active callers remain

---

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] `app/api/admin/guides/upload-url/route.ts` — GET signed URL for body images
- [x] `app/api/admin/guides/upload-url/confirm/route.ts` — POST confirm body images
- [x] `app/api/admin/guides/upload-url/cover/route.ts` — GET signed URL for covers
- [x] `app/api/admin/guides/upload-url/cover-confirm/route.ts` — POST confirm covers
- [x] `lib/utils/uploadToSignedUrl.ts` — shared upload utility
- [x] `app/admin/content/components/ImageUploadExtension.ts` — drop + paste handler
- [x] `app/admin/content/components/TiptapEditor.tsx` — toolbar + extension wired up
- [x] `app/admin/content/components/CoverImageUploader.tsx` — migrated to signed URL
- [x] Old proxy route stubbed out
**Next:** Verify Vercel Preview build green, test image upload in all three entry points (toolbar, drag, paste) and cover image upload.