### PR TITLE
hotfix: add /erc2026 to public routes

### DIFF
--- a/lib/public-routes.ts
+++ b/lib/public-routes.ts
@@ -11,6 +11,7 @@ import { createRouteMatcher } from '@clerk/nextjs/server'
  *   /library(.*)       library index + guide detail (was /guides before rename)
  *   /sign-in(.*)       auth
  *   /sign-up(.*)       auth
+ *   /erc2026           ERC 2026 trip guide (public link, no login required)
  *   /api/webhooks/(.*) Clerk + Stripe webhooks
  *   /api/calendar      public calendar API
  *   /api/calendar/(.*) public calendar API
@@ -28,6 +29,7 @@ export const PUBLIC_ROUTE_PATTERNS = [
   '/events/(.*)',
   '/sign-in(.*)',
   '/sign-up(.*)',
+  '/erc2026',
   '/api/webhooks/(.*)',
   '/api/calendar',
   '/api/calendar/(.*)',


### PR DESCRIPTION
## What
Adds `/erc2026` to `PUBLIC_ROUTE_PATTERNS` in `lib/public-routes.ts`.

## Why
The ERC 2026 trip guide page was redirecting unauthenticated visitors to `/sign-in`. The page has no auth dependency — it's a static trip guide intended to be shared via link to anyone in the group.

## Change
`lib/public-routes.ts` — one entry added, comment block updated.

## Risk
None. No data access, no Supabase queries, no Clerk dependency on the page itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the `/erc2026` route publicly accessible to guest users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->