### PR TITLE
[2605-BUG-397] Add delete action to payments list

### DIFF
--- a/app/admin/payments/components/PaymentsClient.tsx
+++ b/app/admin/payments/components/PaymentsClient.tsx
@@ -8,6 +8,16 @@ import { t } from '@/lib/i18n'
 import type { Payment } from '@/lib/types/payments'
 import { PendingPaymentsSection } from './PendingPaymentsSection'
 import { LogPaymentDrawer } from './LogPaymentDrawer'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 // ── Helpers ──────────────────────────────────────────────
 
@@ -35,6 +45,7 @@ export function PaymentsClient({
   const [statusFilter, setStatusFilter] = useState<'all' | 'pending' | 'approved' | 'rejected'>('all')
   const [reviewNotes, setReviewNotes] = useState<Record<string, string>>({})
   const [payError, setPayError] = useState<string | null>(null)
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
 
   const payments = useMemo(
     () => statusFilter === 'all'
@@ -66,6 +77,17 @@ export function PaymentsClient({
         body: JSON.stringify({ admin_status, admin_note }),
       }).then(async r => { if (!r.ok) throw new Error((await r.json()).error); return r.json() }),
     onSuccess: () => router.refresh(),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) =>
+      fetch(`/api/admin/payments/${id}`, { method: 'DELETE' })
+        .then(async r => { if (!r.ok) throw new Error((await r.json()).error) }),
+    onSuccess: () => {
+      setDeleteTargetId(null)
+      router.refresh()
+    },
+    onSettled: () => setDeleteTargetId(null),
   })
 
   const STATUS_FILTERS = [
@@ -120,6 +142,7 @@ export function PaymentsClient({
           {payments.map((p, i) => {
             const pill = statusPill(p.admin_status)
             const entityLabel = p.trips?.title ?? p.payable_items?.title ?? '—'
+            const isDeleting = deleteMutation.isPending && deleteTargetId === p.id
             return (
               <div key={p.id} className="px-5 py-3 flex items-center justify-between gap-4"
                 style={{ borderTop: i > 0 ? '1px solid var(--border-default)' : 'none' }}>
@@ -133,15 +156,45 @@ export function PaymentsClient({
                     {p.payment_method && ` · ${p.payment_method}`}
                   </p>
                 </div>
-                <span className="text-[10px] font-semibold px-2.5 py-1 rounded-full flex-shrink-0"
-                  style={{ backgroundColor: pill.bg, color: pill.color }}>
-                  {p.admin_status}
-                </span>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <span className="text-[10px] font-semibold px-2.5 py-1 rounded-full"
+                    style={{ backgroundColor: pill.bg, color: pill.color }}>
+                    {p.admin_status}
+                  </span>
+                  <button
+                    onClick={() => setDeleteTargetId(p.id)}
+                    disabled={isDeleting}
+                    className="text-xs px-2 py-1 rounded-lg border transition-colors hover:bg-black/5 disabled:opacity-40"
+                    style={{ borderColor: 'var(--border-default)', color: 'var(--brand-crimson)' }}
+                    aria-label="Delete payment"
+                  >
+                    {isDeleting ? '…' : 'Delete'}
+                  </button>
+                </div>
               </div>
             )
           })}
         </div>
       )}
+
+      <AlertDialog open={deleteTargetId !== null} onOpenChange={open => { if (!open) setDeleteTargetId(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this payment?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => { if (deleteTargetId) deleteMutation.mutate(deleteTargetId) }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <LogPaymentDrawer
         open={drawerOpen}

--- a/app/admin/payments/components/PaymentsClient.tsx
+++ b/app/admin/payments/components/PaymentsClient.tsx
@@ -83,10 +83,7 @@ export function PaymentsClient({
     mutationFn: (id: string) =>
       fetch(`/api/admin/payments/${id}`, { method: 'DELETE' })
         .then(async r => { if (!r.ok) throw new Error((await r.json()).error) }),
-    onSuccess: () => {
-      setDeleteTargetId(null)
-      router.refresh()
-    },
+    onSuccess: () => router.refresh(),
     onSettled: () => setDeleteTargetId(null),
   })
 
@@ -177,7 +174,10 @@ export function PaymentsClient({
         </div>
       )}
 
-      <AlertDialog open={deleteTargetId !== null} onOpenChange={open => { if (!open) setDeleteTargetId(null) }}>
+      <AlertDialog
+        open={deleteTargetId !== null}
+        onOpenChange={open => { if (!open && !deleteMutation.isPending) setDeleteTargetId(null) }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete this payment?</AlertDialogTitle>
@@ -186,11 +186,15 @@ export function PaymentsClient({
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => { if (deleteTargetId) deleteMutation.mutate(deleteTargetId) }}
+              disabled={deleteMutation.isPending}
+              onClick={e => {
+                e.preventDefault()
+                if (deleteTargetId) deleteMutation.mutate(deleteTargetId)
+              }}
             >
-              Delete
+              {deleteMutation.isPending ? '…' : 'Delete'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/app/api/admin/payments/[id]/route.ts
+++ b/app/api/admin/payments/[id]/route.ts
@@ -81,3 +81,22 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 
   return Response.json(data)
 }
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const ctx = await getCallerContext(userId, supabase, 'adminOrCore')
+  if (ctx.guard) return ctx.guard
+
+  const { id } = await params
+
+  const { error } = await supabase.from('payments').delete().eq('id', id)
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+
+  return new Response(null, { status: 204 })
+}


### PR DESCRIPTION
## Summary

Adds per-row delete to `/admin/payments`. Each payment row gets a "Delete" button that opens a shared `AlertDialog`. Confirmed deletes hard-delete the row and refresh the list.

## Changes

- `app/api/admin/payments/[id]/route.ts` — adds `DELETE` handler: auth via existing `getCallerContext(userId, supabase, 'adminOrCore')`; hard-deletes the row; returns 204
- `app/admin/payments/components/PaymentsClient.tsx` — adds `deleteMutation`, `deleteTargetId` state, per-row "Delete" button (`flex-shrink-0`, right of status pill), shared `AlertDialog` controlled by `deleteTargetId`; `isPending` scoped to the row being deleted

Closes #397

## Session State
**Status:** DONE
**Completed:**
- [x] `DELETE /api/admin/payments/[id]` — adminOrCore auth, hard-delete, 204
- [x] `PaymentsClient` — deleteMutation, deleteTargetId, per-row button, shared AlertDialog
**Next:** GCR