### PR TITLE
[hotfix] Re-sync Clerk publicMetadata.role from DB for all primary profiles

### DIFF
--- a/app/api/admin/clerk-role-sync/route.ts
+++ b/app/api/admin/clerk-role-sync/route.ts
@@ -29,7 +29,7 @@ export async function POST(): Promise<NextResponse> {
 
   const { data: profiles, error } = await supabase
     .from('profiles')
-    .select('clerk_id, role, first_name, last_name')
+    .select('clerk_id, role')
     .in('role', ['admin', 'core', 'member'])
     .is('primary_profile_id', null)
 

--- a/app/api/admin/clerk-role-sync/route.ts
+++ b/app/api/admin/clerk-role-sync/route.ts
@@ -1,0 +1,58 @@
+import { auth, clerkClient } from '@clerk/nextjs/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST /api/admin/clerk-role-sync
+ *
+ * Incident recovery route — re-syncs Clerk publicMetadata.role for every
+ * primary profile where the DB role is non-guest. Idempotent; safe to call
+ * multiple times. Admin-only.
+ */
+export async function POST(): Promise<NextResponse> {
+  const { userId } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+
+  const { data: callerProfile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (!callerProfile || callerProfile.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { data: profiles, error } = await supabase
+    .from('profiles')
+    .select('clerk_id, role, first_name, last_name')
+    .in('role', ['admin', 'core', 'member'])
+    .is('primary_profile_id', null)
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  const clerk = await clerkClient()
+  const results: { clerk_id: string; role: string; status: string }[] = []
+
+  for (const profile of profiles ?? []) {
+    try {
+      await clerk.users.updateUserMetadata(profile.clerk_id, {
+        publicMetadata: { role: profile.role },
+      })
+      results.push({ clerk_id: profile.clerk_id, role: profile.role, status: 'ok' })
+    } catch (e) {
+      results.push({
+        clerk_id: profile.clerk_id,
+        role: profile.role,
+        status: `error: ${e instanceof Error ? e.message : String(e)}`,
+      })
+    }
+  }
+
+  const failed = results.filter(r => r.status !== 'ok')
+  return NextResponse.json({ synced: results.length, failed: failed.length, results })
+}


### PR DESCRIPTION
## Incident recovery

All users are showing as `guest` in the app despite having correct roles in the DB. Root cause: Clerk `publicMetadata.role` is out of sync — `get_my_role()` reads from the JWT claim, so every RLS policy treating any non-guest operation fails.

This adds a single admin-only POST route that:
1. Fetches all primary profiles with role `admin | core | member` from Supabase
2. Calls `clerk.users.updateUserMetadata` for each with the DB role as source of truth
3. Returns a summary of synced/failed

**After merging:** hit the Vercel preview URL then call `POST /api/admin/clerk-role-sync` as the admin user. All users need to sign out and back in (or wait for JWT expiry ~1h) to get fresh tokens.

Closes nothing — hotfix only. Route can be deleted in a follow-up once root cause of the desync is identified and prevented.