### PR TITLE
[2607-DEV-491] Fix malformed Markdown table separators in REF.md §6

### DIFF
--- a/docs/ai/REF.md
+++ b/docs/ai/REF.md
@@ -415,7 +415,7 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 
 ### Member routes
 | Route | Method | Notes |
-|---|---|
+|---|---|---|
 | `/api/profile` | GET, PATCH | |
 | `/api/profile/verify-abo` | POST | LOS-validated at submit: existence check + sponsor match + duplicate ABO check. Returns `abo_has_primary` error_code if the existing holder is a primary (ADR-016). Guard added #350: secondary accounts (`primary_profile_id IS NOT NULL`) receive 400 `secondary_cannot_verify`. |
 | `/api/profile/spouse-link` | GET, POST, DELETE | ADR-016: GET own request; POST submit (guest only, guards: requester is guest with no primary_profile_id, claimed_primary is member with abo_number and no existing secondary); DELETE cancel own pending |
@@ -446,7 +446,7 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 
 ### Admin routes
 | Route | Method | Notes |
-|---|---|
+|---|---|---|
 | `/api/admin/announcements` | GET, POST, PATCH, DELETE | |
 | `/api/admin/calendar` | GET, POST, PATCH, DELETE | |
 | `/api/admin/calendar-sync` | POST | Triggers sync-google-calendar edge function |


### PR DESCRIPTION
## Summary
Follow-up to #491/PR #518 (already merged). Code review of the batch of PRs from that session caught a bug I introduced while hand-reconstructing `docs/ai/REF.md` for that PR's `push_files` call: the "Member routes" and "Admin routes" tables in §6 ended up with a 3-column header (`| Route | Method | Notes |`) followed by a 2-column separator (`|---|---|`) instead of `|---|---|---|`. Confirmed this is live on `main` right now and was NOT present in the file before PR #491.

This fixes both separators back to 3 columns. No other content changes.

## Test plan
- [x] Diffed against the pre-#491 version of the file to confirm this is the only structural difference from the bug
- [x] Verified both tables now have matching header/separator column counts

## Session State
**Status:** DONE
**Completed:**
- [x] Fixed both malformed table separators in §6
**Next:** Merge via GitHub UI.
