### PR TITLE
[2605-BUG-396] Add delete action to trip detail page

### DIFF
--- a/app/admin/trips/[id]/components/DeleteTripButton.tsx
+++ b/app/admin/trips/[id]/components/DeleteTripButton.tsx
@@ -21,6 +21,7 @@ export function DeleteTripButton({ tripId }: { tripId: string }) {
   const [open, setOpen] = useState(false)
 
   async function handleDelete() {
+    if (isPending) return
     setIsPending(true)
     setError(null)
     try {

--- a/app/admin/trips/[id]/components/DeleteTripButton.tsx
+++ b/app/admin/trips/[id]/components/DeleteTripButton.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+
+export function DeleteTripButton({ tripId }: { tripId: string }) {
+  const router = useRouter()
+  const [isPending, setIsPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [open, setOpen] = useState(false)
+
+  async function handleDelete() {
+    setIsPending(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/admin/trips/${tripId}`, { method: 'DELETE' })
+      if (res.status === 204) {
+        router.push('/admin/trips')
+        return
+      }
+      const json = await res.json()
+      if (res.status === 409 && json.error === 'has_dependents') {
+        const parts: string[] = []
+        if (json.registrations > 0) parts.push(`${json.registrations} registration${json.registrations !== 1 ? 's' : ''}`)
+        if (json.payments > 0) parts.push(`${json.payments} payment${json.payments !== 1 ? 's' : ''}`)
+        if (json.attachments > 0) parts.push(`${json.attachments} attachment${json.attachments !== 1 ? 's' : ''}`)
+        if (json.messages > 0) parts.push(`${json.messages} message${json.messages !== 1 ? 's' : ''}`)
+        setError(`Cannot delete: this trip has ${parts.join(', ')} attached. Remove them first.`)
+      } else {
+        setError(json.error ?? 'Failed to delete trip')
+      }
+      setOpen(false)
+    } catch {
+      setError('Failed to delete trip')
+      setOpen(false)
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogTrigger asChild>
+          <button
+            disabled={isPending}
+            className="text-sm font-semibold px-4 py-2 rounded-xl border transition-colors hover:bg-black/5 disabled:opacity-40"
+            style={{ borderColor: 'var(--brand-crimson)', color: 'var(--brand-crimson)' }}
+          >
+            {isPending ? 'Deleting…' : 'Delete Trip'}
+          </button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this trip?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {error && (
+        <p className="text-sm" style={{ color: 'var(--brand-crimson)' }}>{error}</p>
+      )}
+    </div>
+  )
+}

--- a/app/admin/trips/[id]/page.tsx
+++ b/app/admin/trips/[id]/page.tsx
@@ -8,6 +8,7 @@ import { TripHeroSection } from './components/TripHeroSection'
 import { TripMetaForm } from './components/TripMetaForm'
 import { MilestonesSection } from './components/MilestonesSection'
 import { AccessRolesSection } from './components/AccessRolesSection'
+import { DeleteTripButton } from './components/DeleteTripButton'
 import type { Trip } from '@/lib/types/trips'
 
 export const dynamic = 'force-dynamic'
@@ -94,6 +95,18 @@ export default async function TripManagePage({
         <AccessRolesSection tripId={tripId} initialRoles={typedTrip.access_roles ?? []} />
         <TripFilesSection tripId={tripId} />
         <TripMessagesSection tripId={tripId} />
+      </div>
+
+      {/* ── Danger zone ── */}
+      <div
+        className="rounded-2xl p-5 space-y-3"
+        style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+      >
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>Danger zone</h2>
+        <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+          Permanently delete this trip. Only possible when all registrations, payments, attachments, and messages have been removed.
+        </p>
+        <DeleteTripButton tripId={tripId} />
       </div>
     </div>
   )

--- a/app/api/admin/trips/[id]/route.ts
+++ b/app/api/admin/trips/[id]/route.ts
@@ -69,6 +69,9 @@ export async function DELETE(
     supabase.from('trip_messages').select('id', { count: 'exact', head: true }).eq('trip_id', id),
   ])
 
+  const dbError = regResult.error || payResult.error || attResult.error || msgResult.error
+  if (dbError) return Response.json({ error: dbError.message }, { status: 500 })
+
   const registrations = regResult.count ?? 0
   const payments = payResult.count ?? 0
   const attachments = attResult.count ?? 0

--- a/app/api/admin/trips/[id]/route.ts
+++ b/app/api/admin/trips/[id]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 const HEX_RE = /^#[0-9a-fA-F]{6}$/
 
@@ -46,4 +47,42 @@ export async function PATCH(
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
   return Response.json(trip)
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const { id } = await params
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
+
+  // Pre-flight: count all FK-dependent rows
+  const [regResult, payResult, attResult, msgResult] = await Promise.all([
+    supabase.from('trip_registrations').select('id', { count: 'exact', head: true }).eq('trip_id', id),
+    supabase.from('payments').select('id', { count: 'exact', head: true }).eq('trip_id', id),
+    supabase.from('trip_attachments').select('id', { count: 'exact', head: true }).eq('trip_id', id),
+    supabase.from('trip_messages').select('id', { count: 'exact', head: true }).eq('trip_id', id),
+  ])
+
+  const registrations = regResult.count ?? 0
+  const payments = payResult.count ?? 0
+  const attachments = attResult.count ?? 0
+  const messages = msgResult.count ?? 0
+
+  if (registrations > 0 || payments > 0 || attachments > 0 || messages > 0) {
+    return Response.json(
+      { error: 'has_dependents', registrations, payments, attachments, messages },
+      { status: 409 }
+    )
+  }
+
+  const { error } = await supabase.from('trips').delete().eq('id', id)
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+
+  return new Response(null, { status: 204 })
 }


### PR DESCRIPTION
## Summary

Adds a Delete Trip action to `/admin/trips/[id]`. A "Danger zone" section at the bottom of the page surfaces a "Delete Trip" button behind an `AlertDialog`. The API pre-flights for dependent rows before deleting — if any exist the UI explains exactly what needs to be cleared first.

## Changes

- `app/api/admin/trips/[id]/route.ts` — adds `DELETE` handler: admin-only via `getCallerContext`; parallel count of `trip_registrations`, `payments`, `trip_attachments`, `trip_messages`; returns 409 with counts if any non-zero; otherwise hard-deletes and returns 204
- `app/admin/trips/[id]/components/DeleteTripButton.tsx` — new client component: `AlertDialog`-gated delete; 409 dependency error surfaced inline; `isPending` guard; 390px safe
- `app/admin/trips/[id]/page.tsx` — adds "Danger zone" card with `DeleteTripButton` at bottom of both desktop and mobile layouts

Closes #396

## Session State
**Status:** DONE
**Completed:**
- [x] `DELETE /api/admin/trips/[id]` — pre-flight guard + hard-delete
- [x] `DeleteTripButton.tsx` — AlertDialog, 409 error display, isPending
- [x] `page.tsx` — Danger zone card, both layouts
**Next:** GCR