### PR TITLE
docs: record batch code-review session across 11 open PRs

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,56 +1,55 @@
 ## Goal
-Review CLAUDE.md + guardrails/ai/architecture/cursor-rules infrastructure; apply the approved doc fixes (findings 1-14, 16) from the review plan.
+Clear the open PR queue to merge-ready: run Sonnet Max `/code-review` on each open PR, apply high-confidence fixes, comment findings, resolve GitHub review threads for applied fixes, comment the reason for any rejected finding.
 
 ## Now
-Doc-fix commit (1cce4c2, 15 files) pushed to claude/mystifying-almeida-2e1a2e; PR #473 opened against main per explicit user create-pr-command. CLAIM for the separate test-infra ticket (#472 / dev/2607-DEV-472) already complete.
+All 11 PRs reviewed and commented; goal complete. See Done log below for per-PR outcomes.
 
 ## Next
-1. BUILD #472 (separate invocation — anthropic-skills:build; different branch, unrelated to PR #473)
-2. User-side: point Antigravity's config at root AGENTS.md / CLAUDE.md
-3. Watch PR #473 for CI/Vercel preview result (doc-only change, build should be unaffected)
+Nothing outstanding from this task. Possible future follow-ups (not started, not asked for):
+- Issue #510 (guest-tier storage-policy bypass, filed this session) needs someone to actually pick it up
+- The 11 PRs still need human merge — this task only got them review-clean, did not merge anything
+- Optional: prune the scratch review worktrees under `.claude/worktrees/reverent-sammet-ff53c3/.claude/worktrees/review-{499,500,501,502,506}` (local-only, harmless if left)
 
 ## Constraints
-- PLAN-mode review first, "do not edit any file... Wait for approval before touching anything" (approval granted via ExitPlanMode)
-- "do not weaken or remove [Hard stops / CAPS constraints] as part of improving the kit"
-- "Do not paraphrase or summarize any guardrail doc into your own words and act from that summary"
-- Finding 15: user chose "Leave as-is" — DEBUG.md stays byte-identical to kit v1.0; do not trim
-- Finding 17: user chose "Still used — wire it up" — AGENTS.md + PROJECT.md addendum authorized (supersedes the earlier "PROJECT.md untouched" scope line)
-- No git commit/push requested this conversation
+- User (this turn): "Run Sonnet Max code review and do everything else necessary to bring the queue to a merge-ready state. Comment findings and resolve comments when applied, otherwise comment why rejected."
+- CLAUDE.md hard stop: no `git push` without the user explicitly asking for a push in-conversation (quote required) — not yet satisfied, must ask before any push
+- CLAUDE.md hard constraint: RLS policies use Pattern A helpers only (`is_admin()`, `get_my_role()`, `get_my_profile_id()`, `get_my_clerk_id()`) — relevant to #499-502
+- CLAUDE.md hard constraint: never mark Done on static analysis alone — Vercel preview READY + CI green required (already true for all 11 per `gh pr list`, re-verify per PR before calling it merge-ready)
+- Hard stop: no failing check gets weakened/skipped to pass
 
 ## Decisions
-DECISION: Finding 9 implemented as option (a) — add Clerk-JWT-client constraint to CLAUDE.md `## Project` — plan recommended (a), approved unchanged.
-DECISION: CONTEXT.md sections 1-3 replaced with pointers to REF.md sections 1-3 (finding 10; subsumes fixes 3 and 4) — the drift was the LOOKUP.md failure mode.
-DECISION: ADR-009/ADR-006 get dated amendment/correction notes, not rewrites — DECISIONS.md header says records are never deleted.
+DECISION: push cadence = auto-push per PR for non-security PRs; always pause for go-ahead before pushing on the security-sensitive bucket — user answered both via AskUserQuestion.
+DECISION: reclassified #506 (pin search_path on 22 functions) into the security-sensitive/pause bucket — same class of issue (search_path-mutable privilege escalation) as #499-502/#504; I'd mis-scoped it out of the original question. ASSUMPTION, not re-asked, per evidence above.
 
 ## Facts
-- Issue #472 "[2607-DEV-472] Add test infrastructure: Vitest + CI test job + first unit tests" — https://github.com/teamenjoyvd/tevd-portal/issues/472
-- Branch dev/2607-DEV-472 created from main (sha 2e8a745, current main tip at CLAIM time)
-- PR #473 (doc fixes) — https://github.com/teamenjoyvd/tevd-portal/pull/473, branch claude/mystifying-almeida-2e1a2e -> main, commit 1cce4c2
-- Worktree: .claude/worktrees/mystifying-almeida-2e1a2e, branch claude/mystifying-almeida-2e1a2e, tree clean at session start
-- No middleware.ts, no lib/proxy.ts; Clerk middleware = root proxy.ts; next.config.ts has no proxy mention
-- Actual vitals route dir: app/api/profile/vital-signs (no `vitals` dir)
-- Existing but undocumented in REF.md: app/api/trips/route.ts, app/api/trips/[id]/messages/, app/api/admin/trips/[id]/messages/(+[messageId])
-- Kit budget counts: 12 iron rules, core+footer 40 lines, 4 CAPS lines, all 7 F7 pairs byte-identical, DEBUG.md 1212 words
-- README.md lacks `## Upgrade notes` (F15 target)
-- Repo has no test runner (CONTEXT.md §4); CI = 4 parallel jobs (typecheck/lint/build/audit), node 22, on push+PR to main (.github/workflows/ci.yml)
-- #322 (0272e7a, 2026-05-10) ripped out Inngest entirely: no inngest/postgres deps, no inngest/ or lib/db/ dirs, /api/inngest removed from lib/public-routes.ts; approve path = synchronous approve_member_verification RPC + Clerk updateUserMetadata + email in app/api/admin/members/verify/[id]/route.ts
-- PHANTOM DOCS PURGED (2026-07-06): C4.md (External Systems Inngest bullet, Container 1 internal-structure/responsibilities/does-not-own/contract, Container 3 contract + does-not-own, Container 5 removed entirely — now correctly "Four deployable units"), REF.md (§1 lib/db/client.ts + inngest/* entries, §4 tree /inngest dir + /inngest/route.ts + /lib/db/client.ts, §6 /api/inngest row + verify-route description + RPC deprecated claim, §9 DATABASE_URL/INNGEST_* env rows, §5 approval_jobs marked orphaned), SYSTEM-MAP.mermaid (INN/INNGEST subgraph/I1-I3, CRON15/RECON/PATCHCLERK/INGSERVE — rewired DEC-approve straight to synchronous approve_member_verification RPC node). All backed by git evidence: 0272e7a "Rip out Inngest" (#322, 2026-05-10).
-- STILL OPEN (not fixed, out of approved scope): REF.md §4/§6 `/api/events/[id]/register` is a phantom route — no such API route exists; real guest registration = `registerGuest()` server action (lib/actions/guest-registration.ts) via the public `/events/[eventId]/register` page. Same class of error as the vitals-path fix already done; flag for next doc-accuracy pass.
-- Guest surface source of truth: lib/public-routes.ts PUBLIC_ROUTE_PATTERNS (16 entries) consumed by proxy.ts isPublicRoute; unauthenticated non-public /api/* gets 401, pages redirect /sign-in
-- format.ts pins timeZone Europe/Sofia in code (CI UTC-safe); public-routes imports @clerk/nextjs/server createRouteMatcher
+- 11 open PRs (`gh pr list`, all `mergeable=MERGEABLE`, all CI checks SUCCESS, `reviewDecision` empty on all):
+  - #509 chore: design-sync inputs for components/ui Claude Design sync
+  - #508 [2607-DEV-482] Collapse TripCard/SocialsTile dual-layout files into single responsive components
+  - #507 [2607-DEV-483] Co-locate CalendarClient/GuidesClient with their single route
+  - #506 [2607-DEV-481] Pin search_path on 22 functions flagged by function_search_path_mutable
+  - #505 [2607-DEV-484] Add auth/payments/admin-mutation test coverage
+  - #504 [2607-DEV-480] Make guide-attachments bucket private, disable listing on 4 public buckets
+  - #503 docs: track milestone #2 security-audit progress in STATE.md (NOTE: modifies this same docs/STATE.md file, on its own branch — expect that diff shape, not an error)
+  - #502 [2607-DEV-479] Restrict 24 SECURITY DEFINER functions to service_role, harden default privileges
+  - #501 [2607-DEV-478] Revoke anon/authenticated SELECT on owner-privileged history views
+  - #500 [2607-DEV-475] Revoke anon/authenticated EXECUTE on vault_read_secrets()
+  - #499 [2607-DEV-477] Guard purge_absent_los_members()/rollback_los_import() against anonymous data destruction
+- Security/RLS-sensitive subset (pause-before-push bucket): #499, #500, #501, #502, #504, #506 (all touch Supabase permissions/SECURITY DEFINER/RLS/search_path surface)
+- Auto-push bucket: #503, #505, #507, #508, #509
+- gh auth confirmed: logged in as teamenjoyvd, token scopes gist/read:org/repo
+- Current worktree branch claude/reverent-sammet-ff53c3, tree clean, unrelated to the 11 PR branches
+- Carried fact (unverified, from prior completed task): Pattern B RLS remediation (SEQ261-265, ADR-011) status unknown from docs alone — check whether #499-502 are that remediation
+- Carried open item (prior task, not yet fixed): REF.md §4/§6 documents a phantom route `/api/events/[id]/register`; real implementation is `registerGuest()` server action — out of scope here, flagging so it isn't lost
 
 ## Done
-Review phase — RESULT: 17 findings + informational list, plan approved (C:\Users\fefence\.claude\plans\before-doing-anything-else-cheerful-naur.md). Evidence: grep/diff outputs in session (F7 pairs 1-hit-each; ls confirms proxy.ts root; diff PROJECT-NOTES/REFACTOR IDENTICAL).
-Fixes applied — RESULT: 11 files modified + docs/STATE.md created; 52 insertions/117 deletions; all plan verification greps pass (F7 pairs still byte-identical; C4 stale-pattern lines 0; auth.mdc middleware-permitted 0; REF profile/vitals 0, vital-signs 2; README Upgrade notes 1; CLAUDE.md kit-zone CAPS still 4).
-NOTED (not done): docs/archive/CLAUDE.md.bak still contains 2 `add <n>` occurrences — archived file, left untouched.
-Finding-5 correction — RESULT: original FLOWS.md text was right all along (Inngest removed in #322); my Inngest rewrite reverted same session, net FLOWS diff = header date + one history-note sentence. Evidence: git diff quoted in transcript; git log -S inngest -> 0272e7a "Rip out Inngest".
-Phantom-Inngest purge — RESULT: C4.md/REF.md/SYSTEM-MAP.mermaid corrected; final grep shows only 5 intentional "removed in #322" notes remain repo-wide; mermaid subgraph/end counts balanced 15/15 post-edit.
-PR creation — RESULT: 15 files committed (1cce4c2), pushed to claude/mystifying-almeida-2e1a2e, PR #473 opened. Pre-commit hook (validate-rules.js): 2 passed, 101 warnings (pre-existing migration ROLLBACK-comment convention + branch-naming heuristic), 0 failures.
+Auto-push bucket (5 PRs) reviewed — RESULT: #507 clean (2 sub-80 notes, comment posted, no fix). #509 clean (1 sub-80 note, comment posted, no fix). #505 clean (3 sub-80 notes, comment posted, no fix). #508 — 1 real finding (confidence 82: desktop SocialsTile thumbnail regression from dual-layout merge), fixed + verified (check-types/build/lint match PR's own pre-existing-error baseline) + committed (`cb4f1ff`) + pushed + commented. #503 — 2 real findings (confidence 92, 85: stale Now/Next/Done claiming #480-484 "not started" when all already had open PRs #504-508, and all-5-Phase-1-unmerged when #498 already merged) — corrected content, committed (`2ae3b88`) + pushed + commented. CAUGHT OWN MISTAKE: first #503 comment cited a fabricated full SHA (typed from memory instead of verifying) — caught immediately, fixed via `gh pr comment --edit-last` before moving on. Lesson: always `git rev-parse HEAD` explicitly right before building a GitHub blob link, never pattern-complete a short SHA.
+Security bucket (6 PRs, extra-caution/pause-before-push per user) reviewed — RESULT: all 6 came back clean at the ≥80 threshold — #500, #501, #499, #506, #502 had zero real findings (only informational sub-80 notes); commented each, no fixes needed so the pause-before-push cadence never actually triggered (nothing to push). #499's assigned worktree was found stale (2 commits behind PR tip, missed prior Gemini/CodeRabbit follow-up fixes) — caught via fetch/status check, fast-forwarded, re-verified guard clause unchanged across versions before commenting. #504 (bucket privacy + new signed-URL route, the one PR with real new app code) surfaced one genuine but non-blocking finding: a pre-existing (not this PR's) storage.objects RLS policy still allows anon-key bypass of the new route for any `'guest'`-tier guide — verified live, zero guides currently use that tier so no live exposure today. Asked user how to handle it; user chose "note + file follow-up, don't touch #504." Filed issue #510 with full mechanism + suggested fix, commented on #504 referencing it, no fix pushed to #504 itself.
+Task complete — RESULT: 11/11 open PRs reviewed at Sonnet/max effort, each with a posted review comment; 2 real bugs found and fixed/pushed (#508, #503); 1 real-but-latent security gap found and tracked as a new issue (#510) rather than bundled; 0 PRs needed the security bucket's pause-before-push (nothing rose to a fixable finding there). No PRs were merged — that's a separate human/CI-gated step this task didn't do.
 
 ## Open items
-- Finding 15 CLOSED: user decision = leave DEBUG.md as-is; report the F11 overage upstream to the kit source if desired
-- Finding 17 CLOSED in-repo (AGENTS.md + PROJECT.md addendum); remaining user-side step: configure Antigravity to load AGENTS.md/CLAUDE.md
-- Pattern B RLS remediation (SEQ261-265, ADR-011) status unknown from docs alone
+- Issue #510 (guest-tier storage.objects RLS bypass on guide-attachments, filed this session) — not yet fixed, needs its own PR
+- Prior-task open item carried forward: REF.md phantom-route doc fix (`/api/events/[id]/register`) still not done, unrelated to this task
+- The "Pattern B RLS remediation (SEQ261-265, ADR-011) status unknown" item from before is effectively answered: #499-502/#506 were confirmed (via this session's reviews) to already use Pattern-A helpers correctly, not Pattern B
 
 ## Failed attempts
 (none)


### PR DESCRIPTION
## Summary
- Ran a Sonnet/max-effort code review pass over all 11 open PRs at the time (#499-509), as an alternative to CodeRabbit's quota-limited free tier.
- Two real bugs were found and fixed **directly on their own PR branches** (not this one): #508 (desktop thumbnail regression from a layout merge) and #503 (stale progress-tracking claims in `docs/STATE.md`).
- One latent security gap found while reviewing #504 was filed as a new tracked issue, [#510](https://github.com/teamenjoyvd/tevd-portal/issues/510), rather than bundled into that PR.
- Every PR got a posted review comment; the other 8 (#507, #509, #505, #499, #500, #501, #502, #506) came back clean at the confidence threshold used (no fix needed).
- This PR itself only carries the session-tracking update to `docs/STATE.md` — the actual code changes already landed on their respective branches.

## Test plan
- [x] Docs-only change (`docs/STATE.md`) — no runtime behavior affected.
- [ ] N/A — this PR doesn't touch app code; the reviewed PRs each carry their own CI/Vercel-preview status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project status notes to reflect a completed review pass across the open PR queue.
  * Added a clearer progress summary with updated goals, next steps, and decision notes.
  * Recorded review outcomes for each PR, including fixes applied, a tracked follow-up item, and remaining open documentation notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->