### PR TITLE
docs: fix stale/contradictory guardrails, architecture, and cursor-rules content

### DIFF
--- a/.cursor/rules/auth.mdc
+++ b/.cursor/rules/auth.mdc
@@ -1,6 +1,6 @@
 ---
 description: Enforces Clerk authentication, protected routes, middleware scope, and proxy routing
-globs: ["app/api/**/*.ts", "proxy.ts", "lib/public-routes.ts"]
+globs: ["app/api/**/*.ts", "proxy.ts", "lib/public-routes.ts", "lib/actions/**/*.ts", "app/**/actions/**/*.ts"]
 alwaysApply: false
 ---
 # Authentication and Edge Protection Rule

--- a/.cursor/rules/auth.mdc
+++ b/.cursor/rules/auth.mdc
@@ -1,17 +1,17 @@
 ---
 description: Enforces Clerk authentication, protected routes, middleware scope, and proxy routing
-globs: ["app/api/**/*.ts", "middleware.ts", "lib/proxy.ts"]
+globs: ["app/api/**/*.ts", "proxy.ts", "lib/public-routes.ts"]
 alwaysApply: false
 ---
 # Authentication and Edge Protection Rule
 
 This rule enforces constraints regarding Clerk authentication, protected routes, middleware scope, and proxy routing.
 
-## Middleware Scope (Option C Hybrid)
+## Middleware Scope (proxy.ts only)
 
-- Root `middleware.ts` is permitted **ONLY** for Clerk's `clerkMiddleware()` — no other logic.
-- Custom API proxy/routing logic must be implemented in `lib/proxy.ts`.
-- **NEVER** add custom routing, request rewriting, or header manipulation logic to `middleware.ts`.
+- The Clerk middleware lives in root `proxy.ts` — the only middleware file in this project.
+- **NEVER create `middleware.ts`** — not even for `clerkMiddleware()`. See `docs/architecture/DECISIONS.md` ADR-006.
+- Custom routing, request rewriting, and header manipulation logic belongs in root `proxy.ts`; the public-route list lives in `lib/public-routes.ts`.
 
 ## Clerk Integration
 

--- a/.cursor/rules/database.mdc
+++ b/.cursor/rules/database.mdc
@@ -12,6 +12,8 @@ This rule enforces the strict usage of RLS policies, Pattern A helpers, and deta
 - **RLS policies must ONLY reference Pattern A helper functions** which live in `20260315000000_baseline.sql`:
   - `get_my_clerk_id()` - Returns the Clerk user ID from the JWT custom claim.
   - `get_my_profile_id()` - Returns the profile ID for the current Clerk user.
+  - `get_my_role()` - Returns the `user_role` claim from the JWT (`user_role` enum).
+  - `is_admin()` - Returns true when `get_my_role()` = 'admin'.
 - **NEVER** use raw `auth.jwt()` or other inline mechanisms within RLS policies.
 
 ### Helper Definitions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md — rules pointer for non-Claude agents (Antigravity, Gemini, Cursor)
+
+Governing ruleset: read `CLAUDE.md` in full — routing table, iron rules, `## Project` (constants + Hard Constraints), and `## Hard stops`. It is the single source of law for every agent working in this repo. This file is a pointer only; never duplicate rules from `CLAUDE.md` here.
+
+- Project workflow (SSU / PLAN / CLAIM / BUILD / GCR), ID format, issue labels, CLAIM-complete definition: `docs/guardrails/PROJECT.md`
+- Sharp edges: `docs/ai/GOTCHAS.md` — read in full at SHAPE and GATHER
+- Reference tables (schema, routes, design system, env vars): `docs/ai/REF.md` — sections on demand at GATHER
+- Architecture: `docs/architecture/` (C4.md, FLOWS.md, DECISIONS.md)
+- Multi-agent coexistence: `docs/guardrails/PROJECT.md#multi-agent-coexistence` — the PR `## Session State` block is the sole cross-agent handoff.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Violation = immediate stop, no exceptions.
 - **NEVER write data to Supabase from a Preview URL** — preview URLs hit production DB.
 - **390px mobile-first.** Every new UI surface must render correctly at 390px.
 - **RLS policies use Pattern A helpers only** — `is_admin()`, `get_my_role()`, `get_my_profile_id()`, `get_my_clerk_id()`. Never raw `auth.jwt()`.
+- **NEVER introduce a Clerk JWT Supabase client on the server.** All server DB access uses `createServiceClient()` (service role); a JWT client requires a ticket explicitly scoping it (ADR-002/ADR-011).
 - **shadcn/ui for all interactive primitives** — dialog, popover, dropdown, sheet, tooltip, select, combobox, alert dialog.
 - **Component co-location** — new components scoped to one route go in `app/[route]/components/`. Promote to `/components` only when used by 2+ unrelated routes.
 - **Layout Decision Rules (Quantitative)** — Default is a single responsive layout file. Dual layout (separate files) is required only for: tables with 5+ columns, complex touch vs mouse drag-and-drop, persistent sidebar layouts, or interactive canvases/maps/rich-text editors. Refer to `.cursor/rules/frontend.mdc` for precise triggers.

--- a/README.md
+++ b/README.md
@@ -626,3 +626,7 @@ lib/hooks/
   color: var(--crimson) !important;
 }
 ```
+
+## Upgrade notes
+
+- 2026-07-06 — Guardrails review follow-up: added Hard Constraint "NEVER introduce a Clerk JWT Supabase client on the server" to `CLAUDE.md` `## Project` (implements the mitigation ADR-002 already claimed existed). Kit core/footer untouched — sentinel stays `guardrails-kit: v1.0`. Doc corrections in the same change: C4.md RLS lines now cite Pattern A helpers (ADR-011); FLOWS.md §1/§4 briefly rewritten to an Inngest approval flow per REF/C4, then reverted same-day — git history (#322 "Rip out Inngest") proved Inngest was removed and REF/C4 are the stale docs (net FLOWS change: one history note in §1); CONTEXT.md §1-§3 de-duplicated into pointers to REF.md; auth.mdc rewritten (middleware.ts never permitted; globs now match root `proxy.ts`); REF.md vitals route corrected to `/api/profile/vital-signs` + trips/messages routes added; ADR-009 marked Amended (quantitative layout rules govern); ADR-006 next.config claim corrected; QA.md/database.mdc/GOTCHAS.md minor corrections.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,12 +2,12 @@
 Review CLAUDE.md + guardrails/ai/architecture/cursor-rules infrastructure; apply the approved doc fixes (findings 1-14, 16) from the review plan.
 
 ## Now
-CLAIM complete for the test-infra ticket: GitHub issue #472, branch dev/2607-DEV-472 (from main), Design Checklist + ## Branch both on the issue body. Phantom-Inngest doc purge also complete and grep-verified clean.
+Doc-fix commit (1cce4c2, 15 files) pushed to claude/mystifying-almeida-2e1a2e; PR #473 opened against main per explicit user create-pr-command. CLAIM for the separate test-infra ticket (#472 / dev/2607-DEV-472) already complete.
 
 ## Next
-1. BUILD #472 (separate invocation — anthropic-skills:build; BUILD does no design work, CLAIM already complete)
-2. This worktree's local doc-fix edits (11+ files, uncommitted) are unrelated to #472's branch — if user wants them committed/pushed, confirm target branch first (never main; never push unless asked)
-3. User-side: point Antigravity's config at root AGENTS.md / CLAUDE.md
+1. BUILD #472 (separate invocation — anthropic-skills:build; different branch, unrelated to PR #473)
+2. User-side: point Antigravity's config at root AGENTS.md / CLAUDE.md
+3. Watch PR #473 for CI/Vercel preview result (doc-only change, build should be unaffected)
 
 ## Constraints
 - PLAN-mode review first, "do not edit any file... Wait for approval before touching anything" (approval granted via ExitPlanMode)
@@ -25,6 +25,7 @@ DECISION: ADR-009/ADR-006 get dated amendment/correction notes, not rewrites —
 ## Facts
 - Issue #472 "[2607-DEV-472] Add test infrastructure: Vitest + CI test job + first unit tests" — https://github.com/teamenjoyvd/tevd-portal/issues/472
 - Branch dev/2607-DEV-472 created from main (sha 2e8a745, current main tip at CLAIM time)
+- PR #473 (doc fixes) — https://github.com/teamenjoyvd/tevd-portal/pull/473, branch claude/mystifying-almeida-2e1a2e -> main, commit 1cce4c2
 - Worktree: .claude/worktrees/mystifying-almeida-2e1a2e, branch claude/mystifying-almeida-2e1a2e, tree clean at session start
 - No middleware.ts, no lib/proxy.ts; Clerk middleware = root proxy.ts; next.config.ts has no proxy mention
 - Actual vitals route dir: app/api/profile/vital-signs (no `vitals` dir)
@@ -44,6 +45,7 @@ Fixes applied — RESULT: 11 files modified + docs/STATE.md created; 52 insertio
 NOTED (not done): docs/archive/CLAUDE.md.bak still contains 2 `add <n>` occurrences — archived file, left untouched.
 Finding-5 correction — RESULT: original FLOWS.md text was right all along (Inngest removed in #322); my Inngest rewrite reverted same session, net FLOWS diff = header date + one history-note sentence. Evidence: git diff quoted in transcript; git log -S inngest -> 0272e7a "Rip out Inngest".
 Phantom-Inngest purge — RESULT: C4.md/REF.md/SYSTEM-MAP.mermaid corrected; final grep shows only 5 intentional "removed in #322" notes remain repo-wide; mermaid subgraph/end counts balanced 15/15 post-edit.
+PR creation — RESULT: 15 files committed (1cce4c2), pushed to claude/mystifying-almeida-2e1a2e, PR #473 opened. Pre-commit hook (validate-rules.js): 2 passed, 101 warnings (pre-existing migration ROLLBACK-comment convention + branch-naming heuristic), 0 failures.
 
 ## Open items
 - Finding 15 CLOSED: user decision = leave DEBUG.md as-is; report the F11 overage upstream to the kit source if desired

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,0 +1,54 @@
+## Goal
+Review CLAUDE.md + guardrails/ai/architecture/cursor-rules infrastructure; apply the approved doc fixes (findings 1-14, 16) from the review plan.
+
+## Now
+CLAIM complete for the test-infra ticket: GitHub issue #472, branch dev/2607-DEV-472 (from main), Design Checklist + ## Branch both on the issue body. Phantom-Inngest doc purge also complete and grep-verified clean.
+
+## Next
+1. BUILD #472 (separate invocation — anthropic-skills:build; BUILD does no design work, CLAIM already complete)
+2. This worktree's local doc-fix edits (11+ files, uncommitted) are unrelated to #472's branch — if user wants them committed/pushed, confirm target branch first (never main; never push unless asked)
+3. User-side: point Antigravity's config at root AGENTS.md / CLAUDE.md
+
+## Constraints
+- PLAN-mode review first, "do not edit any file... Wait for approval before touching anything" (approval granted via ExitPlanMode)
+- "do not weaken or remove [Hard stops / CAPS constraints] as part of improving the kit"
+- "Do not paraphrase or summarize any guardrail doc into your own words and act from that summary"
+- Finding 15: user chose "Leave as-is" — DEBUG.md stays byte-identical to kit v1.0; do not trim
+- Finding 17: user chose "Still used — wire it up" — AGENTS.md + PROJECT.md addendum authorized (supersedes the earlier "PROJECT.md untouched" scope line)
+- No git commit/push requested this conversation
+
+## Decisions
+DECISION: Finding 9 implemented as option (a) — add Clerk-JWT-client constraint to CLAUDE.md `## Project` — plan recommended (a), approved unchanged.
+DECISION: CONTEXT.md sections 1-3 replaced with pointers to REF.md sections 1-3 (finding 10; subsumes fixes 3 and 4) — the drift was the LOOKUP.md failure mode.
+DECISION: ADR-009/ADR-006 get dated amendment/correction notes, not rewrites — DECISIONS.md header says records are never deleted.
+
+## Facts
+- Issue #472 "[2607-DEV-472] Add test infrastructure: Vitest + CI test job + first unit tests" — https://github.com/teamenjoyvd/tevd-portal/issues/472
+- Branch dev/2607-DEV-472 created from main (sha 2e8a745, current main tip at CLAIM time)
+- Worktree: .claude/worktrees/mystifying-almeida-2e1a2e, branch claude/mystifying-almeida-2e1a2e, tree clean at session start
+- No middleware.ts, no lib/proxy.ts; Clerk middleware = root proxy.ts; next.config.ts has no proxy mention
+- Actual vitals route dir: app/api/profile/vital-signs (no `vitals` dir)
+- Existing but undocumented in REF.md: app/api/trips/route.ts, app/api/trips/[id]/messages/, app/api/admin/trips/[id]/messages/(+[messageId])
+- Kit budget counts: 12 iron rules, core+footer 40 lines, 4 CAPS lines, all 7 F7 pairs byte-identical, DEBUG.md 1212 words
+- README.md lacks `## Upgrade notes` (F15 target)
+- Repo has no test runner (CONTEXT.md §4); CI = 4 parallel jobs (typecheck/lint/build/audit), node 22, on push+PR to main (.github/workflows/ci.yml)
+- #322 (0272e7a, 2026-05-10) ripped out Inngest entirely: no inngest/postgres deps, no inngest/ or lib/db/ dirs, /api/inngest removed from lib/public-routes.ts; approve path = synchronous approve_member_verification RPC + Clerk updateUserMetadata + email in app/api/admin/members/verify/[id]/route.ts
+- PHANTOM DOCS PURGED (2026-07-06): C4.md (External Systems Inngest bullet, Container 1 internal-structure/responsibilities/does-not-own/contract, Container 3 contract + does-not-own, Container 5 removed entirely — now correctly "Four deployable units"), REF.md (§1 lib/db/client.ts + inngest/* entries, §4 tree /inngest dir + /inngest/route.ts + /lib/db/client.ts, §6 /api/inngest row + verify-route description + RPC deprecated claim, §9 DATABASE_URL/INNGEST_* env rows, §5 approval_jobs marked orphaned), SYSTEM-MAP.mermaid (INN/INNGEST subgraph/I1-I3, CRON15/RECON/PATCHCLERK/INGSERVE — rewired DEC-approve straight to synchronous approve_member_verification RPC node). All backed by git evidence: 0272e7a "Rip out Inngest" (#322, 2026-05-10).
+- STILL OPEN (not fixed, out of approved scope): REF.md §4/§6 `/api/events/[id]/register` is a phantom route — no such API route exists; real guest registration = `registerGuest()` server action (lib/actions/guest-registration.ts) via the public `/events/[eventId]/register` page. Same class of error as the vitals-path fix already done; flag for next doc-accuracy pass.
+- Guest surface source of truth: lib/public-routes.ts PUBLIC_ROUTE_PATTERNS (16 entries) consumed by proxy.ts isPublicRoute; unauthenticated non-public /api/* gets 401, pages redirect /sign-in
+- format.ts pins timeZone Europe/Sofia in code (CI UTC-safe); public-routes imports @clerk/nextjs/server createRouteMatcher
+
+## Done
+Review phase — RESULT: 17 findings + informational list, plan approved (C:\Users\fefence\.claude\plans\before-doing-anything-else-cheerful-naur.md). Evidence: grep/diff outputs in session (F7 pairs 1-hit-each; ls confirms proxy.ts root; diff PROJECT-NOTES/REFACTOR IDENTICAL).
+Fixes applied — RESULT: 11 files modified + docs/STATE.md created; 52 insertions/117 deletions; all plan verification greps pass (F7 pairs still byte-identical; C4 stale-pattern lines 0; auth.mdc middleware-permitted 0; REF profile/vitals 0, vital-signs 2; README Upgrade notes 1; CLAUDE.md kit-zone CAPS still 4).
+NOTED (not done): docs/archive/CLAUDE.md.bak still contains 2 `add <n>` occurrences — archived file, left untouched.
+Finding-5 correction — RESULT: original FLOWS.md text was right all along (Inngest removed in #322); my Inngest rewrite reverted same session, net FLOWS diff = header date + one history-note sentence. Evidence: git diff quoted in transcript; git log -S inngest -> 0272e7a "Rip out Inngest".
+Phantom-Inngest purge — RESULT: C4.md/REF.md/SYSTEM-MAP.mermaid corrected; final grep shows only 5 intentional "removed in #322" notes remain repo-wide; mermaid subgraph/end counts balanced 15/15 post-edit.
+
+## Open items
+- Finding 15 CLOSED: user decision = leave DEBUG.md as-is; report the F11 overage upstream to the kit source if desired
+- Finding 17 CLOSED in-repo (AGENTS.md + PROJECT.md addendum); remaining user-side step: configure Antigravity to load AGENTS.md/CLAUDE.md
+- Pattern B RLS remediation (SEQ261-265, ADR-011) status unknown from docs alone
+
+## Failed attempts
+(none)

--- a/docs/ai/CONTEXT.md
+++ b/docs/ai/CONTEXT.md
@@ -1,5 +1,5 @@
 # CONTEXT.md — teamenjoyVD Portal
-> Last updated: 2026-06-20.
+> Last updated: 2026-07-06.
 > **Read at GATHER start. Never read at SSU.**
 > For reference tables (schema, design system, i18n, env vars, API map): `docs/ai/REF.md` §4-§11 — see its own Section Map.
 > For architecture, flows, and decisions: `docs/architecture/`
@@ -11,107 +11,22 @@
 
 | Section | Read when ticket touches |
 |---|---|
-| §1 Key Files & Patterns | `lib/`, `components/`, established patterns |
-| §2 Navigation | Header, Footer, AdminNav, `lib/nav.ts` |
-| §3 Admin Pages | Any `/admin/*` page |
+| §1-§3 → `docs/ai/REF.md` §1-§3 | Key files & patterns, navigation, admin pages |
 | §4 CI | `types/supabase.ts`, `ci.yml` |
 | §5 Releases | Release history, pending issues |
 
 ---
 
-## 1. Key Files & Patterns
+## 1-3. Key Files & Patterns / Navigation / Admin Pages — moved to REF.md
 
-### `lib/nav.ts`
-Single source of truth for all navigation. Never hardcode nav labels in components.
-```ts
-PUBLIC_NAV          // Home, About, Calendar, Trips
-MEMBER_NAV          // Guides, My Network (/los), Profile (/profile)
-FOOTER_MEMBER_NAV   // MEMBER_NAV filtered — excludes /los
-ADMIN_NAV           // Approval Hub, Operations, Calendar, Content, Notifications, Members
-```
-Nav labels use inline `labels: { en, bg }` — NOT the `t()` i18n system.
+Removed from this file on 2026-07-06. These sections duplicated `docs/ai/REF.md` §1-§3 and had drifted:
+this file still said `lib/supabase/service.ts` is a singleton (the singleton was removed in #307 — it
+returns a fresh client per call), still prescribed `window.confirm` for deletes (all deletes use
+`AlertDialog`), and was missing the Event Reminders nav entry and admin pages. That is the same
+duplication failure that killed LOOKUP.md twice.
 
-### `lib/format.ts`
-EET/EEST regional formatting. Always import from here — never inline `toLocaleDateString` or Intl.
-```ts
-formatDate(iso)       // 18.03.2026
-formatShortDate(iso)  // 18.03.
-formatLongDate(iso)   // Сряда, 18.03.2026
-formatTime(iso)       // 14:30
-formatDateTime(iso)   // 18.03.2026, 14:30
-formatCurrency(n)     // 1.234,00 €
-calDay(iso)           // 18
-calMonth(iso)         // MAR
-```
-
-### `lib/hooks/useTheme.ts`
-Single-source-of-truth theme hook. Returns `{ theme, mounted, toggle }`. Same-tab sync via `tevd-theme-change` CustomEvent. Cross-tab via `StorageEvent`. Key: `tevd-theme`.
-
-### `lib/role-colors.ts`
-Always `getRoleColors(role)` — never hardcode role bg/font inline.
-
-### `lib/supabase/service.ts`
-Singleton service role client. Do not create a new client per request.
-
-### `lib/i18n/translations.ts`
-`TranslationKey = keyof typeof translations` — strict union. Every new `t()` call requires a corresponding entry or the build breaks.
-
-### `lib/og-scrape.ts`
-Server-only. Returns nulls for IG/FB URLs. Preview endpoint: `/api/admin/social-posts/preview?url=...`.
-
-### `lib/email/send.ts`
-Two public dispatchers — never import `sendEmail` (removed):
-- `sendNotificationEmail(payload)` — fire-and-forget (`Promise<void>`). Respects `email_config.enabled` and per-type toggles. All errors swallowed and written to `email_log`.
-- `sendTransactionalEmail(payload)` — returns `Promise<TransactionalEmailResult>`. Bypasses all config gates. Caller must check `result.sent`. Use for flows where the email IS the feature (magic links, access links).
-- Both delegate to private `_dispatch()` — do not inline send/log logic.
-
-### `components/ui/Drawer.tsx`
-Right slide-over. Use for ALL admin create/edit forms and member-facing modal flows.
-Props: `open`, `onClose`, `title`, `children`. Backdrop click + Escape close. Body scroll locked.
-Exceptions: Announcements create + Quick Links create stay as inline cards. Delete stays inline with `window.confirm`.
-
-### `components/about/AboutMapTile.tsx`
-Client Mapbox tile. Theme-aware (`outdoors-v12` light / `dark-v11` dark). MutationObserver on `data-theme`.
-
-### `components/events/EventPopup.tsx`
-- **Mobile (<768px):** Fixed bottom sheet — `85dvh` max, drag handle, `overflow-y-auto`. Backdrop tap-to-close.
-- **Desktop:** Anchor-relative popover, clamped to viewport, `maxHeight: 360` on body scroll container.
-- **Guest / unauthenticated:** Roles section hidden entirely.
-
-### About Page (`app/(dashboard)/about/page.tsx`) — CANONICAL DUAL LAYOUT REFERENCE
-`hidden md:block` desktop grid + `md:hidden` mobile stack. Read before implementing any new dual-layout page.
-
----
-
-## 2. Navigation
-
-### Header
-- Public: `/`, `/about`, `/calendar`, `/trips`
-- Auth-only: `/profile`, `/notifications`, `/los`, `/guides`, `/admin`
-- Desktop nav: `hidden lg:flex` (1024px+). Mobile hamburger: `lg:hidden`.
-- Nav color: `var(--text-nav)` → `var(--brand-parchment)` in dark mode.
-
-### Footer
-- Nav order: Home → About → Calendar → Trips → Guides → Profile
-- 3-col: brand | nav | socials
-- Bottom bar: `© 2026 teamenjoyVD · All rights reserved` | `Built with ♥ by Vera & Deniz in Sofia.`
-- **NO BottomNav. Mobile nav = Header hamburger only.**
-
----
-
-## 3. Admin Pages
-
-| Page | Notes |
-|---|---|
-| `/admin/approval-hub` | ABO + manual verification + Path C direct-verify |
-| `/admin/calendar` | Events ascending by `start_time`. Create/edit via Drawer. |
-| `/admin/content` | Tabs: Announcements \| Quick Links \| Guides \| Social Posts \| Bento. Edit via Drawer. |
-| `/admin/data-center` | LOS import + reconciliation panel |
-| `/admin/notifications` | All-time audit log incl. soft-deleted, paginated 50/page |
-| `/admin/operations` | 3 URL-param tabs: `?tab=trips\|items\|payments`. All create/edit via Drawer. |
-| `/admin/payable-items` | `redirect()` → `/admin/operations?tab=items` |
-
-**Operations payments tab:** Log Payment Drawer with `<optgroup>` entity select; member selector from `/api/admin/members`; status filter pills; pending member submissions at top.
+Read `docs/ai/REF.md` §1 (Key Files & Patterns), §2 (Navigation), §3 (Admin Pages) instead.
+Do not re-add reference content here — REF.md is the single canonical reference doc.
 
 ---
 

--- a/docs/ai/GOTCHAS.md
+++ b/docs/ai/GOTCHAS.md
@@ -15,7 +15,7 @@ Read in full during SHAPE and GATHER. Add new entries here immediately when a sh
 | Large GitHub files | `create_or_update_file` times out above ~10KB. Use `push_files`. |
 | Mapbox | CDN only — never npm. Dupe guard on load. |
 | Mapbox theme swap | `map.setStyle()` + `styledata` event. MutationObserver on `data-theme`. |
-| shadcn install | NEVER `npx shadcn@latest init` — corrupts globals.css. Use `npx shadcn@latest add <n>`. After each add, revert any injected `@layer base` blocks. |
+| shadcn install | NEVER `npx shadcn@latest init` — corrupts globals.css. Use `npx shadcn@latest add <component>`. After each add, revert any injected `@layer base` blocks. |
 | shadcn CSS vars | Edit vended source in `components/ui/` to use project tokens (`--bg-card`, `--text-primary`) not shadcn defaults. |
 | shadcn Tabs | NEVER `defaultValue`. Always `value={tab}` + `onValueChange` → `router.replace(?tab=..., { scroll: false })`. Wrap in `<Suspense>`. |
 | `--bg-global-rgb` dark | MUST be `26, 31, 24`. Wrong value = white navbar in dark mode. |

--- a/docs/ai/QA.md
+++ b/docs/ai/QA.md
@@ -25,7 +25,7 @@ This document compiles technical questions, answers, and the current backlog of 
 
 **Question:** If I had to ask you to refactor the authentication, how should that prompt look like?
 
-**Answer:** Use the issue structure defined in `CLAUDE.md`:
+**Answer:** Use the issue structure defined in `docs/guardrails/PROJECT.md` (`#id-format`, `#claim-complete-definition`):
 ```markdown
 REFACTOR: [Short description of the authentication refactor]
 
@@ -33,7 +33,7 @@ REFACTOR: [Short description of the authentication refactor]
 [Explain the goal of the refactor. For example: "We need to split API routes into public/private tiers, update public-routes helper list, or introduce role-based API protection via custom headers set in proxy.ts."]
 
 ## Design
-- **Proxy/Routing:** All custom authentication routing, request rewriting, or route matching must reside inside `proxy.ts` (Option C Hybrid middleware structure). Do not place custom routing logic directly in `middleware.ts`.
+- **Proxy/Routing:** All custom authentication routing, request rewriting, or route matching must reside inside root `proxy.ts`. Never create `middleware.ts` (CLAUDE.md hard constraint; `docs/architecture/DECISIONS.md` ADR-006).
 - **Async Verification:** All check/verification sites must use the asynchronous `auth()` call:
   ```typescript
   const { userId } = await auth();

--- a/docs/ai/REF.md
+++ b/docs/ai/REF.md
@@ -64,19 +64,11 @@ Used by `TripHeroSection` (admin canvas sampling) and `shared.tsx` (member count
 
 **`lib/supabase/service.ts`** — returns a fresh `createClient` on every call. No module-level singleton (removed in #307 — singleton risked auth-header contamination across warm lambda requests).
 
-**`lib/db/client.ts`** — postgres.js direct connection client (port 5432). Use ONLY inside Inngest job steps where explicit transactions are required. Never use in Next.js route handlers or RSC — use `createServiceClient()` there.
-
 **`lib/email/send.ts`** — two public dispatchers:
 - `sendNotificationEmail(payload)` — `Promise<void>`, fire-and-forget, respects `email_config` gates, errors swallowed to `email_log`.
 - `sendTransactionalEmail(payload)` — `Promise<TransactionalEmailResult>`, bypasses gates, caller checks `result.sent`. Use when the email IS the feature (magic links, access links).
 
 **`lib/notifications/share-events.ts`** — `notifySharerOfRegistration()` and `notifySharerOfAttendance()`. Fire-and-forget calls made from `lib/actions/guest-registration.ts` (on registration, when a `shareToken` resolves) and from the `/events/[eventId]/join` page (on attendance, when the guest's registration has a `share_link_id`). Both ultimately call `sendNotificationEmail` with `ShareGuestRegisteredEmail` / `ShareGuestAttendedEmail`.
-
-**`inngest/client.ts`** — shared Inngest client (`id: 'tevd-portal'`). Import `inngest` from here to send events or create functions.
-
-**`inngest/functions/approve-verification.ts`** — 3-step durable function for member approval: Step 1 DB transaction, Step 2 Clerk sync, Step 3 notifications+email.
-
-**`inngest/functions/clerk-reconciliation.ts`** — scheduled function (every 15 min): detects and patches any split-state profiles where Supabase role=member but Clerk metadata stale.
 
 **`components/ui/Drawer.tsx`** — right slide-over. Props: `open`, `onClose`, `title`, `children`. Use for ALL admin create/edit forms. Exceptions: Announcements + Quick Links create = inline cards. All deletes use `AlertDialog`.
 
@@ -190,6 +182,8 @@ Operations payments tab: Log Payment Drawer with `<optgroup>` entity select; mem
     /admin/spouse-link-requests/[id]/route.ts  # ADR-016: PATCH approve/deny
     /admin/trips/route.ts
     /admin/trips/[id]/route.ts     # PATCH: counter_bg_color (hex validation), admin-only
+    /admin/trips/[id]/messages/route.ts             # GET, POST — trip messages admin CRUD
+    /admin/trips/[id]/messages/[messageId]/route.ts # PATCH, DELETE
     /admin/trips/registrations/[id]/cancel/route.ts
     /admin/verify/route.ts
     /admin/vital-sign-definitions/route.ts
@@ -200,7 +194,6 @@ Operations payments tab: Log Payment Drawer with `<optgroup>` entity select; mem
     /events/[id]/register/route.ts # POST — guest registration (public)
     /guides/route.ts
     /home/route.ts                 # GET — home_settings for homepage RSC
-    /inngest/route.ts              # Inngest serve handler — public route, signing key auth only
     /links/route.ts                # GET — active links for member view
     /los/tree/route.ts             # GET — member LOS tree
     /notifications/route.ts        # GET, PATCH — own notifications
@@ -212,11 +205,13 @@ Operations payments tab: Log Payment Drawer with `<optgroup>` entity select; mem
     /profile/route.ts
     /profile/spouse-link/route.ts  # ADR-016: GET own request, POST submit, DELETE cancel
     /profile/verify-abo/route.ts
-    /profile/vitals/route.ts
+    /profile/vital-signs/route.ts
     /profile/event-roles/route.ts
     /profile/los-summary/route.ts
     /profile/upline/route.ts
     /profile/trips/[id]/cancel/route.ts
+    /trips/route.ts                # GET — role-filtered trips list (unauthenticated → guest); POST — admin-only create
+    /trips/[id]/messages/route.ts  # GET — member read-only trip bulletin
     /trips/[id]/payments/route.ts
     /socials/route.ts
     /webhooks/clerk/route.ts
@@ -233,14 +228,8 @@ Operations payments tab: Log Payment Drawer with `<optgroup>` entity select; mem
   /layout/UserPopup.tsx
   /layout/BottomNav.tsx            # DEAD STUB — do not import
   /ui/Drawer.tsx
-/inngest
-  /client.ts                      # Inngest client (id: 'tevd-portal')
-  /functions/
-    /approve-verification.ts      # 3-step durable approval function
-    /clerk-reconciliation.ts      # Scheduled Clerk drift patch (every 15 min)
 /lib
   /color.ts                       # clampLuminance, hslToHex, sampleImageRegion — trip counter colour helpers
-  /db/client.ts                   # postgres.js direct connection — Inngest steps only
   /format.ts
   /hooks/useTheme.ts
   /hooks/useLanguage.ts
@@ -419,6 +408,7 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 **`approval_jobs`** — `id, request_id → abo_verification_requests, inngest_event_id, status (processing|clerk_synced|done|failed), error, created_at, updated_at, settled_at`
 - RLS: service role only.
 - UNIQUE on `request_id`.
+- Orphaned since #322 (Inngest removed) — table exists in schema but no application code writes to it; do not build new features assuming it is populated.
 
 ---
 
@@ -430,7 +420,7 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 | `/api/profile` | GET, PATCH | |
 | `/api/profile/verify-abo` | POST | LOS-validated at submit: existence check + sponsor match + duplicate ABO check. Returns `abo_has_primary` error_code if the existing holder is a primary (ADR-016). Guard added #350: secondary accounts (`primary_profile_id IS NOT NULL`) receive 400 `secondary_cannot_verify`. |
 | `/api/profile/spouse-link` | GET, POST, DELETE | ADR-016: GET own request; POST submit (guest only, guards: requester is guest with no primary_profile_id, claimed_primary is member with abo_number and no existing secondary); DELETE cancel own pending |
-| `/api/profile/vitals` | GET | |
+| `/api/profile/vital-signs` | GET | |
 | `/api/profile/event-roles` | GET | |
 | `/api/profile/event-shares` | GET, POST | GET: own share links + nested guest registrations, filterable by `event_id`/`status`/`method`/`from`/`to`/`q`. POST: create or update a share link for an event (`event_id`, `share_method: 'native'\|'clipboard'`); 403 for guests; 400 if target event has `allow_guest_registration = false`. |
 | `/api/profile/event-shares/export` | GET | `?format=csv` — streams a CSV of the member's own share links + guest rows. Same filters as GET above. |
@@ -440,6 +430,8 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 | `/api/profile/trips/[id]/cancel` | POST | |
 | `/api/payable-items` | GET | Active items only |
 | `/api/payments` | GET, POST | Unified |
+| `/api/trips` | GET, POST | GET: role-filtered list (unauthenticated → guest). POST: admin-only create |
+| `/api/trips/[id]/messages` | GET | Read-only trip bulletin (admin-authored; no author shown to members) |
 | `/api/trips/[id]/payments` | GET | |
 | `/api/calendar` | GET | Role-filtered; no `?month` → agenda from today |
 | `/api/calendar/feed.ics` | GET | iCal feed; `?token=` JWT auth; emits LOCATION + URL + CATEGORIES |
@@ -494,12 +486,13 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 | `/api/admin/spouse-link-requests/[id]` | PATCH | ADR-016: approve/deny. On approve: writes profile + request + audit + Clerk sync + welcome email |
 | `/api/admin/trips` | GET, POST | |
 | `/api/admin/trips/[id]` | GET, PATCH, DELETE | PATCH accepts `counter_bg_color: string \| null` — hex validation `/^#[0-9a-fA-F]{6}$/` |
+| `/api/admin/trips/[id]/messages` | GET, POST | Trip messages admin CRUD |
+| `/api/admin/trips/[id]/messages/[messageId]` | PATCH, DELETE | |
 | `/api/admin/trips/registrations/[id]/cancel` | POST | Triggers `sendNotificationEmail` |
 | `/api/admin/verify` | POST | ABO approve/deny — MUST sync Clerk metadata |
 | `/api/admin/vital-sign-definitions` | GET, POST | |
 | `/api/admin/vital-sign-definitions/[id]` | PATCH, DELETE | |
-| `/api/inngest` | GET, POST, PUT | Inngest serve handler — **public route**; Inngest signing key auth only. Must be in proxy.ts public list. |
-| `/api/admin/members/verify/[id]` | PATCH | approve → 202+enqueue Inngest job; deny → synchronous in-route |
+| `/api/admin/members/verify/[id]` | PATCH | approve → synchronous: `approve_member_verification` RPC + Clerk sync + email; deny → synchronous in-route |
 
 ### Supabase RPCs
 | RPC | Purpose |
@@ -509,7 +502,7 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 | `rebuild_tree_paths` | Cascade ABO label rename to descendants |
 | `upsert_tree_node(p_profile_id, p_abo_number, p_sponsor_abo_number?)` | Insert/update tree node; walks `los_members` sponsor chain (max 20 hops, cycle guard) if direct sponsor has no portal profile |
 | `increment_share_link_click(p_token text)` | Atomic click-count increment on `event_share_links`, called when a guest lands on the registration page via a share token |
-| `approve_member_verification(p_request_id, p_admin_note?)` | **DEPRECATED** — retained as fallback only. Logic now in Inngest Step 1. Guard added #350: raises `P0002` if `profile.primary_profile_id IS NOT NULL`. |
+| `approve_member_verification(p_request_id, p_admin_note?)` | Live path for ABO approval — called directly by `/api/admin/members/verify/[id]` PATCH (an Inngest-based version was tried in #308, removed in #322). Guard added #350: raises `P0002` if `profile.primary_profile_id IS NOT NULL`. |
 | `patch_member_role(p_profile_id, p_new_role, p_changed_by, p_note?)` | Role update with audit trail |
 | `get_trip_team_attendees(p_trip_id, p_viewer_profile)` | Returns Core/admin attendees for a trip |
 | `import_los_members(p_rows, p_imported_by?, p_expected_row_count?)` | Transactional LOS import: concurrency check → snapshot → upsert → server-side delete → `rebuild_tree_paths` → insert `los_imports`. Returns `{ inserted, removed, import_id, errors }`. |
@@ -617,9 +610,6 @@ Period selector order: AGENDA → DAY → WEEK → MONTH
 | `ICAL_TOKEN_SECRET` | ✅ |
 | `NEXT_PUBLIC_APP_URL` | ⚠️ **Conflicting values found in source docs as of 2026-06-20** — `https://www.teamenjoyvd.com` in one prior copy of this reference, `https://tevd-portal.vercel.app` in another. Not resolved here; check the actual Vercel project env vars before relying on either value. |
 | `RESEND_API_KEY` | ✅ |
-| `DATABASE_URL` | ⚠️ **Must be set** — direct Postgres connection (port 5432, NOT pooler 6543). Used by `lib/db/client.ts` inside Inngest jobs. |
-| `INNGEST_SIGNING_KEY` | ⚠️ **Must be set** — authenticates Inngest callbacks to `/api/inngest`. Signing key is the only security gate. |
-| `INNGEST_EVENT_KEY` | ⚠️ **Must be set** — authenticates event ingestion from `inngest.send()`. |
 | `INSTAGRAM_ACCESS_TOKEN` | ⏳ pending |
 | `FB_PAGE_ACCESS_TOKEN` | ⏳ pending |
 | `FB_PAGE_ID` | ⏳ pending |

--- a/docs/architecture/C4.md
+++ b/docs/architecture/C4.md
@@ -1,5 +1,5 @@
 # C4.md — System Architecture
-> tevd-portal · Last updated: 2026-05-10
+> tevd-portal · Last updated: 2026-07-06
 > Scope: L1 (System Context) + L2 (Containers). L3 flows live in FLOWS.md. L4 is owned by TypeScript.
 
 ---
@@ -36,8 +36,6 @@ Can view public pages (`/`, `/about`, `/calendar`, `/trips`) and initiate a veri
 
 **Meta OG / External URLs** — Social post previews scraped server-side via `/api/admin/social-posts/preview`. Instagram and Facebook block server fetches; those return null thumbnails by design.
 
-**Inngest** — Serverless job queue. Receives events from tevd-portal API routes via `inngest.send()`, executes durable multi-step functions with built-in retry and idempotency, and calls back into tevd-portal's registered serve handler at `/api/inngest`. Used for the member verification approval workflow (DB transaction + Clerk sync + notifications) and a scheduled Clerk reconciliation job.
-
 **Resend** — Transactional email delivery. Called server-side only via `lib/email/send.ts`. Never contacted from the browser. API key is server-only (`RESEND_API_KEY`). All sends are audited in the `email_log` table. Notification emails respect the `email_config` toggle in `settings`; transactional emails bypass the toggle.
 
 ### What tevd-portal does NOT have
@@ -62,7 +60,6 @@ Four deployable units. All communication is over HTTPS.
 - Client boundary — TanStack Query v5 for user-triggered fetches and cache invalidation. `"use client"` only where state, effects, or browser APIs are required.
 - API routes (`/api/*`) — Next.js Route Handlers. All protected routes call `await auth()` and return 401 if `userId` is null. All DB access uses `createServiceClient()` (service role). Never anon key on server.
 - `proxy.ts` — Clerk middleware. The only middleware file. Never `middleware.ts`.
-- `/api/inngest` — Inngest serve handler. Receives and executes job callbacks from Inngest cloud. Must be publicly reachable (no Clerk auth guard — Inngest uses signing key verification instead).
 
 **Responsibilities:**
 - Routing, rendering, and auth gating for all pages
@@ -71,15 +68,13 @@ Four deployable units. All communication is over HTTPS.
 - Serving Mapbox tiles context (token injection only — rendering is client-side CDN)
 - OG scraping for social post previews
 - Receiving and verifying Clerk webhooks
-- Enqueuing Inngest events for async multi-step workflows
 
 **Does NOT own:**
 - Identity state (Clerk owns this)
 - Persistent data (Supabase owns this)
 - File storage (Supabase Storage owns this)
-- Job execution (Inngest owns this)
 
-**Contract:** Any new page or API route must declare its auth requirement explicitly. No route is implicitly public. Public routes are enumerated in `proxy.ts`. The `/api/inngest` route is public by necessity — security is enforced by Inngest signing key verification in the SDK, not Clerk.
+**Contract:** Any new page or API route must declare its auth requirement explicitly. No route is implicitly public. Public routes are enumerated in `lib/public-routes.ts` and consumed by `proxy.ts`.
 
 ---
 
@@ -89,7 +84,7 @@ Four deployable units. All communication is over HTTPS.
 
 **Internal structure:**
 - PostgreSQL 17 — primary relational store
-- RLS — row-level security on every user-facing table. Policies use `auth.jwt() ->> 'sub'` (Clerk user ID) and `auth.jwt() ->> 'user_role'`
+- RLS — row-level security on every user-facing table. Policies use Pattern A helpers only — `is_admin()`, `get_my_role()`, `get_my_profile_id()`, `get_my_clerk_id()` (reading `request.jwt.claims`). Never raw `auth.jwt()`; `auth.jwt() ->> 'sub'` is a Supabase Auth UUID that Clerk users do not have — see DECISIONS.md ADR-011
 - pg_cron — scheduled jobs (LOS digest at 06:00 UTC daily)
 - pg_net — outbound HTTP from triggers/functions
 - ltree extension — organisation hierarchy (`tree_nodes.path`)
@@ -117,14 +112,14 @@ Four deployable units. All communication is over HTTPS.
 
 **Responsibilities:**
 - Issuing and validating session tokens consumed by `proxy.ts`
-- Storing `role` in `publicMetadata` — this is what the JWT carries, and what RLS policies read via `auth.jwt() ->> 'user_role'`
+- Storing `role` in `publicMetadata` — this is what the JWT carries, and what RLS policies read via the Pattern A helper `get_my_role()` (from `request.jwt.claims -> 'user_role'`)
 - Emitting `user.created` and `user.deleted` webhooks to `/api/webhooks/clerk`
 
-**Contract:** Every route that promotes a user's role in Supabase (`profiles.role`) MUST also call `clerk.users.updateUserMetadata(clerkId, { publicMetadata: { role } })`. If this is skipped, Clerk metadata and Supabase data diverge, RLS policies break for that user, and the only fix is a re-login. As of #308, the approve path executes this call in Inngest Step 2 (with retry). Affected routes: `/api/admin/verify`, `/api/admin/members/verify/[id]` (approve path via Inngest), `/api/admin/members/[id]` PATCH.
+**Contract:** Every route that promotes a user's role in Supabase (`profiles.role`) MUST also call `clerk.users.updateUserMetadata(clerkId, { publicMetadata: { role } })`. If this is skipped, Clerk metadata and Supabase data diverge, RLS policies break for that user, and the only fix is a re-login. Every promotion route calls both writes synchronously (an Inngest-based durable version was tried in #308 and removed in #322 — see `docs/architecture/FLOWS.md` §1). Affected routes: `/api/admin/verify`, `/api/admin/members/verify/[id]`, `/api/admin/members/[id]` PATCH.
 
 **Does NOT own:**
 - Application data (Supabase owns this)
-- Role assignment logic (Next.js API routes / Inngest functions own this, Clerk merely stores the result)
+- Role assignment logic (Next.js API routes own this, Clerk merely stores the result)
 
 ---
 
@@ -139,29 +134,6 @@ Four deployable units. All communication is over HTTPS.
 **Contract:** Token is `NEXT_PUBLIC_MAPBOX_TOKEN` (public `pk.` prefix — safe to expose). Theme switching uses `map.setStyle()` + `styledata` event. Style swap is triggered by MutationObserver on `data-theme` attribute. Mapbox logo and attribution are hidden via `globals.css`. A dupe-guard prevents double-initialisation on hot reload.
 
 **Does NOT own:** Any application data. Pure rendering concern.
-
----
-
-### Container 5: Inngest (Job Queue)
-
-**What it is:** Serverless-native durable job queue. Receives events from tevd-portal, executes multi-step functions with automatic retry, and delivers results back to the application. No persistent infrastructure to manage — fully managed cloud service.
-
-**Internal structure:**
-- Event bus — events enqueued via `inngest.send()` from Next.js API routes
-- Step functions — each step is independently retried on failure; completed steps are not re-executed
-- Scheduled functions — cron-triggered jobs registered in the serve handler
-- Inngest dashboard — observable execution history, step logs, retry status
-
-**Responsibilities:**
-- Executing the member verification approval workflow durably: Step 1 DB transaction (postgres.js direct connection), Step 2 Clerk metadata sync (with retry), Step 3 notifications + email
-- Reconciling split-state profiles every 15 minutes: detect `profiles.role = member` where Clerk `publicMetadata.role ≠ member`, patch Clerk silently, log to `verification_log`
-
-**Does NOT own:**
-- Application data (Supabase owns this)
-- Identity state (Clerk owns this)
-- HTTP routing (Next.js owns this)
-
-**Contract:** `INNGEST_SIGNING_KEY` and `INNGEST_EVENT_KEY` must be set in Vercel environment. The serve handler at `/api/inngest` must NOT be guarded by Clerk auth — Inngest SDK verifies the signing key internally. All Inngest functions must be registered in the serve handler array; unregistered functions are silently unreachable.
 
 ---
 

--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -17,7 +17,7 @@
 | ADR-006 | proxy.ts as the sole middleware file (never middleware.ts) | 2026-03 | Active |
 | ADR-007 | Unified payments table (single table, entity check constraint) | 2026-03 | Active |
 | ADR-008 | Strict TranslationKey union over i18n library | 2026-03 | Active |
-| ADR-009 | Dual-layout pattern (two complete layouts, not responsive) | 2026-03 | Active |
+| ADR-009 | Dual-layout pattern (two complete layouts, not responsive) | 2026-03 | Amended 2026-07-06 |
 | ADR-010 | 12-column CSS grid for BentoGrid (not a component library) | 2026-03 | Active |
 | ADR-011 | RLS as defence-in-depth layer; canonical policy pattern uses Clerk JWT helper functions | 2026-03 | Active |
 | ADR-012 | Feature-based folder structure: co-locate route-scoped components | 2026-03 | Active |
@@ -204,7 +204,7 @@ Supabase Auth is tightly coupled to the Supabase JWT secret. Clerk provides a mo
 Next.js middleware runs on every request and is the correct place to enforce Clerk authentication at the edge. Next.js looks for `middleware.ts` by default.
 
 ### Decision
-The middleware file is named `proxy.ts`, not `middleware.ts`. This is configured explicitly in `next.config.ts`. Creating a `middleware.ts` file is a hard constraint violation.
+The middleware file is named `proxy.ts`, not `middleware.ts`. Creating a `middleware.ts` file is a hard constraint violation. (Correction 2026-07-06: no `next.config.ts` setting exists or is needed — Next.js 16 resolves root `proxy.ts` natively, having renamed the `middleware.ts` convention to `proxy.ts`.)
 
 ### Why not middleware.ts
 During early development, a naming conflict or accidental creation of `middleware.ts` alongside `proxy.ts` caused two middleware files to run simultaneously, producing unpredictable auth behaviour. Renaming to `proxy.ts` makes the unconventional choice explicit and prevents accidental recreation.
@@ -221,7 +221,7 @@ During early development, a naming conflict or accidental creation of `middlewar
 
 **Mitigations:**
 - Documented as the first hard constraint in CLAUDE.md
-- `next.config.ts` explicitly points to `proxy.ts`
+- Next.js 16 resolves root `proxy.ts` natively; no `next.config.ts` configuration exists (corrected 2026-07-06)
 
 ---
 
@@ -288,7 +288,7 @@ next-intl and react-i18next both require: a provider wrapping the app, locale de
 ## ADR-009 — Dual-Layout Pattern (Two Complete Layouts, Not Responsive)
 
 **Date:** 2026-03
-**Status:** Active
+**Status:** Amended 2026-07-06 — the quantitative Layout Decision Rules (CLAUDE.md `## Project` and `.cursor/rules/frontend.mdc`) now govern when a dual layout applies: default is a single responsive layout; dual layout only on the four listed triggers. When a trigger applies, the pattern below remains the canonical dual-layout implementation.
 
 ### Context
 Pages need to render correctly on both desktop (1024px+) and mobile (390px+). Options: a single responsive layout using breakpoint utilities, or two separate complete layout trees with `hidden md:block` / `md:hidden`.
@@ -542,7 +542,7 @@ Existing hand-rolled components (`Drawer.tsx`, `UserDropdown`, `UserPopup`, `Not
 | Hover hint | `Tooltip` | `npx shadcn@latest add tooltip` |
 
 ### Installation note
-`npx shadcn@latest init` was intentionally NOT run in SEQ247 — the CLI assumes Tailwind v3 and would have corrupted `globals.css`. Components are added individually via `npx shadcn@latest add <n>`, which only touches `components/ui/`. This is the correct workflow for this stack.
+`npx shadcn@latest init` was intentionally NOT run in SEQ247 — the CLI assumes Tailwind v3 and would have corrupted `globals.css`. Components are added individually via `npx shadcn@latest add <component>`, which only touches `components/ui/`. This is the correct workflow for this stack.
 
 ### Consequences
 

--- a/docs/architecture/DECISIONS.md
+++ b/docs/architecture/DECISIONS.md
@@ -288,13 +288,13 @@ next-intl and react-i18next both require: a provider wrapping the app, locale de
 ## ADR-009 — Dual-Layout Pattern (Two Complete Layouts, Not Responsive)
 
 **Date:** 2026-03
-**Status:** Amended 2026-07-06 — the quantitative Layout Decision Rules (CLAUDE.md `## Project` and `.cursor/rules/frontend.mdc`) now govern when a dual layout applies: default is a single responsive layout; dual layout only on the four listed triggers. When a trigger applies, the pattern below remains the canonical dual-layout implementation.
+**Status:** Amended 2026-07-06 — the quantitative Layout Decision Rules (CLAUDE.md `## Project` and `.cursor/rules/frontend.mdc`) now govern when a dual layout applies: default is a single responsive layout; use the canonical dual-layout pattern only when one of the four listed triggers applies.
 
 ### Context
 Pages need to render correctly on both desktop (1024px+) and mobile (390px+). Options: a single responsive layout using breakpoint utilities, or two separate complete layout trees with `hidden md:block` / `md:hidden`.
 
 ### Decision
-Every page that has meaningfully different desktop and mobile UX uses two separate complete layout trees. No hybrid responsive layout. Canonical reference: `app/(dashboard)/about/page.tsx`.
+Use two separate complete layout trees only for the four documented triggers; otherwise prefer a single responsive layout. Canonical reference: `app/(dashboard)/about/page.tsx`.
 
 ### Why not a single responsive layout
 Desktop and mobile UX contracts for this application are fundamentally different: navigation pattern (persistent header nav vs. hamburger), content density (multi-column bento grid vs. stacked single column), and component behaviour (popovers vs. bottom sheets in `EventPopup`). A single responsive layout that satisfies both produces compromises on both. Two complete layouts make each contract explicit and independently maintainable.
@@ -542,7 +542,7 @@ Existing hand-rolled components (`Drawer.tsx`, `UserDropdown`, `UserPopup`, `Not
 | Hover hint | `Tooltip` | `npx shadcn@latest add tooltip` |
 
 ### Installation note
-`npx shadcn@latest init` was intentionally NOT run in SEQ247 — the CLI assumes Tailwind v3 and would have corrupted `globals.css`. Components are added individually via `npx shadcn@latest add <component>`, which only touches `components/ui/`. This is the correct workflow for this stack.
+`npx shadcn@latest init` was intentionally NOT run in SEQ247 — the CLI assumes Tailwind v3 and would have corrupted `globals.css`. Components are added individually via `npx shadcn@latest add <component>`, but each install still needs a diff review because it may also touch `globals.css` and other shadcn-managed files. This is the correct workflow for this stack.
 
 ### Consequences
 

--- a/docs/architecture/FLOWS.md
+++ b/docs/architecture/FLOWS.md
@@ -46,7 +46,7 @@ sequenceDiagram
 
 ### Role Promotion
 
-Role promotion happens through three admin routes. Every promotion is a two-write atomic operation: Supabase first, then Clerk. If the Clerk write fails, the Supabase write is not rolled back — this is a known gap. Re-login by the user will re-read Clerk metadata, but Supabase will already have the new role. (An Inngest-based durable approve path with retry + reconciliation was added in #310 and removed again in #322 "Rip out Inngest" — do not re-document it as current.)
+Role promotion happens through three admin routes. Every promotion is a two-write synchronous operation: Supabase first, then Clerk. If the Clerk write fails, the Supabase write is not rolled back — this is a known gap. Re-login by the user will re-read Clerk metadata, but Supabase will already have the new role. (An Inngest-based durable approve path with retry + reconciliation was added in #310 and removed again in #322 "Rip out Inngest" — do not re-document it as current.)
 
 ```mermaid
 sequenceDiagram

--- a/docs/architecture/FLOWS.md
+++ b/docs/architecture/FLOWS.md
@@ -1,5 +1,5 @@
 # FLOWS.md — Component Flows (C4 L3)
-> tevd-portal · Last updated: 2026-06-20
+> tevd-portal · Last updated: 2026-07-06
 > Scope: Ambiguous zones only. Simple CRUD with no branching logic is not documented here.
 > Tooling: Mermaid state and sequence diagrams.
 
@@ -46,7 +46,7 @@ sequenceDiagram
 
 ### Role Promotion
 
-Role promotion happens through three admin routes. Every promotion is a two-write atomic operation: Supabase first, then Clerk. If the Clerk write fails, the Supabase write is not rolled back — this is a known gap. Re-login by the user will re-read Clerk metadata, but Supabase will already have the new role.
+Role promotion happens through three admin routes. Every promotion is a two-write atomic operation: Supabase first, then Clerk. If the Clerk write fails, the Supabase write is not rolled back — this is a known gap. Re-login by the user will re-read Clerk metadata, but Supabase will already have the new role. (An Inngest-based durable approve path with retry + reconciliation was added in #310 and removed again in #322 "Rip out Inngest" — do not re-document it as current.)
 
 ```mermaid
 sequenceDiagram

--- a/docs/architecture/SYSTEM-MAP.mermaid
+++ b/docs/architecture/SYSTEM-MAP.mermaid
@@ -159,24 +159,16 @@ flowchart TD
             A7d["Email log (delivery audit)"]
         end
 
-        A8["Legacy /api/admin/verify\nstandalone ABO+upline approve/deny,\nno Inngest, direct Clerk sync"]
+        A8["/api/admin/verify\nstandalone ABO+upline approve/deny,\ndirect Clerk sync"]
     end
 
     AVR --> A1a
     A1a --> DEC{Admin decision}
     DEC -- deny --> DENY["status: denied"]
     DENY --> DENYEMAIL["AboVerificationEmail (denied) to guest"]
-    DEC -- approve --> INN["202 + Inngest event enqueued\napproval_jobs row created"]
-
-    subgraph INNGEST["Inngest: approve-verification (3-step durable job)"]
-        I1["Step 1 - DB transaction\nrole to member/core, abo_number set\nupline_abo_number written\nupsert_tree_node (LOS chain walk, max 20 hops)"]
-        I2["Step 2 - Clerk metadata sync\nrole + abo_number pushed"]
-        I3["Step 3 - Notifications fan-out\n+ AboVerificationEmail (approved/Welcome)"]
-        I1 --> I2 --> I3
-    end
-    INN --> INNGEST
-    I3 --> MD
-    I1 -. on exception .-> VLOG[("verification_log\nerror_code/context")]
+    DEC -- approve --> APPR["approve_member_verification RPC\nrole to member/core, abo_number set\nupline_abo_number written\nupsert_tree_node (LOS chain walk, max 20 hops)\n+ Clerk metadata sync\n+ AboVerificationEmail (approved/Welcome)"]
+    APPR --> MD
+    APPR -. on exception .-> VLOG[("verification_log\nerror_code/context")]
 
     SLR --> A1b
     A1b --> SDEC{Admin decision}
@@ -226,12 +218,6 @@ flowchart TD
     DIGESTCHECK -- yes --> DIGESTNOTIF["in-app notification\ntype: los_digest, per Core member\n(skips if already sent today)"]
     DIGESTCHECK -- no --> DIGESTSKIP["no-op"]
 
-    CRON15["Inngest scheduled - every 15 min"] --> RECON["clerk-reconciliation function\nDetects Supabase role=member but\nstale/missing Clerk metadata"]
-    RECON --> PATCHCLERK["Patches Clerk publicMetadata\nto match Supabase (source of truth)"]
-
-    INGSERVE["/api/inngest serve handler\npublic route - Inngest signing-key auth only"] -. "hosts" .-> INNGEST
-    INGSERVE -. "hosts" .-> RECON
-
     subgraph EMAIL["Email Infrastructure"]
         direction LR
         EC["email_config in settings\n(master toggle + per-template gates)"]
@@ -244,7 +230,7 @@ flowchart TD
     SGR --> EMAIL
     SGA --> EMAIL
     DENYEMAIL --> EMAIL
-    I3 --> EMAIL
+    APPR --> EMAIL
     SLREMAIL --> EMAIL
     SAPPR --> EMAIL
     ERREMAIL --> EMAIL

--- a/docs/architecture/SYSTEM-MAP.mermaid
+++ b/docs/architecture/SYSTEM-MAP.mermaid
@@ -76,7 +76,7 @@ flowchart TD
         subgraph M_PROFILE["/profile (multi-bento, drag/drop)"]
             M5a["Personal details - GET/PATCH /api/profile"]
             M5b["Payments - GET/POST /profile/payments\n+ proof upload (signed URL)"]
-            M5c["Vital signs (read-only) - GET /profile/vitals"]
+            M5c["Vital signs (read-only) - GET /api/profile/vital-signs"]
             M5d["Participation - GET /profile/event-roles"]
             M5e["Bento reorder/collapse - PATCH ui_prefs jsonb"]
         end

--- a/docs/guardrails/PROJECT.md
+++ b/docs/guardrails/PROJECT.md
@@ -104,6 +104,11 @@ _Transported verbatim from `docs/ai/RULES.md` §4 (pre-migration). Live requirem
   - Antigravity must format its planning mode `implementation_plan.md` artifact to exactly match the `PLAN` output layout from `docs/ai/PLAN.md`.
   - PR descriptors must include an `Agent Type: Antigravity | Claude` tag in their session state block.
 
+_Addendum (2026-07-06, guardrails review — clarifies how the transported rules above execute in practice):_
+- The "brain directory" (`implementation_plan.md`, `task.md`) is Antigravity-internal workspace state outside this repo; Claude has no path to it and never reads it directly. Cross-agent state flows only through repo/GitHub artifacts.
+- The PR `## Session State` block is the sole cross-agent handoff (per `docs/ai/BUILD.md`); Antigravity mirrors its plan into GitHub using the `docs/ai/PLAN.md` output layout, which satisfies the brain-directory sync intent.
+- Since `docs/ai/RULES.md` was deleted (see `docs/guardrails/MIGRATION-LOG.md`), the shared 1:1 ruleset surface is `CLAUDE.md`; non-Claude agents load it via the root `AGENTS.md` pointer.
+
 ## Carried technical notes
 
 _Transported verbatim from `docs/ai/RULES.md` §1-§2 (pre-migration). The unique items that had no equivalent in the pre-migration CLAUDE.md Hard Constraints._


### PR DESCRIPTION
## Summary
- Fixed real contradictions with live Hard Constraints: C4.md/SYSTEM-MAP.mermaid taught raw `auth.jwt() ->> 'sub'`/`'user_role'` RLS access instead of the mandatory Pattern A helpers (the exact mistake `database.mdc` warns has been reintroduced 3+ times); `auth.mdc` licensed creating the forbidden `middleware.ts` and had globs that never matched the real `proxy.ts`; `CONTEXT.md` told agents `lib/supabase/service.ts` is a singleton and deletes use `window.confirm` — both reversed since #307/shadcn adoption.
- Purged a phantom Inngest subsystem from `C4.md`, `REF.md`, and `SYSTEM-MAP.mermaid` — approval workflow, Clerk reconciliation cron, `/api/inngest` route, `DATABASE_URL`/`INNGEST_*` env vars — all removed by [#322 "Rip out Inngest"](https://github.com/teamenjoyvd/tevd-portal/pull/322) on 2026-05-10 but still documented as live. `FLOWS.md`'s existing synchronous-approve description was correct all along. Left 5 "removed in #322" historical/orphan-schema notes intentionally.
- Smaller corrections: `REF.md` vitals route path + missing trips-route entries; `ADR-009` marked Amended now that quantitative layout rules (`.cursor/rules/frontend.mdc`) govern dual-layout triggers; `ADR-006` `next.config.ts` claim corrected; `QA.md`/`GOTCHAS.md`/`DECISIONS.md` placeholder and staleness fixes; `database.mdc` was missing 2 of the 4 Pattern A helpers; added the Clerk-JWT-Supabase-client Hard Constraint to `CLAUDE.md` that `ADR-002` already claimed existed; added `AGENTS.md` as a rules pointer for Antigravity/other non-Claude agents plus a multi-agent coexistence addendum in `PROJECT.md`; added `README.md`'s `## Upgrade notes` section required by `_FORMAT.md` F15.
- Every finding verified against actual file content, `git log`/`git show`, and live route/schema checks before fixing — no inferred issues. Kit budget and F7 sanctioned-pair byte-identity re-verified after edits; no Hard Stop or CAPS constraint weakened.

## Test plan
- [x] `git diff --stat HEAD` scope-audited — every changed file traces to a specific finding
- [x] Re-ran F7 sanctioned-pair byte-identity greps across all 6 pairs — unchanged
- [x] Grepped for residual phantom Inngest content repo-wide — only 5 intentional "removed in #322" historical notes remain
- [x] Verified `SYSTEM-MAP.mermaid` `subgraph`/`end` counts still balanced (15/15) after removing the Inngest job-queue subgraph
- [ ] Doc-only change — no build/behavior verification applicable; Vercel preview should still build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance and architecture docs to reflect current authentication, routing, and database access rules.
  * Clarified the current admin verification flow, removed outdated job-queue references, and refreshed route/API maps.
  * Added new reference and handoff documents to keep project state, constraints, and setup notes current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->