### PR TITLE
[2607-DEV-480] Make guide-attachments bucket private, disable listing on 4 public buckets

### DIFF
--- a/app/(dashboard)/library/[slug]/components/GuideBody.tsx
+++ b/app/(dashboard)/library/[slug]/components/GuideBody.tsx
@@ -36,10 +36,12 @@ export default function GuideBody({
   body,
   lang,
   attachments = [],
+  guideId,
 }: {
   body: JSONContent | null
   lang: string
   attachments?: Attachment[]
+  guideId: string
 }) {
   const { t } = useLanguage()
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null)
@@ -70,7 +72,7 @@ export default function GuideBody({
               {attachments.map(att => (
                 <a
                   key={att.id}
-                  href={att.file_url}
+                  href={`/api/guides/${guideId}/attachments/${att.id}/download`}
                   target="_blank"
                   rel="noopener noreferrer"
                   download

--- a/app/(dashboard)/library/[slug]/page.tsx
+++ b/app/(dashboard)/library/[slug]/page.tsx
@@ -111,7 +111,7 @@ export default async function LibraryDetailPage({
       </h1>
 
       {/* Body + Downloads */}
-      <GuideBody body={body ?? null} lang={lang} attachments={attachments} />
+      <GuideBody body={body ?? null} lang={lang} attachments={attachments} guideId={guide.id} />
     </div>
   )
 }

--- a/app/api/guides/[id]/attachments/[attachmentId]/download/route.ts
+++ b/app/api/guides/[id]/attachments/[attachmentId]/download/route.ts
@@ -22,26 +22,30 @@ export async function GET(
 
   const role = await getRoleForAccess()
 
-  const { data: guide } = await supabase
-    .from('guides')
-    .select('id, is_published, access_roles')
-    .eq('id', guideId)
-    .eq('is_published', true)
-    .single()
+  const [guideRes, attachmentRes] = await Promise.all([
+    supabase
+      .from('guides')
+      .select('id, is_published, access_roles')
+      .eq('id', guideId)
+      .eq('is_published', true)
+      .single(),
+    supabase
+      .from('guide_attachments')
+      .select('id, file_url, file_name')
+      .eq('id', attachmentId)
+      .eq('guide_id', guideId)
+      .single(),
+  ])
+
+  const guide = guideRes.data
+  const attachment = attachmentRes.data
 
   if (!guide) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
-  const accessRoles = guide.access_roles as string[]
+  const accessRoles = (guide.access_roles as string[] | null) ?? []
   if (!accessRoles.includes(role)) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
-
-  const { data: attachment } = await supabase
-    .from('guide_attachments')
-    .select('id, file_url, file_name')
-    .eq('id', attachmentId)
-    .eq('guide_id', guideId)
-    .single()
 
   if (!attachment) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 

--- a/app/api/guides/[id]/attachments/[attachmentId]/download/route.ts
+++ b/app/api/guides/[id]/attachments/[attachmentId]/download/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { getRoleForAccess } from '@/lib/server/guides'
+
+export const dynamic = 'force-dynamic'
+
+const SIGNED_URL_TTL_SECONDS = 60
+
+// Signed-URL read endpoint for guide-attachments, gated by the same
+// is_published + access_roles check used for the guide itself
+// (see app/(dashboard)/library/[slug]/page.tsx and
+// guides.howtos_select_published RLS policy). guide-attachments is a
+// private bucket (see supabase/migrations, issue #480) — public URLs
+// stored on guide_attachments.file_url no longer resolve; this route
+// is the only supported read path.
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; attachmentId: string }> }
+): Promise<NextResponse> {
+  const { id: guideId, attachmentId } = await params
+  const supabase = createServiceClient()
+
+  const role = await getRoleForAccess()
+
+  const { data: guide } = await supabase
+    .from('guides')
+    .select('id, is_published, access_roles')
+    .eq('id', guideId)
+    .eq('is_published', true)
+    .single()
+
+  if (!guide) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const accessRoles = guide.access_roles as string[]
+  if (!accessRoles.includes(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { data: attachment } = await supabase
+    .from('guide_attachments')
+    .select('id, file_url, file_name')
+    .eq('id', attachmentId)
+    .eq('guide_id', guideId)
+    .single()
+
+  if (!attachment) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  let storagePath: string | undefined
+  try {
+    storagePath = decodeURIComponent(
+      new URL(attachment.file_url).pathname.split('/guide-attachments/')[1] ?? ''
+    )
+  } catch {
+    storagePath = undefined
+  }
+
+  if (!storagePath) {
+    return NextResponse.json({ error: 'Invalid attachment' }, { status: 500 })
+  }
+
+  const { data: signed, error } = await supabase.storage
+    .from('guide-attachments')
+    .createSignedUrl(storagePath, SIGNED_URL_TTL_SECONDS, { download: attachment.file_name })
+
+  if (error || !signed) {
+    return NextResponse.json({ error: error?.message ?? 'Failed to sign URL' }, { status: 500 })
+  }
+
+  return NextResponse.redirect(signed.signedUrl)
+}

--- a/supabase/migrations/20260707130000_secure_public_storage_buckets.sql
+++ b/supabase/migrations/20260707130000_secure_public_storage_buckets.sql
@@ -1,0 +1,30 @@
+-- =============================================================================
+-- Migration: secure_public_storage_buckets
+-- Issue: #480 (2607-DEV-480) — public storage buckets bypass role-gated content
+--        access and allow anonymous object listing.
+-- =============================================================================
+
+-- 1. guide-attachments: make the bucket private. Public buckets bypass RLS
+--    entirely for object GET via the public URL (confirmed via Supabase docs),
+--    so the role-check SELECT policy added in 20260706175419 never actually
+--    gated downloads. Reads now go through a signed-URL route that performs
+--    its own app-level role check before calling createSignedUrl.
+UPDATE storage.buckets SET public = false WHERE id = 'guide-attachments';
+
+-- The existing "guide-attachments public read" policy (role/access_roles gated)
+-- is left in place — now meaningful for private-bucket .list()/authenticated
+-- download paths. No change needed to it here.
+
+-- 2. Disable anonymous listing on the four lower-sensitivity public buckets.
+--    Per Supabase docs, public buckets do not need a SELECT policy on
+--    storage.objects for object-URL access (that path bypasses RLS). The only
+--    effect of these broad SELECT policies is enabling anonymous `.list()`
+--    calls against the bucket (flagged by advisor public_bucket_allows_listing).
+--    Repo-wide grep found the only .list() caller (trip-hero-images, in
+--    app/api/admin/trips/[id]/hero/route.ts) uses a service-role client, which
+--    bypasses RLS regardless — so dropping these policies has no effect on any
+--    legitimate app functionality.
+DROP POLICY IF EXISTS "Public read guide-covers" ON storage.objects;
+DROP POLICY IF EXISTS "guide_images_public_read" ON storage.objects;
+DROP POLICY IF EXISTS "social-thumbnails public read" ON storage.objects;
+DROP POLICY IF EXISTS "Public can read trip hero images" ON storage.objects;


### PR DESCRIPTION
## Summary
- `guide-attachments` was `public = true` in `storage.buckets` even though its parent content (`guides`/`guide_attachments`) is role-gated (`guides.howtos_select_published`: `is_published = true AND get_my_role() = ANY(access_roles)`). Confirmed via Supabase docs (`search_docs`) that public-bucket object GET via the public URL **bypasses RLS entirely** — so the role-check SELECT policy added in a prior migration (`20260706175419_fix_guide_attachments_bucket.sql`) never actually stopped anonymous downloads of members-only attachments.
- `guide-covers`, `guide-images`, `social-thumbnails`, `trip-hero-images` each had a broad public SELECT policy on `storage.objects`, flagged by the Supabase advisor `public_bucket_allows_listing` — these enable anonymous `.list()` calls (bucket enumeration), which public buckets don't need for normal object-URL access.

## Changes
- **Migration** `supabase/migrations/20260707130000_secure_public_storage_buckets.sql` (applied directly to prod via Supabase MCP):
  - `storage.buckets`: `guide-attachments.public → false`.
  - Drops the 4 broad anonymous SELECT policies on `storage.objects` for `guide-covers`, `guide-images`, `social-thumbnails`, `trip-hero-images`.
- **New route** `app/api/guides/[id]/attachments/[attachmentId]/download/route.ts` — modeled on the existing `app/api/admin/guides/upload-url/*` signed-URL pattern. Resolves caller role via `getRoleForAccess()` (`lib/server/guides.ts`), checks `guides.is_published` + `access_roles.includes(role)`, then issues a 60s `createSignedUrl` via the service client and 307-redirects.
- **Updated call site**: `app/(dashboard)/library/[slug]/components/GuideBody.tsx` download links now point at the new route instead of the (now-private, non-resolving) `file_url`; `app/(dashboard)/library/[slug]/page.tsx` passes `guideId` through.

## Decision on the 4 listing-enabled buckets (per issue's "do not leave un-reviewed" instruction)
Checked for any anonymous gallery/browse feature that would need bucket listing — found none. Repo-wide grep for `.storage.from(...).list(` on these 4 buckets found exactly one caller (`trip-hero-images`, in `app/api/admin/trips/[id]/hero/route.ts`'s `purgeStorageFolder` helper), and it uses `createServiceClient()` (service role), which bypasses RLS regardless of the `storage.objects` policy. Dropping the anon-facing SELECT policy has no effect on it. **Decision: disable listing on all four** (no legitimate anonymous/authenticated use found) rather than leave it open for "lower sensitivity" reasons.

## Verification
```sql
select id, public from storage.buckets
where id in ('guide-attachments','guide-covers','guide-images','social-thumbnails','trip-hero-images');
-- guide-attachments: false (was true)
-- guide-covers / guide-images / social-thumbnails / trip-hero-images: true (unchanged — public URL access still works, only listing removed)
```
- `get_advisors(type: security)` re-run post-migration: `public_bucket_allows_listing` **no longer appears** for any bucket (previously flagged guide-covers, guide-images, social-thumbnails, trip-hero-images).
- Anon request to an existing `guide_attachments.file_url` (the stored public-URL format):
  ```
  curl https://ynykjpnetfwqzdnsgkkg.supabase.co/storage/v1/object/public/guide-attachments/<guide_id>/<file>.png
  → HTTP 400, {"statusCode":"404","error":"Bucket not found","message":"Bucket not found"}
  ```
  Confirms anonymous/non-member access to the raw object URL is rejected now that the bucket is private.
- `npm run check-types` → clean (`tsc --noEmit`, no errors).
- `npm run test` → 45/45 passing (2 test files, pre-existing suite — no test regressions from this change; no tests exist yet for the new route, noted below).

## NOTED (not done) — out of scope for #480
- `guide_attachments_select_authenticated` (table RLS on `public.guide_attachments`, `cmd=SELECT`, `roles={authenticated}`, `qual=true`) lets any authenticated user read attachment metadata regardless of the parent guide's `access_roles`. Not currently exploitable through the app (all app routes use the service-role client + their own role check; this app never issues a Clerk-JWT Supabase client per ADR-002/ADR-011), only through a direct PostgREST call with a user JWT, which doesn't happen today. Flagged as a candidate for a follow-up ticket, not bundled into this fix to keep the diff scoped to the storage-bucket issue in #480.
- No unit test added for the new download route (reprioritized to the manual curl verification above given the Vitest suite in this repo doesn't yet have a pattern for mocking Next.js route handlers + Clerk auth + Supabase storage together).

Closes #480

## Session State
**Agent Type:** Claude
**Status:** DONE
**Completed:**
- [x] Migration written, applied to prod via Supabase MCP, verified (`guide-attachments.public = false`, 4 listing policies dropped)
- [x] New signed-URL download route added and wired into the library page/GuideBody
- [x] `get_advisors(type: security)` re-run — `public_bucket_allows_listing` no longer flagged
- [x] Anon curl to a real `guide_attachments.file_url` confirmed rejected (400/"Bucket not found")
- [x] `check-types` clean, existing test suite (45 tests) still green
**Next:** Await CI (`check-types`) + Vercel preview, then merge. Manually spot-check `/library/[slug]` guide-attachment downloads still work for a member with the correct role (signed URL redirect), and that a guest/anon session gets 403/404 from the new route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guide attachments now download through a secure app-managed link instead of opening storage URLs directly.

* **Bug Fixes**
  * Improved download reliability and access control for published guides.
  * Prevented unauthorized public access to guide attachments and reduced unintended file listing from storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->