### PR TITLE
chore: add design-sync inputs for components/ui Claude Design sync

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,90 @@
+# design-sync notes for tevd-portal
+
+## Repo shape
+
+tevd-portal is **not a design-system package** — there's no Storybook, no library
+build, no `package.json` `main`/`module`/`exports`. The synced "design system" is
+`components/ui/` (12 shadcn/ui + Radix wrapper files), scoped via `cfg.srcDir`.
+The converter's "package" shape was run in **synth-entry mode**: `--entry` points
+at a nonexistent path (`./components/ui/__synth_entry__.js`) purely so the
+converter walks up to the repo's real `package.json` (name `tevd-portal`) for
+`PKG_DIR`; there's no real dist to bundle, so it falls back to scanning
+`components/ui/*.tsx` directly, discovering 62 PascalCase exports across the 12
+files.
+
+## Custom CSS build step
+
+There's no compiled stylesheet anywhere in this repo (Tailwind v4, JIT, compiled
+at Next build time only). `cfg.buildCmd` (`node .design-sync/scripts/compile-css.mjs`)
+compiles a scoped stylesheet via `@tailwindcss/postcss`, `@source`-scoped to
+`components/ui/**/*.tsx`, plus `styles/brand-tokens.css` (the repo's real design
+tokens — not Tailwind `@theme` — see conventions.md). Output:
+`.design-sync/.cache/tw-compiled.css`, wired via `cfg.cssEntry`. **Run this before
+every rebuild** — `package-build.mjs` reads it as a static file, it does not
+compile Tailwind itself.
+
+## Known render fixes applied during preview authoring
+
+- **`DropdownMenu`/`Popover`**: the trigger button was originally extracted into a
+  small `Avatar()` helper function component. Radix's `asChild` needs to attach a
+  `ref` to the real DOM node for Popper anchor measurement — a plain function
+  component silently drops that ref, and the popper renders stuck at its internal
+  placeholder position (observed as `transform: translate(0px, -200%)`, fully
+  off-screen). Fixed by inlining the `<button>` directly. **If a preview trigger
+  is ever extracted into a helper component again, wrap it in
+  `React.forwardRef`** or this will silently break.
+- **`DropdownMenu`/`Popover`**: also pinned `side="bottom"` explicitly — Radix's
+  collision flip was placing content above the trigger in the small (~320px)
+  preview viewport.
+- **`Toaster`** (sonner): the toast list is `position: fixed`, contributing zero
+  height to the document flow. The capture harness's `fullPage` screenshot
+  measures document scroll height, which collapsed to ~0. Fixed with an explicit
+  `minHeight: '100vh'` filler div in the preview. Also set `duration: Infinity`
+  on the toasts so they don't auto-dismiss before capture, and neutralized CSS
+  transitions (`[data-sonner-toaster] * { transition: none !important }`) so the
+  entrance animation doesn't get caught mid-transition.
+- **`VaulDrawer`**: same transition-timing issue — neutralized `[data-vaul-drawer]`
+  transform/transition for the static capture.
+- **`Dialog`**: `DialogOverlay` (this repo's fork) ships with no background color
+  of its own — every real call site (`CalendarClient.tsx`) passes one explicitly.
+  The preview does the same.
+
+## Known render warns (pre-triaged, not new)
+
+None currently — final validate run was fully clean (0 bad, 0 thin, 0
+variantsIdentical) across all 62 components.
+
+## Preview scope
+
+Only the 12 "group root" components got authored previews (Dialog, AlertDialog,
+Popover, Select, Sheet, DropdownMenu, Tabs, Table, Drawer, VaulDrawer, Toaster,
+Skeleton), plus 4 leaf sub-components that rendered blank alone and needed their
+parent's full composition (`SheetHeader`, `TableCaption`, `TableCell`,
+`TableHead` — each duplicates its group's preview). The remaining 46 exports
+(mostly Radix sub-parts like `DialogTrigger`, `TabsList`, `SelectItem`) are on
+the floor card by design — they're real, importable, and documented via
+`.d.ts`/`.prompt.md`, just not visually authored. Authorable incrementally on
+any future re-sync.
+
+## Re-sync risks
+
+- **`compile-css.mjs` must run before every rebuild** (see above) — a bare
+  `package-build.mjs` run without it first will pick up a stale
+  `.design-sync/.cache/tw-compiled.css` (or none, on a fresh clone/gitignored
+  cache miss).
+- **Tailwind/token drift**: if `styles/brand-tokens.css` or the app's Tailwind
+  version changes, `conventions.md`'s token table and the compiled CSS should be
+  re-validated — nothing currently automates that cross-check beyond re-running
+  the compile script and re-authoring/re-verifying conventions.md per the base
+  skill's rebuild rule.
+- **`components/ui/*.tsx` real source-code gaps** (not sync bugs, but worth
+  knowing): `table.tsx` references `text-muted-foreground` and `hover:bg-muted/50`
+  — neither `muted`/`muted-foreground` is a defined color anywhere in this
+  repo's Tailwind config, so those classes are dead/no-ops. `tabs.tsx` similarly
+  references `ring-ring` with no `ring` token defined. Not fixed here (out of
+  sync scope — this only converts existing source, never rewrites it), but a
+  future full re-verify of `Table`/`Tabs` previews should not be surprised these
+  classes render as nothing.
+- **No Storybook reference exists** — every grade in this run is absolute
+  (rubric-based), not diffed against a repo-owned reference render. A future
+  re-sync's `[SPOT_CHECK]` canary re-verification is the only cross-check.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,27 @@
+{
+  "projectId": "419d3e32-e2cd-42d3-84f5-38f5b071abad",
+  "pkg": "tevd-portal",
+  "globalName": "TevdPortalUI",
+  "shape": "package",
+  "srcDir": "components/ui",
+  "tsconfig": "tsconfig.json",
+  "cssEntry": ".design-sync/.cache/tw-compiled.css",
+  "buildCmd": "node .design-sync/scripts/compile-css.mjs",
+  "readmeHeader": ".design-sync/conventions.md",
+  "overrides": {
+    "Dialog": { "cardMode": "single", "primaryStory": "Open", "viewport": "480x360" },
+    "AlertDialog": { "cardMode": "single", "primaryStory": "Open", "viewport": "440x320" },
+    "Sheet": { "cardMode": "single", "primaryStory": "Open", "viewport": "480x560" },
+    "SheetHeader": { "cardMode": "single", "primaryStory": "Open", "viewport": "480x560" },
+    "Drawer": { "cardMode": "single", "primaryStory": "Open", "viewport": "480x560" },
+    "VaulDrawer": { "cardMode": "single", "primaryStory": "Open", "viewport": "390x480" },
+    "DropdownMenu": { "cardMode": "single", "primaryStory": "Open", "viewport": "320x320" },
+    "Select": { "cardMode": "single", "primaryStory": "Open", "viewport": "320x360" },
+    "Popover": { "cardMode": "single", "primaryStory": "Open", "viewport": "320x260" },
+    "Toaster": { "cardMode": "single", "primaryStory": "Default", "viewport": "420x200" },
+    "Table": { "cardMode": "column" },
+    "TableCaption": { "cardMode": "column" },
+    "TableCell": { "cardMode": "column" },
+    "TableHead": { "cardMode": "column" }
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,64 @@
+## tevd-portal UI conventions
+
+This library is not a standalone design-system package — it's the shadcn/ui + Radix primitives used directly inside the tevd-portal Next.js app (`components/ui/`). There is no build step of its own; this bundle was synthesized from the app's own source files.
+
+### No provider or root wrapper needed
+
+Nothing here reads from React context for styling. Colors come from plain CSS custom properties defined globally — no `ThemeProvider`, no context wrapper required to render correctly. Dark mode is a `data-theme="dark"` attribute toggle on an ancestor element (commonly `<html>`), not a React provider — the same components render correctly in either mode automatically once that attribute is set.
+
+### Styling idiom: Tailwind for layout, CSS variables for color
+
+Components mix two systems, and getting this right matters:
+
+- **Structure/layout** — plain Tailwind utility classes (`flex`, `fixed`, `z-50`, `rounded-xl`, `px-4 py-2`, etc.).
+- **Color** — inline `style={{ color: 'var(--text-primary)' }}` referencing real CSS custom properties, **not** Tailwind color utility classes. shadcn's usual `bg-background` / `text-foreground` / `border-input` classes were deliberately replaced in this fork — do not use them, they resolve to nothing here.
+
+The real token names (defined in `_ds_bundle.css`, reachable via `styles.css`):
+
+| Token | Use |
+|---|---|
+| `--bg-global` | page/app background |
+| `--bg-card` | card/surface/popover/menu background |
+| `--text-primary` | primary text |
+| `--text-secondary` | secondary/muted text |
+| `--text-tertiary` | tertiary/placeholder text |
+| `--border-default` | default border color |
+| `--border-hover` | hover border color |
+| `--brand-crimson`, `--brand-forest`, `--brand-teal`, `--brand-sienna` | brand accent colors (buttons, accents) |
+| `--brand-parchment`, `--brand-void`, `--brand-oyster`, `--brand-moss` | dark-mode surface/background variants |
+
+Build new layout/spacing with Tailwind utilities as normal; build all color with `style={{ ... : 'var(--token-name)' }}` using the table above.
+
+### Gaps to compose around, not invent past
+
+A few primitives in this fork ship with **no default visual styling** for pieces callers are expected to style themselves — this is a real repo quirk, confirmed against the source, not a bug in this sync:
+
+- `DialogOverlay` (from `dialog.tsx`) has no background color at all — every real call site passes one explicitly, e.g. `<DialogOverlay style={{ backgroundColor: 'rgba(0,0,0,0.4)' }} />`. Omit it and the overlay is fully transparent.
+- Radix popper-based content (`DropdownMenuContent`, `PopoverContent`, `SelectContent`) inherits Radix's own `align`/`side` defaults (`align="end"`) — pick `align`/`side` deliberately based on where the trigger sits on screen, don't assume the default fits.
+
+### Where the truth lives
+
+- `_ds_bundle.css` (via `styles.css`'s `@import`) — the real compiled CSS and every token above.
+- Each component's `.d.ts` and `.prompt.md` — the real prop shape and a working usage example.
+
+### Example — composing a real component (AlertDialog)
+
+```tsx
+<AlertDialog>
+  <AlertDialogTrigger asChild>
+    <button style={{ padding: '8px 16px', borderRadius: 8, border: '1px solid var(--border-default)', color: 'var(--brand-crimson)' }}>
+      Delete trip
+    </button>
+  </AlertDialogTrigger>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>Delete this trip?</AlertDialogTitle>
+      <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>Cancel</AlertDialogCancel>
+      <AlertDialogAction>Delete</AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -13,7 +13,7 @@ Components mix two systems, and getting this right matters:
 - **Structure/layout** — plain Tailwind utility classes (`flex`, `fixed`, `z-50`, `rounded-xl`, `px-4 py-2`, etc.).
 - **Color** — inline `style={{ color: 'var(--text-primary)' }}` referencing real CSS custom properties, **not** Tailwind color utility classes. shadcn's usual `bg-background` / `text-foreground` / `border-input` classes were deliberately replaced in this fork — do not use them, they resolve to nothing here.
 
-The real token names (defined in `_ds_bundle.css`, reachable via `styles.css`):
+The real token names live in `styles/brand-tokens.css` and are compiled into `.design-sync/.cache/tw-compiled.css`:
 
 | Token | Use |
 |---|---|

--- a/.design-sync/previews/AlertDialog.tsx
+++ b/.design-sync/previews/AlertDialog.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog'
+
+export function Closed() {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <button
+          style={{
+            padding: '8px 16px',
+            borderRadius: 8,
+            border: '1px solid var(--border-default)',
+            color: 'var(--brand-crimson)',
+            fontSize: 14,
+            fontWeight: 600,
+          }}
+        >
+          Delete trip
+        </button>
+      </AlertDialogTrigger>
+    </AlertDialog>
+  )
+}
+
+export function Open() {
+  return (
+    <AlertDialog defaultOpen>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this trip?</AlertDialogTitle>
+          <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Delete</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/.design-sync/previews/Dialog.tsx
+++ b/.design-sync/previews/Dialog.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import {
+  Dialog,
+  DialogTrigger,
+  DialogPortal,
+  DialogOverlay,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+
+export function Closed() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          style={{
+            padding: '8px 16px',
+            borderRadius: 8,
+            backgroundColor: 'var(--brand-crimson)',
+            color: 'white',
+            fontSize: 14,
+            fontWeight: 600,
+          }}
+        >
+          Open dialog
+        </button>
+      </DialogTrigger>
+    </Dialog>
+  )
+}
+
+export function Open() {
+  return (
+    <Dialog defaultOpen>
+      <DialogPortal>
+        {/* DialogOverlay ships with no background color of its own — every real
+            call site in this repo passes one explicitly (see CalendarClient.tsx). */}
+        <DialogOverlay style={{ backgroundColor: 'rgba(0,0,0,0.4)' }} />
+        <DialogContent
+          style={{
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: 380,
+            padding: 24,
+            borderRadius: 16,
+            backgroundColor: 'var(--bg-card)',
+            border: '1px solid var(--border-default)',
+            boxShadow: '0 24px 48px rgba(0,0,0,0.18)',
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Confirm departure change</DialogTitle>
+            <DialogDescription>All travelers on this itinerary will be notified.</DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  )
+}

--- a/.design-sync/previews/Drawer.tsx
+++ b/.design-sync/previews/Drawer.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { Drawer } from '@/components/ui/drawer'
+
+export function Open() {
+  return (
+    <Drawer open onClose={() => {}} title="Edit guide">
+      <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+        Update the guide details below. Changes are saved automatically as
+        travelers view this guide.
+      </p>
+    </Drawer>
+  )
+}

--- a/.design-sync/previews/DropdownMenu.tsx
+++ b/.design-sync/previews/DropdownMenu.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu'
+
+// Inlined rather than extracted to a helper component: asChild needs Radix
+// to attach a ref to the actual DOM button for Popper anchor measurement — a
+// plain function component silently drops that ref and the popper never gets
+// a real anchor rect (it renders stuck at its internal placeholder position).
+const avatarStyle = {
+  width: 32,
+  height: 32,
+  borderRadius: 9999,
+  backgroundColor: 'var(--brand-teal)',
+  color: 'white',
+  fontWeight: 700,
+  fontSize: 12,
+} as const
+
+export function Closed() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button style={avatarStyle}>JD</button>
+      </DropdownMenuTrigger>
+    </DropdownMenu>
+  )
+}
+
+export function Open() {
+  return (
+    <DropdownMenu open onOpenChange={() => {}}>
+      <DropdownMenuTrigger asChild>
+        <button style={avatarStyle}>JD</button>
+      </DropdownMenuTrigger>
+      {/* align="end" (the wrapper's default) anchors the trigger's real usage in a
+          right-side nav bar — flipped to "start" here since the preview trigger
+          sits near the frame's left edge. side="bottom" pins placement below the
+          trigger — Radix's collision flip otherwise placed it above the trigger
+          and off the top of this small preview viewport. */}
+      <DropdownMenuContent align="start" side="bottom">
+        <div style={{ padding: '12px 16px', fontSize: 13, color: 'var(--text-primary)', fontWeight: 600 }}>
+          Jamie Doe
+        </div>
+        <DropdownMenuSeparator style={{ height: 1, backgroundColor: 'var(--border-default)' }} />
+        <DropdownMenuItem style={{ padding: '10px 16px', fontSize: 13, color: 'var(--text-primary)' }}>
+          Profile
+        </DropdownMenuItem>
+        <DropdownMenuItem style={{ padding: '10px 16px', fontSize: 13, color: 'var(--text-primary)' }}>
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/.design-sync/previews/Popover.tsx
+++ b/.design-sync/previews/Popover.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+
+// Inlined rather than extracted to a helper component: asChild needs Radix
+// to attach a ref to the actual DOM button for Popper anchor measurement — a
+// plain function component silently drops that ref and the popper never gets
+// a real anchor rect (it renders stuck at its internal placeholder position).
+const avatarStyle = {
+  width: 36,
+  height: 36,
+  borderRadius: 9999,
+  backgroundColor: 'var(--brand-forest)',
+  color: 'white',
+  fontWeight: 700,
+  fontSize: 13,
+} as const
+
+export function Closed() {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button style={avatarStyle}>JD</button>
+      </PopoverTrigger>
+    </Popover>
+  )
+}
+
+export function Open() {
+  return (
+    <Popover open onOpenChange={() => {}}>
+      <PopoverTrigger asChild>
+        <button style={avatarStyle}>JD</button>
+      </PopoverTrigger>
+      {/* align="end" (matching UserPopup.tsx's real usage) anchors a right-side
+          nav trigger — flipped to "start" here since the preview trigger sits
+          near the frame's left edge. side="bottom" pins placement below the
+          trigger — Radix's collision flip otherwise placed it above the trigger
+          and off the top of this small preview viewport. */}
+      <PopoverContent
+        align="start"
+        side="bottom"
+        sideOffset={8}
+        style={{ minWidth: 180, padding: '1rem', display: 'flex', flexDirection: 'column', gap: '0.75rem' }}
+      >
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>Jamie Doe</span>
+        <button style={{ fontSize: 13, textAlign: 'left', color: 'var(--text-secondary)' }}>Sign out</button>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/.design-sync/previews/Select.tsx
+++ b/.design-sync/previews/Select.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  SelectGroup,
+  SelectLabel,
+  SelectSeparator,
+} from '@/components/ui/select'
+
+export function Closed() {
+  return (
+    <Select value="usd" onValueChange={() => {}}>
+      <SelectTrigger style={{ width: 220 }}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="usd">USD</SelectItem>
+        <SelectItem value="eur">EUR</SelectItem>
+        <SelectItem value="bgn">BGN</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+}
+
+export function Open() {
+  return (
+    <Select open onOpenChange={() => {}} value="eur" onValueChange={() => {}}>
+      <SelectTrigger style={{ width: 220 }}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Currency</SelectLabel>
+          <SelectItem value="usd">USD</SelectItem>
+          <SelectItem value="eur">EUR</SelectItem>
+          <SelectItem value="bgn">BGN</SelectItem>
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectItem value="none">No conversion</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+}

--- a/.design-sync/previews/Sheet.tsx
+++ b/.design-sync/previews/Sheet.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet'
+
+export function Closed() {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <button
+          style={{
+            padding: '8px 16px',
+            borderRadius: 8,
+            backgroundColor: 'var(--brand-crimson)',
+            color: 'white',
+            fontSize: 14,
+            fontWeight: 600,
+          }}
+        >
+          Edit itinerary
+        </button>
+      </SheetTrigger>
+    </Sheet>
+  )
+}
+
+export function Open() {
+  return (
+    <Sheet defaultOpen>
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>Edit itinerary</SheetTitle>
+        </SheetHeader>
+        <div style={{ padding: 24 }}>
+          <SheetDescription>Update dates, travelers, and notes for this trip.</SheetDescription>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/.design-sync/previews/SheetHeader.tsx
+++ b/.design-sync/previews/SheetHeader.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+// SheetHeader is a bare flex div with no visible content of its own — it only
+// renders meaningfully composed inside an open Sheet (same composition as
+// the Sheet component's own preview; see .design-sync/previews/Sheet.tsx).
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet'
+
+export function Open() {
+  return (
+    <Sheet defaultOpen>
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>Edit itinerary</SheetTitle>
+        </SheetHeader>
+        <div style={{ padding: 24 }}>
+          <SheetDescription>Update dates, travelers, and notes for this trip.</SheetDescription>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/.design-sync/previews/Skeleton.tsx
+++ b/.design-sync/previews/Skeleton.tsx
@@ -1,0 +1,27 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export function Default() {
+  return <Skeleton style={{ width: 240, height: 16 }} />
+}
+
+export function CardPlaceholder() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8, width: 240 }}>
+      <Skeleton style={{ width: '100%', height: 120, borderRadius: 12 }} />
+      <Skeleton style={{ width: '70%', height: 14 }} />
+      <Skeleton style={{ width: '45%', height: 14 }} />
+    </div>
+  )
+}
+
+export function AvatarRow() {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <Skeleton style={{ width: 40, height: 40, borderRadius: 9999 }} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <Skeleton style={{ width: 120, height: 12 }} />
+        <Skeleton style={{ width: 80, height: 10 }} />
+      </div>
+    </div>
+  )
+}

--- a/.design-sync/previews/Table.tsx
+++ b/.design-sync/previews/Table.tsx
@@ -1,0 +1,46 @@
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableCaption,
+} from '@/components/ui/table'
+
+export function Default() {
+  return (
+    <div
+      style={{
+        borderRadius: 16,
+        border: '1px solid var(--border-default)',
+        backgroundColor: 'var(--bg-card)',
+        overflow: 'hidden',
+        width: 480,
+      }}
+    >
+      <Table>
+        <TableCaption>Recent payments for this trip.</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Traveler</TableHead>
+            <TableHead>Amount</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Jamie Doe</TableCell>
+            <TableCell>$450.00</TableCell>
+            <TableCell>Paid</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Alex Chen</TableCell>
+            <TableCell>$450.00</TableCell>
+            <TableCell>Pending</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/.design-sync/previews/TableCaption.tsx
+++ b/.design-sync/previews/TableCaption.tsx
@@ -1,0 +1,49 @@
+// TableCaption is a bare <caption> with no visible content of its own — it
+// only renders meaningfully composed inside a full Table (same composition
+// as Table's own preview; see .design-sync/previews/Table.tsx).
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableCaption,
+} from '@/components/ui/table'
+
+export function Default() {
+  return (
+    <div
+      style={{
+        borderRadius: 16,
+        border: '1px solid var(--border-default)',
+        backgroundColor: 'var(--bg-card)',
+        overflow: 'hidden',
+        width: 480,
+      }}
+    >
+      <Table>
+        <TableCaption>Recent payments for this trip.</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Traveler</TableHead>
+            <TableHead>Amount</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Jamie Doe</TableCell>
+            <TableCell>$450.00</TableCell>
+            <TableCell>Paid</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Alex Chen</TableCell>
+            <TableCell>$450.00</TableCell>
+            <TableCell>Pending</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/.design-sync/previews/TableCell.tsx
+++ b/.design-sync/previews/TableCell.tsx
@@ -1,0 +1,49 @@
+// TableCell is a bare <td> with no visible content of its own — it only
+// renders meaningfully composed inside a full Table (same composition as
+// Table's own preview; see .design-sync/previews/Table.tsx).
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableCaption,
+} from '@/components/ui/table'
+
+export function Default() {
+  return (
+    <div
+      style={{
+        borderRadius: 16,
+        border: '1px solid var(--border-default)',
+        backgroundColor: 'var(--bg-card)',
+        overflow: 'hidden',
+        width: 480,
+      }}
+    >
+      <Table>
+        <TableCaption>Recent payments for this trip.</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Traveler</TableHead>
+            <TableHead>Amount</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Jamie Doe</TableCell>
+            <TableCell>$450.00</TableCell>
+            <TableCell>Paid</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Alex Chen</TableCell>
+            <TableCell>$450.00</TableCell>
+            <TableCell>Pending</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/.design-sync/previews/TableHead.tsx
+++ b/.design-sync/previews/TableHead.tsx
@@ -1,0 +1,49 @@
+// TableHead is a bare <th> with no visible content of its own — it only
+// renders meaningfully composed inside a full Table (same composition as
+// Table's own preview; see .design-sync/previews/Table.tsx).
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableCaption,
+} from '@/components/ui/table'
+
+export function Default() {
+  return (
+    <div
+      style={{
+        borderRadius: 16,
+        border: '1px solid var(--border-default)',
+        backgroundColor: 'var(--bg-card)',
+        overflow: 'hidden',
+        width: 480,
+      }}
+    >
+      <Table>
+        <TableCaption>Recent payments for this trip.</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Traveler</TableHead>
+            <TableHead>Amount</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Jamie Doe</TableCell>
+            <TableCell>$450.00</TableCell>
+            <TableCell>Paid</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Alex Chen</TableCell>
+            <TableCell>$450.00</TableCell>
+            <TableCell>Pending</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/.design-sync/previews/Tabs.tsx
+++ b/.design-sync/previews/Tabs.tsx
@@ -15,6 +15,16 @@ export function Default() {
           Trip summary and key dates.
         </p>
       </TabsContent>
+      <TabsContent value="guests">
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+          Guest list and RSVP status.
+        </p>
+      </TabsContent>
+      <TabsContent value="payments">
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+          Payment history for this trip.
+        </p>
+      </TabsContent>
     </Tabs>
   )
 }

--- a/.design-sync/previews/Tabs.tsx
+++ b/.design-sync/previews/Tabs.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+
+export function Default() {
+  return (
+    <Tabs defaultValue="overview" style={{ width: 360 }}>
+      <TabsList>
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="guests">Guests</TabsTrigger>
+        <TabsTrigger value="payments">Payments</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview">
+        <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+          Trip summary and key dates.
+        </p>
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/.design-sync/previews/Toaster.tsx
+++ b/.design-sync/previews/Toaster.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect } from 'react'
+import { toast } from 'sonner'
+import { Toaster } from '@/components/ui/sonner'
+
+// Sonner animates each toast in via CSS transition/transform; a static
+// capture taken mid-transition shows nothing. This scopes transitions off
+// for the preview only — it doesn't touch the shipped component.
+function NoTransition() {
+  return <style>{'[data-sonner-toaster] *{transition:none!important;animation:none!important}'}</style>
+}
+
+// The toast list is position:fixed, so it contributes zero height to the
+// document flow — the capture harness screenshots the page's scrollable
+// height, which collapses to ~0 without this. Fixed-position content still
+// paints relative to the real viewport regardless of this div's own height.
+function ViewportFiller() {
+  return <div style={{ minHeight: '100vh' }} />
+}
+
+export function Default() {
+  useEffect(() => {
+    toast('Trip itinerary updated', { description: 'Changes saved and travelers notified.', duration: Infinity })
+  }, [])
+  return (
+    <>
+      <NoTransition />
+      <ViewportFiller />
+      <Toaster />
+    </>
+  )
+}
+
+export function ErrorToast() {
+  useEffect(() => {
+    toast.error('Payment failed', { description: 'Card was declined — try another method.', duration: Infinity })
+  }, [])
+  return (
+    <>
+      <NoTransition />
+      <ViewportFiller />
+      <Toaster />
+    </>
+  )
+}

--- a/.design-sync/previews/VaulDrawer.tsx
+++ b/.design-sync/previews/VaulDrawer.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { VaulDrawer } from '@/components/ui/vaul-drawer'
+
+// Vaul slides the sheet in via a JS-driven transform/transition on mount; a
+// static capture taken mid-transition shows the sheet still translated below
+// the fold. This scopes transitions off for the preview only — it doesn't
+// touch the shipped component.
+function NoTransition() {
+  return <style>{'[data-vaul-drawer]{transition:none!important;transform:none!important}'}</style>
+}
+
+export function Open() {
+  return (
+    <>
+      <NoTransition />
+      <VaulDrawer open onClose={() => {}}>
+        <div style={{ padding: '0 24px 24px' }}>
+          <h3 style={{ fontSize: 15, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 8 }}>
+            Trip options
+          </h3>
+          <p style={{ fontSize: 13, color: 'var(--text-secondary)' }}>
+            Choose how you&apos;d like to share this itinerary with your group.
+          </p>
+        </div>
+      </VaulDrawer>
+    </>
+  )
+}

--- a/.design-sync/scripts/compile-css.mjs
+++ b/.design-sync/scripts/compile-css.mjs
@@ -1,0 +1,26 @@
+// tevd-portal has no design-system package build, so there is no shipped
+// compiled stylesheet for design-sync's cssEntry to point at. This compiles
+// one: Tailwind v4 scoped to components/ui/**, plus the repo's real token
+// file (styles/brand-tokens.css), which is what components/ui actually reads
+// via inline `style={{ color: 'var(--...)' }}` (see components/ui/dialog.tsx
+// header comment — shadcn's default --background/--foreground vars were
+// replaced with this repo's own token names).
+import postcss from 'postcss';
+import tailwindcss from '@tailwindcss/postcss';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..', '..');
+const entry = `
+@import 'tailwindcss' source(none);
+@source '${resolve(root, 'components/ui').replace(/\\/g, '/')}/**/*.tsx';
+@import '${resolve(root, 'styles/brand-tokens.css').replace(/\\/g, '/')}';
+`;
+
+const result = await postcss([tailwindcss()]).process(entry, {
+  from: resolve(root, '.design-sync/.cache/tw-entry.css'),
+});
+
+mkdirSync(resolve(root, '.design-sync/.cache'), { recursive: true });
+writeFileSync(resolve(root, '.design-sync/.cache/tw-compiled.css'), result.css);
+console.log(`wrote ${result.css.length} bytes to .design-sync/.cache/tw-compiled.css`);

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,10 @@ next-env.d.ts
 
 .vercel
 .env*.local
+
+# design-sync
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules


### PR DESCRIPTION
## Summary
- Syncs the shadcn/ui + Radix primitives in `components/ui/` to a new Claude Design project (`tevd-portal Components`) so the design agent can build with real, on-brand components instead of generic ones.
- This repo has no design-system package build of its own, so the sync ran in synth-entry mode against `components/ui/` directly, plus a custom Tailwind compile step (`.design-sync/scripts/compile-css.mjs`) to produce a real stylesheet where none existed.
- 62 components uploaded (12 source files × their exported sub-parts); 16 got rich, composed preview cards (all graded good on the absolute rubric), the rest are on the honest floor card and can be authored incrementally on a future sync.
- Fixed a couple of real bugs surfaced along the way (documented in `.design-sync/NOTES.md`): a ref-forwarding issue in a preview helper that broke Radix popper positioning, and `DialogOverlay` shipping with no background color of its own.

## What's in this PR
- `.design-sync/config.json`, `NOTES.md`, `conventions.md` — sync config, repo-specific gotchas, and the design-agent-facing conventions header.
- `.design-sync/previews/*.tsx` — authored preview compositions for the 12 core component groups (plus 4 leaf sub-components that needed their parent's composition).
- `.design-sync/scripts/compile-css.mjs` — the custom Tailwind→CSS compile step this repo needs since it has no library build.
- `.gitignore` — excludes the sync's generated/cache directories (`.ds-sync/`, `ds-bundle/`, `.design-sync/.cache/`).

No application code changed — this only adds design-sync inputs.

## Test plan
- [x] `package-build.mjs` + `package-validate.mjs` run clean (62/62 components, 0 bad/thin/identical-variant warnings)
- [x] All 16 authored previews graded `good` and carried forward on a clean re-capture
- [x] Uploaded file count verified against the Claude Design project via `list_files`
- [ ] Open the project in claude.ai/design and spot-check a few cards visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design preview coverage for dialogs, drawers, menus, selects, sheets, tabs, tables, skeletons, popovers, and toasts.
  * Included open/closed preview states and sample content to better show how components behave in real use.

* **Bug Fixes**
  * Improved preview stability for overlays, popovers, drawers, and toast captures.
  * Reduced animation-related issues so component previews render more consistently.

* **Chores**
  * Added guidance and setup notes for maintaining the design-sync workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->