### PR TITLE
Resolve shared ABO/upline for spouse-linked secondary profiles

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -42,11 +42,14 @@ export async function GET() {
     upline_abo_number: string | null
   } | null = null
   if (primaryProfileId) {
-    const { data: primary } = await supabase
+    const { data: primary, error: primaryError } = await supabase
       .from('profiles')
       .select('id, first_name, last_name, abo_number, upline_abo_number')
       .eq('id', primaryProfileId)
       .maybeSingle()
+    if (primaryError) {
+      return Response.json({ error: primaryError.message }, { status: 500 })
+    }
     primaryInfo = primary ?? null
   }
 

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -28,16 +28,42 @@ export async function GET() {
   const role: string = data.role
   const primaryProfileId: string | null = data.primary_profile_id ?? null
 
+  // Spouse-linked secondary profiles (primary_profile_id set) intentionally have
+  // null abo_number/upline_abo_number — the primary profile holds the shared ABO
+  // account (ADR-016), so it can't also live on the secondary's row without
+  // tripping the abo_partnership_unique_constraint. Resolve the primary once here
+  // so the upline lookup and the abo_number/upline_abo_number returned to the
+  // client reflect the shared account instead of showing blank.
+  let primaryInfo: {
+    id: string
+    first_name: string
+    last_name: string
+    abo_number: string | null
+    upline_abo_number: string | null
+  } | null = null
+  if (primaryProfileId) {
+    const { data: primary } = await supabase
+      .from('profiles')
+      .select('id, first_name, last_name, abo_number, upline_abo_number')
+      .eq('id', primaryProfileId)
+      .maybeSingle()
+    primaryInfo = primary ?? null
+  }
+
+  const effectiveAboNumber: string | null = aboNumber ?? primaryInfo?.abo_number ?? null
+  const effectiveUplineAboNumber: string | null = uplineAboNumber ?? primaryInfo?.upline_abo_number ?? null
+
   const [upline, verRequest, spouse, pendingSpouseLinkCount] = await Promise.all([
-    // Resolve upline for any verified member.
+    // Resolve upline for any verified member (own account, or via the primary
+    // profile's shared ABO when this is a spouse-linked secondary).
     // Standard path: abo_number set — look up sponsor via los_members tree.
     // Manual path: abo_number null but upline_abo_number set — resolve name directly.
-    aboNumber
+    effectiveAboNumber
       ? (async () => {
           const { data: losMember } = await supabase
             .from('los_members')
             .select('sponsor_abo_number')
-            .eq('abo_number', aboNumber)
+            .eq('abo_number', effectiveAboNumber)
             .single()
 
           if (!losMember?.sponsor_abo_number) {
@@ -55,18 +81,18 @@ export async function GET() {
             upline_abo_number: uplineMember?.abo_number ?? null,
           }
         })()
-      : uplineAboNumber
+      : effectiveUplineAboNumber
         ? (async () => {
             // Manual path: upline ABO already known, just resolve the name
             const { data: uplineMember } = await supabase
               .from('los_members')
               .select('abo_number, name')
-              .eq('abo_number', uplineAboNumber)
+              .eq('abo_number', effectiveUplineAboNumber)
               .single()
 
             return {
               upline_name: uplineMember?.name ?? null,
-              upline_abo_number: uplineMember?.abo_number ?? uplineAboNumber,
+              upline_abo_number: uplineMember?.abo_number ?? effectiveUplineAboNumber,
             }
           })()
         : Promise.resolve(null),
@@ -84,13 +110,10 @@ export async function GET() {
     // Returns null for unlinked profiles.
     (async () => {
       if (primaryProfileId) {
-        // This profile is a secondary — fetch the primary
-        const { data: primary } = await supabase
-          .from('profiles')
-          .select('id, first_name, last_name')
-          .eq('id', primaryProfileId)
-          .maybeSingle()
-        return primary ?? null
+        // This profile is a secondary — reuse the primary fetched above
+        return primaryInfo
+          ? { id: primaryInfo.id, first_name: primaryInfo.first_name, last_name: primaryInfo.last_name }
+          : null
       } else {
         // This profile may be a primary — fetch any secondary linked to it
         const { data: secondary } = await supabase
@@ -115,7 +138,15 @@ export async function GET() {
       : Promise.resolve(0),
   ])
 
-  return Response.json({ ...data, upline, verRequest, spouse, pendingSpouseLinkCount })
+  return Response.json({
+    ...data,
+    abo_number: effectiveAboNumber,
+    upline_abo_number: effectiveUplineAboNumber,
+    upline,
+    verRequest,
+    spouse,
+    pendingSpouseLinkCount,
+  })
 }
 
 export async function PATCH(req: Request): Promise<Response> {


### PR DESCRIPTION
## Summary
- `GET /api/profile` never resolved ABO/upline for spouse-linked secondary profiles (`primary_profile_id` set), whose own `abo_number`/`upline_abo_number` are intentionally `NULL` — the primary profile holds the shared ABO account (ADR-016). This left secondaries permanently stuck in the blank `member_manual` render mode on their own profile page.
- Discovered via Mario Topalov's profile, which showed `—` for ABO/upline despite being spouse-linked to Rumyana Topalova's confirmed account.
- Fix: fetch the primary's ABO/upline once and use it as the "effective" value for both the upline lookup and the JSON response. No frontend change needed — `AboInfoContent.tsx`'s existing `confirmed` branch already renders the co-owner name, it was just unreachable for secondaries.
- The `profiles` table itself is untouched — Mario's row correctly stays `NULL`/`NULL`; this is a read-side resolution fix only.

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [x] Replicated the new query chain in SQL against the live DB for Mario's real row — confirms `abo_number: 8896402`, `upline_abo_number: 8887520`, `upline_name: ДАНЕВА, МАЛВИНА`, `spouse: Rumyana Topalova`
- [ ] Verify on Vercel PR preview that Mario Topalov's profile page now renders ABO/upline/co-owner instead of dashes (couldn't do this from the worktree — no Clerk session for his account)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the profile API output for spouse-linked secondary profiles so shared account and sponsor details no longer appear blank.
  * Ensured secondary profiles return the correct account (ABO) and upline numbers, aligned with the linked primary’s effective values.
  * Reduced redundant profile lookups when resolving linked spouse information, improving response consistency and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->