### PR TITLE
[2607-DEV-531] Refresh server-rendered content on language toggle

### DIFF
--- a/lib/context/LangProvider.tsx
+++ b/lib/context/LangProvider.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { createContext, useContext, useState, useCallback, useMemo } from 'react'
+import { useRouter } from 'next/navigation'
 import { translate, TranslationKey, Lang } from '@/lib/i18n/translations'
 
 const COOKIE_KEY = 'tevd_lang'
@@ -21,6 +22,7 @@ export function LangProvider({
   children: React.ReactNode
 }) {
   const [lang, setLang] = useState<Lang>(initialLang)
+  const router = useRouter()
 
   const toggle = useCallback(() => {
     const next: Lang = lang === 'en' ? 'bg' : 'en'
@@ -28,7 +30,8 @@ export function LangProvider({
     document.cookie = `${COOKIE_KEY}=${next}; path=/; max-age=${
       60 * 60 * 24 * 365
     }; SameSite=Lax`
-  }, [lang])
+    router.refresh()
+  }, [lang, router])
 
   const t = useCallback(
     (key: TranslationKey) => translate(key, lang),


### PR DESCRIPTION
Closes #531

## What
`LangProvider.toggle()` now calls `router.refresh()` after setting the `tevd_lang` cookie, so Server Components that read the cookie at render time (`library/[slug]`, `news/[slug]`, `events/[eventId]/join`, `events/[eventId]/register`, root/dashboard layouts) re-render with the new language immediately instead of requiring a hard reload.

## Why
Switching language left guide/news/event pages showing the previous language until a manual reload — the cookie updated but nothing told Next.js to re-fetch the server-rendered subtree.

Agent Type: Claude

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] `router.refresh()` added to `LangProvider.toggle()`
**Next:** Verify on Vercel preview — toggle language on `/library/[slug]` and `/events/[eventId]/register`; confirm content updates without reload and register form input isn't cleared. Then confirm CI green and mark DONE.

## Test plan
- [ ] Deploy preview READY
- [ ] Toggle language on `/library/[slug]` — content updates without manual reload
- [ ] Toggle language on `/events/[eventId]/register` with partially filled form — input not cleared
- [ ] `tsc --noEmit` / CI green