### PR TITLE
[2605-BUG-403] Add missing card frame to InvitesBento

### DIFF
--- a/app/(dashboard)/profile/components/InvitesBento.tsx
+++ b/app/(dashboard)/profile/components/InvitesBento.tsx
@@ -52,50 +52,52 @@ export function InvitesBento() {
   ]
 
   return (
-    <div className="p-4 flex flex-col gap-4 h-full">
-      {/* Header */}
-      <p className="text-[10px] font-semibold tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>
-        {t('profile.bento.invites')}
-      </p>
+    <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+      <div className="flex flex-col gap-4 h-full">
+        {/* Header */}
+        <p className="text-[10px] font-semibold tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>
+          {t('profile.bento.invites')}
+        </p>
 
-      {/* Stat chips */}
-      {isLoading ? (
-        <div className="grid grid-cols-2 gap-2">
-          {[...Array(4)].map((_, i) => (
-            <div
-              key={i}
-              className="h-14 rounded-xl animate-pulse"
-              style={{ backgroundColor: 'rgba(0,0,0,0.06)' }}
-            />
-          ))}
-        </div>
-      ) : (
-        <div className="grid grid-cols-2 gap-2">
-          {stats.map(({ label, value }) => (
-            <div
-              key={label}
-              className="rounded-xl px-3 py-2 flex flex-col gap-0.5"
-              style={{ backgroundColor: 'rgba(0,0,0,0.04)' }}
-            >
-              <span className="text-xl font-bold tabular-nums" style={{ color: 'var(--text-primary)' }}>
-                {value}
-              </span>
-              <span className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>
-                {label}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
+        {/* Stat chips */}
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-2">
+            {[...Array(4)].map((_, i) => (
+              <div
+                key={i}
+                className="h-14 rounded-xl animate-pulse"
+                style={{ backgroundColor: 'rgba(0,0,0,0.06)' }}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-2">
+            {stats.map(({ label, value }) => (
+              <div
+                key={label}
+                className="rounded-xl px-3 py-2 flex flex-col gap-0.5"
+                style={{ backgroundColor: 'rgba(0,0,0,0.04)' }}
+              >
+                <span className="text-xl font-bold tabular-nums" style={{ color: 'var(--text-primary)' }}>
+                  {value}
+                </span>
+                <span className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>
+                  {label}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
 
-      {/* CTA */}
-      <Link
-        href="/profile/invites"
-        className="mt-auto text-xs font-semibold px-3 py-2 rounded-xl transition-opacity hover:opacity-70 text-left block"
-        style={{ backgroundColor: 'rgba(0,0,0,0.05)', color: 'var(--text-primary)' }}
-      >
-        {t('profile.invites.viewAll')} →
-      </Link>
+        {/* CTA */}
+        <Link
+          href="/profile/invites"
+          className="mt-auto text-xs font-semibold px-3 py-2 rounded-xl transition-opacity hover:opacity-70 text-left block"
+          style={{ backgroundColor: 'rgba(0,0,0,0.05)', color: 'var(--text-primary)' }}
+        >
+          {t('profile.invites.viewAll')} →
+        </Link>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #403\n\n## What\n\nAdded missing card frame to `InvitesBento` — `rounded-2xl`, `bg-card`, `border` outer wrapper with inner flex layout div.\n\n## Why\n\n`SortableBento` provides no visual shell when expanded — the card frame must come from the Section component itself. Every other profile bento tile (`PaymentsSection`, `TripsSection`, etc.) does this. `InvitesBento` was the only one missing it, rendering frameless on the profile page.\n\n## Changes\n- `app/(dashboard)/profile/components/InvitesBento.tsx`