### PR TITLE
[2605-BUG-392] Fix React #31 crash on /trips — JSONContent description rendered as React child

### DIFF
--- a/app/(dashboard)/trips/components/TripCardDesktop.tsx
+++ b/app/(dashboard)/trips/components/TripCardDesktop.tsx
@@ -1,9 +1,11 @@
 import { TripImage, TripBadges, PriceDisplay, DateBadge, PinIcon } from './TripShared'
+import { excerptFromJSONContent } from '@/lib/format'
 import type { CardProps } from '../TripsClient'
 
 export default function TripCardDesktop(props: CardProps) {
   const { trip, ctaNode } = props
   const isGuest = props.userRole === 'guest'
+  const descriptionText = excerptFromJSONContent(trip.description)
   return (
     <div
       className="rounded-2xl overflow-hidden flex flex-col h-full"
@@ -27,7 +29,7 @@ export default function TripCardDesktop(props: CardProps) {
             priceClassName="text-xl"
           />
         </div>
-        {trip.description && (
+        {descriptionText && (
           <p className="text-sm leading-relaxed" style={{
             color: 'var(--text-secondary)',
             display: '-webkit-box',
@@ -35,7 +37,7 @@ export default function TripCardDesktop(props: CardProps) {
             WebkitBoxOrient: 'vertical',
             overflow: 'hidden',
           }}>
-            {trip.description}
+            {descriptionText}
           </p>
         )}
         {trip.location && (

--- a/app/(dashboard)/trips/page.tsx
+++ b/app/(dashboard)/trips/page.tsx
@@ -1,6 +1,7 @@
 import TripsClient from './TripsClient'
 import { createServiceClient } from '@/lib/supabase/service'
 import { auth } from '@clerk/nextjs/server'
+import type { JSONContent } from '@tiptap/core'
 
 export const dynamic = 'force-dynamic'
 
@@ -8,7 +9,7 @@ type Trip = {
   id: string
   title: string
   destination: string
-  description: string
+  description: JSONContent | null
   image_url: string | null
   start_date: string
   end_date: string

--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -42,7 +42,9 @@ export async function POST(req: Request) {
     .insert({
       title:              body.title,
       destination:        body.destination,
-      description:        body.description ?? '',
+      // description is jsonb (JSONContent | null) — null is the correct empty default;
+      // empty string '' is incompatible with the jsonb column type.
+      description:        body.description ?? null,
       image_url:          body.image_url ?? null,
       start_date:         body.start_date,
       end_date:           body.end_date,

--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -43,8 +43,9 @@ export async function POST(req: Request) {
       title:              body.title,
       destination:        body.destination,
       // description is jsonb (JSONContent | null) — null is the correct empty default;
-      // empty string '' is incompatible with the jsonb column type.
-      description:        body.description ?? null,
+      // || null coerces both undefined and empty string '' to null, defending
+      // against any client path that sends an empty string instead of null/undefined.
+      description:        body.description || null,
       image_url:          body.image_url ?? null,
       start_date:         body.start_date,
       end_date:           body.end_date,

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -168,12 +168,17 @@ export function timeAgoMs(
 /**
  * Extracts a plain-text excerpt from a Tiptap JSONContent document.
  *
- * Walks the node tree recursively, collecting text leaf values (nodes with
- * type === 'text' and a string `text` property). Joins them with a single
- * space, then trims to `maxLength` characters with a trailing ellipsis.
+ * Walks the node tree recursively:
+ * - Text leaf nodes contribute their text directly (no space inserted between
+ *   adjacent text nodes sharing a parent — preserves mark-split words like
+ *   <b>He</b>llo which Tiptap represents as two sibling text nodes).
+ * - hardBreak nodes contribute a space.
+ * - Block-level nodes (paragraph, heading, listItem) append a space after
+ *   their children so consecutive blocks are separated in the excerpt.
+ * Final string collapses multiple whitespace runs and trims before truncating.
  *
- * Safe to call in client components — no Tiptap extensions or generateHTML
- * involved. Returns '' for null input (trips created before the jsonb migration).
+ * Safe to call in client components — no Tiptap extensions or generateHTML.
+ * Returns '' for null input (trips created before the jsonb migration).
  */
 export function excerptFromJSONContent(
   doc: JSONContent | null,
@@ -186,18 +191,21 @@ export function excerptFromJSONContent(
   function walk(node: JSONContent): void {
     if (node.type === 'text' && typeof node.text === 'string') {
       parts.push(node.text)
-      return
-    }
-    if (Array.isArray(node.content)) {
-      for (const child of node.content) {
-        walk(child)
+    } else if (node.type === 'hardBreak') {
+      parts.push(' ')
+    } else if (Array.isArray(node.content)) {
+      for (const child of node.content) walk(child)
+      // Separate block-level nodes with a space so consecutive paragraphs,
+      // headings, and list items don't run together in the excerpt string.
+      if (['paragraph', 'heading', 'listItem'].includes(node.type || '')) {
+        parts.push(' ')
       }
     }
   }
 
   walk(doc)
 
-  const full = parts.join(' ').trim()
+  const full = parts.join('').replace(/\s+/g, ' ').trim()
   if (full.length <= maxLength) return full
   return full.slice(0, maxLength).trimEnd() + '…'
 }

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -4,6 +4,7 @@
 // timeZone is explicit on every formatter — Vercel server runs UTC; without
 // this, server and client produce different strings → React hydration error #418.
 
+import type { JSONContent } from '@tiptap/core'
 import { TranslationKey } from '@/lib/i18n/translations'
 
 export const TZ = 'Europe/Sofia'
@@ -162,4 +163,41 @@ export function timeAgoMs(
   if (mins < 60)  return `${mins}${t('home.time.minutesAgo')}`
   if (hours < 24) return `${hours}${t('home.time.hoursAgo')}`
   return `${days}${t('home.time.daysAgo')}`
+}
+
+/**
+ * Extracts a plain-text excerpt from a Tiptap JSONContent document.
+ *
+ * Walks the node tree recursively, collecting text leaf values (nodes with
+ * type === 'text' and a string `text` property). Joins them with a single
+ * space, then trims to `maxLength` characters with a trailing ellipsis.
+ *
+ * Safe to call in client components — no Tiptap extensions or generateHTML
+ * involved. Returns '' for null input (trips created before the jsonb migration).
+ */
+export function excerptFromJSONContent(
+  doc: JSONContent | null,
+  maxLength = 160,
+): string {
+  if (!doc) return ''
+
+  const parts: string[] = []
+
+  function walk(node: JSONContent): void {
+    if (node.type === 'text' && typeof node.text === 'string') {
+      parts.push(node.text)
+      return
+    }
+    if (Array.isArray(node.content)) {
+      for (const child of node.content) {
+        walk(child)
+      }
+    }
+  }
+
+  walk(doc)
+
+  const full = parts.join(' ').trim()
+  if (full.length <= maxLength) return full
+  return full.slice(0, maxLength).trimEnd() + '…'
 }


### PR DESCRIPTION
# [2605-BUG-392] Fix React #31 crash on /trips — JSONContent description rendered as React child

Closes #392

## Root cause

`TripCardDesktop` rendered `{trip.description}` directly inside `<p>`. After the #385 migration `trips.description` is `jsonb` (Tiptap `JSONContent` — an object `{type, content, ...}`), not a string. React cannot render objects as children → error #31 → `/trips` 500s.

## Changes

**`lib/format.ts`**
- Adds `excerptFromJSONContent(doc: JSONContent | null, maxLength = 160): string`
- Walks the JSONContent node tree recursively, collecting `text` leaf values, joins with space, trims to `maxLength` with `…`
- Handles `null` input (trips pre-#385 migration) — returns `''`
- Pure function — no Tiptap extensions, no `generateHTML`, safe in client components

**`app/(dashboard)/trips/components/TripCardDesktop.tsx`**
- Calls `excerptFromJSONContent(trip.description)` — result is a plain string
- Replaces direct `{trip.description}` render with `{descriptionText}`

**`app/(dashboard)/trips/page.tsx`**
- Local `Trip` type: `description: string` → `description: JSONContent | null`
- Was suppressed by `as Trip[]` cast so TypeScript didn't surface it

**`app/api/trips/route.ts`** POST handler
- `description: body.description ?? ''` → `description: body.description ?? null`
- Empty string `''` is incompatible with `jsonb` column — `null` is correct

## Session State
**Status:** DONE
**Completed:**
- [x] `excerptFromJSONContent` added to `lib/format.ts`
- [x] `TripCardDesktop` uses `excerptFromJSONContent`
- [x] `Trip` type in `trips/page.tsx` updated
- [x] POST route `description` default fixed
**Next:** Verify Vercel Preview READY + CI green, then merge