### PR TITLE
[2607-DEV-535] Reduce root layout blocking cost (scripts, package imports, debounce)

### DIFF
--- a/app/admin/calendar/components/AdminCalendarClient.tsx
+++ b/app/admin/calendar/components/AdminCalendarClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { formatDateTime, toSofiaLocalInput } from '@/lib/format'
@@ -37,18 +37,25 @@ export default function AdminCalendarClient() {
   const [form, setForm] = useState<EventFormState>(emptyForm())
   const [formError, setFormError] = useState<string | null>(null)
 
-  // ── Filter state ─────────────────────────────────────────────────────────────────────
+  // ── Filter state ────────────────────────────────────────────────────────────────────
+  const [searchInput, setSearchInput] = useState('')
   const [search, setSearch] = useState('')
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('All')
   const [timeScope, setTimeScope] = useState<TimeScope>('upcoming')
   const [monthFilter, setMonthFilter] = useState<string>('')
+
+  // Debounce the search input so filtering/refetching doesn't run on every keystroke.
+  useEffect(() => {
+    const timeout = setTimeout(() => setSearch(searchInput), 250)
+    return () => clearTimeout(timeout)
+  }, [searchInput])
 
   const { data: events = [], isLoading } = useQuery<CalEvent[]>({
     queryKey: ['admin-calendar'],
     queryFn: () => fetch('/api/admin/calendar').then(async r => { if (!r.ok) throw new Error('Failed to fetch events'); return r.json() }),
   })
 
-  // ── Derived filter options ───────────────────────────────────────────────────────────
+  // ── Derived filter options ────────────────────────────────────────────────────────────
   const availableMonths = useMemo(() => {
     const seen = new Set<string>()
     const months: { value: string; label: string }[] = []
@@ -72,7 +79,7 @@ export default function AdminCalendarClient() {
     setMonthFilter('')
   }
 
-  // ── Filtered events ───────────────────────────────────────────────────────────────────
+  // ── Filtered events ───────────────────────────────────────────────────────────────
   const now = new Date()
   const filteredEvents = useMemo(() => {
     return events.filter(ev => {
@@ -215,16 +222,16 @@ export default function AdminCalendarClient() {
         <div className="flex gap-2 flex-wrap">
           <div className="relative flex-1 min-w-[180px]">
             <input
-              value={search}
-              onChange={e => setSearch(e.target.value)}
+              value={searchInput}
+              onChange={e => setSearchInput(e.target.value)}
               placeholder="Search events…"
               className="w-full border rounded-xl px-3 py-2 text-sm pr-8"
               style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
             />
-            {search && (
+            {searchInput && (
               <button
                 type="button"
-                onClick={() => setSearch('')}
+                onClick={() => { setSearchInput(''); setSearch('') }}
                 className="absolute right-2.5 top-1/2 -translate-y-1/2 text-sm leading-none hover:opacity-70"
                 style={{ color: 'var(--text-secondary)' }}
               >

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,25 +60,20 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       >
         <head>
           {/*
-            Blocking inline script: apply stored theme BEFORE first paint.
-            This prevents the flash-of-light-mode on refresh when dark is stored.
-            Must be inline (not deferred/async) so it runs synchronously during HTML parse.
+            Blocking inline script: apply stored theme + gate the bento-enter
+            animation BEFORE first paint. Merged into one script tag to avoid a
+            second parser-blocking round-trip; both must still run synchronously
+            during HTML parse (before first paint), so this stays inline/non-deferred.
+            - Theme: prevents flash-of-light-mode on refresh when dark is stored.
+            - Animation gate (SEQ298): sessionStorage persists across hard reloads
+              (Ctrl+F5) within a session but clears on new tab / browser restart —
+              matching 'first ever load' exactly. On subsequent loads
+              data-animated="done" is set before paint, suppressing the animation
+              via CSS before any tile mounts.
           */}
           <script
             dangerouslySetInnerHTML={{
-              __html: `(function(){try{var t=localStorage.getItem('tevd-theme');if(t==='dark'||t==='light'){document.documentElement.setAttribute('data-theme',t);}}catch(e){}})();`,
-            }}
-          />
-          {/*
-            SEQ298: Gate bento-enter animation on first-ever session load only.
-            sessionStorage persists across hard reloads (Ctrl+F5) within a session
-            but clears on new tab / browser restart — matching 'first ever load' exactly.
-            On subsequent loads data-animated="done" is set before paint, suppressing
-            the animation via CSS before any tile mounts.
-          */}
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `(function(){try{if(sessionStorage.getItem('tevd-visited')){document.documentElement.setAttribute('data-animated','done');}else{sessionStorage.setItem('tevd-visited','1');}}catch(e){}})();`,
+              __html: `(function(){try{var t=localStorage.getItem('tevd-theme');if(t==='dark'||t==='light'){document.documentElement.setAttribute('data-theme',t);}}catch(e){}try{if(sessionStorage.getItem('tevd-visited')){document.documentElement.setAttribute('data-animated','done');}else{sessionStorage.setItem('tevd-visited','1');}}catch(e){}})();`,
             }}
           />
         </head>

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  experimental: {
+    optimizePackageImports: ['lucide-react', '@tanstack/react-query'],
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
Closes #535

## What
- `app/layout.tsx`: merged the two blocking inline `<script>` tags (theme + animation-gate) into one.
- `next.config.ts`: added `experimental.optimizePackageImports` for `lucide-react` and `@tanstack/react-query`.
- `app/admin/calendar/components/AdminCalendarClient.tsx`: search input is now debounced (250ms) via a separate `searchInput`/`search` state pair instead of filtering on every keystroke.

## Excluded
Per-route font scoping (4 always-loaded Google font families) — real architectural change with regression risk, left as a follow-up rather than bundled into this low-priority cleanup. Noted in the issue.

## Note on overlap with #533
This branch and #533's branch both touch `AdminCalendarClient.tsx` (different concerns — #533 moves filtering server-side, this PR debounces the search input). Expect a merge conflict depending on merge order; not a correctness issue, just a heads-up for whoever merges second.

Agent Type: Claude

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] Scripts merged
- [x] optimizePackageImports added
- [x] Search input debounced
**Next:** Confirm CI green, verify preview theme/animation-flash behavior unchanged, then mark DONE.

## Test plan
- [ ] Deploy preview READY
- [ ] Theme (dark/light) still applies before paint, no flash regression
- [ ] First-load bento animation still gates correctly on repeat visits
- [ ] Admin calendar search: typing doesn't refilter/refetch per keystroke
- [ ] `tsc --noEmit` / CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved calendar event search by reducing unnecessary updates while typing.
  - Updated the clear button to consistently reset the search field and results.

- **Performance**
  - Improved application loading efficiency for commonly used interface components.

- **Visual Experience**
  - Streamlined theme initialization and session-based animations for a smoother page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->