### PR TITLE
[2605-SEC-407] Make trip-attachments bucket private; serve documents via auth-gated signed download URLs

### DIFF
--- a/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
+++ b/app/(dashboard)/trips/[id]/components/TripDocumentsTile.tsx
@@ -123,7 +123,7 @@ export function TripDocumentsTile({ tripId }: { tripId: string }) {
                 </p>
               </div>
               <a
-                href={a.file_url}
+                href={`/api/trips/${tripId}/attachments/${a.id}/download`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs flex-shrink-0 hover:opacity-70 transition-opacity"

--- a/app/admin/trips/[id]/components/TripFilesSection.tsx
+++ b/app/admin/trips/[id]/components/TripFilesSection.tsx
@@ -21,6 +21,8 @@ import { useSignedUpload } from '@/lib/hooks/useSignedUpload'
 type Attachment = {
   id: string
   file_name: string
+  // file_url stores the storage path (not a public URL) after the bucket was made private.
+  // Use /api/admin/trips/[tripId]/attachments/[id]/download for reading.
   file_url: string
   file_type: 'pdf' | 'image'
   sort_order: number
@@ -36,7 +38,8 @@ export function TripFilesSection({ tripId }: { tripId: string }) {
   const qc = useQueryClient()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null)
-  // Optimistic entries appended on upload; cleared when server query resolves with real ids
+  // Optimistic entries appended on upload; cleared when server query resolves with real ids.
+  // file_url on optimistic rows is the storage path (returned as `url` from confirm).
   const [optimistic, setOptimistic] = useState<Attachment[]>([])
   const [sizeError, setSizeError] = useState<string | null>(null)
   const { t } = useLanguage()
@@ -54,10 +57,9 @@ export function TripFilesSection({ tripId }: { tripId: string }) {
       }),
   })
 
-  // Remove confirmed optimistic entries post-render. Guard on length > 0 so this
-  // is a no-op while loading (default [] reference is stable but length check is
-  // explicit insurance). Filter-based removal preserves in-flight entries that
-  // haven't landed in the server list yet.
+  // Remove confirmed optimistic entries post-render.
+  // Dedup by file_url (storage path) — works because confirm now returns path as url,
+  // so optimistic file_url === server file_url after the row lands.
   useEffect(() => {
     if (serverAttachments.length > 0) {
       setOptimistic(prev => prev.filter(o => !serverAttachments.some(s => s.file_url === o.file_url)))
@@ -74,8 +76,6 @@ export function TripFilesSection({ tripId }: { tripId: string }) {
     const file = e.target.files?.[0]
     if (!file) return
     e.target.value = ''
-    // Reset size error on every invocation. Note: uploadError from
-    // useSignedUpload is managed by the hook and cannot be reset here.
     setSizeError(null)
     if (file.size > MAX_FILE_SIZE) {
       setSizeError(t('trips.error_file_too_large'))
@@ -83,6 +83,7 @@ export function TripFilesSection({ tripId }: { tripId: string }) {
     }
     try {
       const { url } = await upload(file)
+      // url is now a storage path — used only for optimistic dedup, not as an href
       setOptimistic(prev => [
         ...prev,
         {
@@ -152,31 +153,45 @@ export function TripFilesSection({ tripId }: { tripId: string }) {
         <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No files uploaded yet.</p>
       ) : (
         <ul className="space-y-2">
-          {attachments.map(a => (
-            <li
-              key={a.id}
-              className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg"
-              style={{ backgroundColor: 'var(--bg-global)', border: '1px solid var(--border-default)' }}
-            >
-              <a
-                href={a.file_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm truncate hover:underline"
-                style={{ color: 'var(--text-primary)' }}
+          {attachments.map(a => {
+            const isOptimistic = a.id.startsWith('optimistic-')
+            return (
+              <li
+                key={a.id}
+                className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg"
+                style={{ backgroundColor: 'var(--bg-global)', border: '1px solid var(--border-default)' }}
               >
-                {a.file_name}
-              </a>
-              <button
-                onClick={() => setDeleteTarget({ id: a.id, name: a.file_name })}
-                className="flex-shrink-0 hover:opacity-70 transition-opacity"
-                style={{ color: 'var(--brand-crimson)' }}
-                aria-label={`Delete ${a.file_name}`}
-              >
-                <Trash2 size={14} />
-              </button>
-            </li>
-          ))}
+                {isOptimistic ? (
+                  // Optimistic row: no real id yet, download link unavailable
+                  <span
+                    className="text-sm truncate"
+                    style={{ color: 'var(--text-secondary)' }}
+                  >
+                    {a.file_name}
+                  </span>
+                ) : (
+                  <a
+                    href={`/api/admin/trips/${tripId}/attachments/${a.id}/download`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm truncate hover:underline"
+                    style={{ color: 'var(--text-primary)' }}
+                  >
+                    {a.file_name}
+                  </a>
+                )}
+                <button
+                  onClick={() => !isOptimistic && setDeleteTarget({ id: a.id, name: a.file_name })}
+                  disabled={isOptimistic}
+                  className="flex-shrink-0 hover:opacity-70 transition-opacity disabled:opacity-30"
+                  style={{ color: 'var(--brand-crimson)' }}
+                  aria-label={`Delete ${a.file_name}`}
+                >
+                  <Trash2 size={14} />
+                </button>
+              </li>
+            )
+          })}
         </ul>
       )}
 

--- a/app/api/admin/trips/[id]/attachments/[attachmentId]/download/route.ts
+++ b/app/api/admin/trips/[id]/attachments/[attachmentId]/download/route.ts
@@ -23,12 +23,13 @@ export async function GET(
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const { attachmentId } = await params
+  const { id: tripId, attachmentId } = await params
 
   const { data: attachment } = await supabase
     .from('trip_attachments')
     .select('id, file_url')
     .eq('id', attachmentId)
+    .eq('trip_id', tripId)
     .single()
 
   if (!attachment || !attachment.file_url) {
@@ -40,6 +41,7 @@ export async function GET(
     .createSignedUrl(attachment.file_url, 3600)
 
   if (error || !signed?.signedUrl) {
+    console.error('[ADMIN_DOWNLOAD_ERROR]', error)
     return NextResponse.json({ error: 'Could not generate download URL' }, { status: 500 })
   }
 

--- a/app/api/admin/trips/[id]/attachments/[attachmentId]/download/route.ts
+++ b/app/api/admin/trips/[id]/attachments/[attachmentId]/download/route.ts
@@ -2,7 +2,9 @@ import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { NextRequest, NextResponse } from 'next/server'
 
-export async function DELETE(
+export const dynamic = 'force-dynamic'
+
+export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string; attachmentId: string }> }
 ): Promise<NextResponse> {
@@ -21,30 +23,25 @@ export async function DELETE(
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const { id: tripId, attachmentId } = await params
+  const { attachmentId } = await params
 
-  const { data: attachment, error: fetchError } = await supabase
+  const { data: attachment } = await supabase
     .from('trip_attachments')
-    .select('id, file_url, trip_id')
+    .select('id, file_url')
     .eq('id', attachmentId)
-    .eq('trip_id', tripId)
     .single()
 
-  if (fetchError || !attachment) {
+  if (!attachment || !attachment.file_url) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
 
-  // file_url now stores the storage path directly — no URL parsing needed
-  if (attachment.file_url) {
-    await supabase.storage.from('trip-attachments').remove([attachment.file_url])
+  const { data: signed, error } = await supabase.storage
+    .from('trip-attachments')
+    .createSignedUrl(attachment.file_url, 3600)
+
+  if (error || !signed?.signedUrl) {
+    return NextResponse.json({ error: 'Could not generate download URL' }, { status: 500 })
   }
 
-  const { error: deleteError } = await supabase
-    .from('trip_attachments')
-    .delete()
-    .eq('id', attachmentId)
-
-  if (deleteError) return NextResponse.json({ error: deleteError.message }, { status: 500 })
-
-  return new NextResponse(null, { status: 204 })
+  return NextResponse.redirect(signed.signedUrl, 302)
 }

--- a/app/api/admin/trips/[id]/upload-url/confirm/route.ts
+++ b/app/api/admin/trips/[id]/upload-url/confirm/route.ts
@@ -46,10 +46,6 @@ export async function POST(
     return Response.json({ error: 'Unsupported file type' }, { status: 415 })
   }
 
-  const { data: { publicUrl } } = supabase.storage
-    .from('trip-attachments')
-    .getPublicUrl(path)
-
   // Derive sort_order as max existing + 1
   const { data: maxRow } = await supabase
     .from('trip_attachments')
@@ -61,11 +57,15 @@ export async function POST(
 
   const sort_order = (maxRow?.sort_order ?? -1) + 1
 
+  // Store the storage path directly — not a public URL.
+  // The bucket is private; reading is done via /api/admin/trips/[id]/attachments/[attachmentId]/download.
+  // useSignedUpload expects { url } in the confirm response — return path under the `url` key
+  // for backwards compatibility. TripFilesSection receives the full attachment row alongside.
   const { data: attachment, error: insertError } = await supabase
     .from('trip_attachments')
     .insert({
       trip_id: tripId,
-      file_url: publicUrl,
+      file_url: path,
       file_name: filename,
       file_type: fileTypeMapped,
       sort_order,
@@ -80,7 +80,5 @@ export async function POST(
     return Response.json({ error: insertError.message }, { status: 500 })
   }
 
-  // useSignedUpload expects { url } in the confirm response.
-  // Spread attachment fields alongside so TripFilesSection still gets the full row.
-  return Response.json({ url: publicUrl, ...attachment }, { status: 201 })
+  return Response.json({ url: path, ...attachment }, { status: 201 })
 }

--- a/app/api/trips/[id]/attachments/[attachmentId]/download/route.ts
+++ b/app/api/trips/[id]/attachments/[attachmentId]/download/route.ts
@@ -56,6 +56,7 @@ export async function GET(
     .createSignedUrl(attachment.file_url, 3600)
 
   if (error || !signed?.signedUrl) {
+    console.error('[MEMBER_DOWNLOAD_ERROR]', error)
     return NextResponse.json({ error: 'Could not generate download URL' }, { status: 500 })
   }
 

--- a/app/api/trips/[id]/attachments/[attachmentId]/download/route.ts
+++ b/app/api/trips/[id]/attachments/[attachmentId]/download/route.ts
@@ -1,0 +1,63 @@
+import { auth } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string; attachmentId: string }> }
+): Promise<NextResponse> {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { id: tripId, attachmentId } = await params
+
+  // Resolve profile
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id, role')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (!profile) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  // Admins bypass the registration gate
+  if (profile.role !== 'admin') {
+    const { data: reg } = await supabase
+      .from('trip_registrations')
+      .select('id')
+      .eq('trip_id', tripId)
+      .eq('profile_id', profile.id)
+      .eq('status', 'approved')
+      .maybeSingle()
+
+    if (!reg) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+  }
+
+  const { data: attachment } = await supabase
+    .from('trip_attachments')
+    .select('id, file_url')
+    .eq('id', attachmentId)
+    .eq('trip_id', tripId)
+    .single()
+
+  if (!attachment || !attachment.file_url) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const { data: signed, error } = await supabase.storage
+    .from('trip-attachments')
+    .createSignedUrl(attachment.file_url, 3600)
+
+  if (error || !signed?.signedUrl) {
+    return NextResponse.json({ error: 'Could not generate download URL' }, { status: 500 })
+  }
+
+  return NextResponse.redirect(signed.signedUrl, 302)
+}

--- a/supabase/migrations/20260517_003_2605_sec_407_trip_attachments_private.sql
+++ b/supabase/migrations/20260517_003_2605_sec_407_trip_attachments_private.sql
@@ -1,0 +1,26 @@
+-- [2605-SEC-407] Make trip-attachments bucket private; backfill file_url to path-only
+--
+-- Prerequisites:
+--   1. Flip trip-attachments bucket to private in Supabase dashboard FIRST.
+--   2. Then apply this migration.
+--
+-- This migration:
+--   a. Drops the public read storage policy on trip-attachments.
+--   b. Backfills trip_attachments.file_url: strips the public URL prefix, leaving only the storage path.
+--      NOTE: the column is named file_url but its contract changes to storage path-only.
+--      The column is not renamed to avoid cascading schema/type/reference changes.
+
+-- a) Drop the public read policy
+DROP POLICY IF EXISTS "trip_attachments_public_select" ON storage.objects;
+
+-- b) Backfill file_url: convert full public URLs to path-only
+--    Pattern: https://<host>/storage/v1/object/public/trip-attachments/<path>
+--    Result:  <path>  (e.g. "trip-uuid/filename.pdf")
+UPDATE trip_attachments
+SET file_url = regexp_replace(
+  file_url,
+  '^.+/storage/v1/object/public/trip-attachments/',
+  ''
+)
+WHERE file_url IS NOT NULL
+  AND file_url LIKE '%/storage/v1/object/public/trip-attachments/%';


### PR DESCRIPTION
## Summary

Makes the `trip-attachments` storage bucket private and replaces direct public URL access with auth-gated signed download URLs. Trip documents (itineraries, booking confirmations, PDFs) are now inaccessible without an authenticated session and an approved registration (or admin role).

## Changes

**Migration** (`20260517_003_2605_sec_407_trip_attachments_private.sql`)
- Drops `trip_attachments_public_select` storage policy
- Backfills `trip_attachments.file_url`: strips full public URL prefix, leaving storage path only (`tripId/filename.ext`)

**API — admin download** (`/api/admin/trips/[id]/attachments/[attachmentId]/download/route.ts`) — new
- Admin auth + role check
- Fetches attachment row, calls `createSignedUrl(file_url, 3600)`, returns 302 redirect

**API — member download** (`/api/trips/[id]/attachments/[attachmentId]/download/route.ts`) — new
- Clerk auth + approved `trip_registrations` check (admins bypass)
- Same signed URL + redirect pattern

**Confirm route** (`/api/admin/trips/[id]/upload-url/confirm/route.ts`)
- Stores `path` (not `getPublicUrl()`) in `trip_attachments.file_url`
- Returns `{ url: path, ...attachment }` — `useSignedUpload` contract unchanged

**DELETE route** (`/api/admin/trips/[id]/attachments/[attachmentId]/route.ts`)
- Simplified: `file_url` is now a path, no URL parsing needed for `storage.remove()`

**`TripFilesSection.tsx`**
- Download link: `/api/admin/trips/${tripId}/attachments/${a.id}/download`
- Optimistic rows (`id.startsWith('optimistic-')`) render as `<span>` — no broken download link
- Dedup by `file_url` (storage path) — works now that confirm returns path as `url`

**`TripDocumentsTile.tsx`**
- `href={a.file_url}` → `href={/api/trips/${tripId}/attachments/${a.id}/download}`

## Manual prerequisite

The `trip-attachments` bucket must be flipped to **private** in the Supabase dashboard before files are fully locked. The migration drops the storage policy; the bucket toggle is the final gate.

## Session State
**Status:** DONE
**Completed:**
- [x] Migration written, applied to prod
- [x] Admin download route
- [x] Member download route (with registration gate)
- [x] Confirm route stores path, not public URL
- [x] DELETE route simplified
- [x] TripFilesSection — download links, optimistic row handling
- [x] TripDocumentsTile — download endpoint hrefs
- [x] PR created
**Next:** GCR, then manually toggle bucket to private in Supabase dashboard

Closes #407