### PR TITLE
[2607-DEV-532] Fix Agenda view scroll-to-today firing before content loads

### DIFF
--- a/app/(dashboard)/calendar/components/AgendaView.tsx
+++ b/app/(dashboard)/calendar/components/AgendaView.tsx
@@ -19,6 +19,7 @@ export function AgendaView({
   const { t } = useLanguage()
   const highlightRef = useRef<HTMLButtonElement | null>(null)
   const anchorRef = useRef<HTMLDivElement | null>(null)
+  const hasScrolledRef = useRef(false)
 
   const todaySofia = SOFIA_DATE_FMT.format(new Date())
 
@@ -42,14 +43,16 @@ export function AgendaView({
     return dates.find(d => d >= todaySofia) ?? dates[dates.length - 1]
   }, [grouped, todaySofia])
 
-  // Mount-only: scroll to today once on load.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Scroll to today once real content (not the loading skeleton) has rendered.
+  // Guarded by hasScrolledRef so later re-renders (filter toggles, etc.) don't rescroll.
   useEffect(() => {
+    if (isLoading || hasScrolledRef.current) return
     const raf = requestAnimationFrame(() => {
       anchorRef.current?.scrollIntoView({ behavior: 'instant', block: 'start' })
+      hasScrolledRef.current = true
     })
     return () => cancelAnimationFrame(raf)
-  }, [])
+  }, [isLoading, anchorDateKey])
 
   // Deep-link scroll: fires only when highlightId changes.
   useEffect(() => {


### PR DESCRIPTION
Closes #532

## What
`AgendaView`'s scroll-to-today effect now depends on `isLoading`/`anchorDateKey` (guarded by `hasScrolledRef`) instead of firing once on mount with an empty dependency array.

## Why
The old effect ran once on mount while the loading skeleton was still showing, found `anchorRef.current === null`, and silently no-op'd — it never re-fired once real content rendered, so switching to the Agenda tab never actually scrolled to today.

## Note
Coordinates with #533 (calendar query bounding) — that issue's planned date-window fix must keep "today" inside the fetched range or this anchor has nothing to scroll to.

Agent Type: Claude

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] Scroll effect re-scoped to fire once content (not skeleton) is present
**Next:** Verify on Vercel preview — switch Month → Agenda on both mobile and desktop layouts, confirm it scrolls to today's entry. Then confirm CI green and mark DONE.

## Test plan
- [ ] Deploy preview READY
- [ ] Desktop: switch to Agenda view, confirm auto-scroll to today
- [ ] Mobile (390px): switch to Agenda view, confirm auto-scroll to today
- [ ] `tsc --noEmit` / CI green