### PR TITLE
[2607-DEV-479] Restrict 24 SECURITY DEFINER functions to service_role, harden default privileges

### DIFF
--- a/supabase/migrations/20260707120400_tighten_definer_grants.sql
+++ b/supabase/migrations/20260707120400_tighten_definer_grants.sql
@@ -1,0 +1,68 @@
+-- AUDIT #479 (HIGH, root cause of #475/#476/#477): every SECURITY DEFINER
+-- function in public defaulted to anon/authenticated EXECUTE. Traced every
+-- app call site (grep for .rpc(...) plus createServiceClient()/createBrowserClient
+-- usage) for the 24 unguarded, no-legitimate-anon-need signatures below —
+-- all are called exclusively via service_role, pg_cron, or internal
+-- function-to-function calls (which run as the owner regardless of grants).
+-- Restrict to service_role only.
+--
+-- NOT touched here: approve_event_role_request, approve_member_verification,
+-- dissolve_partnership, promote_to_primary — these already self-guard
+-- (auth.role() <> 'service_role' AND NOT is_admin()) per the issue's own
+-- lower-risk classification; left as-is to keep this diff scoped to the
+-- systemic default-grant fix.
+
+REVOKE EXECUTE ON FUNCTION public.fn_guard_abo_number_null() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.fn_profiles_field_audit() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.fn_reschedule_guest_reminders() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.fn_schedule_guest_reminders() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.fn_schedule_guest_reminders_record(uuid, timestamptz, text) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_core_ancestors(uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_los_members_with_profiles() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_trip_team_attendees(uuid, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.import_los_members(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.import_los_members(jsonb, uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.increment_share_link_click(uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_calendar_event_created() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_doc_expiry() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_registration_status_change() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_role_request() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_role_request_status_change() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_trip_attachment() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_trip_created() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_trip_message() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_trip_request() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notify_verification_request() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.pin_social_post(uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.run_los_digest() FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.upsert_tree_node(uuid, text, text) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.fn_guard_abo_number_null() TO service_role;
+GRANT EXECUTE ON FUNCTION public.fn_profiles_field_audit() TO service_role;
+GRANT EXECUTE ON FUNCTION public.fn_reschedule_guest_reminders() TO service_role;
+GRANT EXECUTE ON FUNCTION public.fn_schedule_guest_reminders() TO service_role;
+GRANT EXECUTE ON FUNCTION public.fn_schedule_guest_reminders_record(uuid, timestamptz, text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_core_ancestors(uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_los_members_with_profiles() TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_trip_team_attendees(uuid, uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.import_los_members(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.import_los_members(jsonb, uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.increment_share_link_click(uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.notify_calendar_event_created() TO service_role;
+GRANT EXECUTE ON FUNCTION public.notify_doc_expiry() TO service_role;
+GRANT EXECUTE ON FUNCTION public.notify_registration_status_change() TO service_role;
+GRANT EXECUTE ON FUNCTION public.notify_role_request() TO service_role;
+GRANT EXECUTE ON FUNCTION public.notify_role_request_status_change() TO service_role;
+GRANT EXECUTE ON FUNCTION public.notify_trip_attachment() TO service_role;
+GRANT EXECUTE ON FUNCTION public.notify_trip_created() TO service_role;
+GRANT EXECUTE ON FUNCTION public.notify_trip_message() TO service_role;
+GRANT EXECUTE ON FUNCTION public.notify_trip_request() TO service_role;
+GRANT EXECUTE ON FUNCTION public.notify_verification_request() TO service_role;
+GRANT EXECUTE ON FUNCTION public.pin_social_post(uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.run_los_digest() TO service_role;
+GRANT EXECUTE ON FUNCTION public.upsert_tree_node(uuid, text, text) TO service_role;
+
+-- Systemic fix: default Postgres behavior grants EXECUTE on new functions to
+-- PUBLIC. Future SECURITY DEFINER functions in this schema will no longer be
+-- anon/authenticated-executable unless explicitly granted.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;

--- a/supabase/migrations/20260707120400_tighten_definer_grants.sql
+++ b/supabase/migrations/20260707120400_tighten_definer_grants.sql
@@ -3,8 +3,12 @@
 -- app call site (grep for .rpc(...) plus createServiceClient()/createBrowserClient
 -- usage) for the 24 unguarded, no-legitimate-anon-need signatures below —
 -- all are called exclusively via service_role, pg_cron, or internal
--- function-to-function calls (which run as the owner regardless of grants).
--- Restrict to service_role only.
+-- function-to-function calls. The internal-call paths are safe to restrict
+-- because every function involved (including the SECURITY INVOKER
+-- rebuild_tree_paths(), which calls upsert_tree_node() from inside
+-- purge_absent_los_members/rollback_los_import/promote_to_primary) is owned
+-- by postgres — function owners always retain implicit EXECUTE on their own
+-- functions regardless of REVOKE. Restrict to service_role only.
 --
 -- NOT touched here: approve_event_role_request, approve_member_verification,
 -- dissolve_partnership, promote_to_primary — these already self-guard
@@ -63,6 +67,9 @@ GRANT EXECUTE ON FUNCTION public.run_los_digest() TO service_role;
 GRANT EXECUTE ON FUNCTION public.upsert_tree_node(uuid, text, text) TO service_role;
 
 -- Systemic fix: default Postgres behavior grants EXECUTE on new functions to
--- PUBLIC. Future SECURITY DEFINER functions in this schema will no longer be
--- anon/authenticated-executable unless explicitly granted.
-ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+-- PUBLIC. Explicit FOR ROLE postgres (the owner of every function in this
+-- schema, confirmed via pg_proc.proowner) rather than relying on whichever
+-- role happens to run the migration. Future SECURITY DEFINER functions in
+-- this schema will no longer be anon/authenticated-executable unless
+-- explicitly granted.
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;


### PR DESCRIPTION
## Summary
- Default Postgres behavior grants `EXECUTE` on new functions to `PUBLIC` — the systemic root cause behind #475, #476, and #477.
- Traced every app call site (`.rpc()` calls cross-referenced with `createServiceClient`/`createBrowserClient` usage) for the 24 unguarded function signatures not already fixed by those three tickets:
  - `fn_guard_abo_number_null`, `fn_profiles_field_audit`, `fn_reschedule_guest_reminders`, `fn_schedule_guest_reminders`, `fn_schedule_guest_reminders_record`, `get_core_ancestors`, 9× `notify_*`, `run_los_digest` — zero direct RPC callers (trigger/`pg_cron`/internal-only).
  - `get_los_members_with_profiles`, `get_trip_team_attendees`, `import_los_members` (both overloads), `increment_share_link_click`, `pin_social_post`, `upsert_tree_node` — called via `.rpc()`, but every site uses `createServiceClient()`.
- All 24 restricted to `service_role` only. Added `ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC` so future functions default closed.
- Migration applied directly to prod via Supabase MCP; verified post-apply.

## Explicitly not touched
`approve_event_role_request`, `approve_member_verification`, `dissolve_partnership`, `promote_to_primary` — these already self-guard (`auth.role() <> 'service_role' AND NOT is_admin()`). Their call sites also happen to all use service_role today, but tightening their grants is separate, lower-urgency hardening left for a future pass, per the issue's own risk classification.

## Verification
Queried `has_function_privilege` for all 24 signatures post-migration: `anon`/`authenticated` → `false`, `service_role` → `true` across the board (full table in issue #479).

Closes #479

## Session State
**Agent Type:** Claude
**Status:** DONE
**Completed:**
- [x] 24 functions restricted to service_role, applied to prod, verified
- [x] `ALTER DEFAULT PRIVILEGES` set for future functions
**Next:** Await CI (`check-types`) + Vercel preview, then merge. Spot-check LOS import/tree, trip attendee roster, share-link click tracking, social-post pin, ABO tree assign, and guest-reminder scheduling still work post-merge.
