### PR TITLE
[2605-BUG-422] Fix iCal feed excluding Personal events for users promoted after token issuance

### DIFF
--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -14,11 +14,12 @@ export async function GET(req: Request) {
     return new Response('Missing token', { status: 400 })
   }
 
-  // Verify JWT
-  let payload: { profile_id: string; role: string }
+  // Verify JWT — role is intentionally not extracted here; role is always resolved
+  // live from the DB below to avoid stale-token promotion issues
+  let payload: { profile_id: string }
   try {
     const { payload: p } = await jwtVerify(token, secret)
-    payload = p as { profile_id: string; role: string }
+    payload = p as { profile_id: string }
   } catch {
     return new Response('Invalid or expired token', { status: 401 })
   }

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -24,10 +24,11 @@ export async function GET(req: Request) {
   }
 
   // Verify token matches stored token (allows revocation via regenerate)
+  // Also fetch role live so promoted users see the correct event set immediately
   const supabase = createServiceClient()
   const { data: profile } = await supabase
     .from('profiles')
-    .select('ical_token')
+    .select('ical_token, role')
     .eq('id', payload.profile_id)
     .single()
 
@@ -35,11 +36,11 @@ export async function GET(req: Request) {
     return new Response('Token revoked', { status: 401 })
   }
 
-  // Fetch events filtered by role
+  // Fetch events filtered by live profile role (not stale JWT role)
   const { data: events } = await supabase
     .from('calendar_events')
     .select('id, title, description, start_time, end_time, category, location, meeting_url')
-    .contains('access_roles', [payload.role])
+    .contains('access_roles', [profile.role])
     .order('start_time')
 
   // Build iCal — no timezone set so dates are emitted as UTC (DTSTART:...Z)


### PR DESCRIPTION
## Summary

Fixes iCal feed silently excluding Personal events for users whose role was promoted after their feed token was first issued.

## Root Cause

`feed.ics` was filtering events using `payload.role` from the JWT. That role is frozen at token-issuance time and never updated unless the user explicitly regenerates their token. Users promoted from `guest` → `member` retained a stale `role: 'guest'` in their JWT indefinitely, causing Personal events (`access_roles = ['member','core','admin']`) to be excluded from their feed.

## Fix

The profile row was already being fetched for revocation checking. Added `role` to that select and replaced `payload.role` with `profile.role` in the `access_roles` filter. Role is now always resolved live from the DB.

## Changes

- `app/api/calendar/feed.ics/route.ts`: add `role` to profiles select; use `profile.role` instead of `payload.role` for event filter

## DoD
- [x] `app/api/calendar/feed.ics/route.ts`: `role` added to profiles select, `profile.role` used in `access_roles` filter

## Session State
IN PROGRESS: awaiting Vercel preview + CI green
