### PR TITLE
[2605-FEAT-385] Tiptap for trips description + TiptapEditor reuse

### DIFF
--- a/app/admin/content/components/ImageUploadExtension.ts
+++ b/app/admin/content/components/ImageUploadExtension.ts
@@ -4,18 +4,23 @@ import type { EditorView } from '@tiptap/pm/view'
 import { uploadToSignedUrl } from '@/lib/utils/uploadToSignedUrl'
 import { toast } from 'sonner'
 
+const DEFAULT_GET = '/api/admin/guides/upload-url'
+const DEFAULT_CONFIRM = '/api/admin/guides/upload-url/confirm'
+
 /**
  * Upload a file and insert an image node at the given position (or current
  * selection if pos is undefined). Exported so TiptapEditor can reuse it
  * for the toolbar file-picker path without duplicating the upload call.
  */
-export async function uploadAndInsert(file: File, view: EditorView, pos?: number): Promise<void> {
+export async function uploadAndInsert(
+  file: File,
+  view: EditorView,
+  pos?: number,
+  getUrl: string = DEFAULT_GET,
+  confirmUrl: string = DEFAULT_CONFIRM,
+): Promise<void> {
   try {
-    const url = await uploadToSignedUrl(
-      file,
-      '/api/admin/guides/upload-url',
-      '/api/admin/guides/upload-url/confirm',
-    )
+    const url = await uploadToSignedUrl(file, getUrl, confirmUrl)
     const { schema } = view.state
     const node = schema.nodes.image.create({ src: url })
     const tr = view.state.tr
@@ -30,10 +35,18 @@ export async function uploadAndInsert(file: File, view: EditorView, pos?: number
   }
 }
 
-export const ImageUploadExtension = Extension.create({
+export const ImageUploadExtension = Extension.create<{ getUrl: string; confirmUrl: string }>({
   name: 'imageUpload',
 
+  addOptions() {
+    return {
+      getUrl: DEFAULT_GET,
+      confirmUrl: DEFAULT_CONFIRM,
+    }
+  },
+
   addProseMirrorPlugins() {
+    const { getUrl, confirmUrl } = this.options
     return [
       new Plugin({
         props: {
@@ -47,7 +60,7 @@ export const ImageUploadExtension = Extension.create({
             const pos = coords?.pos
 
             for (const image of images) {
-              void uploadAndInsert(image, view, pos)
+              void uploadAndInsert(image, view, pos, getUrl, confirmUrl)
             }
             return true
           },
@@ -63,7 +76,7 @@ export const ImageUploadExtension = Extension.create({
             for (const item of imageItems) {
               const file = item.getAsFile()
               if (!file) continue
-              void uploadAndInsert(file, view)
+              void uploadAndInsert(file, view, undefined, getUrl, confirmUrl)
             }
             return true
           },

--- a/app/admin/content/components/TiptapEditor.tsx
+++ b/app/admin/content/components/TiptapEditor.tsx
@@ -139,11 +139,13 @@ export function TiptapEditor({
   onChange,
   placeholder,
   label,
+  imageUploadUrls,
 }: {
   value: JSONContent | null
   onChange: (v: JSONContent) => void
   placeholder?: string
   label?: string
+  imageUploadUrls?: { get: string; confirm: string }
 }): React.JSX.Element {
   const [imageUploading, setImageUploading] = useState(false)
   const imageInputRef = useRef<HTMLInputElement>(null)
@@ -154,7 +156,11 @@ export function TiptapEditor({
       Link.configure({ openOnClick: false }),
       Image.configure({ inline: false, allowBase64: false }),
       Placeholder.configure({ placeholder: placeholder ?? 'Write here…' }),
-      ImageUploadExtension,
+      ImageUploadExtension.configure(
+        imageUploadUrls
+          ? { getUrl: imageUploadUrls.get, confirmUrl: imageUploadUrls.confirm }
+          : {},
+      ),
     ],
     content: value ?? undefined,
     onUpdate: ({ editor: ed }) => {
@@ -176,12 +182,15 @@ export function TiptapEditor({
     if (!editor) return
     setImageUploading(true)
     try {
-      // Reuse uploadAndInsert from the extension — same upload endpoints,
-      // same insertion logic, no duplication.
-      await uploadAndInsert(file, editor.view)
+      await uploadAndInsert(
+        file,
+        editor.view,
+        undefined,
+        imageUploadUrls?.get,
+        imageUploadUrls?.confirm,
+      )
     } catch {
-      // uploadAndInsert handles its own toast.error; catch here only to
-      // ensure setImageUploading(false) runs in the finally block.
+      // uploadAndInsert handles its own toast.error
     } finally {
       setImageUploading(false)
     }
@@ -218,7 +227,6 @@ export function TiptapEditor({
         onChange={e => {
           const file = e.target.files?.[0]
           if (file) void handleImageFileSelected(file)
-          // reset so same file can be re-selected
           e.target.value = ''
         }}
       />

--- a/app/admin/trips/[id]/components/TripMetaForm.tsx
+++ b/app/admin/trips/[id]/components/TripMetaForm.tsx
@@ -2,11 +2,13 @@
 
 import { useState } from 'react'
 import type { Trip } from '@/lib/types/trips'
+import type { JSONContent } from '@tiptap/core'
+import { TiptapEditor } from '@/app/admin/content/components/TiptapEditor'
 
 type MetaFormState = {
   title: string
   destination: string
-  description: string
+  descriptionJson: JSONContent | null
   start_date: string
   end_date: string
   total_cost: number
@@ -20,7 +22,7 @@ function toFormState(trip: Trip): MetaFormState {
   return {
     title: trip.title,
     destination: trip.destination,
-    description: trip.description,
+    descriptionJson: trip.description,
     start_date: trip.start_date,
     end_date: trip.end_date,
     total_cost: trip.total_cost,
@@ -37,7 +39,7 @@ export function TripMetaForm({ trip }: { trip: Trip }) {
   const [error, setError] = useState<string | null>(null)
   const [saved, setSaved] = useState(false)
 
-  function field(key: keyof MetaFormState) {
+  function field(key: Exclude<keyof MetaFormState, 'descriptionJson'>) {
     return {
       value: String(form[key]),
       onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
@@ -53,7 +55,7 @@ export function TripMetaForm({ trip }: { trip: Trip }) {
       const payload = {
         title: form.title,
         destination: form.destination,
-        description: form.description,
+        description: form.descriptionJson,
         start_date: form.start_date,
         end_date: form.end_date,
         total_cost: Number(form.total_cost),
@@ -105,7 +107,15 @@ export function TripMetaForm({ trip }: { trip: Trip }) {
         </div>
         <div>
           <label className="block text-xs font-medium mb-1" style={{ color: 'var(--text-secondary)' }}>Description</label>
-          <textarea className={inputCls} style={inputStyle} rows={4} {...field('description')} />
+          <TiptapEditor
+            value={form.descriptionJson}
+            onChange={v => setForm(prev => ({ ...prev, descriptionJson: v }))}
+            placeholder="Write a trip description…"
+            imageUploadUrls={{
+              get: `/api/admin/trips/${trip.id}/upload-url`,
+              confirm: `/api/admin/trips/${trip.id}/upload-url/inline-confirm`,
+            }}
+          />
         </div>
         <div className="grid grid-cols-2 gap-3">
           <div>

--- a/app/api/admin/trips/[id]/upload-url/inline-confirm/route.ts
+++ b/app/api/admin/trips/[id]/upload-url/inline-confirm/route.ts
@@ -1,0 +1,46 @@
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: tripId } = await params
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (profile?.role !== 'admin') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const body = await req.json().catch(() => ({})) as { path?: string }
+  const { path } = body
+
+  if (!path || typeof path !== 'string') {
+    return Response.json({ error: 'path is required' }, { status: 400 })
+  }
+
+  // Traversal guard
+  if (path.includes('..')) {
+    return Response.json({ error: 'Invalid path' }, { status: 400 })
+  }
+
+  // Ownership: path must be scoped to this trip (same as confirm route)
+  if (!path.startsWith(`${tripId}/`)) {
+    return Response.json({ error: 'Path does not belong to this trip' }, { status: 403 })
+  }
+
+  // Inline images live in JSONContent only — no trip_attachments row.
+  const { data: { publicUrl } } = supabase.storage
+    .from('trip-attachments')
+    .getPublicUrl(path)
+
+  return Response.json({ url: publicUrl })
+}

--- a/lib/types/trips.ts
+++ b/lib/types/trips.ts
@@ -1,6 +1,7 @@
 // Canonical Trip and Milestone types.
 // ALL_ROLES and MemberRole live in lib/roles.ts — do not re-declare here.
 import type { MemberRole } from '@/lib/roles'
+import type { JSONContent } from '@tiptap/core'
 
 export type Milestone = { label: string; amount: number; due_date: string }
 
@@ -13,11 +14,12 @@ export type Trip = {
   total_cost: number
   milestones: Milestone[]
   currency: string
-  description: string
+  description: JSONContent | null
   image_url: string | null
   location: string | null
   accommodation_type: string | null
   inclusions: string[]
   trip_type: string | null
   access_roles: MemberRole[]
+  counter_bg_color: string | null
 }

--- a/supabase/migrations/20260516_003_trips_description_jsonb.sql
+++ b/supabase/migrations/20260516_003_trips_description_jsonb.sql
@@ -1,0 +1,24 @@
+-- Migrate trips.description from text to jsonb (Tiptap JSONContent).
+-- Drop the ''::text default first (incompatible with jsonb).
+-- Existing plain-text descriptions are wrapped in a minimal valid doc node.
+-- Empty strings and NULLs map to NULL.
+
+ALTER TABLE trips ALTER COLUMN description DROP DEFAULT;
+
+ALTER TABLE trips
+  ALTER COLUMN description TYPE jsonb
+  USING CASE
+    WHEN description IS NULL OR description = ''
+    THEN NULL
+    ELSE jsonb_build_object(
+      'type', 'doc',
+      'content', jsonb_build_array(
+        jsonb_build_object(
+          'type', 'paragraph',
+          'content', jsonb_build_array(
+            jsonb_build_object('type', 'text', 'text', description)
+          )
+        )
+      )
+    )
+  END;


### PR DESCRIPTION
## Summary

Migrates `trips.description` from `text` to `jsonb` (Tiptap JSONContent) and wires `TiptapEditor` into `TripMetaForm` for rich-text editing with inline image support via the `trip-attachments` bucket.

## Changes

- `supabase/migrations/20260516_003_trips_description_jsonb.sql` — drops `''::text` default, alters column to `jsonb` with `USING` clause that wraps existing plain-text into minimal paragraph nodes; applied via Supabase MCP
- `lib/types/trips.ts` — `description: string` → `description: JSONContent | null`
- `app/api/admin/trips/[id]/upload-url/inline-confirm/route.ts` (new) — admin auth; `..` traversal guard; `path.startsWith(tripId + '/')` ownership check; `getPublicUrl` only — no `trip_attachments` row insert (inline images tracked in JSONContent only)
- `app/admin/trips/[id]/components/TripMetaForm.tsx` — `description: string` removed from `MetaFormState`; `descriptionJson: JSONContent | null` added; textarea replaced with `<TiptapEditor>` passing `imageUploadUrls` pointing to this trip's upload-url + inline-confirm routes; `handleSave` sends `description: form.descriptionJson`

## Notes

Migration filename is `_003` — `_001` (`counter_bg_color`) and `_002` (`guide_images_bucket`) were both applied today on main before this branch.

The `''::text` default was incompatible with jsonb and meaningless on a nullable rich-text column — dropped without replacement.

## Session State
**Status:** DONE
**Completed:**
- [x] Migration applied — `trips.description` is now `jsonb`
- [x] `lib/types/trips.ts` updated
- [x] `inline-confirm` route created
- [x] `TripMetaForm` wired to `TiptapEditor`
**Next:** Merge when Vercel preview is green; then build #386 (member-facing render)

Closes #385