### PR TITLE
[2607-DEV-487] Consolidate inline profile/role lookups onto shared guards

### DIFF
--- a/app/api/admin/calendar-sync/route.ts
+++ b/app/api/admin/calendar-sync/route.ts
@@ -1,20 +1,14 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function POST() {
   const { userId } = await auth()
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (profile?.role !== 'admin') {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/sync-google-calendar`,

--- a/app/api/admin/calendar/route.ts
+++ b/app/api/admin/calendar/route.ts
@@ -1,6 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
-import { requireAdmin } from '@/lib/supabase/guards'
+import { requireAdmin, getCallerContext } from '@/lib/supabase/guards'
 
 export async function GET(): Promise<Response> {
   const { userId } = await auth()
@@ -21,8 +21,9 @@ export async function POST(req: Request): Promise<Response> {
   const { userId } = await auth()
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
   const supabase = createServiceClient()
-  const { data: caller } = await supabase.from('profiles').select('id, role').eq('clerk_id', userId).single()
-  if (caller?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
+  const caller = ctx.profile
 
   const body = await req.json()
   // Auto-compute week_number from start_time if not provided

--- a/app/api/admin/event-role-requests/[id]/route.ts
+++ b/app/api/admin/event-role-requests/[id]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 type RoleEmailPayload = {
   contactEmail: string
@@ -45,9 +46,8 @@ export async function PATCH(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: adminProfile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (adminProfile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { status } = await req.json()
   if (!['approved', 'denied'].includes(status)) {

--- a/app/api/admin/event-role-requests/route.ts
+++ b/app/api/admin/event-role-requests/route.ts
@@ -1,14 +1,14 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function GET(): Promise<Response> {
   const { userId } = await auth()
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (profile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { data, error } = await supabase
     .from('event_role_requests')

--- a/app/api/admin/events/[id]/registrations/route.ts
+++ b/app/api/admin/events/[id]/registrations/route.ts
@@ -4,6 +4,7 @@
 
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function GET(
   _req: Request,
@@ -14,15 +15,8 @@ export async function GET(
 
   const supabase = createServiceClient()
 
-  const { data: caller } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (!caller || caller.role !== 'admin') {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { id } = await params
 

--- a/app/api/admin/guides/upload-url/confirm/route.ts
+++ b/app/api/admin/guides/upload-url/confirm/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   const supabase = createServiceClient()
   const ctx = await getCallerContext(userId, supabase, 'admin')
-  if (ctx.guard) return ctx.guard
+  if (ctx.guard) return ctx.guard as NextResponse
 
   const body = await req.json() as { path?: string }
   const { path } = body

--- a/app/api/admin/guides/upload-url/confirm/route.ts
+++ b/app/api/admin/guides/upload-url/confirm/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export const dynamic = 'force-dynamic'
 
@@ -9,12 +10,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: caller } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-  if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const body = await req.json() as { path?: string }
   const { path } = body

--- a/app/api/admin/guides/upload-url/cover/confirm/route.ts
+++ b/app/api/admin/guides/upload-url/cover/confirm/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   const supabase = createServiceClient()
   const ctx = await getCallerContext(userId, supabase, 'admin')
-  if (ctx.guard) return ctx.guard
+  if (ctx.guard) return ctx.guard as NextResponse
 
   const body = await req.json().catch(() => ({})) as { path?: string }
   const { path } = body

--- a/app/api/admin/guides/upload-url/cover/confirm/route.ts
+++ b/app/api/admin/guides/upload-url/cover/confirm/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export const dynamic = 'force-dynamic'
 
@@ -9,12 +10,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: caller } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-  if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const body = await req.json().catch(() => ({})) as { path?: string }
   const { path } = body

--- a/app/api/admin/guides/upload-url/cover/route.ts
+++ b/app/api/admin/guides/upload-url/cover/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 import { randomUUID } from 'crypto'
 
 export const dynamic = 'force-dynamic'
@@ -10,12 +11,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: caller } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-  if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
   const parts = filename.split('.')

--- a/app/api/admin/guides/upload-url/cover/route.ts
+++ b/app/api/admin/guides/upload-url/cover/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   const supabase = createServiceClient()
   const ctx = await getCallerContext(userId, supabase, 'admin')
-  if (ctx.guard) return ctx.guard
+  if (ctx.guard) return ctx.guard as NextResponse
 
   const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
   const parts = filename.split('.')

--- a/app/api/admin/guides/upload-url/route.ts
+++ b/app/api/admin/guides/upload-url/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 import { randomUUID } from 'crypto'
 
 export const dynamic = 'force-dynamic'
@@ -10,12 +11,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: caller } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-  if (caller?.role !== 'admin') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
   const parts = filename.split('.')

--- a/app/api/admin/guides/upload-url/route.ts
+++ b/app/api/admin/guides/upload-url/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   const supabase = createServiceClient()
   const ctx = await getCallerContext(userId, supabase, 'admin')
-  if (ctx.guard) return ctx.guard
+  if (ctx.guard) return ctx.guard as NextResponse
 
   const filename = req.nextUrl.searchParams.get('filename') ?? 'upload'
   const parts = filename.split('.')

--- a/app/api/admin/links/[id]/route.ts
+++ b/app/api/admin/links/[id]/route.ts
@@ -1,22 +1,19 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
-
-async function requireAdmin() {
-  const { userId } = await auth()
-  if (!userId) return null
-  const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  return profile?.role === 'admin' ? supabase : null
-}
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function PATCH(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
   const { id } = await params
-  const supabase = await requireAdmin()
-  if (!supabase) return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
+
   const body = await req.json() as Record<string, unknown>
   const { data, error } = await supabase
     .from('links').update(body).eq('id', id).select().single()
@@ -29,8 +26,13 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
   const { id } = await params
-  const supabase = await requireAdmin()
-  if (!supabase) return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
+
   const { error } = await supabase.from('links').delete().eq('id', id)
   if (error) return Response.json({ error: error.message }, { status: 500 })
   return Response.json({ deleted: true })

--- a/app/api/admin/members/[id]/assign-abo/route.ts
+++ b/app/api/admin/members/[id]/assign-abo/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 // PATCH /api/admin/members/[id]/assign-abo
 // Links a manually-verified no-ABO profile to a real LOS ABO number.
@@ -13,9 +14,8 @@ export async function PATCH(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: admin } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (admin?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { abo_number, sponsor_abo_number } = await req.json()
   if (!abo_number) {

--- a/app/api/admin/members/[id]/vital-signs/[definitionId]/route.ts
+++ b/app/api/admin/members/[id]/vital-signs/[definitionId]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function PATCH(
   _req: Request,
@@ -9,9 +10,8 @@ export async function PATCH(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (profile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { id: memberId, definitionId } = await params
 

--- a/app/api/admin/members/[id]/vital-signs/route.ts
+++ b/app/api/admin/members/[id]/vital-signs/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function GET(
   _req: Request,
@@ -9,9 +10,8 @@ export async function GET(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (profile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { id: memberId } = await params
 
@@ -56,9 +56,9 @@ export async function POST(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: adminProfile } = await supabase
-    .from('profiles').select('id, role').eq('clerk_id', userId).single()
-  if (adminProfile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
+  const adminProfile = ctx.profile
 
   const { id: memberId } = await params
   const body: { definition_id: string; recorded_at?: string; note?: string } = await req.json()

--- a/app/api/admin/members/verify/[id]/route.ts
+++ b/app/api/admin/members/verify/[id]/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server'
 import { clerkClient } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 import { sendTransactionalEmail } from '@/lib/email/send'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { AboVerificationEmail } from '@/lib/email/templates/AboVerificationEmail'
@@ -32,13 +33,8 @@ export async function PATCH(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: admin } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-  if (admin?.role !== 'admin')
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { action, admin_note } = await req.json()
   if (!['approve', 'deny'].includes(action)) {

--- a/app/api/admin/payable-items/[id]/route.ts
+++ b/app/api/admin/payable-items/[id]/route.ts
@@ -1,16 +1,14 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
   const { userId } = await auth()
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (!profile || (profile.role !== 'admin' && profile.role !== 'core')) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'adminOrCore')
+  if (ctx.guard) return ctx.guard
 
   const { id } = await params
   const body = await req.json()
@@ -49,11 +47,8 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (!profile || (profile.role !== 'admin' && profile.role !== 'core')) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'adminOrCore')
+  if (ctx.guard) return ctx.guard
 
   const { id } = await params
 

--- a/app/api/admin/payable-items/route.ts
+++ b/app/api/admin/payable-items/route.ts
@@ -1,6 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
-import { requireAdminOrCore } from '@/lib/supabase/guards'
+import { requireAdminOrCore, getCallerContext } from '@/lib/supabase/guards'
 
 export async function GET(): Promise<Response> {
   const { userId } = await auth()
@@ -24,12 +24,9 @@ export async function POST(req: Request): Promise<Response> {
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  // Need caller.id for created_by — fetch id + role together
-  const { data: profile } = await supabase
-    .from('profiles').select('id, role').eq('clerk_id', userId).single()
-  if (!profile || (profile.role !== 'admin' && profile.role !== 'core')) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'adminOrCore')
+  if (ctx.guard) return ctx.guard
+  const profile = ctx.profile
 
   const body = await req.json()
   const { title, description, amount, currency, item_type, linked_trip_id } = body

--- a/app/api/admin/payments/[id]/proof/route.ts
+++ b/app/api/admin/payments/[id]/proof/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,16 +15,8 @@ export async function GET(
   const { id } = await params
   const supabase = createServiceClient()
 
-  // Admin check via profile
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (!profile || profile.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   // Fetch payment — no ownership restriction for admin
   const { data: payment } = await supabase

--- a/app/api/admin/payments/[id]/proof/route.ts
+++ b/app/api/admin/payments/[id]/proof/route.ts
@@ -16,7 +16,7 @@ export async function GET(
   const supabase = createServiceClient()
 
   const ctx = await getCallerContext(userId, supabase, 'admin')
-  if (ctx.guard) return ctx.guard
+  if (ctx.guard) return ctx.guard as NextResponse
 
   // Fetch payment — no ownership restriction for admin
   const { data: payment } = await supabase

--- a/app/api/admin/registrations/[id]/route.ts
+++ b/app/api/admin/registrations/[id]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 import { sendNotificationEmail } from '@/lib/email/send'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
@@ -10,9 +11,8 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (profile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { status } = await req.json()
   if (!['approved', 'denied'].includes(status)) {

--- a/app/api/admin/social-posts/[id]/route.ts
+++ b/app/api/admin/social-posts/[id]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 import { mirrorToStorage, isCdnUrl } from '@/lib/social-thumbnail'
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -7,9 +8,8 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (profile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { id } = await params
   const body: Partial<{
@@ -57,9 +57,8 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (profile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { id } = await params
   const { error } = await supabase.from('social_posts').delete().eq('id', id)

--- a/app/api/admin/trips/[id]/attachments/[attachmentId]/download/route.ts
+++ b/app/api/admin/trips/[id]/attachments/[attachmentId]/download/route.ts
@@ -15,7 +15,7 @@ export async function GET(
   const supabase = createServiceClient()
 
   const ctx = await getCallerContext(userId, supabase, 'admin')
-  if (ctx.guard) return ctx.guard
+  if (ctx.guard) return ctx.guard as NextResponse
 
   const { id: tripId, attachmentId } = await params
 

--- a/app/api/admin/trips/[id]/attachments/[attachmentId]/download/route.ts
+++ b/app/api/admin/trips/[id]/attachments/[attachmentId]/download/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 import { NextRequest, NextResponse } from 'next/server'
 
 export const dynamic = 'force-dynamic'
@@ -13,15 +14,8 @@ export async function GET(
 
   const supabase = createServiceClient()
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (!profile || profile.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { id: tripId, attachmentId } = await params
 

--- a/app/api/admin/trips/[id]/attachments/[attachmentId]/route.ts
+++ b/app/api/admin/trips/[id]/attachments/[attachmentId]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function DELETE(
@@ -11,15 +12,8 @@ export async function DELETE(
 
   const supabase = createServiceClient()
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (!profile || profile.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { id: tripId, attachmentId } = await params
 

--- a/app/api/admin/trips/[id]/attachments/[attachmentId]/route.ts
+++ b/app/api/admin/trips/[id]/attachments/[attachmentId]/route.ts
@@ -13,7 +13,7 @@ export async function DELETE(
   const supabase = createServiceClient()
 
   const ctx = await getCallerContext(userId, supabase, 'admin')
-  if (ctx.guard) return ctx.guard
+  if (ctx.guard) return ctx.guard as NextResponse
 
   const { id: tripId, attachmentId } = await params
 

--- a/app/api/admin/trips/[id]/attachments/route.ts
+++ b/app/api/admin/trips/[id]/attachments/route.ts
@@ -17,7 +17,7 @@ export async function GET(
   const supabase = createServiceClient()
 
   const ctx = await getCallerContext(userId, supabase, 'admin')
-  if (ctx.guard) return ctx.guard
+  if (ctx.guard) return ctx.guard as NextResponse
 
   const { id: tripId } = await params
 

--- a/app/api/admin/trips/[id]/attachments/route.ts
+++ b/app/api/admin/trips/[id]/attachments/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 import { NextRequest, NextResponse } from 'next/server'
 
 // POST handler removed — upload flow now uses signed URL via
@@ -15,15 +16,8 @@ export async function GET(
 
   const supabase = createServiceClient()
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('id, role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (!profile || profile.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { id: tripId } = await params
 

--- a/app/api/admin/trips/[id]/hero/route.ts
+++ b/app/api/admin/trips/[id]/hero/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 // POST handler removed — hero upload flow now uses signed URL via
 // GET  /api/admin/trips/[id]/upload-url/hero
@@ -28,15 +29,8 @@ export async function DELETE(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (profile?.role !== 'admin') {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   await purgeStorageFolder(supabase, id)
 

--- a/app/api/admin/trips/[id]/messages/route.ts
+++ b/app/api/admin/trips/[id]/messages/route.ts
@@ -13,7 +13,7 @@ export async function GET(
   const supabase = createServiceClient()
 
   const ctx = await getCallerContext(userId, supabase, 'admin')
-  if (ctx.guard) return ctx.guard
+  if (ctx.guard) return ctx.guard as NextResponse
 
   const { id: tripId } = await params
 
@@ -38,7 +38,7 @@ export async function POST(
   const supabase = createServiceClient()
 
   const ctx = await getCallerContext(userId, supabase, 'admin')
-  if (ctx.guard) return ctx.guard
+  if (ctx.guard) return ctx.guard as NextResponse
   const profile = ctx.profile
 
   const { id: tripId } = await params

--- a/app/api/admin/trips/[id]/messages/route.ts
+++ b/app/api/admin/trips/[id]/messages/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 import { NextResponse } from 'next/server'
 
 export async function GET(
@@ -11,15 +12,8 @@ export async function GET(
 
   const supabase = createServiceClient()
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('id, role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (!profile || profile.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { id: tripId } = await params
 
@@ -43,15 +37,9 @@ export async function POST(
 
   const supabase = createServiceClient()
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('id, role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (!profile || profile.role !== 'admin') {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
+  const profile = ctx.profile
 
   const { id: tripId } = await params
 

--- a/app/api/admin/trips/[id]/upload-url/confirm/route.ts
+++ b/app/api/admin/trips/[id]/upload-url/confirm/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 const ALLOWED_MIME: Record<string, 'pdf' | 'image'> = {
   'application/pdf': 'pdf',
@@ -19,15 +20,9 @@ export async function POST(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('id, role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (!profile || profile.role !== 'admin') {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
+  const profile = ctx.profile
 
   const body = await req.json().catch(() => ({})) as { path?: string; filename?: string; fileType?: string }
   const { path, filename, fileType } = body

--- a/app/api/admin/trips/[id]/upload-url/hero/confirm/route.ts
+++ b/app/api/admin/trips/[id]/upload-url/hero/confirm/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function POST(
   req: Request,
@@ -10,15 +11,8 @@ export async function POST(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (profile?.role !== 'admin') {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const body = await req.json().catch(() => ({})) as { path?: string }
   const { path } = body

--- a/app/api/admin/trips/[id]/upload-url/hero/route.ts
+++ b/app/api/admin/trips/[id]/upload-url/hero/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function GET(
   req: Request,
@@ -10,15 +11,8 @@ export async function GET(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (profile?.role !== 'admin') {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const url = new URL(req.url)
   const filename = url.searchParams.get('filename') ?? 'hero'

--- a/app/api/admin/trips/[id]/upload-url/inline-confirm/route.ts
+++ b/app/api/admin/trips/[id]/upload-url/inline-confirm/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function POST(
   req: Request,
@@ -10,15 +11,8 @@ export async function POST(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (profile?.role !== 'admin') {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const body = await req.json().catch(() => ({})) as { path?: string }
   const { path } = body

--- a/app/api/admin/trips/[id]/upload-url/route.ts
+++ b/app/api/admin/trips/[id]/upload-url/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function GET(
   req: Request,
@@ -10,15 +11,8 @@ export async function GET(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('clerk_id', userId)
-    .single()
-
-  if (profile?.role !== 'admin') {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const url = new URL(req.url)
   const filename = url.searchParams.get('filename') ?? 'file'

--- a/app/api/admin/trips/registrations/[id]/cancel/route.ts
+++ b/app/api/admin/trips/registrations/[id]/cancel/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 import { sendNotificationEmail } from '@/lib/email/send'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { TripRegistrationEmail } from '@/lib/email/templates/TripRegistrationEmail'
@@ -10,11 +11,9 @@ export async function POST(_req: Request, { params }: { params: Promise<{ id: st
 
   const supabase = createServiceClient()
 
-  const { data: adminProfile } = await supabase
-    .from('profiles').select('id, role').eq('clerk_id', userId).single()
-  if (!adminProfile || (adminProfile.role !== 'admin' && adminProfile.role !== 'core')) {
-    return Response.json({ error: 'Forbidden' }, { status: 403 })
-  }
+  const ctx = await getCallerContext(userId, supabase, 'adminOrCore')
+  if (ctx.guard) return ctx.guard
+  const adminProfile = ctx.profile
 
   const { id: registrationId } = await params
 

--- a/app/api/admin/vital-sign-definitions/[id]/route.ts
+++ b/app/api/admin/vital-sign-definitions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
 
 export async function PATCH(
   req: Request,
@@ -9,9 +10,8 @@ export async function PATCH(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (profile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { id } = await params
   const body: Partial<{ is_active: boolean; sort_order: number; label: string }> = await req.json()

--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -1,5 +1,5 @@
 import { createServiceClient } from '@/lib/supabase/service'
-import { auth } from '@clerk/nextjs/server'
+import { getRoleForAccess } from '@/lib/server/guides'
 
 export async function GET(req: Request) {
   const supabase = createServiceClient()
@@ -8,15 +8,7 @@ export async function GET(req: Request) {
 
   // Resolve role for access_roles filtering.
   // Unauthenticated and authenticated-but-no-profile both resolve to 'guest'.
-  let role = 'guest'
-  try {
-    const { userId } = await auth()
-    if (userId) {
-      const { data: profile } = await supabase
-        .from('profiles').select('role').eq('clerk_id', userId).single()
-      if (profile?.role) role = profile.role
-    }
-  } catch { /* unauthenticated */ }
+  const role = await getRoleForAccess()
 
   let query = supabase
     .from('calendar_events')

--- a/app/api/events/[id]/request-role/route.ts
+++ b/app/api/events/[id]/request-role/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerProfile } from '@/lib/supabase/guards'
 
 export async function POST(
   req: Request,
@@ -10,8 +11,7 @@ export async function POST(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('id, role').eq('clerk_id', userId).single()
+  const profile = await getCallerProfile(userId, supabase)
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
   // Guests cannot request roles
@@ -74,8 +74,7 @@ export async function DELETE(
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('id').eq('clerk_id', userId).single()
+  const profile = await getCallerProfile(userId, supabase)
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
   const { error } = await supabase

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { createClient } from '@/lib/supabase/server'
+import { getCallerProfile } from '@/lib/supabase/guards'
 
 export async function GET(
   _req: Request,
@@ -21,8 +22,7 @@ export async function GET(
 
   const supabase = createServiceClient()
 
-  const { data: callerProfile } = await supabase
-    .from('profiles').select('id, role').eq('clerk_id', userId).single()
+  const callerProfile = await getCallerProfile(userId, supabase)
   if (!callerProfile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
   const { data: event, error } = await supabase

--- a/app/api/guides/[slug]/route.ts
+++ b/app/api/guides/[slug]/route.ts
@@ -1,5 +1,5 @@
-import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getRoleForAccess } from '@/lib/server/guides'
 
 export async function GET(
   _req: Request,
@@ -8,15 +8,7 @@ export async function GET(
   const { slug } = await params
   const supabase = createServiceClient()
 
-  let role = 'guest'
-  try {
-    const { userId } = await auth()
-    if (userId) {
-      const { data: profile } = await supabase
-        .from('profiles').select('role').eq('clerk_id', userId).single()
-      if (profile?.role) role = profile.role
-    }
-  } catch { /* unauthenticated */ }
+  const role = await getRoleForAccess()
 
   const { data, error } = await supabase
     .from('guides')

--- a/app/api/payments/route.ts
+++ b/app/api/payments/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerProfile } from '@/lib/supabase/guards'
 
 export async function GET(): Promise<Response> {
   const { userId } = await auth()
@@ -7,9 +8,8 @@ export async function GET(): Promise<Response> {
 
   const supabase = createServiceClient()
 
-  const { data: profile } = await supabase
-    .from('profiles').select('id').eq('clerk_id', userId).single()
-  if (!profile?.id) return Response.json({ error: 'Profile not found' }, { status: 404 })
+  const profile = await getCallerProfile(userId, supabase)
+  if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('payments')
@@ -27,9 +27,8 @@ export async function POST(req: Request): Promise<Response> {
 
   const supabase = createServiceClient()
 
-  const { data: profile } = await supabase
-    .from('profiles').select('id, role').eq('clerk_id', userId).single()
-  if (!profile?.id) return Response.json({ error: 'Profile not found' }, { status: 404 })
+  const profile = await getCallerProfile(userId, supabase)
+  if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
   if (profile.role === 'guest') return Response.json({ error: 'Forbidden' }, { status: 403 })
 
   const body = await req.json()

--- a/app/api/profile/event-shares/route.ts
+++ b/app/api/profile/event-shares/route.ts
@@ -4,6 +4,7 @@
 
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerProfile } from '@/lib/supabase/guards'
 import { randomBytes } from 'crypto'
 import { z } from 'zod'
 import { NextRequest } from 'next/server'
@@ -26,11 +27,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   const { event_id, share_method } = parsed.data
   const supabase = createServiceClient()
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('id, role')
-    .eq('clerk_id', userId)
-    .single()
+  const profile = await getCallerProfile(userId, supabase)
 
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
   if (profile.role === 'guest') return Response.json({ error: 'Guests cannot share events' }, { status: 403 })
@@ -89,11 +86,7 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   const supabase = createServiceClient()
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('id')
-    .eq('clerk_id', userId)
-    .single()
+  const profile = await getCallerProfile(userId, supabase)
 
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 

--- a/app/api/profile/payments/route.ts
+++ b/app/api/profile/payments/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerProfile } from '@/lib/supabase/guards'
 
 export async function GET(): Promise<Response> {
   const { userId } = await auth()
@@ -7,9 +8,8 @@ export async function GET(): Promise<Response> {
 
   const supabase = createServiceClient()
 
-  const { data: profile } = await supabase
-    .from('profiles').select('id').eq('clerk_id', userId).single()
-  if (!profile?.id) return Response.json({ error: 'Profile not found' }, { status: 404 })
+  const profile = await getCallerProfile(userId, supabase)
+  if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
   // Registrations with trip details — include cancelled_at so the UI can detect cancellation
   const { data: registrations, error: regError } = await supabase

--- a/app/api/trips/[id]/payments/route.ts
+++ b/app/api/trips/[id]/payments/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerProfile } from '@/lib/supabase/guards'
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
   const { id: trip_id } = await params
@@ -7,8 +8,7 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('id, role').eq('clerk_id', userId).single()
+  const profile = await getCallerProfile(userId, supabase)
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
   let query = supabase

--- a/app/api/trips/[id]/registrations/route.ts
+++ b/app/api/trips/[id]/registrations/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerProfile } from '@/lib/supabase/guards'
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id: trip_id } = await params
@@ -7,8 +8,7 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('id, role').eq('clerk_id', userId).single()
+  const profile = await getCallerProfile(userId, supabase)
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
   // Admins get the full registration list for the trip.

--- a/app/api/trips/[id]/route.ts
+++ b/app/api/trips/[id]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext, getCallerProfile } from '@/lib/supabase/guards'
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -8,12 +9,8 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
 
   const supabase = createServiceClient()
 
-  const { data: profile, error: profileError } = await supabase
-    .from('profiles')
-    .select('id')
-    .eq('clerk_id', userId)
-    .single()
-  if (profileError || !profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
+  const profile = await getCallerProfile(userId, supabase)
+  if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
   const { data: trip, error: tripError } = await supabase
     .from('trips')
@@ -45,9 +42,8 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (profile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const body = await req.json()
   const { data, error } = await supabase
@@ -63,9 +59,8 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ id: 
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-  if (profile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const { error } = await supabase.from('trips').delete().eq('id', id)
   if (error) return Response.json({ error: error.message }, { status: 500 })

--- a/app/api/trips/route.ts
+++ b/app/api/trips/route.ts
@@ -1,20 +1,12 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
+import { getRoleForAccess } from '@/lib/server/guides'
 import { ALL_ROLES } from '@/lib/roles'
 
 export async function GET() {
   const supabase = createServiceClient()
-
-  // Determine role for filtering — guest if unauthenticated
-  let role = 'guest'
-  try {
-    const { userId } = await auth()
-    if (userId) {
-      const { data: profile } = await supabase
-        .from('profiles').select('role').eq('clerk_id', userId).single()
-      if (profile?.role) role = profile.role
-    }
-  } catch { /* unauthenticated — treat as guest */ }
+  const role = await getRoleForAccess()
 
   const { data, error } = await supabase
     .from('trips')
@@ -31,10 +23,8 @@ export async function POST(req: Request) {
   if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const supabase = createServiceClient()
-  const { data: profile } = await supabase
-    .from('profiles').select('role').eq('clerk_id', userId).single()
-
-  if (profile?.role !== 'admin') return Response.json({ error: 'Forbidden' }, { status: 403 })
+  const ctx = await getCallerContext(userId, supabase, 'admin')
+  if (ctx.guard) return ctx.guard
 
   const body = await req.json()
   const { data, error } = await supabase

--- a/lib/supabase/guards.ts
+++ b/lib/supabase/guards.ts
@@ -39,6 +39,29 @@ export async function getCallerContext(
 }
 
 /**
+ * Fetches the caller's profile in a single DB round trip with no role
+ * requirement — for routes that need the caller's id/role to branch
+ * response shape or ownership, not to gate access. Returns null if no
+ * profile row exists for this clerk_id.
+ *
+ * Usage:
+ *   const profile = await getCallerProfile(userId, supabase)
+ *   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
+ */
+export async function getCallerProfile(
+  userId: string,
+  supabase: SupabaseClient
+): Promise<CallerProfile | null> {
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id, role')
+    .eq('clerk_id', userId)
+    .single()
+
+  return profile ?? null
+}
+
+/**
  * @deprecated Use getCallerContext instead.
  * Returns a 403 Response if the caller is not an admin, null otherwise.
  */


### PR DESCRIPTION
## Summary
Fixes #487. The issue named 3 coexisting patterns for resolving caller role/profile: `getCallerContext` (already the most-consolidated), inline `.from('profiles').select('id, role')...` manual branching, and `getRoleForAccess()`. A first grep found 9 inline sites; a deeper sweep (per user direction to finish everything, not just the easy subset) turned up **43 files total** with the duplicated pattern.

**`lib/supabase/guards.ts`**: added `getCallerProfile(userId, supabase)` — fetches the caller's profile with no role requirement, for routes that need id/role to branch response shape or ownership, not to gate access. `getCallerContext` (admin/adminOrCore reject-gate) already existed, unchanged.

**~28 admin/adminOrCore-only routes** migrated onto `getCallerContext` — mechanical, zero behavior change (same reject condition, same 403).

**~10 routes** (guest-blocking, admin-bypass, or ownership-filter logic that isn't a simple accept/reject) migrated onto the new `getCallerProfile` — also zero behavior change, pure DRY.

**3 route files** (`trips/route.ts`, `calendar/route.ts`, `guides/[slug]/route.ts`) duplicated `getRoleForAccess()`'s exact try/catch/default-to-guest logic inline instead of importing the existing canonical implementation in `lib/server/guides.ts` — now import it. `getRoleForAccess()` itself is untouched.

**Left inline, out of scope:**
- `app/api/profile/payments/route.ts` POST — needs an extra `first_name` column alongside id/role; doesn't fit either shared helper without a second query or unrequested helper generalization.
- The ~20 files already using the deprecated `requireAdmin`/`requireAdminOrCore` wrapper functions — those already delegate to `getCallerContext` internally, so they weren't one of the 3 problematic patterns named in the issue.

**One noted behavior change**: `app/api/admin/links/[id]/route.ts` had a local `requireAdmin()` closure (unrelated to the exported deprecated function of the same name) that folded "unauthenticated" and "authenticated but not admin" into a single 403. Migrating it onto `getCallerContext` splits this into 401 Unauthorized (no `userId`) / 403 Forbidden (wrong role) — matching the convention every other route in the codebase already uses. Flagging explicitly since it's the one place this PR isn't purely mechanical.

## Test plan
- [x] Exhaustive grep (`from('profiles')...select(...role...)`) confirms only the one intentionally-left-inline site (`profile/payments/route.ts` POST) remains
- [x] Per-file diff review confirms no orphaned variable references after removing inline queries (checked every `profile.`/`caller.`/`adminProfile.`/`admin.` reference post-edit resolves to a bound variable)
- [ ] CI (Build/Test/Lint/Type Check/Security Audit) — this worktree can't run `npm install` locally (Windows host, Linux-only optional deps in the lockfile), so this is CI-only verification
- [ ] Vercel preview READY — manually spot-check a few migrated flows (event role request as guest, admin trip upload URL, admin links CRUD) behave identically to `main`

## Session State
**Status:** DONE
**Completed:**
- [x] `getCallerProfile` helper added
- [x] 43 files migrated off inline profile/role queries
**Next:** Merge via GitHub UI after CI green + preview READY. Given the size, a careful review pass before merge is warranted despite the mechanical nature of most hunks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of access control across admin and user endpoints, including calendar, events, guides, payments, trips, registrations, and member/record actions.
  * Unauthorized/insufficient-permission requests now return more consistent responses while keeping existing success/error behavior intact.

* **Refactor**
  * Centralized caller-profile and authorization checks across the application to ensure role-based decisions are uniform.
  * Standardized how roles are resolved for calendar and guide access filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->