### PR TITLE
[2607-DEV-467] Commit guide-attachments bucket migration

### DIFF
--- a/supabase/migrations/20260701132009_create_guide_attachments_bucket.sql
+++ b/supabase/migrations/20260701132009_create_guide_attachments_bucket.sql
@@ -1,0 +1,19 @@
+-- Create guide-attachments bucket for guide attachment files (PDF, images, and
+-- other document types allow-listed at the app level).
+-- Uploads/deletes go through the service_role-only route handler, which bypasses
+-- RLS by design (service_role has BYPASSRLS). This policy only covers public
+-- read of the resulting public URLs.
+-- No bucket-level MIME allow-list: arbitrary types (e.g. .docx, .zip) are
+-- intentionally permitted through the app-level check as 'other'; a bucket-level
+-- allow-list would block them before that logic ever runs.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit)
+VALUES ('guide-attachments', 'guide-attachments', true, 20971520)
+ON CONFLICT (id) DO NOTHING;
+
+-- Public read
+CREATE POLICY "guide-attachments public read"
+ON storage.objects
+FOR SELECT
+TO public
+USING (bucket_id = 'guide-attachments');

--- a/supabase/migrations/20260701132009_create_guide_attachments_bucket.sql
+++ b/supabase/migrations/20260701132009_create_guide_attachments_bucket.sql
@@ -12,6 +12,8 @@ VALUES ('guide-attachments', 'guide-attachments', true, 20971520)
 ON CONFLICT (id) DO NOTHING;
 
 -- Public read
+DROP POLICY IF EXISTS "guide-attachments public read" ON storage.objects;
+
 CREATE POLICY "guide-attachments public read"
 ON storage.objects
 FOR SELECT


### PR DESCRIPTION
Closes #467

No application code changes. The `guide-attachments` bucket was created directly against the project DB via Supabase MCP but the migration was never committed, so `supabase/migrations/` had no record of it — a fresh `db reset` or a new Supabase branch would not have this bucket.

This PR adds `supabase/migrations/20260701132009_create_guide_attachments_bucket.sql`, matching the live bucket exactly:
- `public = true`, `file_size_limit = 20971520` (20MB)
- No bucket-level `allowed_mime_types` — intentional, so the app-level check (which allows arbitrary types through as `'other'`) remains the sole enforcer
- `guide-attachments public read` SELECT policy for `public`

Verified directly against the DB before writing this:
- Bucket config matches DoD (public, 20MB limit)
- `service_role` has `rolbypassrls = true`, so upload/delete via the route handler works regardless of `storage.objects` policies — no separate service_role policy was needed or added
- The migration version prefix (`20260701132009`) matches what's already recorded in `supabase_migrations.schema_migrations` on the project, so this file documents state rather than re-applying it

Still outstanding, not covered by this PR: manual verification (upload PDF + image via `/admin/content/guides/[id]/edit` on this PR's Vercel preview) — needs an actual browser test once the preview is up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new public attachment storage area for guides.
  * Set a 20MB upload limit for files in that storage area.
  * Enabled public read access for shared attachment links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->