### PR TITLE
[2607-DEV-481] Pin search_path on 22 functions flagged by function_search_path_mutable

### DIFF
--- a/supabase/migrations/20260707_001_add_function_search_path.sql
+++ b/supabase/migrations/20260707_001_add_function_search_path.sql
@@ -1,0 +1,40 @@
+-- [2607-DEV-481] Pin search_path on 22 functions flagged by the Supabase advisor
+-- `function_search_path_mutable`, including the 4 Pattern-A RLS helper functions
+-- used by every RLS policy in this schema.
+--
+-- Uses `SET search_path = public` (not `''`) because most function bodies already
+-- fully-qualify references, and `get_core_ancestors` uses the `ltree` `@>` operator,
+-- which lives in the `public` schema (the `ltree` extension is installed there per
+-- the `extension_in_public` advisor finding) -- an empty search_path would break
+-- operator resolution for that function.
+--
+-- This migration is search_path pinning only. No authorization-check logic is
+-- added or changed (that scope belongs to #476/#477/#479, already shipped).
+
+-- Pattern-A RLS helper functions (load-bearing for every RLS policy in this schema)
+ALTER FUNCTION public.is_admin() SET search_path = public;
+ALTER FUNCTION public.get_my_role() SET search_path = public;
+ALTER FUNCTION public.get_my_profile_id() SET search_path = public;
+ALTER FUNCTION public.get_my_clerk_id() SET search_path = public;
+
+-- Remaining flagged functions
+ALTER FUNCTION public.vault_read_secrets() SET search_path = public;
+ALTER FUNCTION public.purge_absent_los_members(text[], uuid) SET search_path = public;
+ALTER FUNCTION public.rollback_los_import(uuid) SET search_path = public;
+ALTER FUNCTION public.increment_share_link_click(uuid) SET search_path = public;
+ALTER FUNCTION public.update_howtos_updated_at() SET search_path = public;
+ALTER FUNCTION public.pin_social_post(uuid) SET search_path = public;
+ALTER FUNCTION public.update_bento_config_updated_at() SET search_path = public;
+ALTER FUNCTION public.get_core_ancestors(uuid) SET search_path = public;
+ALTER FUNCTION public.update_vital_signs_updated_at() SET search_path = public;
+ALTER FUNCTION public.get_trip_team_attendees(uuid, uuid) SET search_path = public;
+-- import_los_members(rows jsonb) already has search_path=public set; only the
+-- (p_rows jsonb, p_imported_by uuid) overload is mutable.
+ALTER FUNCTION public.import_los_members(jsonb, uuid) SET search_path = public;
+ALTER FUNCTION public.abo_to_ltree_label(text) SET search_path = public;
+ALTER FUNCTION public.rebuild_tree_paths() SET search_path = public;
+ALTER FUNCTION public.get_los_members_with_profiles() SET search_path = public;
+ALTER FUNCTION public.update_notification_queue_updated_at() SET search_path = public;
+ALTER FUNCTION public.get_event_years() SET search_path = public;
+ALTER FUNCTION public.update_notification_preferences_updated_at() SET search_path = public;
+ALTER FUNCTION public.update_notification_config_updated_at() SET search_path = public;


### PR DESCRIPTION
## Summary
- Supabase advisor `function_search_path_mutable` flagged 22 functions with no `SET search_path`, including the 4 Pattern-A RLS helper functions (`is_admin`, `get_my_role`, `get_my_profile_id`, `get_my_clerk_id`) used by every RLS policy in this schema.
- Without a pinned `search_path`, these functions are vulnerable to search-path hijacking if a lower-privileged role can create objects in a schema earlier in the caller's `search_path` — this compounds the SECURITY DEFINER grant issue already fixed in #479.
- Confirmed via a live `pg_proc` query that the 22-function count actually spans 22 *signatures*: 21 distinct function names plus a second overload of `import_los_members(p_rows jsonb, p_imported_by uuid)` — its sibling overload `import_los_members(rows jsonb)` already had `search_path=public` set from prior work, so it was excluded from this migration.
- Used `SET search_path = public` (not `= ''`) for all 22, because `get_core_ancestors` uses the `ltree` `@>` operator, and the `ltree` extension is installed in the `public` schema (per the `extension_in_public` advisor finding) — an empty search_path would break operator resolution for that function. Every other function body already fully-qualifies its `public.` references, so `= public` is safe across the board.
- This is search_path pinning only — no authorization-check logic was added or changed (that scope belongs to #476/#477/#479, already shipped).

## Changes
- **Migration** `supabase/migrations/20260707_001_add_function_search_path.sql` (applied directly to prod via Supabase MCP): 22 `ALTER FUNCTION ... SET search_path = public;` statements, one per flagged signature.

## Verification
- Before: `get_advisors(type: security)` listed 21 `function_search_path_mutable` WARN entries for these names (the mutable `import_los_members(p_rows jsonb, p_imported_by uuid)` overload wasn't independently surfaced by the advisor's cache but was confirmed mutable via a direct `pg_proc` query — the issue's own "22 functions" count matches 21 names + 1 extra overload).
- After: re-ran `get_advisors(type: security)` — `function_search_path_mutable` no longer appears anywhere in the output.
- Direct re-query of `pg_proc.proconfig` for all 22 targeted signatures (23 rows including the already-fixed `import_los_members(rows jsonb)` overload) confirms all now show `proconfig = ["search_path=public"]`.
- Spot-checked the 4 Pattern-A RLS helpers post-migration — all execute without error with expected unauthenticated-session defaults:
  ```sql
  select public.is_admin(), public.get_my_role(), public.get_my_profile_id(), public.get_my_clerk_id();
  -- is_admin: false, my_role: guest, my_profile_id: null, my_clerk_id: null
  ```
- `check-types`/CI: no application code touched, migration-only change.

## NOTED (not done) — out of scope for #481
- No authorization-check logic was added to any function (that's the scope of the already-shipped #476/#477/#479, not this ticket).

Closes #481

## Session State
**Agent Type:** Claude
**Status:** DONE
**Completed:**
- [x] Enumerated all 22 flagged function signatures via live advisor + `pg_proc` query, confirmed the `import_los_members` two-overload nuance
- [x] Migration written (`supabase/migrations/20260707_001_add_function_search_path.sql`), applied directly to prod via Supabase MCP
- [x] `get_advisors(type: security)` re-run — `function_search_path_mutable` no longer flagged for any of the 22 signatures
- [x] Direct `pg_proc` re-query confirms `search_path=public` set on all 22
- [x] Spot-checked the 4 Pattern-A RLS helpers still execute correctly post-migration
**Next:** Await CI (`check-types`) + Vercel preview, then merge.
