### PR TITLE
[2607-DEV-510] Drop guide-attachments public-read storage RLS policy

### DIFF
--- a/supabase/migrations/20260710_001_drop_guide_attachments_public_read_policy.sql
+++ b/supabase/migrations/20260710_001_drop_guide_attachments_public_read_policy.sql
@@ -1,0 +1,12 @@
+-- Issue #510: "guide-attachments public read" (storage.objects) is a pre-existing
+-- policy that grants public/anon read access to any attachment on a guide tagged
+-- 'guest' in access_roles, bypassing the signed-URL download route entirely
+-- (app/api/guides/[slug]/attachments/[attachmentId]/download/route.ts). That route
+-- already uses createServiceClient() (bypasses RLS) and performs its own
+-- is_published + access_roles check, so this policy is redundant with the only
+-- legitimate read path and is otherwise an unenforceable authorization boundary
+-- (get_my_role() defaults to 'guest' for every anon-key caller, per ADR-002/ADR-011 —
+-- no Clerk-JWT Supabase client is ever minted). Confirmed zero other code paths
+-- (admin routes, upload/delete) rely on this policy — they all use the service client.
+
+DROP POLICY IF EXISTS "guide-attachments public read" ON storage.objects;


### PR DESCRIPTION
## Summary
Fixes #510. The pre-existing `"guide-attachments public read"` policy on `storage.objects` granted public/anon read access to any attachment on a guide tagged `'guest'` in `access_roles`, bypassing the signed-URL download route (`app/api/guides/[slug]/attachments/[attachmentId]/download/route.ts`) entirely.

**Root cause confirmed:** that route already uses `createServiceClient()` (service role — bypasses RLS) and independently performs the `is_published` + `access_roles` check before minting a 60s signed URL. The dropped policy was never load-bearing for the legitimate read path, and as an authorization boundary it was unenforceable anyway — `get_my_role()` defaults to `'guest'` for every request authenticated with only the public anon key, since this app never mints a real Supabase JWT for end users (ADR-002/ADR-011).

**Verified no other code path depends on it** — grepped `guide-attachments` across `app/`; the only other consumers are the admin attachments CRUD route and the download route, both using the service client, not the anon key.

**Verified live**, before/after, against Supabase project `ynykjpnetfwqzdnsgkkg`:
- Before: `pg_policies` showed `"guide-attachments public read"` on `storage.objects`.
- Applied migration via `apply_migration` MCP.
- After: policy no longer present; `get_advisors` (security) shows no new warnings (all findings pre-existing and unrelated).

Bucket confirmed non-public (`storage.buckets.public = false` for `guide-attachments`), and zero guides currently carry `'guest'` in `access_roles` — so this closes a latent gap before it can be triggered by a content edit, not a live incident.

## Test plan
- [x] `pg_policies` query before/after confirms the policy is gone
- [x] `get_advisors` (security) shows no new warnings after the change
- [x] Grep confirmed no other code path (admin routes, upload/delete) relies on this policy — all use the service client
- [ ] CI green
- [ ] Vercel preview READY

## Session State
**Status:** DONE (migration applied to Supabase project directly, per project convention for RLS/DDL changes; committed to repo for history)
**Completed:**
- [x] Migration applied + verified live
**Next:** Merge via GitHub UI after CI green + preview READY.
