### PR TITLE
chore: bump @clerk/nextjs to 7.5.15 for annual-only billing plans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "tevd-portal",
       "version": "0.1.0",
       "dependencies": {
-        "@clerk/nextjs": "^7.0.4",
+        "@clerk/nextjs": "^7.5.15",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^9.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -326,12 +326,12 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.0.tgz",
-      "integrity": "sha512-3APNJ5jt5Db9f441FPVTjgzvPxjLhekygomkMOhsvPpItRNNEHgFZM/bGXYetgcOtUrO6vWcuhf1rlNSTRelhg==",
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.11.2.tgz",
+      "integrity": "sha512-HaHAnKzThRpdRi+QJkMo3+Cx/3hJUt+UdbQ62Ikzwwt0zIhUE0+qgG+zgUHjAdYhSbfiUzEWYsLdnBsfQ7yv7g==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.3.0",
+        "@clerk/shared": "^4.25.1",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -340,14 +340,14 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.0.4.tgz",
-      "integrity": "sha512-Vnx+2akiAxogvLW0ZdRU1idREdznRuhUYxSOI/YLfqVzZ+ORtTz5lrNlSKiBx9oSM6nd11LSKfFnVkLaAbU0fQ==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.5.15.tgz",
+      "integrity": "sha512-CNRdvIZ9YHpDLJVng69Ot9qfxF2ycMml0fr8N1LhPLiTDZ//bkBtnK4/XL6sN/aNTygLeoN5nyFIlWDU+enu6w==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^3.2.0",
-        "@clerk/react": "^6.1.0",
-        "@clerk/shared": "^4.3.0",
+        "@clerk/backend": "^3.11.2",
+        "@clerk/react": "^6.12.1",
+        "@clerk/shared": "^4.25.1",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -361,12 +361,12 @@
       }
     },
     "node_modules/@clerk/react": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.1.0.tgz",
-      "integrity": "sha512-xHFvpQGBZGuuAp/d7+n2LAPoaeqPsqrG5ValR0//Ol6gRGCttnjJ0CVk806dlIzs7JZNLO68+i/MZanowCjEMw==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.12.1.tgz",
+      "integrity": "sha512-FFIv0SUQh9R8lBOCpHfAC5ki+FjU0WlvBrujJUPQgBTJX7uaRUlbzKswB/ZfRlauGKnE9c80H5dnir08cEtLgw==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.3.0",
+        "@clerk/shared": "^4.25.1",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -378,17 +378,15 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.3.0.tgz",
-      "integrity": "sha512-Ydt8YGohNXEs6aBBLnti80OJT551yYWVTugFTO8Ee+uIZpStyqXF+ufBtJleuhfxs1D5KjtpIxc+hTqkZtqMyQ==",
-      "hasInstallScript": true,
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.1.tgz",
+      "integrity": "sha512-+FHoFEJ8zGenUymf03gARKEAYOLxOKm6B437tgukxP7oM5ORfI+ZND62W25S8ddVsDLlNTS0VEHlhDm3F+NF0A==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.16",
+        "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.5",
-        "std-env": "^3.9.0"
+        "js-cookie": "3.0.7"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -2604,9 +2602,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.16",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
-      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6426,12 +6424,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {
@@ -8701,12 +8699,6 @@
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
       }
-    },
-    "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "db:clean-fixes": "node -e \"const fs = require('fs'); if (fs.existsSync('apply_fixes.sql')) fs.unlinkSync('apply_fixes.sql')\""
   },
   "dependencies": {
-    "@clerk/nextjs": "^7.0.4",
+    "@clerk/nextjs": "^7.5.15",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^9.0.0",
     "@dnd-kit/utilities": "^3.2.2",


### PR DESCRIPTION
## Summary
- Clerk's dashboard "Annual-only billing plans" update requires `@clerk/nextjs` v7.0.6+; the app was pinned to v7.0.4.
- Bumped `@clerk/nextjs` ^7.0.4 → ^7.5.15, with matching transitive bumps for `@clerk/backend`, `@clerk/react`, `@clerk/shared`.
- No code changes needed: the app has no custom Clerk sign-in flow (uses the prebuilt `<SignIn/>` component in `app/(auth)/sign-in/[[...sign-in]]/page.tsx`), so the related "Client Trust Status" dashboard update (min v7.0.0+) was already safe and is unaffected by this bump.

## Test plan
- [x] `npm run check-types` — clean
- [x] `npm run build` — compiles and prerenders successfully (verified with local-only dummy env vars, no real credentials, no Supabase writes)
- [x] `npm run test` — 77/77 passing
- [ ] Vercel PR preview READY + CI green
- [ ] After merge: enable "Annual-only billing plans" in the Clerk dashboard (irreversible per Clerk's own warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the authentication package to a newer version, bringing in the latest fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->