### PR TITLE
[2607-DEV-541] Extract shared fetchJson() helper; guard 27 unguarded fetch call sites

### DIFF
--- a/app/admin/approval-hub/components/EventRolesTab.tsx
+++ b/app/admin/approval-hub/components/EventRolesTab.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from '@/lib/toast'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatDate, formatTime } from '@/lib/format'
+import { fetchJson } from '@/lib/utils/fetchJson'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -84,7 +85,7 @@ export function EventRolesTab() {
 
   const { data: roleRequests = [], isLoading } = useQuery<RoleRequest[]>({
     queryKey: ['role-requests', 'all'],
-    queryFn: () => fetch('/api/admin/event-role-requests').then(r => r.json()),
+    queryFn: () => fetchJson<RoleRequest[]>('/api/admin/event-role-requests'),
   })
 
   const eventsWithRequests = Array.from(
@@ -97,11 +98,11 @@ export function EventRolesTab() {
 
   const updateMutation = useMutation({
     mutationFn: ({ id, status }: { id: string; status: 'approved' | 'denied' }) =>
-      fetch(`/api/admin/event-role-requests/${id}`, {
+      fetchJson(`/api/admin/event-role-requests/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status }),
-      }).then(r => r.json()),
+      }),
     onMutate: async ({ id, status }) => {
       await qc.cancelQueries({ queryKey: ['role-requests', 'all'] })
       const prev = qc.getQueryData<RoleRequest[]>(['role-requests', 'all'])

--- a/app/admin/approval-hub/components/TripRegistrationsTab.tsx
+++ b/app/admin/approval-hub/components/TripRegistrationsTab.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from '@/lib/toast'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { fetchJson } from '@/lib/utils/fetchJson'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -64,7 +65,7 @@ export function TripRegistrationsTab() {
 
   const { data: registrations = [], isLoading } = useQuery<TripRegistration[]>({
     queryKey: ['registrations', 'all'],
-    queryFn: () => fetch('/api/admin/registrations').then(r => r.json()),
+    queryFn: () => fetchJson<TripRegistration[]>('/api/admin/registrations'),
   })
 
   const trips = Array.from(

--- a/app/admin/approval-hub/page.tsx
+++ b/app/admin/approval-hub/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
+import { fetchJson } from '@/lib/utils/fetchJson'
 import AdminTabs, { TabsContent } from '@/app/admin/components/AdminTabs'
 import { TripRegistrationsTab } from './components/TripRegistrationsTab'
 import { AboVerificationTab } from './components/VerificationsTab'
@@ -20,19 +21,19 @@ function ApprovalHubInner() {
 
   const { data: registrations = [] } = useQuery<TripRegistration[]>({
     queryKey: ['registrations', 'all'],
-    queryFn: () => fetch('/api/admin/registrations').then(r => r.json()),
+    queryFn: () => fetchJson<TripRegistration[]>('/api/admin/registrations'),
   })
 
   // Fetch role requests from the dedicated admin endpoint — same query key used by EventRolesTab
   // so this is a cache hit when the tab renders, not a second network request.
   const { data: roleRequests = [] } = useQuery<{ id: string; status: string }[]>({
     queryKey: ['role-requests', 'all'],
-    queryFn: () => fetch('/api/admin/event-role-requests').then(r => r.json()),
+    queryFn: () => fetchJson<{ id: string; status: string }[]>('/api/admin/event-role-requests'),
   })
 
   const { data: spouseRequests = [] } = useQuery<SpouseLinkRequest[]>({
     queryKey: ['spouse-link-requests'],
-    queryFn: () => fetch('/api/admin/spouse-link-requests').then(r => r.json()),
+    queryFn: () => fetchJson<SpouseLinkRequest[]>('/api/admin/spouse-link-requests'),
   })
 
   const pendingTrips  = registrations.filter(r => r.status === 'pending').length

--- a/app/admin/content/components/GuidesTab.tsx
+++ b/app/admin/content/components/GuidesTab.tsx
@@ -21,6 +21,7 @@ import { makeDragHandlers } from './useDragSort'
 import { GuideForm } from './GuideForm'
 import { emptyGuide, type Guide } from './guide-types'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { fetchJson } from '@/lib/utils/fetchJson'
 
 export function GuidesTab() {
   const qc = useQueryClient()
@@ -33,7 +34,7 @@ export function GuidesTab() {
 
   const { data: guidesRaw = [], isLoading: guidesLoading } = useQuery<Guide[]>({
     queryKey: ['admin-guides'],
-    queryFn: () => fetch('/api/admin/guides').then(r => r.json()),
+    queryFn: () => fetchJson<Guide[]>('/api/admin/guides'),
   })
   const [localGuides, setLocalGuides] = useState<Guide[]>(() => [...guidesRaw])
   const [prevGuidesRaw, setPrevGuidesRaw] = useState(guidesRaw)
@@ -44,10 +45,10 @@ export function GuidesTab() {
 
   const reorderGuides = useMutation({
     mutationFn: (items: { id: string; sort_order: number }[]) =>
-      fetch('/api/admin/guides', {
+      fetchJson('/api/admin/guides', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ items }),
-      }).then(r => r.json()),
+      }),
     onError: () => setLocalGuides([...guidesRaw]),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['admin-guides'] }),
   })

--- a/app/admin/content/components/LinksTab.tsx
+++ b/app/admin/content/components/LinksTab.tsx
@@ -17,6 +17,7 @@ import { AdminStatusBadge } from '@/app/admin/components/AdminStatusBadge'
 import { useAdminDrawer } from '@/app/admin/components/useAdminDrawer'
 import { makeDragHandlers } from './useDragSort'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { fetchJson } from '@/lib/utils/fetchJson'
 import { LinkForm, ALL_ROLES } from './LinkForm'
 import { LinkEditDrawer } from './LinkEditDrawer'
 import type { LinkFormData } from './LinkForm'
@@ -47,7 +48,7 @@ export function LinksTab() {
 
   const { data: linksRaw = [] } = useQuery<SiteLink[]>({
     queryKey: ['admin-links'],
-    queryFn: () => fetch('/api/admin/links').then(r => r.json()),
+    queryFn: () => fetchJson<SiteLink[]>('/api/admin/links'),
   })
   const [localLinks, setLocalLinks] = useState<SiteLink[]>(() => [...linksRaw])
   const [prevLinksRaw, setPrevLinksRaw] = useState(linksRaw)
@@ -58,20 +59,20 @@ export function LinksTab() {
 
   const reorderLinks = useMutation({
     mutationFn: (items: { id: string; sort_order: number }[]) =>
-      fetch('/api/admin/links', {
+      fetchJson('/api/admin/links', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ items }),
-      }).then(r => r.json()),
+      }),
     onError: () => setLocalLinks([...linksRaw]),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['admin-links'] }),
   })
 
   const createLink = useMutation({
     mutationFn: (data: LinkFormData) =>
-      fetch('/api/admin/links', {
+      fetchJson('/api/admin/links', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
-      }).then(r => r.json()),
+      }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['admin-links'] })
       qc.invalidateQueries({ queryKey: ['links', 'list'] })
@@ -90,10 +91,10 @@ export function LinksTab() {
 
   const updateLink = useMutation({
     mutationFn: ({ id, ...data }: { id: string } & LinkFormData) =>
-      fetch(`/api/admin/links/${id}`, {
+      fetchJson(`/api/admin/links/${id}`, {
         method: 'PATCH', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
-      }).then(r => r.json()),
+      }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['admin-links'] })
       qc.invalidateQueries({ queryKey: ['links', 'list'] })
@@ -103,10 +104,10 @@ export function LinksTab() {
 
   const toggleLinkActive = useMutation({
     mutationFn: ({ id, is_active }: { id: string; is_active: boolean }) =>
-      fetch(`/api/admin/links/${id}`, {
+      fetchJson(`/api/admin/links/${id}`, {
         method: 'PATCH', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ is_active }),
-      }).then(r => r.json()),
+      }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['admin-links'] })
       qc.invalidateQueries({ queryKey: ['links', 'list'] })

--- a/app/admin/content/components/NewsTab.tsx
+++ b/app/admin/content/components/NewsTab.tsx
@@ -20,6 +20,7 @@ import { makeDragHandlers } from './useDragSort'
 import { NewsForm, emptyNewsItem, type NewsItem } from './NewsForm'
 import { formatDate } from '@/lib/format'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { fetchJson } from '@/lib/utils/fetchJson'
 
 export function NewsTab() {
   const qc = useQueryClient()
@@ -30,7 +31,7 @@ export function NewsTab() {
 
   const { data: rawItems = [], isLoading } = useQuery<NewsItem[]>({
     queryKey: ['announcements'],
-    queryFn: () => fetch('/api/admin/announcements').then(r => r.json()),
+    queryFn: () => fetchJson<NewsItem[]>('/api/admin/announcements'),
   })
   const [localItems, setLocalItems] = useState<NewsItem[]>(() => [...rawItems])
   const [prevRaw, setPrevRaw] = useState(rawItems)
@@ -41,20 +42,20 @@ export function NewsTab() {
 
   const reorder = useMutation({
     mutationFn: (items: { id: string; sort_order: number }[]) =>
-      fetch('/api/admin/announcements', {
+      fetchJson('/api/admin/announcements', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ items }),
-      }).then(r => r.json()),
+      }),
     onError: () => setLocalItems([...rawItems]),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['announcements'] }),
   })
 
   const createItem = useMutation({
     mutationFn: (body: Omit<NewsItem, 'id' | 'created_at'>) =>
-      fetch('/api/admin/announcements', {
+      fetchJson('/api/admin/announcements', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
-      }).then(r => r.json()),
+      }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['announcements'] })
       newsDrawer.close()
@@ -63,10 +64,10 @@ export function NewsTab() {
 
   const toggleItem = useMutation({
     mutationFn: ({ id, is_active }: { id: string; is_active: boolean }) =>
-      fetch(`/api/admin/announcements/${id}`, {
+      fetchJson(`/api/admin/announcements/${id}`, {
         method: 'PATCH', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ is_active }),
-      }).then(r => r.json()),
+      }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['announcements'] }),
   })
 
@@ -78,10 +79,10 @@ export function NewsTab() {
 
   const updateItem = useMutation({
     mutationFn: ({ id, ...body }: { id: string } & Omit<NewsItem, 'id' | 'created_at'>) =>
-      fetch(`/api/admin/announcements/${id}`, {
+      fetchJson(`/api/admin/announcements/${id}`, {
         method: 'PATCH', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
-      }).then(r => r.json()),
+      }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['announcements'] })
       newsDrawer.close()

--- a/app/admin/content/components/SocialTab.tsx
+++ b/app/admin/content/components/SocialTab.tsx
@@ -18,6 +18,7 @@ import { AdminStatusBadge } from '@/app/admin/components/AdminStatusBadge'
 import { useAdminDrawer } from '@/app/admin/components/useAdminDrawer'
 import { makeDragHandlers } from './useDragSort'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { fetchJson } from '@/lib/utils/fetchJson'
 import { SocialPostForm, InstagramIcon, FacebookIcon } from './SocialPostForm'
 import type { SocialPostFormData } from './SocialPostForm'
 
@@ -44,7 +45,7 @@ export function SocialTab() {
 
   const { data: socialPostsRaw = [] } = useQuery<SocialPost[]>({
     queryKey: ['admin-social-posts'],
-    queryFn: () => fetch('/api/admin/social-posts').then(r => r.json()),
+    queryFn: () => fetchJson<SocialPost[]>('/api/admin/social-posts'),
   })
   const [localSocials, setLocalSocials] = useState<SocialPost[]>(() => [...socialPostsRaw])
   const [prevSocialsRaw, setPrevSocialsRaw] = useState(socialPostsRaw)
@@ -55,10 +56,10 @@ export function SocialTab() {
 
   const reorderSocials = useMutation({
     mutationFn: (items: { id: string; sort_order: number }[]) =>
-      fetch('/api/admin/social-posts', {
+      fetchJson('/api/admin/social-posts', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ items }),
-      }).then(r => r.json()),
+      }),
     onError: () => setLocalSocials([...socialPostsRaw]),
     onSuccess: () => { qc.invalidateQueries({ queryKey: ['admin-social-posts'] }); qc.invalidateQueries({ queryKey: ['socials'] }) },
   })
@@ -113,11 +114,11 @@ export function SocialTab() {
 
   const patchSocialPost = useMutation({
     mutationFn: ({ id, ...patch }: { id: string } & Partial<SocialPost>) =>
-      fetch(`/api/admin/social-posts/${id}`, {
+      fetchJson(`/api/admin/social-posts/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(patch),
-      }).then(r => r.json()),
+      }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['admin-social-posts'] })
       qc.invalidateQueries({ queryKey: ['socials'] })

--- a/app/admin/content/guides/[id]/edit/components/GuideAttachmentsPanel.tsx
+++ b/app/admin/content/guides/[id]/edit/components/GuideAttachmentsPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { makeDragHandlers } from '@/app/admin/content/components/useDragSort'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { fetchJson } from '@/lib/utils/fetchJson'
 
 type Attachment = {
   id: string
@@ -49,7 +50,7 @@ export function GuideAttachmentsPanel({ guideId }: { guideId: string }) {
   const { data: attachments = [], isLoading } = useQuery<Attachment[]>({
     queryKey,
     queryFn: () =>
-      fetch(`/api/admin/guides/${guideId}/attachments`).then(r => r.json()),
+      fetchJson<Attachment[]>(`/api/admin/guides/${guideId}/attachments`),
   })
 
   useEffect(() => {

--- a/app/admin/payments/components/LogPaymentDrawer.tsx
+++ b/app/admin/payments/components/LogPaymentDrawer.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Drawer } from '@/components/ui/drawer'
 import { t } from '@/lib/i18n'
+import { fetchJson } from '@/lib/utils/fetchJson'
 import { LogPaymentForm } from './LogPaymentForm'
 import type { Trip } from '@/lib/types/trips'
 import type { PayableItem } from '@/lib/types/items'
@@ -25,21 +26,21 @@ export function LogPaymentDrawer({
   // Lazy fetch — only runs while drawer is open
   const { data: trips = [] } = useQuery<Trip[]>({
     queryKey: ['trips'],
-    queryFn: () => fetch('/api/trips').then(r => r.json()),
+    queryFn: () => fetchJson<Trip[]>('/api/trips'),
     enabled: open,
     staleTime: 60_000,
   })
 
   const { data: items = [] } = useQuery<PayableItem[]>({
     queryKey: ['payable-items'],
-    queryFn: () => fetch('/api/admin/payable-items').then(r => r.json()),
+    queryFn: () => fetchJson<PayableItem[]>('/api/admin/payable-items'),
     enabled: open,
     staleTime: 60_000,
   })
 
   const { data: membersData } = useQuery<MembersResponse>({
     queryKey: ['admin-members'],
-    queryFn: () => fetch('/api/admin/members').then(r => r.json()),
+    queryFn: () => fetchJson<MembersResponse>('/api/admin/members'),
     enabled: open,
     staleTime: 60_000,
   })

--- a/app/admin/settings/components/EmailLogTable.tsx
+++ b/app/admin/settings/components/EmailLogTable.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { t } from '@/lib/i18n'
+import { fetchJson } from '@/lib/utils/fetchJson'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -73,7 +74,7 @@ export function EmailLogTable() {
 
   const { data, isLoading } = useQuery<LogsResponse>({
     queryKey: ['email-log', statusFilter, templateFilter, page],
-    queryFn: () => fetch(`/api/admin/email-log?${params}`).then(r => r.json()),
+    queryFn: () => fetchJson<LogsResponse>(`/api/admin/email-log?${params}`),
     staleTime: 30_000,
   })
 

--- a/components/layout/UserDropdown.tsx
+++ b/components/layout/UserDropdown.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { useTheme } from '@/lib/hooks/useTheme'
 import { getRoleColors } from '@/lib/role-colors'
+import { fetchJson } from '@/lib/utils/fetchJson'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -50,7 +51,7 @@ export default function UserDropdown() {
 
   const { data: profileData } = useQuery<ProfileData>({
     queryKey: ['profile'],
-    queryFn: () => fetch('/api/profile').then(r => r.json()),
+    queryFn: () => fetchJson<ProfileData>('/api/profile'),
     staleTime: 5 * 60 * 1000,
   })
 

--- a/lib/hooks/useNotifications.ts
+++ b/lib/hooks/useNotifications.ts
@@ -1,17 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-
-// fetch() only rejects on network failure — a 4xx/5xx response still resolves
-// with a parseable JSON error body (e.g. { error: 'Unauthorized' }), which
-// would otherwise be treated as valid query/mutation data (an object, not an
-// array) and crash any `.filter`/`.map` caller downstream.
-async function fetchJson<T>(input: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(input, init)
-  if (!res.ok) {
-    const body = await res.json().catch(() => null)
-    throw new Error(body?.error ?? `Request failed: ${res.status}`)
-  }
-  return res.json()
-}
+import { fetchJson } from '@/lib/utils/fetchJson'
 
 export type Notification = {
   id: string

--- a/lib/utils/fetchJson.test.ts
+++ b/lib/utils/fetchJson.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchJson } from '@/lib/utils/fetchJson'
+
+function mockFetchOnce(response: Response): ReturnType<typeof vi.fn> {
+  const mock = vi.fn().mockResolvedValue(response)
+  vi.stubGlobal('fetch', mock)
+  return mock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('fetchJson', () => {
+  it('returns the parsed JSON body on an ok response', async () => {
+    mockFetchOnce(new Response(JSON.stringify([{ id: '1' }]), { status: 200 }))
+    await expect(fetchJson<{ id: string }[]>('/api/notifications')).resolves.toEqual([{ id: '1' }])
+  })
+
+  it('passes input and init through to fetch', async () => {
+    const mock = mockFetchOnce(new Response('{}', { status: 200 }))
+    const init = { method: 'PATCH', body: JSON.stringify({ is_read: true }) }
+    await fetchJson('/api/notifications/1', init)
+    expect(mock).toHaveBeenCalledWith('/api/notifications/1', init)
+  })
+
+  it('throws the server-provided error message on a non-ok response', async () => {
+    mockFetchOnce(new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }))
+    await expect(fetchJson('/api/notifications')).rejects.toThrow('Unauthorized')
+  })
+
+  it('falls back to the status code when the error body has no error field', async () => {
+    mockFetchOnce(new Response(JSON.stringify({ message: 'nope' }), { status: 500 }))
+    await expect(fetchJson('/api/notifications')).rejects.toThrow('Request failed: 500')
+  })
+
+  it('falls back to the status code when the error body is not JSON', async () => {
+    mockFetchOnce(new Response('<html>Bad Gateway</html>', { status: 502 }))
+    await expect(fetchJson('/api/notifications')).rejects.toThrow('Request failed: 502')
+  })
+
+  it('does not treat a JSON error body on a 200 as a failure', async () => {
+    mockFetchOnce(new Response(JSON.stringify({ error: 'soft error payload' }), { status: 200 }))
+    await expect(fetchJson('/api/x')).resolves.toEqual({ error: 'soft error payload' })
+  })
+})

--- a/lib/utils/fetchJson.ts
+++ b/lib/utils/fetchJson.ts
@@ -1,0 +1,16 @@
+// fetch() only rejects on network failure — a 4xx/5xx response still resolves
+// with a parseable JSON error body (e.g. { error: 'Unauthorized' }), which
+// would otherwise be treated as valid query/mutation data (an object, not an
+// array) and crash any `.filter`/`.map` caller downstream.
+//
+// Minimal by design: unlike `lib/apiClient.ts` it performs no 401 redirect and
+// sets no headers, so converting a call site changes nothing but the non-ok
+// path (which now throws instead of returning the error body as data).
+export async function fetchJson<T>(input: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, init)
+  if (!res.ok) {
+    const body = await res.json().catch(() => null)
+    throw new Error(body?.error ?? `Request failed: ${res.status}`)
+  }
+  return res.json()
+}


### PR DESCRIPTION
Closes #541

## What

`fetch()` only rejects on network failure — a 4xx/5xx response still resolves with a parseable JSON error body, which the unguarded `fetch(...).then(r => r.json())` pattern fed into React Query caches as data (an error object where an array was expected), crashing `.filter`/`.map` consumers instead of surfacing an error state. PR #514 fixed this in `lib/hooks/useNotifications.ts` with a module-private `fetchJson()`; this PR extracts that helper and applies it everywhere the pattern remained.

## Changes

- **New** `lib/utils/fetchJson.ts` — shared helper (verbatim behavior from #514: throws `body.error` or `Request failed: <status>` on non-ok). Deliberately minimal vs `lib/apiClient.ts` — no 401 redirect side-effect, no header injection — so converted sites keep their existing UI behavior except that non-ok responses now throw.
- **New** `lib/utils/fetchJson.test.ts` — 6 vitest cases (ok path, init passthrough, server error message, non-`error` body fallback, non-JSON body fallback, 200-with-error-body not treated as failure).
- `lib/hooks/useNotifications.ts` — imports the shared helper instead of defining it locally.
- 27 previously unguarded call sites converted across 11 files (queries received explicit generics matching their `useQuery<T>`; mutations pass `init` through unchanged):
  - `app/admin/approval-hub/page.tsx` (3), `components/TripRegistrationsTab.tsx` (1), `components/EventRolesTab.tsx` (2)
  - `app/admin/payments/components/LogPaymentDrawer.tsx` (3)
  - `app/admin/content/components/GuidesTab.tsx` (2), `LinksTab.tsx` (5), `NewsTab.tsx` (5), `SocialTab.tsx` (3)
  - `app/admin/content/guides/[id]/edit/components/GuideAttachmentsPanel.tsx` (1)
  - `components/layout/UserDropdown.tsx` (1), `app/admin/settings/components/EmailLogTable.tsx` (1)

## Explicitly not touched

- All sites already guarding on `.ok`/status (e.g. `TripHeroSection.tsx`, `PaymentsClient.tsx`, `AdminCalendarClient.tsx`, `EmailLogTable` retry path) — unchanged per ticket scope.
- `supabase/functions/sync-google-calendar/index.ts:190` — Deno edge function, cannot import `lib/utils` (noted, not done).
- The issue's original 12-file list was stale (`useBentoConfig.ts` no longer exists; `components/admin/*` paths moved); the list above was re-derived from scratch against `main@2fb7d4b` — see the updated issue body.

## Verification

- `npm run check-types` — exit 0
- `npm run test` — 7 files / 82 tests passed (baseline before change: 6 files / 76 tests)
- Residual-pattern grep for unguarded `.then(r => r.json())` in `app/ components/ lib/` — zero hits

## Session State
**Status:** DONE
**Agent Type:** Claude
**Completed:**
- [x] Affected-file list re-derived (27 sites / 11 files confirmed unguarded)
- [x] Shared helper extracted to `lib/utils/fetchJson.ts` + tests
- [x] All call sites converted; check-types and vitest green locally
**Next:** Await CI + Vercel preview READY, then human merge via GitHub UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized data loading and updates across admin dashboards, content management, payments, settings, notifications, and user profile areas.
  * Improved handling and reporting of API errors, including clearer fallback messages when requests fail.

* **Tests**
  * Added coverage for successful responses, request forwarding, error responses, fallback errors, and valid responses containing error fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->