### PR TITLE
[2605-DEV-424] Add iCal feed display name setting to CalendarSection

### DIFF
--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useCallback, useEffect } from 'react'
-import { useQuery, useMutation } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Copy, Check, RefreshCw, Save } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { apiClient } from '@/lib/apiClient'
@@ -13,6 +13,7 @@ const DEFAULT_CALENDAR_NAME = 'teamenjoyVD'
 
 export function CalendarSection({ profileId }: { profileId: string }) {
   const { t } = useLanguage()
+  const queryClient = useQueryClient()
   const [calCopied, setCalCopied] = useState(false)
   const [displayName, setDisplayName] = useState('')
   const [nameSaved, setNameSaved] = useState(false)
@@ -48,6 +49,8 @@ export function CalendarSection({ profileId }: { profileId: string }) {
         body: JSON.stringify({ ui_prefs: { ical_display_name: name || null } }),
       }),
     onSuccess: () => {
+      // Invalidate profile cache so remounts and other sections see fresh ui_prefs
+      queryClient.invalidateQueries({ queryKey: ['profile'] })
       setNameSaved(true)
       setTimeout(() => setNameSaved(false), 2000)
     },

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -1,16 +1,33 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { useQuery, useMutation } from '@tanstack/react-query'
-import { Copy, Check, RefreshCw } from 'lucide-react'
+import { Copy, Check, RefreshCw, Save } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { apiClient } from '@/lib/apiClient'
+import { type Profile } from '../types'
 
 export const CALENDAR_MIN_HEIGHT = 160
+
+const DEFAULT_CALENDAR_NAME = 'teamenjoyVD'
 
 export function CalendarSection({ profileId }: { profileId: string }) {
   const { t } = useLanguage()
   const [calCopied, setCalCopied] = useState(false)
+  const [displayName, setDisplayName] = useState('')
+  const [nameSaved, setNameSaved] = useState(false)
+
+  // Read existing ical_display_name from the profile query cache (populated by ProfileClient)
+  const { data: fullProfile } = useQuery<Profile>({
+    queryKey: ['profile'],
+    enabled: false,
+  })
+
+  useEffect(() => {
+    if (!fullProfile) return
+    const prefs = (fullProfile.ui_prefs ?? {}) as Record<string, unknown>
+    setDisplayName((prefs.ical_display_name as string | undefined) ?? '')
+  }, [fullProfile?.id])
 
   const { data: calData, refetch: refetchCal } = useQuery<{ url: string }>({
     queryKey: ['cal-feed-token'],
@@ -22,6 +39,18 @@ export function CalendarSection({ profileId }: { profileId: string }) {
   const regenerateCal = useMutation({
     mutationFn: () => apiClient('/api/calendar/feed-token', { method: 'POST' }),
     onSuccess: () => refetchCal(),
+  })
+
+  const saveDisplayName = useMutation({
+    mutationFn: (name: string) =>
+      apiClient('/api/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ ui_prefs: { ical_display_name: name || null } }),
+      }),
+    onSuccess: () => {
+      setNameSaved(true)
+      setTimeout(() => setNameSaved(false), 2000)
+    },
   })
 
   const handleCopy = useCallback(() => {
@@ -36,14 +65,20 @@ export function CalendarSection({ profileId }: { profileId: string }) {
     if (confirm('Regenerate your calendar link? Your old link will stop working.')) regenerateCal.mutate()
   }, [regenerateCal])
 
+  const handleSaveName = useCallback(() => {
+    saveDisplayName.mutate(displayName)
+  }, [displayName, saveDisplayName])
+
   return (
     <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
       <p className="text-xs font-semibold tracking-widest uppercase mb-1" style={{ color: 'var(--text-secondary)' }}>{t('profile.calSub')}</p>
       <p className="text-xs mb-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{t('profile.calSubDesc')}</p>
       <p className="text-xs mb-3 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{t('profile.calSubInstructions')}</p>
+
+      {/* Feed URL row */}
       <div className="flex items-center gap-2">
         <input readOnly value={calData?.url ?? ''} placeholder="Generating…"
-          className="flex-1 border rounded-xl px-3 py-2 text-xs font-mono truncate"
+          className="flex-1 min-w-0 border rounded-xl px-3 py-2 text-xs font-mono truncate"
           style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)', backgroundColor: 'var(--bg-global)' }} />
         <button
           onClick={handleCopy}
@@ -64,6 +99,33 @@ export function CalendarSection({ profileId }: { profileId: string }) {
         >
           <RefreshCw size={14} className={regenerateCal.isPending ? 'motion-safe:animate-spin' : ''} />
         </button>
+      </div>
+
+      {/* Display name row */}
+      <div className="mt-3">
+        <p className="text-xs mb-1.5 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
+          {t('profile.calDisplayNameDesc')}
+        </p>
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={displayName}
+            onChange={e => setDisplayName(e.target.value)}
+            placeholder={t('profile.calDisplayNamePlaceholder')}
+            maxLength={64}
+            className="flex-1 min-w-0 border rounded-xl px-3 py-2 text-xs truncate"
+            style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-global)' }}
+          />
+          <button
+            onClick={handleSaveName}
+            disabled={saveDisplayName.isPending}
+            aria-label={nameSaved ? t('profile.saved') : t('profile.calDisplayNameSave')}
+            className="p-2 rounded-xl transition-all disabled:opacity-40 hover:opacity-80 flex-shrink-0"
+            style={{ backgroundColor: 'var(--brand-forest)', color: 'var(--brand-parchment)' }}
+          >
+            {nameSaved ? <Check size={14} /> : <Save size={14} />}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -25,11 +25,12 @@ export async function GET(req: Request) {
   }
 
   // Verify token matches stored token (allows revocation via regenerate)
-  // Also fetch role live so promoted users see the correct event set immediately
+  // Fetch role + ui_prefs live — role avoids stale JWT promotion issues,
+  // ui_prefs provides the member's custom calendar display name.
   const supabase = createServiceClient()
   const { data: profile } = await supabase
     .from('profiles')
-    .select('ical_token, role')
+    .select('ical_token, role, ui_prefs')
     .eq('id', payload.profile_id)
     .single()
 
@@ -44,10 +45,17 @@ export async function GET(req: Request) {
     .contains('access_roles', [profile.role])
     .order('start_time')
 
+  // Use member's custom display name if set; fall back to default.
+  // Note: calendar apps only read this name on first import — changing it
+  // after subscription has no effect in Google Calendar et al.
+  const calendarName =
+    (profile.ui_prefs as Record<string, unknown> | null)?.ical_display_name as string | undefined
+    ?? 'teamenjoyVD'
+
   // Build iCal — no timezone set so dates are emitted as UTC (DTSTART:...Z)
   // start_time/end_time from Supabase are +00 UTC strings; new Date() preserves that.
   const calendar = ical({
-    name: 'teamenjoyVD',
+    name: calendarName,
     prodId: { company: 'teamenjoyVD', product: 'tevd-portal' },
   })
 

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -34,6 +34,13 @@ export const profile = {
   'profile.calSubCopy':         { en: 'Copy link',               bg: 'Копирай линк'             },
   'profile.calSubCopied':       { en: 'Copied!',                 bg: 'Копирано!'                },
   'profile.calSubRegenerate':   { en: 'Regenerate',              bg: 'Регенерирай'              },
+  'profile.calDisplayName':     { en: 'Calendar display name',   bg: 'Показвано име на календара' },
+  'profile.calDisplayNameDesc': {
+    en: 'Set a custom name for this calendar. Only applied when first importing — rename from your calendar app to change it afterwards.',
+    bg: 'Задайте персонализирано име на календара. Прилага се само при първоначален импорт — след това преименувайте от приложението за календар.',
+  },
+  'profile.calDisplayNamePlaceholder': { en: 'teamenjoyVD (default)', bg: 'teamenjoyVD (по подразбиране)' },
+  'profile.calDisplayNameSave': { en: 'Save name',               bg: 'Запази името'             },
   'profile.expiry.ok':          { en: 'Valid — Document does not expire within 6 months', bg: 'Валиден: Документът е валиден за следващите 6 месеца' },
   'profile.expiry.warning':     { en: 'Expiring soon — update within 6 months', bg: 'Изтича скоро — обновете в рамките на 6 месеца' },
   'profile.expiry.critical':    { en: 'Expired or expiring very soon — action required', bg: 'Изтекло или изтича много скоро — необходимо е действие' },


### PR DESCRIPTION
## Summary

Allows members to set a custom display name for their iCal calendar feed. The name is stored in `ui_prefs.ical_display_name` (no migration, no type regen required) and injected into the iCal `X-WR-CALNAME`/`name` field on each feed request. A UI note explains the first-import-only constraint of calendar apps.

## Changes

- `app/api/calendar/feed.ics/route.ts`: adds `ui_prefs` to profiles select; reads `ui_prefs.ical_display_name` with fallback to `'teamenjoyVD'`
- `app/(dashboard)/profile/components/CalendarSection.tsx`: inline name input + save/saved state below the URL row; reads initial value from `['profile']` query cache; sends `PATCH /api/profile` with `{ ui_prefs: { ical_display_name: value || null } }`; blank = reset to default
- `lib/i18n/domains/profile.ts`: 4 new keys — `profile.calDisplayName`, `profile.calDisplayNameDesc`, `profile.calDisplayNamePlaceholder`, `profile.calDisplayNameSave` — EN + BG

## DoD

- [x] `app/api/calendar/feed.ics/route.ts`: `ui_prefs` added to select; `ui_prefs.ical_display_name ?? 'teamenjoyVD'` used as calendar name
- [x] `app/api/profile/route.ts`: no change required — `ui_prefs` already in PATCH allowlist with merge behaviour
- [x] `app/(dashboard)/profile/components/CalendarSection.tsx`: inline name field with save/saved state; first-import description; 390px safe (`min-w-0` on inputs)
- [x] `lib/i18n/domains/profile.ts`: 4 new translation keys with EN + BG values
- [x] UI renders correctly at 390px

Closes #424

## Session State
**Status:** DONE
**Completed:**
- [x] `feed.ics/route.ts` reads `ui_prefs.ical_display_name`
- [x] `CalendarSection.tsx` inline name setting UI
- [x] `profile.ts` i18n keys
**Next:** Vercel preview + CI green → merge
