### PR TITLE
[2607-DEV-513] Fix conflicting dynamic route param names under app/api/guides

### DIFF
--- a/app/api/guides/[slug]/attachments/[attachmentId]/download/route.ts
+++ b/app/api/guides/[slug]/attachments/[attachmentId]/download/route.ts
@@ -15,9 +15,13 @@ const SIGNED_URL_TTL_SECONDS = 60
 // is the only supported read path.
 export async function GET(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string; attachmentId: string }> }
+  { params }: { params: Promise<{ slug: string; attachmentId: string }> }
 ): Promise<NextResponse> {
-  const { id: guideId, attachmentId } = await params
+  // NOTE: despite the `slug` param name (required to match the sibling
+  // app/api/guides/[slug]/route.ts segment — Next.js requires the same
+  // dynamic-segment name at a given route position across the whole app),
+  // this value is the guide's UUID, not its slug. See guides.id query below.
+  const { slug: guideId, attachmentId } = await params
   const supabase = createServiceClient()
 
   const role = await getRoleForAccess()

--- a/lib/hooks/useNotifications.ts
+++ b/lib/hooks/useNotifications.ts
@@ -1,5 +1,18 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 
+// fetch() only rejects on network failure — a 4xx/5xx response still resolves
+// with a parseable JSON error body (e.g. { error: 'Unauthorized' }), which
+// would otherwise be treated as valid query/mutation data (an object, not an
+// array) and crash any `.filter`/`.map` caller downstream.
+async function fetchJson<T>(input: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, init)
+  if (!res.ok) {
+    const body = await res.json().catch(() => null)
+    throw new Error(body?.error ?? `Request failed: ${res.status}`)
+  }
+  return res.json()
+}
+
 export type Notification = {
   id: string
   profile_id: string
@@ -15,7 +28,7 @@ export type Notification = {
 export function useNotifications() {
   return useQuery<Notification[]>({
     queryKey: ['notifications'],
-    queryFn: () => fetch('/api/notifications').then(r => r.json()),
+    queryFn: () => fetchJson<Notification[]>('/api/notifications'),
     refetchInterval: 15_000,
   })
 }
@@ -29,11 +42,11 @@ export function useMarkRead() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (id: string) =>
-      fetch(`/api/notifications/${id}`, {
+      fetchJson(`/api/notifications/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ is_read: true }),
-      }).then(r => r.json()),
+      }),
     onMutate: async (id) => {
       await qc.cancelQueries({ queryKey: ['notifications'] })
       const prev = qc.getQueryData<Notification[]>(['notifications'])
@@ -54,7 +67,7 @@ export function useMarkRead() {
 export function useMarkAllRead() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: () => fetch('/api/notifications/read-all', { method: 'POST' }).then(r => r.json()),
+    mutationFn: () => fetchJson('/api/notifications/read-all', { method: 'POST' }),
     onMutate: async () => {
       await qc.cancelQueries({ queryKey: ['notifications'] })
       const prev = qc.getQueryData<Notification[]>(['notifications'])
@@ -76,11 +89,11 @@ export function useDeleteNotification() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (id: string) =>
-      fetch(`/api/notifications/${id}`, {
+      fetchJson(`/api/notifications/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ deleted_at: new Date().toISOString() }),
-      }).then(r => r.json()),
+      }),
     onMutate: async (id) => {
       await qc.cancelQueries({ queryKey: ['notifications'] })
       const prev = qc.getQueryData<Notification[]>(['notifications'])
@@ -102,11 +115,11 @@ export function useClearAllNotifications() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: () =>
-      fetch('/api/notifications', {
+      fetchJson('/api/notifications', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ all: true }),
-      }).then(r => r.json()),
+      }),
     onMutate: async () => {
       await qc.cancelQueries({ queryKey: ['notifications'] })
       const prev = qc.getQueryData<Notification[]>(['notifications'])


### PR DESCRIPTION
## Summary
- Production has been intermittently 504-ing on unrelated routes (`/api/notifications`, `/api/profile/role`, and likely others) whenever Next.js's router needs to resolve/insert routes under `app/api/guides/*`.
- Root cause: `app/api/guides/[id]/attachments/[attachmentId]/download/route.ts` (added in #504) used `[id]` as its dynamic segment name, while the pre-existing `app/api/guides/[slug]/route.ts` uses `[slug]` at the same route-tree position. Next.js requires the same dynamic-segment name at a given position across the whole app — the mismatch throws `Error: You cannot use different slug names for the same dynamic path ('id' !== 'slug')` as an unhandled rejection inside the router's internal insert step. Turbopack appears to defer this check past build time to request time, so CI/preview never caught it — it only surfaces as a runtime 504 in production.
- Fix: renamed the `[id]` folder to `[slug]` to match its sibling. URL shape is unchanged (single opaque path segment); the one caller (`GuideBody.tsx:75`) just interpolates a guide UUID string into the URL, no parsing involved. Internal param destructuring renamed accordingly with a comment noting the value is still a UUID, not a real slug.

Fixes #513

## How this was found
Investigating a report that member "Deniz Murat" (DB role correctly `core`) saw his own account badge show "Guest" and `/profile` stuck on loading skeletons. Traced to `/api/profile/role` hanging/504ing — reproduced live via a connected browser session, then confirmed via Vercel runtime logs showing the exact router error on `/api/notifications`, and confirmed Postgres had no blocking queries at the time (rules out a DB-layer cause, points to route resolution).

## Test plan
- [ ] Vercel preview build succeeds (this is the real test — the conflict was only ever caught at request time, not build time, so a clean preview + a manual hit on `/api/notifications`, `/api/profile/role`, and `/library/<a-guide-slug>` on the preview URL is the strongest signal)
- [ ] Manually verify guide attachment downloads still work via `GuideBody.tsx`'s download links on the preview
- [ ] Once merged, verify Deniz Murat's `/profile` shows "Core" on production


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed guide attachment downloads so the correct file is retrieved and links work more reliably.
  * Improved notifications by handling failed network requests more safely, preventing inconsistent notification data updates when requests don’t succeed.
  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->