### PR TITLE
[2607-DEV-495] Document orphaned DB tables via COMMENT ON TABLE (no drops)

### DIFF
--- a/supabase/migrations/20260709_001_comment_orphaned_tables.sql
+++ b/supabase/migrations/20260709_001_comment_orphaned_tables.sql
@@ -1,0 +1,8 @@
+-- Documents orphaned tables per issue #495 audit. No DROP TABLE — dropping is explicitly
+-- out of scope for this ticket (destructive, requires separate explicit approval).
+-- email_log and scheduled_reminders already carry DEPRECATED comments from #486; not touched here.
+
+COMMENT ON TABLE public.bento_config IS 'ORPHANED: no live app reference since /api/admin/bento-config route removal. See issue #495.';
+COMMENT ON TABLE public.waiting_list IS 'ORPHANED: RLS-enabled-no-policy, never wired to any code. See issue #495.';
+COMMENT ON TABLE public.verification_log IS 'ORPHANED: superseded by member_event_log / abo_verification_requests. See issue #495.';
+COMMENT ON TABLE public.approval_jobs IS 'ORPHANED: documented for Inngest job lifecycle, but no Inngest code exists in this repo. See issue #495.';


### PR DESCRIPTION
## Summary
Per audit issue #495, adds `COMMENT ON TABLE` documentation to 4 orphaned tables confirmed to have zero app/edge-function references: `bento_config`, `waiting_list`, `verification_log`, `approval_jobs`. `email_log` and `scheduled_reminders` already carry `DEPRECATED` comments from #486 and are untouched here.

**Scope decision:** this PR does NOT drop any tables. Dropping is a destructive, hard-to-reverse DDL operation, and the issue's own text defers that decision ("Any drop is a migration — out of scope for this read-only audit"). `email_log`'s 115 rows in particular need a retention decision this ticket does not make. Comment-only is safe, reversible, and satisfies the issue's "retain as read-only historical table with a comment" remediation option.

Migration applied via `Supabase:apply_migration` MCP (confirmed via `list_tables`) and committed to `supabase/migrations/20260709_001_comment_orphaned_tables.sql`.

Closes #495

## Test plan
- [x] Confirmed live row counts matched the issue exactly before applying
- [x] Applied migration, confirmed all 4 comments present via `list_tables`
- [x] Checked `get_advisors` (performance) — no new warnings introduced, only pre-existing unused-index notices on these already-orphaned tables
- [x] CI/build unaffected (no app code changed)

## Session State
**Status:** DONE
**Completed:**
- [x] Migration applied to Supabase project + committed to repo
**Next:** Merge via GitHub UI. Follow-up (separate ticket, needs explicit approval): decide drop vs. permanent-retain for these 4 tables + `email_log` retention policy.
