### PR TITLE
[2607-DEV-488] Bump ws to 8.21.0 to clear high-severity audit finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9874,9 +9874,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary
Partial action on #488 (user-confirmed scope: fix the easy findings now, keep the CI soft-gate, track the rest separately).

Ran `npm audit --audit-level=high --omit=dev` against current `main`. Findings: **1 critical, 2 high, 5 moderate**.

- **`ws` (high, 2 advisories — GHSA-58qx-3vcg-4xpx uninitialized memory disclosure, GHSA-96hv-2xvq-fx4p memory exhaustion DoS)**: transitive via `@supabase/realtime-js` (`^8.18.2`). Fixed by bumping the resolved lockfile version from `8.19.0` → `8.21.0`, which satisfies the existing semver range — no `package.json` change, no breaking upgrade.
- **`next` (high + the 1 critical) and `postcss` (moderate, transitive via `next`)**: fix requires bumping `next` to `16.2.10`, npm's own output flags this as "outside the stated dependency range" (i.e. a breaking major upgrade). Out of scope here — tracked as a follow-up, not fixed in this PR.
- **`uuid` (moderate, transitive via `svix`→`resend`)**: also left alone — pulling it in isolation risked an inconsistent lockfile state without a real `npm install` to resolve it (this worktree can't run `npm install` locally — see note below); low severity, not blocking.

**Note on verification method:** this worktree's `package-lock.json` pins Linux-only optional binaries (`@tailwindcss/oxide-linux-x64-gnu`), so `npm install`/`npm audit fix` fail locally on Windows with `EBADPLATFORM`. The `ws` lockfile entry was hand-edited (version/resolved/integrity fields only, verified via `npm view ws@8.21.0` against the registry) rather than machine-generated — CI (`ubuntu-latest`) will `npm install` from this lockfile and should resolve cleanly since 8.21.0 satisfies the existing `^8.18.2` range with no dependency-shape changes (ws has no dependencies of its own).

Per #488's own framing as a decision issue, not a code-fix ticket: the CI audit job's `|| true` soft-gate is intentionally left in place in this PR — hard-gating today would fail CI on every PR until the `next` major upgrade lands.

## Test plan
- [x] `npm view ws@8.21.0` confirms version exists, satisfies `^8.18.2`, and has no dependencies of its own (no other lockfile entries need updating)
- [x] Lockfile JSON validated as parseable after the edit
- [ ] CI `npm install` resolves cleanly from the edited lockfile (this is the real verification, since local install isn't possible in this environment)
- [ ] CI green

## Follow-up (not done here)
- File tracking issue for the `next` → `16.2.10` major upgrade (clears the critical + remaining high findings + the `postcss` moderate)
- `uuid` moderate finding (via `svix`/`resend`) left as-is

## Session State
**Status:** DONE (scoped per user decision — see PR body)
**Next:** Merge via GitHub UI after CI green.
