### PR TITLE
[2605-FEAT-411] Tiptap code block toolbar button and copy buttons for rendered output

### DIFF
--- a/app/(dashboard)/library/[slug]/components/GuideBody.tsx
+++ b/app/(dashboard)/library/[slug]/components/GuideBody.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { generateHTML } from '@tiptap/html'
 import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
@@ -13,6 +13,7 @@ import {
   DialogOverlay,
 } from '@/components/ui/dialog'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { useTiptapCopyButtons } from '@/lib/hooks/useTiptapCopyButtons'
 
 type Attachment = {
   id: string
@@ -42,13 +43,17 @@ export default function GuideBody({
 }) {
   const { t } = useLanguage()
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null)
+  const outputRef = useRef<HTMLDivElement>(null)
 
   const html = body ? generateHTML(body, TIPTAP_EXTENSIONS) : ''
+
+  useTiptapCopyButtons(outputRef, [html])
 
   return (
     <>
       <div className="guide-body max-w-2xl">
         <div
+          ref={outputRef}
           className="tiptap-output"
           // Content is generated server-side from admin-controlled JSONContent.
           // No user-submitted HTML reaches this path.

--- a/app/(dashboard)/library/[slug]/components/GuideBody.tsx
+++ b/app/(dashboard)/library/[slug]/components/GuideBody.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { generateHTML } from '@tiptap/html'
 import StarterKit from '@tiptap/starter-kit'
 import Link from '@tiptap/extension-link'
@@ -45,7 +45,7 @@ export default function GuideBody({
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null)
   const outputRef = useRef<HTMLDivElement>(null)
 
-  const html = body ? generateHTML(body, TIPTAP_EXTENSIONS) : ''
+  const html = useMemo(() => (body ? generateHTML(body, TIPTAP_EXTENSIONS) : ''), [body])
 
   useTiptapCopyButtons(outputRef, [html])
 

--- a/app/(dashboard)/trips/[id]/components/shared.tsx
+++ b/app/(dashboard)/trips/[id]/components/shared.tsx
@@ -12,6 +12,7 @@ import { clampLuminance, hslToHex } from '@/lib/color'
 import type { Tables } from '@/types/supabase'
 import type { TripProfile } from '../page'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { useTiptapCopyButtons } from '@/lib/hooks/useTiptapCopyButtons'
 
 type Trip = Tables<'trips'>
 
@@ -182,13 +183,18 @@ export function TripHeroImage({
 // parent re-renders where description hasn't changed.
 // ---------------------------------------------------------------------------
 function TripDescription({ description }: { description: JSONContent | null }) {
+  const outputRef = useRef<HTMLDivElement>(null)
   const html = useMemo(
     () => (description ? generateHTML(description, TIPTAP_EXTENSIONS) : null),
     [description],
   )
+
+  useTiptapCopyButtons(outputRef, [html])
+
   if (!html) return null
   return (
     <div
+      ref={outputRef}
       className="tiptap-output mb-5"
       // Content is generated from admin-controlled JSONContent — no user-submitted HTML.
       dangerouslySetInnerHTML={{ __html: html }}

--- a/app/admin/content/components/TiptapEditor.tsx
+++ b/app/admin/content/components/TiptapEditor.tsx
@@ -124,6 +124,19 @@ function Toolbar({
       </button>
       <button
         type="button"
+        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+        className={TOOLBAR_BTN}
+        style={{
+          borderColor: 'var(--border-default)',
+          color: editor.isActive('codeBlock') ? 'var(--brand-crimson)' : 'var(--text-secondary)',
+          fontFamily: 'monospace',
+        }}
+        aria-label="Code block"
+      >
+        &lt;/&gt;
+      </button>
+      <button
+        type="button"
         onClick={onImageClick}
         disabled={imageUploading}
         className={TOOLBAR_BTN}

--- a/app/globals.css
+++ b/app/globals.css
@@ -135,7 +135,7 @@ body {
 }
 
 /* ── Tiptap rendered output (.tiptap-output) ── */
-/* Used by GuideBody to render JSONContent via generateHTML. */
+/* Used by GuideBody and TripDescription to render JSONContent via generateHTML. */
 .tiptap-output h2 {
   font-size: 1.25rem;
   font-weight: 600;
@@ -208,6 +208,50 @@ body {
   margin-bottom: 0.75rem;
 }
 
+/* ── Tiptap code block — rendered output ── */
+/* position:relative on pre is required for the absolute copy button. */
+.tiptap-output pre {
+  position: relative;
+  background-color: #1e1e1e;
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  margin-bottom: 1.25rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.tiptap-output pre code {
+  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: #d4d4d4;
+  background: none;
+  padding: 0;
+  white-space: pre;
+}
+
+.tiptap-output .tiptap-copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 0.3rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.7rem;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 150ms, color 150ms;
+  line-height: 1.4;
+}
+
+.tiptap-output .tiptap-copy-btn:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.9);
+}
+
 /* ── Tiptap editor chrome (.tiptap-editor) ── */
 /* Applied to EditorContent wrapper in TiptapEditor.tsx */
 .tiptap-editor .ProseMirror {
@@ -261,4 +305,23 @@ body {
   max-width: 100%;
   border-radius: 0.5rem;
   margin: 0.5rem 0;
+}
+
+/* ── Tiptap code block — editor chrome ── */
+.tiptap-editor .ProseMirror pre {
+  background-color: #1e1e1e;
+  border-radius: 0.4rem;
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+}
+
+.tiptap-editor .ProseMirror pre code {
+  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: #d4d4d4;
+  background: none;
+  padding: 0;
+  white-space: pre;
 }

--- a/lib/hooks/useTiptapCopyButtons.ts
+++ b/lib/hooks/useTiptapCopyButtons.ts
@@ -14,7 +14,7 @@ export function useTiptapCopyButtons(
 ): void {
   useEffect(() => {
     const container = ref.current
-    if (!container) return
+    if (!container || !navigator.clipboard) return
 
     const blocks = container.querySelectorAll<HTMLElement>('pre code')
     if (!blocks.length) return
@@ -37,12 +37,14 @@ export function useTiptapCopyButtons(
 
       function handleClick() {
         const text = codeEl.textContent ?? ''
-        void navigator.clipboard.writeText(text).then(() => {
+        navigator.clipboard.writeText(text).then(() => {
           btn.textContent = 'Copied!'
           clearTimeout(timeout)
           timeout = setTimeout(() => {
             btn.textContent = 'Copy'
           }, 2000)
+        }).catch(err => {
+          console.error('Failed to copy code:', err)
         })
       }
 

--- a/lib/hooks/useTiptapCopyButtons.ts
+++ b/lib/hooks/useTiptapCopyButtons.ts
@@ -1,0 +1,64 @@
+import { useEffect } from 'react'
+
+/**
+ * Injects a "Copy" button into every `pre code` block found inside `ref`.
+ * Safe to call on re-renders — guarded by `.tiptap-copy-btn` presence check.
+ * Reads codeEl.textContent at click time (never stale on optimistic updates).
+ *
+ * @param ref   - RefObject pointing at the container element
+ * @param deps  - Extra deps that trigger re-injection (e.g. [html])
+ */
+export function useTiptapCopyButtons(
+  ref: React.RefObject<HTMLElement | null>,
+  deps: unknown[] = [],
+): void {
+  useEffect(() => {
+    const container = ref.current
+    if (!container) return
+
+    const blocks = container.querySelectorAll<HTMLElement>('pre code')
+    if (!blocks.length) return
+
+    const cleanups: (() => void)[] = []
+
+    blocks.forEach(codeEl => {
+      const pre = codeEl.parentElement
+      if (!pre) return
+      // Idempotency guard — skip if already injected
+      if (pre.querySelector('.tiptap-copy-btn')) return
+
+      const btn = document.createElement('button')
+      btn.type = 'button'
+      btn.className = 'tiptap-copy-btn'
+      btn.setAttribute('aria-label', 'Copy code')
+      btn.textContent = 'Copy'
+
+      let timeout: ReturnType<typeof setTimeout>
+
+      function handleClick() {
+        const text = codeEl.textContent ?? ''
+        void navigator.clipboard.writeText(text).then(() => {
+          btn.textContent = 'Copied!'
+          clearTimeout(timeout)
+          timeout = setTimeout(() => {
+            btn.textContent = 'Copy'
+          }, 2000)
+        })
+      }
+
+      btn.addEventListener('click', handleClick)
+      pre.appendChild(btn)
+
+      cleanups.push(() => {
+        clearTimeout(timeout)
+        btn.removeEventListener('click', handleClick)
+        btn.remove()
+      })
+    })
+
+    return () => {
+      cleanups.forEach(fn => fn())
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref, ...deps])
+}


### PR DESCRIPTION
Closes #411

## What

- `lib/hooks/useTiptapCopyButtons.ts` — new `useEffect` hook that queries `pre code` inside a ref and injects an absolutely-positioned Copy button into each `pre`. Idempotent (`.tiptap-copy-btn` guard), reads `textContent` at click time, 2s "Copied!" feedback, full cleanup on unmount.
- `TiptapEditor.tsx` — added `</>` Code Block toolbar button with active-state colour and monospace font. Calls `toggleCodeBlock()` — uses StarterKit's built-in `codeBlock` node, no new packages.
- `GuideBody.tsx` — added `outputRef` on `.tiptap-output` div; calls `useTiptapCopyButtons(outputRef, [html])`.
- `shared.tsx` (`TripDescription`) — added `outputRef` on output div; calls `useTiptapCopyButtons(outputRef, [html])`.
- `globals.css` — added `.tiptap-output pre`, `.tiptap-output pre code`, `.tiptap-output .tiptap-copy-btn` rules (dark bg, `position:relative`, horizontal scroll, ghost button). Also added editor chrome styles for `pre`/`code` in `.tiptap-editor .ProseMirror`.

## Session State
**Status:** DONE
**Completed:**
- [x] `useTiptapCopyButtons` hook
- [x] Toolbar Code Block button
- [x] GuideBody copy buttons
- [x] TripDescription copy buttons
- [x] CSS for rendered output and editor chrome
**Next:** GCR then merge