### PR TITLE
[2605-CHORE-384] Fix upload infrastructure — bucket correctness, server-streaming, ImageUploadExtension parameterisation

### DIFF
--- a/app/admin/content/components/ImageUploadExtension.ts
+++ b/app/admin/content/components/ImageUploadExtension.ts
@@ -4,18 +4,21 @@ import type { EditorView } from '@tiptap/pm/view'
 import { uploadToSignedUrl } from '@/lib/utils/uploadToSignedUrl'
 import { toast } from 'sonner'
 
+export type UploadUrls = { get: string; confirm: string }
+
 /**
  * Upload a file and insert an image node at the given position (or current
  * selection if pos is undefined). Exported so TiptapEditor can reuse it
  * for the toolbar file-picker path without duplicating the upload call.
  */
-export async function uploadAndInsert(file: File, view: EditorView, pos?: number): Promise<void> {
+export async function uploadAndInsert(
+  file: File,
+  view: EditorView,
+  uploadUrls: UploadUrls,
+  pos?: number,
+): Promise<void> {
   try {
-    const url = await uploadToSignedUrl(
-      file,
-      '/api/admin/guides/upload-url',
-      '/api/admin/guides/upload-url/confirm',
-    )
+    const url = await uploadToSignedUrl(file, uploadUrls.get, uploadUrls.confirm)
     const { schema } = view.state
     const node = schema.nodes.image.create({ src: url })
     const tr = view.state.tr
@@ -30,10 +33,20 @@ export async function uploadAndInsert(file: File, view: EditorView, pos?: number
   }
 }
 
-export const ImageUploadExtension = Extension.create({
+export const ImageUploadExtension = Extension.create<{ uploadUrls: UploadUrls }>({
   name: 'imageUpload',
 
+  addOptions() {
+    return {
+      uploadUrls: {
+        get: '/api/admin/guides/upload-url',
+        confirm: '/api/admin/guides/upload-url/confirm',
+      },
+    }
+  },
+
   addProseMirrorPlugins() {
+    const uploadUrls = this.options.uploadUrls
     return [
       new Plugin({
         props: {
@@ -47,7 +60,7 @@ export const ImageUploadExtension = Extension.create({
             const pos = coords?.pos
 
             for (const image of images) {
-              void uploadAndInsert(image, view, pos)
+              void uploadAndInsert(image, view, uploadUrls, pos)
             }
             return true
           },
@@ -63,7 +76,7 @@ export const ImageUploadExtension = Extension.create({
             for (const item of imageItems) {
               const file = item.getAsFile()
               if (!file) continue
-              void uploadAndInsert(file, view)
+              void uploadAndInsert(file, view, uploadUrls)
             }
             return true
           },

--- a/app/admin/content/components/SocialPostForm.tsx
+++ b/app/admin/content/components/SocialPostForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { isCdnUrl, isStorageUrl } from '@/lib/social-thumbnail'
+import { uploadToSignedUrl } from '@/lib/utils/uploadToSignedUrl'
 
 export function InstagramIcon() {
   return (
@@ -79,18 +80,16 @@ export function SocialPostForm({
 
   async function handleFileUpload(file: File) {
     setUploading(true)
+    setPreviewHint(null)
     try {
-      const formData = new FormData()
-      formData.append('file', file)
-      const res = await fetch('/api/admin/social-posts/upload-thumbnail', {
-        method: 'POST',
-        body: formData,
-      })
-      if (!res.ok) throw new Error('Upload failed')
-      const { url } = await res.json() as { url: string }
+      const url = await uploadToSignedUrl(
+        file,
+        '/api/admin/social-posts/upload-url',
+        '/api/admin/social-posts/upload-url/confirm',
+      )
       setForm(f => ({ ...f, thumbnail_url: url }))
-    } catch {
-      setPreviewHint(t('admin.content.social.previewUnavailable'))
+    } catch (err) {
+      setPreviewHint((err as Error).message ?? t('admin.content.social.previewUnavailable'))
     } finally {
       setUploading(false)
     }

--- a/app/admin/content/components/TiptapEditor.tsx
+++ b/app/admin/content/components/TiptapEditor.tsx
@@ -7,11 +7,16 @@ import Image from '@tiptap/extension-image'
 import Placeholder from '@tiptap/extension-placeholder'
 import type { JSONContent } from '@tiptap/core'
 import { useEffect, useRef, useState } from 'react'
-import { toast } from 'sonner'
 import { ImageUploadExtension, uploadAndInsert } from './ImageUploadExtension'
+import type { UploadUrls } from './ImageUploadExtension'
 
 const TOOLBAR_BTN =
   'px-2 py-1 rounded text-xs font-semibold border transition-colors hover:bg-black/5 disabled:opacity-30'
+
+const GUIDE_BODY_IMAGE_URLS: UploadUrls = {
+  get: '/api/admin/guides/upload-url',
+  confirm: '/api/admin/guides/upload-url/confirm',
+}
 
 function Toolbar({
   editor,
@@ -139,14 +144,18 @@ export function TiptapEditor({
   onChange,
   placeholder,
   label,
+  imageUploadUrls,
 }: {
   value: JSONContent | null
   onChange: (v: JSONContent) => void
   placeholder?: string
   label?: string
+  imageUploadUrls?: UploadUrls
 }): React.JSX.Element {
   const [imageUploading, setImageUploading] = useState(false)
   const imageInputRef = useRef<HTMLInputElement>(null)
+
+  const resolvedUploadUrls = imageUploadUrls ?? GUIDE_BODY_IMAGE_URLS
 
   const editor = useEditor({
     extensions: [
@@ -154,7 +163,7 @@ export function TiptapEditor({
       Link.configure({ openOnClick: false }),
       Image.configure({ inline: false, allowBase64: false }),
       Placeholder.configure({ placeholder: placeholder ?? 'Write here…' }),
-      ImageUploadExtension,
+      ImageUploadExtension.configure({ uploadUrls: resolvedUploadUrls }),
     ],
     content: value ?? undefined,
     onUpdate: ({ editor: ed }) => {
@@ -176,9 +185,8 @@ export function TiptapEditor({
     if (!editor) return
     setImageUploading(true)
     try {
-      // Reuse uploadAndInsert from the extension — same upload endpoints,
-      // same insertion logic, no duplication.
-      await uploadAndInsert(file, editor.view)
+      // Thread resolvedUploadUrls through — covers toolbar path and drop/paste path uniformly.
+      await uploadAndInsert(file, editor.view, resolvedUploadUrls)
     } catch {
       // uploadAndInsert handles its own toast.error; catch here only to
       // ensure setImageUploading(false) runs in the finally block.

--- a/app/api/admin/guides/upload-url/confirm/route.ts
+++ b/app/api/admin/guides/upload-url/confirm/route.ts
@@ -23,12 +23,17 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'path is required' }, { status: 400 })
   }
 
-  // Path ownership check — only images/ prefix is valid for body images
-  if (!path.startsWith('images/')) {
+  // Traversal guard
+  if (path.includes('..')) {
     return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
   }
 
-  const { data } = supabase.storage.from('guide-covers').getPublicUrl(path)
+  // Only body/ prefix is valid for guide body images
+  if (!path.startsWith('body/')) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+  }
+
+  const { data } = supabase.storage.from('guide-images').getPublicUrl(path)
 
   return NextResponse.json({ url: data.publicUrl })
 }

--- a/app/api/admin/guides/upload-url/route.ts
+++ b/app/api/admin/guides/upload-url/route.ts
@@ -20,10 +20,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
   const parts = filename.split('.')
   const ext = parts.length > 1 ? parts.pop()! : 'bin'
-  const path = `images/${randomUUID()}.${ext}`
+  const path = `body/${randomUUID()}.${ext}`
 
   const { data, error } = await supabase.storage
-    .from('guide-covers')
+    .from('guide-images')
     .createSignedUploadUrl(path)
 
   if (error || !data) {

--- a/app/api/admin/social-posts/upload-thumbnail/route.ts
+++ b/app/api/admin/social-posts/upload-thumbnail/route.ts
@@ -1,50 +1,14 @@
-import { auth } from '@clerk/nextjs/server'
-import { createServiceClient } from '@/lib/supabase/service'
-import { requireAdmin } from '@/lib/supabase/guards'
-
-const STORAGE_URL_PREFIX = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/social-thumbnails/`
-
 /**
- * POST /api/admin/social-posts/upload-thumbnail
+ * DEPRECATED — replaced by signed URL flow.
+ * Use GET /api/admin/social-posts/upload-url + PUT (direct to storage) +
+ * POST /api/admin/social-posts/upload-url/confirm instead.
  *
- * Accepts a multipart form with a single `file` field.
- * Uploads to the social-thumbnails Storage bucket using the service role client.
- * Returns { url: string } — the permanent public URL.
+ * This route is kept as a stub to avoid breaking any in-flight requests
+ * during deployment. Remove after next release cycle.
  */
-export async function POST(req: Request) {
-  const { userId } = await auth()
-  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
-
-  const supabase = createServiceClient()
-  const guard = await requireAdmin(userId, supabase)
-  if (guard) return guard
-
-  let formData: FormData
-  try {
-    formData = await req.formData()
-  } catch {
-    return Response.json({ error: 'Invalid form data' }, { status: 400 })
-  }
-
-  const file = formData.get('file')
-  if (!(file instanceof File)) {
-    return Response.json({ error: 'Missing file field' }, { status: 400 })
-  }
-
-  const contentType = file.type || 'image/jpeg'
-  const ext = contentType.includes('png') ? 'png'
-    : contentType.includes('webp') ? 'webp'
-    : contentType.includes('gif') ? 'gif'
-    : 'jpg'
-
-  const filename = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
-  const buffer = await file.arrayBuffer()
-
-  const { error } = await supabase.storage
-    .from('social-thumbnails')
-    .upload(filename, buffer, { contentType, upsert: false })
-
-  if (error) return Response.json({ error: error.message }, { status: 500 })
-
-  return Response.json({ url: `${STORAGE_URL_PREFIX}${filename}` })
+export async function POST() {
+  return Response.json(
+    { error: 'This endpoint is deprecated. Use /api/admin/social-posts/upload-url instead.' },
+    { status: 410 },
+  )
 }

--- a/app/api/admin/social-posts/upload-url/confirm/route.ts
+++ b/app/api/admin/social-posts/upload-url/confirm/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const body = await req.json() as { path?: string }
+  const { path } = body
+
+  if (!path || typeof path !== 'string') {
+    return NextResponse.json({ error: 'path is required' }, { status: 400 })
+  }
+
+  if (path.includes('..')) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+  }
+
+  const { data } = supabase.storage.from('social-thumbnails').getPublicUrl(path)
+
+  return NextResponse.json({ url: data.publicUrl })
+}

--- a/app/api/admin/social-posts/upload-url/route.ts
+++ b/app/api/admin/social-posts/upload-url/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
+import { randomUUID } from 'crypto'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
+  const parts = filename.split('.')
+  const ext = parts.length > 1 ? parts.pop()! : 'bin'
+  const path = `${Date.now()}-${randomUUID()}.${ext}`
+
+  const { data, error } = await supabase.storage
+    .from('social-thumbnails')
+    .createSignedUploadUrl(path)
+
+  if (error || !data) {
+    return NextResponse.json({ error: error?.message ?? 'Failed to create signed URL' }, { status: 500 })
+  }
+
+  return NextResponse.json({ signedUrl: data.signedUrl, path })
+}

--- a/app/api/profile/payments/upload-url/confirm/route.ts
+++ b/app/api/profile/payments/upload-url/confirm/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (!profile) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const body = await req.json() as { path?: string }
+  const { path } = body
+
+  if (!path || typeof path !== 'string') {
+    return NextResponse.json({ error: 'path is required' }, { status: 400 })
+  }
+
+  // Traversal guard
+  if (path.includes('..')) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+  }
+
+  // Ownership check — path must be scoped to caller's own profile id
+  if (!path.startsWith(`${profile.id}/`)) {
+    return NextResponse.json({ error: 'Invalid path' }, { status: 400 })
+  }
+
+  const { data } = supabase.storage.from('trip-proofs').getPublicUrl(path)
+
+  return NextResponse.json({ url: data.publicUrl })
+}

--- a/app/api/profile/payments/upload-url/route.ts
+++ b/app/api/profile/payments/upload-url/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
+import { randomUUID } from 'crypto'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  // Any authenticated member (not just admin) can upload their own proof.
+  // getCallerContext with 'adminOrCore' would be too restrictive;
+  // we just need a resolved profile id — so fetch manually with a role check
+  // that excludes only guest (no profile) or unauthenticated.
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id, role')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (!profile) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
+  const parts = filename.split('.')
+  const ext = parts.length > 1 ? parts.pop()! : 'bin'
+  const path = `${profile.id}/${randomUUID()}.${ext}`
+
+  const { data, error } = await supabase.storage
+    .from('trip-proofs')
+    .createSignedUploadUrl(path)
+
+  if (error || !data) {
+    return NextResponse.json({ error: error?.message ?? 'Failed to create signed URL' }, { status: 500 })
+  }
+
+  return NextResponse.json({ signedUrl: data.signedUrl, path })
+}

--- a/app/api/profile/payments/upload/route.ts
+++ b/app/api/profile/payments/upload/route.ts
@@ -1,34 +1,14 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { auth } from '@clerk/nextjs/server'
-import { createServiceClient } from '@/lib/supabase/service'
-
-export const dynamic = 'force-dynamic'
-
-export async function POST(req: NextRequest) {
-  const { userId } = await auth()
-  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-
-  const formData = await req.formData()
-  const file = formData.get('file') as File | null
-  if (!file) return NextResponse.json({ error: 'No file provided' }, { status: 400 })
-
-  const ext = file.name.split('.').pop() ?? 'bin'
-  const fileName = `${userId}/${Date.now()}.${ext}`
-
-  const arrayBuffer = await file.arrayBuffer()
-  const buffer = Buffer.from(arrayBuffer)
-
-  const supabase = createServiceClient()
-
-  const { error } = await supabase.storage
-    .from('trip-proofs')
-    .upload(fileName, buffer, { contentType: file.type, upsert: true })
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
-
-  const { data: { publicUrl } } = supabase.storage
-    .from('trip-proofs')
-    .getPublicUrl(fileName)
-
-  return NextResponse.json({ url: publicUrl })
+/**
+ * DEPRECATED — replaced by signed URL flow.
+ * Use GET /api/profile/payments/upload-url + PUT (direct to storage) +
+ * POST /api/profile/payments/upload-url/confirm instead.
+ *
+ * This route is kept as a stub to avoid breaking any in-flight requests
+ * during deployment. Remove after next release cycle.
+ */
+export async function POST() {
+  return Response.json(
+    { error: 'This endpoint is deprecated. Use /api/profile/payments/upload-url instead.' },
+    { status: 410 },
+  )
 }

--- a/components/payment/PaymentForm.tsx
+++ b/components/payment/PaymentForm.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatCurrency } from '@/lib/format'
+import { uploadToSignedUrl } from '@/lib/utils/uploadToSignedUrl'
 import type { PayableItem } from './types'
 
 type TripContext    = { context?: 'trip';   tripId: string }
@@ -44,12 +45,11 @@ export function PaymentForm(props: PaymentFormProps) {
       let proof_url: string | null = null
 
       if (file) {
-        const fd = new FormData()
-        fd.append('file', file)
-        const uploadRes = await fetch('/api/profile/payments/upload', { method: 'POST', body: fd })
-        const uploadBody = await uploadRes.json().catch(() => ({}))
-        if (!uploadRes.ok) throw new Error(uploadBody.error ?? 'Upload failed')
-        proof_url = uploadBody.url
+        proof_url = await uploadToSignedUrl(
+          file,
+          '/api/profile/payments/upload-url',
+          '/api/profile/payments/upload-url/confirm',
+        )
       }
 
       const entity =

--- a/supabase/migrations/20260516_002_guide_images_bucket.sql
+++ b/supabase/migrations/20260516_002_guide_images_bucket.sql
@@ -1,0 +1,24 @@
+-- Create guide-images bucket for guide body inline images.
+-- guide-covers remains for cover images only — separate concern, separate bucket.
+-- Mirrors the guide-covers RLS pattern exactly.
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('guide-images', 'guide-images', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Public read
+CREATE POLICY "guide_images_public_read"
+ON storage.objects
+FOR SELECT
+TO public
+USING (bucket_id = 'guide-images');
+
+-- Admin insert (signed URL PUT path)
+CREATE POLICY "guide_images_admin_insert"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'guide-images'
+  AND is_admin()
+);


### PR DESCRIPTION
## Summary

Corrects all known bugs in the upload infrastructure and eliminates the two remaining FormData-streaming routes. No new features.

## Changes

**Guide body image bucket fix**
- `supabase/migrations/20260516_002_guide_images_bucket.sql` — creates `guide-images` bucket (public) + admin insert/select RLS policies matching `guide-covers` pattern; applied via Supabase MCP
- `app/api/admin/guides/upload-url/route.ts` — bucket changed from `guide-covers` to `guide-images`; path prefix changed from `images/` to `body/`
- `app/api/admin/guides/upload-url/confirm/route.ts` — bucket changed from `guide-covers` to `guide-images`; prefix check changed from `images/` to `body/`; `..` traversal guard added

**Parameterise `ImageUploadExtension`**
- `app/admin/content/components/ImageUploadExtension.ts` — `UploadUrls` type exported; `uploadAndInsert` takes `uploadUrls: UploadUrls` param; extension uses `addOptions<{ uploadUrls: UploadUrls }>()` with guide body URLs as default; plugin handlers read from `this.options.uploadUrls`
- `app/admin/content/components/TiptapEditor.tsx` — `imageUploadUrls?: UploadUrls` prop added; module-scope `GUIDE_BODY_IMAGE_URLS` constant; `resolvedUploadUrls` threaded into both `ImageUploadExtension.configure()` and the toolbar `uploadAndInsert` call — both paths covered

**Replace social thumbnail FormData streaming**
- `app/api/admin/social-posts/upload-url/route.ts` (new) — admin auth via `getCallerContext`; signed URL on `social-thumbnails`; path `${Date.now()}-${uuid}.${ext}`
- `app/api/admin/social-posts/upload-url/confirm/route.ts` (new) — admin auth; `..` guard; `getPublicUrl`
- `app/admin/content/components/SocialPostForm.tsx` — `handleFileUpload` uses `uploadToSignedUrl`; no FormData
- `app/api/admin/social-posts/upload-thumbnail/route.ts` — stubbed with 410 response + deprecation comment

**Replace payment proof FormData streaming**
- `app/api/profile/payments/upload-url/route.ts` (new) — member auth (any profile); path `${profile.id}/${uuid}.${ext}`
- `app/api/profile/payments/upload-url/confirm/route.ts` (new) — member auth; `..` guard; ownership check `path.startsWith(profile.id + '/')`; `getPublicUrl`
- `components/payment/PaymentForm.tsx` — `submitMutation` uses `uploadToSignedUrl`; FormData POST removed
- `app/api/profile/payments/upload/route.ts` — stubbed with 410 response + deprecation comment

## Session State
**Status:** DONE
**Completed:**
- [x] Migration applied — `guide-images` bucket + RLS
- [x] Guide body upload routes fixed (correct bucket + path prefix)
- [x] `ImageUploadExtension` parameterised; toolbar path threaded
- [x] Social thumbnail signed URL pair + `SocialPostForm` updated; old route stubbed
- [x] Payment proof signed URL pair + `PaymentForm` updated; old route stubbed
**Next:** Merge when Vercel preview is green

Closes #384