### PR TITLE
[2605-BUG-401] Admin trip page overwrites saved counter colour on image load

### DIFF
--- a/app/admin/trips/[id]/components/TripHeroSection.tsx
+++ b/app/admin/trips/[id]/components/TripHeroSection.tsx
@@ -63,7 +63,8 @@ export function TripHeroSection({
   }, [])
 
   function handleImageLoad() {
-    if (saved !== null) return
+    // Skip auto-sampling if we already have a saved color that hasn't been changed
+    if (saved !== null && candidate === saved) return
     sampleRegion(REGIONS[regionIndex])
   }
 

--- a/app/admin/trips/[id]/components/TripHeroSection.tsx
+++ b/app/admin/trips/[id]/components/TripHeroSection.tsx
@@ -63,7 +63,7 @@ export function TripHeroSection({
   }, [])
 
   function handleImageLoad() {
-    // Auto-sample on load using current region
+    if (saved !== null) return
     sampleRegion(REGIONS[regionIndex])
   }
 


### PR DESCRIPTION
Closes #401\n\n## What\n\nGuard `handleImageLoad` in `TripHeroSection` so it skips canvas sampling when a saved custom colour exists.\n\n## Why\n\n`handleImageLoad` was unconditionally calling `sampleRegion` on every image mount, overwriting `candidate` even when it had been correctly initialised from `initialCounterColor`. The member-facing page was unaffected because it reads `counter_bg_color` directly from the DB — only the admin preview was broken.\n\n## Change\n\n`app/admin/trips/[id]/components/TripHeroSection.tsx` — add early return in `handleImageLoad`:\n```ts\nif (saved !== null) return\n```"