### PR TITLE
[2607-DEV-469] Archive and drop deprecated email_log/scheduled_reminders tables

### DIFF
--- a/app/api/admin/settings/email/retry/[id]/route.ts
+++ b/app/api/admin/settings/email/retry/[id]/route.ts
@@ -81,7 +81,7 @@ export async function POST(
     const html = await renderEmailTemplate(element)
 
     // 3. Re-invoke sendNotificationEmail — bypasses no gates since this is an
-    //    admin-triggered retry; a new email_log row is written by the dispatcher.
+    //    admin-triggered retry; a new notification_delivery_log row is written by the dispatcher.
     await sendNotificationEmail({
       to: log.recipient,
       subject: `[RETRY] ${log.template.replace(/_/g, ' ')}`,

--- a/lib/email/send.ts
+++ b/lib/email/send.ts
@@ -48,7 +48,7 @@ export type SendEmailPayload = {
   html: string
   /** Template key used for log + admin toggle check e.g. 'trip_registration_status' */
   template: string
-  /** Any serialisable metadata to store in email_log.payload (profile IDs, amounts...) */
+  /** Any serialisable metadata to store in notification_delivery_log.payload (profile IDs, amounts...) */
   meta?: Record<string, unknown>
 }
 
@@ -111,10 +111,10 @@ async function _dispatch(
 /**
  * Resilient notification email dispatcher.
  *
- * - Never throws -- all errors are caught and written to email_log.
+ * - Never throws -- all errors are caught and written to notification_delivery_log.
  * - Respects the system-wide `email_config.enabled` flag.
  * - Respects per-notification-type toggles in `email_config.notification_types`.
- * - Every attempt (success or failure) is written to email_log for auditability.
+ * - Every attempt (success or failure) is written to notification_delivery_log for auditability.
  *
  * Known callers (dynamic imports evade grep — verify manually after any rename):
  * - `app/api/admin/members/verify/[id]/route.ts`
@@ -144,7 +144,7 @@ export async function sendNotificationEmail(payload: SendEmailPayload): Promise<
  * - Bypasses per-type toggles.
  * - Returns a typed result -- caller decides how to handle failure.
  * - Does NOT swallow errors.
- * - Still writes to email_log for auditability.
+ * - Still writes to notification_delivery_log for auditability.
  */
 export async function sendTransactionalEmail(
   payload: SendEmailPayload,

--- a/supabase/migrations/20260710_002_archive_and_drop_deprecated_notification_tables.sql
+++ b/supabase/migrations/20260710_002_archive_and_drop_deprecated_notification_tables.sql
@@ -1,0 +1,24 @@
+-- Issue #469: drop deprecated public.email_log and public.scheduled_reminders,
+-- superseded by notification_delivery_log and notification_queue respectively
+-- (migrated 2026-07-05, both DB-commented DEPRECATED since). Confirmed zero live
+-- app/edge-function references, zero triggers, zero FKs, zero functions mention
+-- either table.
+--
+-- NOTE: public.notifications is NOT touched here — it was renamed in-place to
+-- public.member_notifications (live, 236 rows), not a separate deprecated table.
+-- The original issue #469 task list was stale on this point (see issue comment,
+-- 2026-07-07).
+--
+-- email_log has 115 rows of historical email-delivery records; archived to
+-- archive.email_log (plain table, data + column shape only, no constraints/
+-- indexes carried over) before dropping so the history remains queryable but
+-- off the public/PostgREST-exposed surface. scheduled_reminders has 0 rows —
+-- nothing to archive.
+
+CREATE SCHEMA IF NOT EXISTS archive;
+
+CREATE TABLE archive.email_log AS SELECT * FROM public.email_log;
+COMMENT ON TABLE archive.email_log IS 'Archived 2026-07-10 from public.email_log before drop. See issue #469. Superseded by public.notification_delivery_log.';
+
+DROP TABLE public.email_log;
+DROP TABLE public.scheduled_reminders;


### PR DESCRIPTION
## Summary
Fixes #469, with a correction confirmed via a 2026-07-07 comment on the issue: the original task-list item 1 ("Drop `public.notifications`") was **stale** — that table doesn't exist under that name anymore. It was renamed in-place to `public.member_notifications`, which is the live table backing the in-app notification feed (236 rows, active RLS policies, read by `app/api/notifications/*`). **Not touched by this PR.**

Only `email_log` (115 rows) and `scheduled_reminders` (0 rows) were dropped — confirmed via direct queries against `pg_trigger`, `pg_constraint`, and `pg_proc` that zero triggers, zero foreign keys, and zero functions reference either table, on top of the zero live app/edge-function code references already established by the issue and its comment.

**Data preservation**: per explicit user direction this session, `email_log`'s 115 rows were archived to a new `archive.email_log` table (plain `CREATE TABLE AS SELECT`, no constraints/indexes carried over) before dropping the live one — history stays queryable but is off the `public`/PostgREST-exposed surface. `scheduled_reminders` had 0 rows, nothing to archive.

Applied directly to the Supabase project (`ynykjpnetfwqzdnsgkkg`) via `apply_migration`, then committed here for repo history, matching this project's established convention for RLS/DDL changes (see #495/#510 in this same batch).

**Also fixed**: 3 doc comments (`lib/email/send.ts` ×3, `app/api/admin/settings/email/retry/[id]/route.ts` ×1) that still referenced `email_log` — the app has written to `notification_delivery_log` since the 2026-07-05 migration; these comments predated that and are now actively wrong since the old table no longer exists.

## Test plan
- [x] Verified live before/after: `information_schema.tables` confirms both `public.email_log` and `public.scheduled_reminders` no longer exist
- [x] `archive.email_log` row count = 115, matches pre-drop count exactly
- [x] `public.member_notifications` row count = 236, unchanged — confirms it was not touched
- [x] `get_advisors` (performance) shows only the expected "no primary key" info-note on the new archive table; no other new warnings
- [ ] CI green

## Session State
**Status:** DONE (migration applied directly to Supabase; PR captures it for review + repo history)
**Next:** Merge via GitHub UI after CI green.
