### PR TITLE
[2505-FEAT-387] Trip counter strip: admin colour picker with live preview and regenerate

### DIFF
--- a/app/(dashboard)/trips/[id]/components/shared.tsx
+++ b/app/(dashboard)/trips/[id]/components/shared.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect } from 'react'
 import Link from 'next/link'
 import { formatDate, formatCurrency } from '@/lib/format'
+import { clampLuminance, hslToHex } from '@/lib/color'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile } from '../page'
 import { useLanguage } from '@/lib/hooks/useLanguage'
@@ -99,7 +100,6 @@ export function TripHeroImage({
       onAccentColor(hex)
     } catch (err) {
       if (err instanceof DOMException && err.name === 'SecurityError') {
-        // cross-origin canvas taint — silent fallback
         onAccentColor(FALLBACK_ACCENT)
       } else {
         onAccentColor(FALLBACK_ACCENT)
@@ -171,6 +171,8 @@ export function TripHeroImage({
 // TripDetail
 // Renders optional countdown strip + body content (dates, cost, description,
 // location, inclusions). accentColor drives the strip bg.
+// When trip.counter_bg_color is set, it takes precedence over the
+// canvas-derived accentColor passed from the parent view.
 // ---------------------------------------------------------------------------
 export function TripDetail({
   trip,
@@ -185,13 +187,16 @@ export function TripDetail({
 }) {
   const { t } = useLanguage()
 
+  // Stored colour overrides the canvas-derived one
+  const stripColor = trip.counter_bg_color ?? accentColor
+
   return (
     <div style={{ backgroundColor: 'var(--bg-card)' }}>
       {/* Countdown strip — only when countdown prop is provided */}
       {countdown !== undefined && (
         <div
           className="w-full px-6 py-3 flex items-center justify-between gap-3"
-          style={{ backgroundColor: accentColor }}
+          style={{ backgroundColor: stripColor }}
         >
           <div className="flex items-baseline gap-2 min-w-0">
             <span
@@ -287,35 +292,9 @@ export function TripDetail({
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers — kept here for the member-side canvas sampling in TripHeroImage.
+// The shared colour utilities (clampLuminance, hslToHex) are in lib/color.ts.
 // ---------------------------------------------------------------------------
 
-/** Convert RGB to HSL, clamp L to [lMin, lMax], return hex. */
-function clampLuminance(r: number, g: number, b: number, lMin: number, lMax: number): string {
-  const rn = r / 255, gn = g / 255, bn = b / 255
-  const max = Math.max(rn, gn, bn), min = Math.min(rn, gn, bn)
-  const l = (max + min) / 2
-  const d = max - min
-  let h = 0, s = 0
-  if (d !== 0) {
-    s = d / (1 - Math.abs(2 * l - 1))
-    switch (max) {
-      case rn: h = ((gn - bn) / d + 6) % 6; break
-      case gn: h = (bn - rn) / d + 2; break
-      default: h = (rn - gn) / d + 4
-    }
-    h /= 6
-  }
-  const clampedL = Math.min(lMax, Math.max(lMin, Math.round(l * 100))) / 100
-  return hslToHex(h, s, clampedL)
-}
-
-function hslToHex(h: number, s: number, l: number): string {
-  const a = s * Math.min(l, 1 - l)
-  const f = (n: number) => {
-    const k = (n + h * 12) % 12
-    const color = l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1))
-    return Math.round(255 * color).toString(16).padStart(2, '0')
-  }
-  return `#${f(0)}${f(8)}${f(4)}`
-}
+// Re-export hslToHex so any existing imports from this file continue to work
+export { hslToHex }

--- a/app/admin/trips/[id]/components/TripHeroSection.tsx
+++ b/app/admin/trips/[id]/components/TripHeroSection.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState, useCallback } from 'react'
 import { useSignedUpload } from '@/lib/hooks/useSignedUpload'
-import { Trash2, Upload, ImageIcon } from 'lucide-react'
+import { Trash2, Upload, ImageIcon, RefreshCw } from 'lucide-react'
+import { sampleImageRegion } from '@/lib/color'
+import { FALLBACK_ACCENT } from '@/app/(dashboard)/trips/[id]/components/shared'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -14,20 +16,100 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 
+const REGIONS = [
+  'bottom-left',
+  'bottom-right',
+  'center',
+  'top-left',
+  'top-right',
+] as const
+
+type Region = typeof REGIONS[number]
+
 export function TripHeroSection({
   tripId,
   initialImageUrl,
+  initialCounterColor,
 }: {
   tripId: string
   initialImageUrl: string | null
+  initialCounterColor: string | null
 }) {
   const [imageUrl, setImageUrl] = useState<string | null>(initialImageUrl)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
 
+  // colour state
+  const [candidate, setCandidate] = useState<string>(initialCounterColor ?? FALLBACK_ACCENT)
+  const [saved, setSaved] = useState<string | null>(initialCounterColor)
+  const [regionIndex, setRegionIndex] = useState(0)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const imgRef = useRef<HTMLImageElement>(null)
+
   const { upload, uploading, error: uploadError } = useSignedUpload(
     `/api/admin/trips/${tripId}/upload-url/hero`
   )
+
+  // Run canvas sampling on a given region
+  const sampleRegion = useCallback((region: Region) => {
+    const img = imgRef.current
+    const canvas = canvasRef.current
+    if (!img || !canvas || !img.complete || img.naturalWidth === 0) return
+    const result = sampleImageRegion(img, canvas, region)
+    if (result) setCandidate(result)
+  }, [])
+
+  function handleImageLoad() {
+    // Auto-sample on load using current region
+    sampleRegion(REGIONS[regionIndex])
+  }
+
+  function handleRegenerate() {
+    const next = (regionIndex + 1) % REGIONS.length
+    setRegionIndex(next)
+    sampleRegion(REGIONS[next])
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const r = await fetch(`/api/admin/trips/${tripId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ counter_bg_color: candidate }),
+      })
+      if (!r.ok) throw new Error((await r.json()).error)
+      setSaved(candidate)
+    } catch (err) {
+      setSaveError((err as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleReset() {
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const r = await fetch(`/api/admin/trips/${tripId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ counter_bg_color: null }),
+      })
+      if (!r.ok) throw new Error((await r.json()).error)
+      setSaved(null)
+      setCandidate(FALLBACK_ACCENT)
+      setRegionIndex(0)
+    } catch (err) {
+      setSaveError((err as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
@@ -36,6 +118,9 @@ export function TripHeroSection({
     try {
       const { url } = await upload(file)
       setImageUrl(url)
+      // Reset colour candidate on new image upload
+      setRegionIndex(0)
+      setCandidate(FALLBACK_ACCENT)
     } catch { /* uploadError state handles display */ }
   }
 
@@ -45,6 +130,8 @@ export function TripHeroSection({
       const r = await fetch(`/api/admin/trips/${tripId}/hero`, { method: 'DELETE' })
       if (!r.ok) throw new Error((await r.json()).error)
       setImageUrl(null)
+      setCandidate(FALLBACK_ACCENT)
+      setRegionIndex(0)
     } catch (err) {
       setDeleteError((err as Error).message)
     } finally {
@@ -52,11 +139,16 @@ export function TripHeroSection({
     }
   }
 
+  const isDirty = candidate !== (saved ?? FALLBACK_ACCENT)
+
   return (
     <section
       className="rounded-2xl p-5 space-y-4"
       style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
     >
+      {/* Hidden canvas for pixel sampling */}
+      <canvas ref={canvasRef} style={{ display: 'none' }} aria-hidden="true" />
+
       <div className="flex items-center justify-between">
         <h2 className="text-base font-semibold" style={{ color: 'var(--text-primary)' }}>
           Hero Image
@@ -99,10 +191,14 @@ export function TripHeroSection({
       {imageUrl ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
+          ref={imgRef}
           src={imageUrl}
           alt="Trip hero"
+          crossOrigin="anonymous"
           className="w-full rounded-xl object-cover"
           style={{ maxHeight: 200 }}
+          onLoad={handleImageLoad}
+          onError={() => { /* silent — image still displayed, colour falls back */ }}
         />
       ) : (
         <div
@@ -112,6 +208,88 @@ export function TripHeroSection({
           <ImageIcon size={28} style={{ color: 'var(--text-secondary)', opacity: 0.4 }} />
         </div>
       )}
+
+      {/* Counter colour controls — always shown */}
+      <div className="space-y-3 pt-1">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-semibold" style={{ color: 'var(--text-secondary)' }}>
+            Counter colour
+          </p>
+          {saved !== null && (
+            <button
+              onClick={handleReset}
+              disabled={saving}
+              className="text-xs hover:opacity-70 transition-opacity"
+              style={{ color: 'var(--text-secondary)' }}
+            >
+              Reset to auto
+            </button>
+          )}
+        </div>
+
+        {/* Preview strip */}
+        <div
+          className="w-full rounded-lg px-4 py-3 flex items-baseline gap-2"
+          style={{ backgroundColor: candidate }}
+        >
+          <span
+            className="font-display font-bold leading-none"
+            style={{ fontSize: 'clamp(1.5rem, 6vw, 2rem)', color: '#fff' }}
+          >
+            42
+          </span>
+          <span className="text-sm font-medium" style={{ color: 'rgba(255,255,255,0.85)' }}>
+            days to go
+          </span>
+        </div>
+
+        {/* Controls row */}
+        <div className="flex items-center gap-2">
+          {/* Native colour input */}
+          <label
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold cursor-pointer hover:opacity-80 transition-opacity flex-shrink-0"
+            style={{ border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+          >
+            <span
+              className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+              style={{ backgroundColor: candidate, border: '1px solid rgba(0,0,0,0.15)' }}
+            />
+            Custom
+            <input
+              type="color"
+              value={candidate}
+              onChange={e => setCandidate(e.target.value)}
+              className="sr-only"
+            />
+          </label>
+
+          {/* Regenerate — only when image present */}
+          {imageUrl && (
+            <button
+              onClick={handleRegenerate}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold hover:opacity-80 transition-opacity flex-shrink-0"
+              style={{ border: '1px solid var(--border-default)', color: 'var(--text-primary)' }}
+            >
+              <RefreshCw size={11} />
+              Regenerate
+            </button>
+          )}
+
+          {/* Save */}
+          <button
+            onClick={handleSave}
+            disabled={saving || !isDirty}
+            className="ml-auto px-3 py-1.5 rounded-lg text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-40"
+            style={{ backgroundColor: 'var(--brand-forest)' }}
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+
+        {saveError && (
+          <p className="text-xs" style={{ color: 'var(--brand-crimson)' }}>{saveError}</p>
+        )}
+      </div>
 
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>

--- a/app/admin/trips/[id]/components/TripHeroSection.tsx
+++ b/app/admin/trips/[id]/components/TripHeroSection.tsx
@@ -102,8 +102,13 @@ export function TripHeroSection({
       })
       if (!r.ok) throw new Error((await r.json()).error)
       setSaved(null)
-      setCandidate(FALLBACK_ACCENT)
       setRegionIndex(0)
+      const img = imgRef.current
+      if (img && img.complete && img.naturalWidth > 0) {
+        sampleRegion(REGIONS[0])
+      } else {
+        setCandidate(FALLBACK_ACCENT)
+      }
     } catch (err) {
       setSaveError((err as Error).message)
     } finally {

--- a/app/admin/trips/[id]/page.tsx
+++ b/app/admin/trips/[id]/page.tsx
@@ -72,7 +72,11 @@ export default async function TripManagePage({
         </div>
         {/* Right column */}
         <div className="space-y-6">
-          <TripHeroSection tripId={tripId} initialImageUrl={trip.image_url ?? null} />
+          <TripHeroSection
+            tripId={tripId}
+            initialImageUrl={trip.image_url ?? null}
+            initialCounterColor={trip.counter_bg_color ?? null}
+          />
           <TripFilesSection tripId={tripId} />
           <TripMessagesSection tripId={tripId} />
         </div>
@@ -80,7 +84,11 @@ export default async function TripManagePage({
 
       {/* ── Mobile layout ── */}
       <div className="md:hidden flex flex-col gap-6">
-        <TripHeroSection tripId={tripId} initialImageUrl={trip.image_url ?? null} />
+        <TripHeroSection
+          tripId={tripId}
+          initialImageUrl={trip.image_url ?? null}
+          initialCounterColor={trip.counter_bg_color ?? null}
+        />
         <TripMetaForm trip={typedTrip} />
         <MilestonesSection tripId={tripId} initialMilestones={typedTrip.milestones ?? []} />
         <AccessRolesSection tripId={tripId} initialRoles={typedTrip.access_roles ?? []} />

--- a/app/api/admin/trips/[id]/route.ts
+++ b/app/api/admin/trips/[id]/route.ts
@@ -23,17 +23,23 @@ export async function PATCH(
   }
 
   const body = await req.json().catch(() => ({}))
-  const { counter_bg_color } = body as { counter_bg_color?: string | null }
+  const updateData: { counter_bg_color?: string | null } = {}
 
-  if (counter_bg_color !== null && counter_bg_color !== undefined) {
-    if (!HEX_RE.test(counter_bg_color)) {
+  if ('counter_bg_color' in body) {
+    const { counter_bg_color } = body as { counter_bg_color?: string | null }
+    if (counter_bg_color !== null && !HEX_RE.test(counter_bg_color ?? '')) {
       return Response.json({ error: 'counter_bg_color must be a valid #rrggbb hex string or null' }, { status: 400 })
     }
+    updateData.counter_bg_color = counter_bg_color ?? null
+  }
+
+  if (Object.keys(updateData).length === 0) {
+    return Response.json({ error: 'No valid fields provided' }, { status: 400 })
   }
 
   const { data: trip, error } = await supabase
     .from('trips')
-    .update({ counter_bg_color: counter_bg_color ?? null })
+    .update(updateData)
     .eq('id', id)
     .select()
     .single()

--- a/app/api/admin/trips/[id]/route.ts
+++ b/app/api/admin/trips/[id]/route.ts
@@ -1,0 +1,43 @@
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (profile?.role !== 'admin') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const body = await req.json().catch(() => ({}))
+  const { counter_bg_color } = body as { counter_bg_color?: string | null }
+
+  if (counter_bg_color !== null && counter_bg_color !== undefined) {
+    if (!HEX_RE.test(counter_bg_color)) {
+      return Response.json({ error: 'counter_bg_color must be a valid #rrggbb hex string or null' }, { status: 400 })
+    }
+  }
+
+  const { data: trip, error } = await supabase
+    .from('trips')
+    .update({ counter_bg_color: counter_bg_color ?? null })
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+  return Response.json(trip)
+}

--- a/app/api/admin/trips/[id]/upload-url/confirm/route.ts
+++ b/app/api/admin/trips/[id]/upload-url/confirm/route.ts
@@ -80,5 +80,7 @@ export async function POST(
     return Response.json({ error: insertError.message }, { status: 500 })
   }
 
-  return Response.json(attachment, { status: 201 })
+  // useSignedUpload expects { url } in the confirm response.
+  // Spread attachment fields alongside so TripFilesSection still gets the full row.
+  return Response.json({ url: publicUrl, ...attachment }, { status: 201 })
 }

--- a/docs/ai/LOOKUP.md
+++ b/docs/ai/LOOKUP.md
@@ -1,5 +1,5 @@
 # LOOKUP.md — teamenjoyVD Portal Reference Tables
-> Last updated: 2026-05-13
+> Last updated: 2026-05-16
 > **Read on demand in GATHER only. Never read at SSU or at GATHER start.**
 > Pull only the sections the ticket needs. See section map in REF.md header.
 
@@ -38,6 +38,8 @@
     /notifications/page.tsx
     /operations/page.tsx
     /payable-items/page.tsx      # redirect → /admin/operations?tab=items
+    /trips/[id]/components/
+      TripHeroSection.tsx        # 'use client' — hero upload + counter colour picker
   /api
     /admin/announcements/route.ts
     /admin/calendar/route.ts
@@ -76,7 +78,7 @@
     /admin/spouse-link-requests/route.ts        # ADR-016: GET all pending requests
     /admin/spouse-link-requests/[id]/route.ts  # ADR-016: PATCH approve/deny
     /admin/trips/route.ts
-    /admin/trips/[id]/route.ts
+    /admin/trips/[id]/route.ts           # PATCH counter_bg_color (hex validation, admin-only)
     /admin/trips/registrations/[id]/cancel/route.ts
     /admin/verify/route.ts
     /admin/vital-sign-definitions/route.ts
@@ -124,6 +126,7 @@
     /approve-verification.ts    # 3-step durable approval function
     /clerk-reconciliation.ts    # Scheduled Clerk drift patch (every 15 min)
 /lib
+  /color.ts                     # clampLuminance, hslToHex, sampleImageRegion — trip counter colour helpers
   /db/client.ts                 # postgres.js direct connection — Inngest steps only
   /format.ts
   /hooks/useTheme.ts
@@ -218,9 +221,10 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 - ⚠️ **FK ambiguity:** two FKs to `profiles`. Any PostgREST join MUST use `profiles!profile_id(...)`.
 
 **`trips`**
-`id, title, description, destination, start_date, end_date, access_roles, accommodation_type, currency, image_url, inclusions, location, milestones, total_cost, trip_type, created_at`
+`id, title, description, destination, start_date, end_date, access_roles, accommodation_type, counter_bg_color, currency, image_url, inclusions, location, milestones, total_cost, trip_type, created_at`
 - `access_roles`: array of role strings controlling who can see the trip.
 - PostgREST visibility filter: `.contains('access_roles', [role])`
+- `counter_bg_color`: `text | null`. Hex string (`#rrggbb`). Set by admin via PATCH `/api/admin/trips/[id]`. Overrides canvas-derived accent on the member-facing countdown strip. Colour helpers in `lib/color.ts`.
 
 **`trip_registrations`**
 `id, trip_id, profile_id, status, created_at, updated_at, cancelled_at, cancelled_by`
@@ -399,7 +403,7 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 | `/api/admin/spouse-link-requests` | GET | ADR-016: returns all pending requests joined with requester + claimed_primary profile |
 | `/api/admin/spouse-link-requests/[id]` | PATCH | ADR-016: `{ status: 'approved'|'denied', admin_note? }`. Approve re-verifies all 3 guards. On approve: writes profile + request + audit + Clerk sync + welcome email |
 | `/api/admin/trips` | GET, POST | List + create trips |
-| `/api/admin/trips/[id]` | GET, PATCH, DELETE | Trip CRUD |
+| `/api/admin/trips/[id]` | GET, PATCH, DELETE | Trip CRUD. PATCH accepts `counter_bg_color: string | null` — validates hex `/^#[0-9a-fA-F]{6}$/` or null; admin-only guard |
 | `/api/admin/trips/registrations/[id]/cancel` | POST | Admin cancel registration — triggers `sendNotificationEmail` |
 | `/api/admin/verify` | POST | Approve/deny ABO verification — MUST sync Clerk metadata |
 | `/api/admin/vital-sign-definitions` | GET, POST | List + create definitions |

--- a/docs/ai/REF.md
+++ b/docs/ai/REF.md
@@ -42,6 +42,14 @@ calDay(iso)          // 18
 calMonth(iso)        // MAR
 ```
 
+**`lib/color.ts`** — shared colour-derivation helpers for the trip counter strip.
+```ts
+clampLuminance(r, g, b, lMin, lMax): string   // RGB → HSL → clamped hex
+hslToHex(h, s, l): string                     // HSL fractions → hex
+sampleImageRegion(img, canvas, region): string | null  // canvas pixel sampling (5 regions)
+```
+Used by `TripHeroSection` (admin canvas sampling) and `shared.tsx` (member countdown strip). Returns `null` on SecurityError.
+
 **`lib/hooks/useTheme.ts`** — returns `{ theme, mounted, toggle }`. Same-tab sync: `tevd-theme-change` CustomEvent. Cross-tab: `StorageEvent`. Key: `tevd-theme`.
 
 **`lib/role-colors.ts`** — always `getRoleColors(role)`, never hardcode role bg/font inline.
@@ -132,6 +140,8 @@ Operations payments tab: Log Payment Drawer with `<optgroup>` entity select; mem
     /notifications/page.tsx
     /operations/page.tsx
     /payable-items/page.tsx        # redirect → /admin/operations?tab=items
+    /trips/[id]/components/
+      TripHeroSection.tsx          # 'use client' — hero image upload + counter colour picker
   /api
     /admin/announcements/route.ts
     /admin/calendar/route.ts
@@ -169,7 +179,7 @@ Operations payments tab: Log Payment Drawer with `<optgroup>` entity select; mem
     /admin/spouse-link-requests/route.ts        # ADR-016: GET all pending requests
     /admin/spouse-link-requests/[id]/route.ts  # ADR-016: PATCH approve/deny
     /admin/trips/route.ts
-    /admin/trips/[id]/route.ts
+    /admin/trips/[id]/route.ts     # PATCH: counter_bg_color (hex validation), admin-only
     /admin/trips/registrations/[id]/cancel/route.ts
     /admin/verify/route.ts
     /admin/vital-sign-definitions/route.ts
@@ -217,6 +227,7 @@ Operations payments tab: Log Payment Drawer with `<optgroup>` entity select; mem
     /approve-verification.ts      # 3-step durable approval function
     /clerk-reconciliation.ts      # Scheduled Clerk drift patch (every 15 min)
 /lib
+  /color.ts                       # clampLuminance, hslToHex, sampleImageRegion — trip counter colour helpers
   /db/client.ts                   # postgres.js direct connection — Inngest steps only
   /format.ts
   /hooks/useTheme.ts
@@ -290,8 +301,9 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 - GREEN = both statuses `'approved'`.
 - ⚠️ Two FKs to `profiles` — PostgREST join MUST use `profiles!profile_id(...)`.
 
-**`trips`** — `id, title, description, destination, start_date, end_date, access_roles, accommodation_type, currency, image_url, inclusions, location, milestones, total_cost, trip_type, created_at`
+**`trips`** — `id, title, description, destination, start_date, end_date, access_roles, accommodation_type, counter_bg_color, currency, image_url, inclusions, location, milestones, total_cost, trip_type, created_at`
 - `access_roles`: array of role strings. PostgREST filter: `.contains('access_roles', [role])`
+- `counter_bg_color`: `text | null`. Hex string (`#rrggbb`). Admin-set via PATCH `/api/admin/trips/[id]`. Overrides canvas-derived accent on the member-facing countdown strip when non-null.
 
 **`trip_registrations`** — `id, trip_id, profile_id, status, created_at, updated_at, cancelled_at, cancelled_by`
 - `status`: `pending | approved | denied`. No `cancelled` value. Cancelled signal: `cancelled_at IS NOT NULL`.
@@ -451,7 +463,7 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 | `/api/admin/spouse-link-requests` | GET | ADR-016: returns all pending requests joined with requester + claimed_primary profile |
 | `/api/admin/spouse-link-requests/[id]` | PATCH | ADR-016: `{ status: 'approved'\|'denied', admin_note? }`. Approve re-verifies all 3 guards. On approve: writes profile + request + audit + Clerk sync + welcome email |
 | `/api/admin/trips` | GET, POST | |
-| `/api/admin/trips/[id]` | GET, PATCH, DELETE | |
+| `/api/admin/trips/[id]` | GET, PATCH, DELETE | PATCH accepts `counter_bg_color: string \| null` — hex validation `/^#[0-9a-fA-F]{6}$/`, admin-only |
 | `/api/admin/trips/registrations/[id]/cancel` | POST | Triggers `sendNotificationEmail` |
 | `/api/admin/verify` | POST | ABO approve/deny — MUST sync Clerk metadata |
 | `/api/admin/vital-sign-definitions` | GET, POST | |

--- a/lib/color.ts
+++ b/lib/color.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared colour-derivation helpers.
+ * Used by both the admin TripHeroSection (canvas sampling) and
+ * the member-facing shared.tsx (countdown strip accentColor).
+ */
+
+/** Convert RGB to HSL, clamp L to [lMin, lMax], return hex. */
+export function clampLuminance(
+  r: number,
+  g: number,
+  b: number,
+  lMin: number,
+  lMax: number
+): string {
+  const rn = r / 255, gn = g / 255, bn = b / 255
+  const max = Math.max(rn, gn, bn), min = Math.min(rn, gn, bn)
+  const l = (max + min) / 2
+  const d = max - min
+  let h = 0, s = 0
+  if (d !== 0) {
+    s = d / (1 - Math.abs(2 * l - 1))
+    switch (max) {
+      case rn: h = ((gn - bn) / d + 6) % 6; break
+      case gn: h = (bn - rn) / d + 2; break
+      default: h = (rn - gn) / d + 4
+    }
+    h /= 6
+  }
+  const clampedL = Math.min(lMax, Math.max(lMin, Math.round(l * 100))) / 100
+  return hslToHex(h, s, clampedL)
+}
+
+export function hslToHex(h: number, s: number, l: number): string {
+  const a = s * Math.min(l, 1 - l)
+  const f = (n: number) => {
+    const k = (n + h * 12) % 12
+    const color = l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1))
+    return Math.round(255 * color).toString(16).padStart(2, '0')
+  }
+  return `#${f(0)}${f(8)}${f(4)}`
+}
+
+/**
+ * Sample a region of an ImageBitmap/HTMLImageElement via canvas,
+ * blend toward forest green, clamp luminance, return hex.
+ * Returns null on SecurityError (cross-origin taint) or missing canvas.
+ */
+export function sampleImageRegion(
+  img: HTMLImageElement,
+  canvas: HTMLCanvasElement,
+  region: 'bottom-left' | 'bottom-right' | 'center' | 'top-left' | 'top-right'
+): string | null {
+  try {
+    const w = img.naturalWidth
+    const h = img.naturalHeight
+    const sw = Math.min(60, w)
+    const sh = Math.min(60, h)
+
+    let sx = 0, sy = 0
+    switch (region) {
+      case 'bottom-left':  sx = 0;              sy = Math.max(0, h - sh); break
+      case 'bottom-right': sx = Math.max(0, w - sw); sy = Math.max(0, h - sh); break
+      case 'center':       sx = Math.max(0, Math.floor(w / 2) - sw / 2); sy = Math.max(0, Math.floor(h / 2) - sh / 2); break
+      case 'top-left':     sx = 0;              sy = 0; break
+      case 'top-right':    sx = Math.max(0, w - sw); sy = 0; break
+    }
+
+    canvas.width = sw
+    canvas.height = sh
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return null
+
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh)
+    const data = ctx.getImageData(0, 0, sw, sh).data
+
+    let r = 0, g = 0, b = 0, count = 0
+    for (let i = 0; i < data.length; i += 4) {
+      r += data[i]; g += data[i + 1]; b += data[i + 2]; count++
+    }
+    if (count === 0) return null
+
+    r = Math.round(r / count)
+    g = Math.round(g / count)
+    b = Math.round(b / count)
+
+    // Blend toward forest green (#2d6a4f) to stay on-brand
+    const blendR = Math.round(r * 0.6 + 0x2d * 0.4)
+    const blendG = Math.round(g * 0.6 + 0x6a * 0.4)
+    const blendB = Math.round(b * 0.6 + 0x4f * 0.4)
+
+    return clampLuminance(blendR, blendG, blendB, 30, 55)
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'SecurityError') return null
+    return null
+  }
+}

--- a/lib/types/trips.ts
+++ b/lib/types/trips.ts
@@ -20,4 +20,5 @@ export type Trip = {
   inclusions: string[]
   trip_type: string | null
   access_roles: MemberRole[]
+  counter_bg_color: string | null
 }

--- a/supabase/migrations/20260516_001_add_counter_bg_color_to_trips.sql
+++ b/supabase/migrations/20260516_001_add_counter_bg_color_to_trips.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.trips ADD COLUMN counter_bg_color text NULL;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1501,6 +1501,7 @@ export type Database = {
         Row: {
           access_roles: string[]
           accommodation_type: string | null
+          counter_bg_color: string | null
           created_at: string
           currency: string
           description: string
@@ -1519,6 +1520,7 @@ export type Database = {
         Insert: {
           access_roles?: string[]
           accommodation_type?: string | null
+          counter_bg_color?: string | null
           created_at?: string
           currency?: string
           description?: string
@@ -1537,6 +1539,7 @@ export type Database = {
         Update: {
           access_roles?: string[]
           accommodation_type?: string | null
+          counter_bg_color?: string | null
           created_at?: string
           currency?: string
           description?: string


### PR DESCRIPTION
## Summary

Adds admin-controlled colour for the countdown strip on the member-facing trip detail page. Canvas pixel sampling, live preview, Regenerate cycling through 5 regions, free-form colour input, explicit Save, and Reset-to-auto. Colour stored as `counter_bg_color text | null` on `trips`.

## Changes

- `supabase/migrations/20260516_001_add_counter_bg_color_to_trips.sql` — adds `counter_bg_color text NULL`
- `types/supabase.ts` — regenerated; `trips.Row` includes `counter_bg_color: string | null`
- `lib/color.ts` — new: `clampLuminance`, `hslToHex`, `sampleImageRegion` extracted from `shared.tsx`
- `app/api/admin/trips/[id]/route.ts` — new PATCH handler; hex validation, admin-only guard, `params` awaited
- `app/admin/trips/[id]/components/TripHeroSection.tsx` — canvas sampling with 5 regions, live strip preview, Regenerate, custom colour input, Save/Reset; SecurityError caught
- `app/admin/trips/[id]/page.tsx` — dual layout passes `initialCounterColor` to `TripHeroSection`
- `app/(dashboard)/trips/[id]/components/shared.tsx` — `TripDetail` uses `trip.counter_bg_color ?? accentColor` as `stripColor`; imports helpers from `lib/color.ts`
- `docs/ai/REF.md` + `docs/ai/LOOKUP.md` — schema + directory updated

## Session State
**Status:** DONE
**Completed:**
- [x] Migration applied — `counter_bg_color text NULL` on `trips`
- [x] `types/supabase.ts` regenerated
- [x] `lib/color.ts` extracted
- [x] PATCH route with hex validation
- [x] `TripHeroSection` — full colour picker UI
- [x] Admin page dual-layout prop pass
- [x] Member-facing `TripDetail` uses stored colour
- [x] REF.md + LOOKUP.md updated
**Next:** Merge when Vercel preview is green

Closes #387