### PR TITLE
[2606-DEV-458] FEAT: roles page quarter-based view + user dropdown profile link

### DIFF
--- a/app/(dashboard)/roles/components/RolesClient.tsx
+++ b/app/(dashboard)/roles/components/RolesClient.tsx
@@ -6,6 +6,7 @@ import type { RoleEvent } from '@/app/api/roles/route'
 
 type Props = {
   events: RoleEvent[]
+  currentTime: string
 }
 
 type SlotLabel = 'HOST' | 'SPEAKER' | 'PRODUCTS'
@@ -34,7 +35,7 @@ function OccupantCell({ name }: { name: string | null }) {
 
 // ── Desktop table ────────────────────────────────────────────────────────────
 
-function RolesTable({ events, headers }: { events: RoleEvent[]; headers: string[] }) {
+function RolesTable({ events, headers, currentTime }: { events: RoleEvent[]; headers: string[]; currentTime: string }) {
   return (
     <div
       className="rounded-2xl overflow-hidden"
@@ -55,7 +56,7 @@ function RolesTable({ events, headers }: { events: RoleEvent[]; headers: string[
 
       {/* Data rows */}
       {events.map((event, i) => {
-        const isPast = new Date(event.start_time) < new Date()
+        const isPast = new Date(event.start_time) < new Date(currentTime)
         return (
           <div
             key={event.id}
@@ -91,11 +92,11 @@ function RolesTable({ events, headers }: { events: RoleEvent[]; headers: string[
 
 // ── Mobile cards ─────────────────────────────────────────────────────────────
 
-function RolesCards({ events, slotLabels }: { events: RoleEvent[]; slotLabels: Record<SlotLabel, string> }) {
+function RolesCards({ events, slotLabels, currentTime }: { events: RoleEvent[]; slotLabels: Record<SlotLabel, string>; currentTime: string }) {
   return (
     <div className="flex flex-col gap-3">
       {events.map(event => {
-        const isPast = new Date(event.start_time) < new Date()
+        const isPast = new Date(event.start_time) < new Date(currentTime)
         return (
           <div
             key={event.id}
@@ -143,7 +144,7 @@ function RolesCards({ events, slotLabels }: { events: RoleEvent[]; slotLabels: R
 
 // ── Main component ───────────────────────────────────────────────────────────
 
-export default function RolesClient({ events }: Props) {
+export default function RolesClient({ events, currentTime }: Props) {
   const { t } = useLanguage()
 
   const headers = [
@@ -181,7 +182,7 @@ export default function RolesClient({ events }: Props) {
             {t('event.rolesEmpty')}
           </p>
         ) : (
-          <RolesTable events={events} headers={headers} />
+          <RolesTable events={events} headers={headers} currentTime={currentTime} />
         )}
       </div>
 
@@ -202,7 +203,7 @@ export default function RolesClient({ events }: Props) {
             {t('event.rolesEmpty')}
           </p>
         ) : (
-          <RolesCards events={events} slotLabels={slotLabels} />
+          <RolesCards events={events} slotLabels={slotLabels} currentTime={currentTime} />
         )}
       </div>
 

--- a/app/(dashboard)/roles/components/RolesClient.tsx
+++ b/app/(dashboard)/roles/components/RolesClient.tsx
@@ -54,32 +54,37 @@ function RolesTable({ events, headers }: { events: RoleEvent[]; headers: string[
       </div>
 
       {/* Data rows */}
-      {events.map((event, i) => (
-        <div
-          key={event.id}
-          className="grid items-center px-4 py-3 text-sm"
-          style={{
-            gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr 1fr',
-            borderTop: i === 0 ? undefined : '1px solid rgba(0,0,0,0.04)',
-          }}
-        >
-          <span
-            className="font-semibold truncate pr-4"
-            style={{ color: 'var(--text-primary)' }}
+      {events.map((event, i) => {
+        const isPast = new Date(event.start_time) < new Date()
+        return (
+          <div
+            key={event.id}
+            className="grid items-center px-4 py-3 text-sm transition-all"
+            style={{
+              gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr 1fr',
+              borderTop: i === 0 ? undefined : '1px solid rgba(0,0,0,0.04)',
+              opacity: isPast ? 0.6 : undefined,
+              filter: isPast ? 'grayscale(0.5)' : undefined,
+            }}
           >
-            {event.title}
-          </span>
-          <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-            {formatDate(event.start_time)}
-          </span>
-          <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-            {formatTime(event.start_time)}
-          </span>
-          <span className="text-xs"><OccupantCell name={event.slots.HOST} /></span>
-          <span className="text-xs"><OccupantCell name={event.slots.SPEAKER} /></span>
-          <span className="text-xs"><OccupantCell name={event.slots.PRODUCTS} /></span>
-        </div>
-      ))}
+            <span
+              className="font-semibold truncate pr-4"
+              style={{ color: 'var(--text-primary)' }}
+            >
+              {event.title}
+            </span>
+            <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+              {formatDate(event.start_time)}
+            </span>
+            <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+              {formatTime(event.start_time)}
+            </span>
+            <span className="text-xs"><OccupantCell name={event.slots.HOST} /></span>
+            <span className="text-xs"><OccupantCell name={event.slots.SPEAKER} /></span>
+            <span className="text-xs"><OccupantCell name={event.slots.PRODUCTS} /></span>
+          </div>
+        )
+      })}
     </div>
   )
 }
@@ -89,15 +94,19 @@ function RolesTable({ events, headers }: { events: RoleEvent[]; headers: string[
 function RolesCards({ events, slotLabels }: { events: RoleEvent[]; slotLabels: Record<SlotLabel, string> }) {
   return (
     <div className="flex flex-col gap-3">
-      {events.map(event => (
-        <div
-          key={event.id}
-          className="rounded-2xl p-4"
-          style={{
-            border: '1px solid rgba(0,0,0,0.07)',
-            backgroundColor: 'var(--bg-card)',
-          }}
-        >
+      {events.map(event => {
+        const isPast = new Date(event.start_time) < new Date()
+        return (
+          <div
+            key={event.id}
+            className="rounded-2xl p-4 transition-all"
+            style={{
+              border: '1px solid rgba(0,0,0,0.07)',
+              backgroundColor: 'var(--bg-card)',
+              opacity: isPast ? 0.6 : undefined,
+              filter: isPast ? 'grayscale(0.5)' : undefined,
+            }}
+          >
           {/* Event title + date/time */}
           <p
             className="text-sm font-semibold mb-1 leading-snug"
@@ -125,8 +134,9 @@ function RolesCards({ events, slotLabels }: { events: RoleEvent[]; slotLabels: R
               </div>
             ))}
           </div>
-        </div>
-      ))}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/app/(dashboard)/roles/loading.tsx
+++ b/app/(dashboard)/roles/loading.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { Loader2 } from 'lucide-react'
+
+export default function RolesLoading() {
+  return (
+    <div className="w-full min-h-[60vh] flex items-center justify-center">
+      <Loader2 className="w-8 h-8 animate-spin" style={{ color: 'var(--brand-forest)' }} />
+    </div>
+  )
+}

--- a/app/(dashboard)/roles/page.tsx
+++ b/app/(dashboard)/roles/page.tsx
@@ -23,8 +23,8 @@ export default async function RolesPage() {
   }
 
   const now = new Date()
-  const year = now.getFullYear()
-  const month = now.getMonth()
+  const year = now.getUTCFullYear()
+  const month = now.getUTCMonth()
   const quarter = Math.floor(month / 3)
   const startMonth = quarter * 3
   const startOfQuarter = new Date(Date.UTC(year, startMonth, 1, 0, 0, 0, 0))
@@ -43,7 +43,7 @@ export default async function RolesPage() {
   )
 
   if (eventsWithSlots.length === 0) {
-    return <RolesClient events={[]} />
+    return <RolesClient events={[]} currentTime={now.toISOString()} />
   }
 
   const eventIds = eventsWithSlots.map(e => e.id)
@@ -75,5 +75,5 @@ export default async function RolesPage() {
     },
   }))
 
-  return <RolesClient events={roleEvents} />
+  return <RolesClient events={roleEvents} currentTime={now.toISOString()} />
 }

--- a/app/(dashboard)/roles/page.tsx
+++ b/app/(dashboard)/roles/page.tsx
@@ -22,11 +22,20 @@ export default async function RolesPage() {
     redirect('/calendar')
   }
 
-  // Fetch upcoming events with slots
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth()
+  const quarter = Math.floor(month / 3)
+  const startMonth = quarter * 3
+  const startOfQuarter = new Date(Date.UTC(year, startMonth, 1, 0, 0, 0, 0))
+  const startOfNextQuarter = new Date(Date.UTC(year, startMonth + 3, 1, 0, 0, 0, 0))
+
+  // Fetch current quarter events with slots
   const { data: events } = await supabase
     .from('calendar_events')
     .select('id, title, start_time, end_time, event_role_slots ( role_label )')
-    .gte('start_time', new Date().toISOString())
+    .gte('start_time', startOfQuarter.toISOString())
+    .lt('start_time', startOfNextQuarter.toISOString())
     .order('start_time', { ascending: true })
 
   const eventsWithSlots = (events ?? []).filter(

--- a/components/layout/UserDropdown.tsx
+++ b/components/layout/UserDropdown.tsx
@@ -116,7 +116,7 @@ export default function UserDropdown() {
 
         {/* Actions */}
         <div>
-          {isAdmin && (
+          {isAdmin ? (
             <DropdownMenuItem asChild>
               <Link
                 href="/admin"
@@ -136,14 +136,32 @@ export default function UserDropdown() {
                 Admin
               </Link>
             </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem asChild>
+              <Link
+                href="/profile"
+                onClick={() => setOpen(false)}
+                className="flex items-center gap-2.5 px-4 py-2.5 text-sm font-medium transition-colors cursor-pointer"
+                style={{ color: 'var(--text-primary)' }}
+                onMouseEnter={e => (e.currentTarget.style.backgroundColor = 'var(--bg-global)')}
+                onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'transparent')}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+                  <circle cx="12" cy="7" r="4" />
+                </svg>
+                {lang === 'en' ? 'Profile' : 'Профил'}
+              </Link>
+            </DropdownMenuItem>
           )}
 
-          {/* Language — borderTop only when Admin row is above it */}
+          {/* Language — borderTop is now unconditional */}
           <DropdownMenuItem
             onSelect={e => e.preventDefault()}
             className="flex items-center justify-between px-4 py-2.5"
             style={{
-              borderTop: isAdmin ? '1px solid var(--border-default)' : '0px solid transparent',
+              borderTop: '1px solid var(--border-default)',
               cursor: 'default',
             }}
           >

--- a/docs/ai/QA.md
+++ b/docs/ai/QA.md
@@ -1,0 +1,83 @@
+# Q&A & Backlog Reference Document
+
+This document compiles technical questions, answers, and the current backlog of planned developments for the `tevd-portal` codebase.
+
+---
+
+## Current Todo Backlog
+
+### 1. Roles Page Refactor (`app/(dashboard)/roles/page.tsx`)
+* **Current Quarter Querying:** Modify the database fetch to retrieve meetings starting from the beginning of the current quarter (e.g., April 1 to June 30 for Q2 2026) instead of only querying future events (`gte('start_time', now)`).
+* **Past Meetings Styling:** Mute or gray out past meetings within the current quarter visually to make them distinct from upcoming ones.
+* **History & Analytics View:** Add a "History" button that triggers a detailed view with:
+  * Full historical data of all past meetings across all quarters and years.
+  * Search/filter options (by Year, Quarter, Roles, and Members).
+  * Counter metrics summarizing participation counts (e.g., total times hosted/spoken/handled products per member).
+
+### 2. User Dropdown Profile Link (`components/layout/UserDropdown.tsx`)
+* **Regular User Profile Action:** When a non-admin user opens the dropdown, render a styled menu item (matching the style and position of the "Admin" button) that links to `/profile` (translating dynamically as "Profile" / "Профил").
+
+---
+
+## Reference Q&A
+
+### 1. Authentication Refactor Prompting
+
+**Question:** If I had to ask you to refactor the authentication, how should that prompt look like?
+
+**Answer:** Use the issue structure defined in `CLAUDE.md`:
+```markdown
+REFACTOR: [Short description of the authentication refactor]
+
+## Context
+[Explain the goal of the refactor. For example: "We need to split API routes into public/private tiers, update public-routes helper list, or introduce role-based API protection via custom headers set in proxy.ts."]
+
+## Design
+- **Proxy/Routing:** All custom authentication routing, request rewriting, or route matching must reside inside `proxy.ts` (Option C Hybrid middleware structure). Do not place custom routing logic directly in `middleware.ts`.
+- **Async Verification:** All check/verification sites must use the asynchronous `auth()` call:
+  ```typescript
+  const { userId } = await auth();
+  ```
+- **Clerk / Supabase separation:** Ensure we do not leak the Supabase service role key to any client-side routes, and that Clerk acts as the single source of truth for the active `userId`.
+
+## Definition of Done
+- [ ] `proxy.ts` updated to route/allow [specific routes/conditions]
+- [ ] `lib/public-routes.ts` updated with [new route matchers]
+- [ ] Protected route handlers verify `userId` asynchronously at the beginning of the function
+- [ ] CI builds successfully and Vercel preview is READY
+
+## Affected Files
+- `proxy.ts` (modify)
+- `lib/public-routes.ts` (modify)
+- `app/api/...` (modify)
+
+## Gotchas & Constraints
+- **NEVER** create or modify a root `middleware.ts` to contain custom routing logic (auth logic belongs in `proxy.ts`).
+- **NEVER** bypass Clerk auth on a protected route.
+- **NEVER** expose `SUPABASE_SERVICE_ROLE_KEY` to the client.
+
+## Branch
+dev/[YYMM]-DEV-[GH#]
+```
+
+### 2. Complete Current Authentication Structure
+
+**Question:** Are you able to list the complete current authentication?
+
+**Answer:** 
+* **The Entry Point Proxy Middleware ([proxy.ts](file:///c:/Users/fefence/Downloads/react/teamenjoyvd/tevd-portal/proxy.ts)):** Consolidates Clerk's middleware and routing logic. Unauthenticated API calls return `401`, and unauthenticated page hits redirect to `/sign-in`.
+* **Public vs. Private Routes ([lib/public-routes.ts](file:///c:/Users/fefence/Downloads/react/teamenjoyvd/tevd-portal/lib/public-routes.ts)):** Controls the list of routes that bypass auth.
+* **Route/Action-Level Verification:** Every protected component, handler, or Action calls `await auth()` asynchronously.
+* **Database RLS Mapping:** Maps Clerk IDs to profiles and evaluates rules via custom RLS helper functions like `is_admin()`.
+
+### 3. Page Reload Stale State during Login/Logout
+
+**Question:** Why are some pages not reloaded properly before/after login/logout?
+
+**Answer:** Next.js uses client-side route caching and pre-renders static routes by default. When authentication changes, the browser cache is not automatically invalidated. To fix it, pages must force dynamic rendering (`export const dynamic = 'force-dynamic'`), and sign-in/out transitions should trigger `router.refresh()` or a full page reload (`window.location.href`).
+
+### 4. Lack of Loading Animation during Page Transitions
+
+**Question:** Why do we not have a loading animation? Some page transitions take a while and loading animation will be in fact useful.
+
+**Answer:** Next.js App Router transitions are blocking by default unless a `loading.tsx` boundary is defined. Because no `loading.tsx` exists at the root or main layout folders, navigations wait silently in the background for Server Components to resolve. Adding a global top loader like `nextjs-toploader` or folder-level `loading.tsx` templates will fix this.

--- a/docs/ai/QA.md
+++ b/docs/ai/QA.md
@@ -65,8 +65,8 @@ dev/[YYMM]-DEV-[GH#]
 **Question:** Are you able to list the complete current authentication?
 
 **Answer:** 
-* **The Entry Point Proxy Middleware ([proxy.ts](file:///c:/Users/fefence/Downloads/react/teamenjoyvd/tevd-portal/proxy.ts)):** Consolidates Clerk's middleware and routing logic. Unauthenticated API calls return `401`, and unauthenticated page hits redirect to `/sign-in`.
-* **Public vs. Private Routes ([lib/public-routes.ts](file:///c:/Users/fefence/Downloads/react/teamenjoyvd/tevd-portal/lib/public-routes.ts)):** Controls the list of routes that bypass auth.
+* **The Entry Point Proxy Middleware ([proxy.ts](../../proxy.ts)):** Consolidates Clerk's middleware and routing logic. Unauthenticated API calls return `401`, and unauthenticated page hits redirect to `/sign-in`.
+* **Public vs. Private Routes ([lib/public-routes.ts](../../lib/public-routes.ts)):** Controls the list of routes that bypass auth.
 * **Route/Action-Level Verification:** Every protected component, handler, or Action calls `await auth()` asynchronously.
 * **Database RLS Mapping:** Maps Clerk IDs to profiles and evaluates rules via custom RLS helper functions like `is_admin()`.
 

--- a/lib/i18n/domains/events.ts
+++ b/lib/i18n/domains/events.ts
@@ -19,7 +19,7 @@ export const events = {
 
   // roles page
   'event.rolesPageTitle':   { en: 'Roles',             bg: 'Роли'                            },
-  'event.rolesEmpty':       { en: 'No upcoming events with roles configured.', bg: 'Няма предстоящи събития с конфигурирани роли.' },
+  'event.rolesEmpty':       { en: 'No events with roles configured this quarter.', bg: 'Няма събития с конфигурирани роли за това тримесечие.' },
 
   // roles page — table headers
   'event.roles.col.event':    { en: 'Event',    bg: 'Събитие'  },


### PR DESCRIPTION
## Context
Implement a quarter-based event view for the roles page, add visual dimming for past quarter events, scope page loading using native Next.js loader components, and expose a profile navigation link in the user avatar dropdown menu.

## Design Checklist
- [x] DoD defined (specific, file-path-level)
- [x] Affected files listed by path
- [x] Gotchas flagged against docs/ai/GOTCHAS.md
- [x] Blocking unknowns: none

## Branch
`dev/2606-DEV-458`

## Session State
Handoff details and verification results are documented in [walkthrough.md](file:///C:/Users/fefence/.gemini/antigravity/brain/8f7d7318-b25c-4a32-9f70-c0e73eb18c1b/walkthrough.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a loading animation for the Roles dashboard page.
  * Roles now shows calendar events for the current quarter (UTC-based).
  * Past events are visually distinguished with reduced opacity and grayscale styling.
  * Updated the user dropdown to show either Admin or Profile menu options.

* **Documentation**
  * Added an AI QA reference guide.

* **UI Text**
  * Updated the Roles empty-state wording to reflect “this quarter.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->