### PR TITLE
[2607-DEV-478] Revoke anon/authenticated SELECT on owner-privileged history views

### DIFF
--- a/supabase/migrations/20260707120300_revoke_history_views.sql
+++ b/supabase/migrations/20260707120300_revoke_history_views.sql
@@ -1,0 +1,8 @@
+-- AUDIT #478 (CRITICAL): v_member_history, v_roles_history, member_roles_history
+-- are owner-privileged views that bypass RLS on profiles_audit/profiles/
+-- event_role_requests, and were SELECT-granted to anon/authenticated. No app
+-- path relies on authenticated-role access — all real callers use
+-- createServiceClient() (service_role), which bypasses grants entirely.
+REVOKE SELECT ON public.v_member_history FROM PUBLIC, anon, authenticated;
+REVOKE SELECT ON public.v_roles_history FROM PUBLIC, anon, authenticated;
+REVOKE SELECT ON public.member_roles_history FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
## Summary
- `v_member_history`, `v_roles_history`, `member_roles_history` run with owner privileges (Postgres view-owner behavior) and bypass RLS on `profiles_audit`/`profiles`/`event_role_requests`. All three had `anon`+`authenticated` SELECT.
- `v_member_history` exposes admin-only ABO-change history from `profiles_audit`; the other two expose member names joined against event-role history.
- Traced every caller: `v_member_history` has zero app-code references; `v_roles_history`/`member_roles_history` are queried only from `app/(dashboard)/roles/page.tsx` via `createServiceClient()` (service_role, bypasses grants). No authenticated-role usage exists to preserve, so a straight revoke (option 2 from the issue) is the minimal safe fix — no view-definition changes needed.
- Migration applied directly to prod via Supabase MCP; verified post-apply.

## Verification
```sql
select has_table_privilege('anon','public.v_member_history','SELECT') as v1_anon,
       has_table_privilege('anon','public.v_roles_history','SELECT') as v2_anon,
       has_table_privilege('anon','public.member_roles_history','SELECT') as v3_anon,
       has_table_privilege('authenticated','public.v_member_history','SELECT') as v1_auth,
       has_table_privilege('authenticated','public.v_roles_history','SELECT') as v2_auth,
       has_table_privilege('authenticated','public.member_roles_history','SELECT') as v3_auth;
-- all six: false
```
`service_role` SELECT confirmed still `true` — `/roles` dashboard page unaffected.

Closes #478

## Session State
**Agent Type:** Claude
**Status:** DONE
**Completed:**
- [x] SELECT revoked from anon/authenticated on all three views, applied to prod, verified
**Next:** Await CI (`check-types`) + Vercel preview, then merge. Manually spot-check `/roles` `history` tab renders correctly post-merge.
