### PR TITLE
[2605-SEC-396] Fix critical RLS policy misconfigurations — email_log, member_vital_signs, payments

### DIFF
--- a/supabase/migrations/20260517_001_fix_rls_email_log_mvs_payments.sql
+++ b/supabase/migrations/20260517_001_fix_rls_email_log_mvs_payments.sql
@@ -1,0 +1,41 @@
+-- [2605-SEC-396] Fix RLS policy misconfigurations
+-- email_log, member_vital_signs, payments
+-- Applied to prod: 2026-05-17
+
+-- ── 1. email_log ──────────────────────────────────────────────────
+-- Was: roles:{public}, qual:true — any authenticated user could write
+-- Fix: scope to service_role only (service role bypasses RLS anyway; this
+--      closes the gap for anon/authenticated keys)
+DROP POLICY IF EXISTS "Service role write email_log" ON public.email_log;
+CREATE POLICY "Service role write email_log"
+  ON public.email_log FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ── 2. member_vital_signs ───────────────────────────────────────────────
+-- Was: raw auth.jwt() ->> 'user_role' = 'admin' (fragile against JWT template drift)
+-- Fix: use is_admin() helper, consistent with every other table
+DROP POLICY IF EXISTS "mvs_delete_admin" ON public.member_vital_signs;
+DROP POLICY IF EXISTS "mvs_insert_admin" ON public.member_vital_signs;
+
+CREATE POLICY "mvs_delete_admin"
+  ON public.member_vital_signs FOR DELETE
+  TO authenticated
+  USING (is_admin());
+
+CREATE POLICY "mvs_insert_admin"
+  ON public.member_vital_signs FOR INSERT
+  TO authenticated
+  WITH CHECK (is_admin());
+
+-- ── 3. payments ─────────────────────────────────────────────────────────────
+-- Was: raw auth.jwt() ->> 'user_role' = ANY (ARRAY['admin', 'core'])
+-- Fix: use get_my_role() cast to user_role enum (Pattern A)
+DROP POLICY IF EXISTS "payments_admin_core_all" ON public.payments;
+
+CREATE POLICY "payments_admin_core_all"
+  ON public.payments FOR ALL
+  TO authenticated
+  USING (get_my_role() = ANY (ARRAY['admin'::user_role, 'core'::user_role]))
+  WITH CHECK (get_my_role() = ANY (ARRAY['admin'::user_role, 'core'::user_role]));

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1504,7 +1504,7 @@ export type Database = {
           counter_bg_color: string | null
           created_at: string
           currency: string
-          description: Json | null
+          description: Json
           destination: string
           end_date: string
           id: string
@@ -1523,7 +1523,7 @@ export type Database = {
           counter_bg_color?: string | null
           created_at?: string
           currency?: string
-          description?: Json | null
+          description: Json
           destination: string
           end_date: string
           id?: string
@@ -1542,7 +1542,7 @@ export type Database = {
           counter_bg_color?: string | null
           created_at?: string
           currency?: string
-          description?: Json | null
+          description?: Json
           destination?: string
           end_date?: string
           id?: string


### PR DESCRIPTION
## Summary

Fixes three RLS policy misconfigurations. Migration-only — no application code changes.

**1. `email_log`** — write policy was scoped to `{public}` (any authenticated user could INSERT/UPDATE/DELETE). Fixed to `TO service_role`.

**2. `member_vital_signs`** — `mvs_insert_admin` and `mvs_delete_admin` used raw `auth.jwt() ->> 'user_role' = 'admin'`. Replaced with `is_admin()` to match Pattern A.

**3. `payments`** — `payments_admin_core_all` used raw `auth.jwt() ->> 'user_role' = ANY (ARRAY['admin', 'core'])`. Replaced with `get_my_role()` cast to `user_role` enum.

## Files Changed

- `supabase/migrations/20260517_001_fix_rls_email_log_mvs_payments.sql` — migration (applied to prod `20260517095034`)
- `types/supabase.ts` — regenerated

## Session State
**Status:** DONE
**Completed:**
- [x] Migration written and applied to prod
- [x] `generate_typescript_types` run and pushed
- [x] PR created
**Next:** Merge via GitHub UI

Closes #405