### PR TITLE
[2607-DEV-546] Local verification tooling: verify, check:env, Playwright 390px smoke, worktree env, Windows npm ci fix

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__github-tevd__pull_request_read",
+      "mcp__github-tevd__get_file_contents",
+      "mcp__github-tevd__issue_read"
+    ]
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Required — `npm run check:env` fails if any of these is missing or empty.
+
 # Clerk
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=
@@ -13,10 +15,8 @@ NEXT_PUBLIC_MAPBOX_TOKEN=
 # iCal feed signing secret — generate with: openssl rand -hex 32
 ICAL_TOKEN_SECRET=
 
-# App base URL (used to build iCal subscription URLs)
-NEXT_PUBLIC_APP_URL=https://tevd-portal.vercel.app
+# --- optional --- (`npm run check:env` warns instead of failing)
 
-# Social feeds (Meta Graph API)
-INSTAGRAM_ACCESS_TOKEN=
-FB_PAGE_ACCESS_TOKEN=
-FB_PAGE_ID=
+# App base URL for absolute links (iCal subscription URLs, notification emails).
+# Every consumer falls back to a sensible default when unset.
+NEXT_PUBLIC_APP_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install
+      - run: npm ci
       - run: npm run check-types
 
   lint:
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install
+      - run: npm ci
       - run: npm run lint
 
   test:
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install
+      - run: npm ci
       - run: npm run test
 
   build:
@@ -59,7 +59,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install
+      - run: npm ci
       - run: npm run build
     env:
       NEXT_PUBLIC_SUPABASE_URL: "https://placeholder.supabase.co"
@@ -70,9 +70,6 @@ jobs:
       SUPABASE_SERVICE_ROLE_KEY: "placeholder"
       CLERK_SECRET_KEY: "placeholder"
       ICAL_TOKEN_SECRET: "placeholder"
-      INSTAGRAM_ACCESS_TOKEN: "placeholder"
-      FB_PAGE_ACCESS_TOKEN: "placeholder"
-      FB_PAGE_ID: "placeholder"
 
   audit:
     name: Security Audit
@@ -83,7 +80,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm install
+      - run: npm ci
       # Soft-gate the audit with '|| true' so vulnerabilities are reported in the logs
       # but do not block pull request merges.
       - run: npm audit --audit-level=high --omit=dev || true

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -1,0 +1,48 @@
+name: Preview Smoke
+
+# Runs the navigation-only Playwright smoke against each Vercel PREVIEW
+# deployment once Vercel reports it ready.
+#
+# Advisory-only for now: deployment_status-triggered runs are not attached
+# to the PR as required checks by default. Once trusted, add the "smoke"
+# job as a required status check in branch protection.
+#
+# The suite is navigation-only because preview deployments hit the
+# production Supabase project (see docs/DEV_WORKFLOW.md and issue #547).
+
+on:
+  deployment_status:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-smoke-${{ github.event.deployment.sha }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: 390px smoke vs preview
+    if: >
+      github.event.deployment_status.state == 'success' &&
+      startsWith(github.event.deployment.environment, 'Preview')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.deployment.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npx playwright test --project=mobile-390
+        env:
+          BASE_URL: ${{ github.event.deployment_status.environment_url }}
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,12 @@ next-env.d.ts
 # supabase CLI artifacts
 supabase/.temp/
 
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # design-sync
 .ds-sync/
 ds-bundle/

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -3,11 +3,11 @@ Dev-infrastructure refactor (2026-07-11, plan-mode approved): supersede PR #544 
 (PARKED, resume after: Milestone #2 "Security & Health Audit — 2026-07" — status snapshot preserved under Open items/Facts below.)
 
 ## Now
-PR A (#545) in progress on `dev/2607-DEV-545`: archive moves done (root README/PROJECT/ORIGINAL_REQUEST/TEST_INFRA/TEST_READY, docs/release-cycle-test.md, `.agents/` → `docs/archive/`), supabase/.temp untracked, .gitignore deduped, config.toml comments fixed, new README + docs/DEV_WORKFLOW.md written. BASELINE: vitest 7 files/82 tests pass.
+Both PRs built and verified locally, committed on their branches, NOT pushed (awaiting explicit user approval). PR A (#545, `dev/2607-DEV-545`): hygiene/docs/archive + eslint ignore retarget (.agents→docs/archive). PR B (#546, `dev/2607-DEV-546`, stacked on A): optionalDependencies fix for Windows EBADPLATFORM (from 4f27d7a) + ci.yml npm ci + verify/check:env/env:worktree scripts + Playwright mobile-390 smoke + preview-smoke.yml (advisory) + turbopack root + .claude/settings.json. Verified: `npm run verify` exit 0 (lint 0 errors / tsc / 82 tests / build 62 pages); `npm run test:mobile` 6/6 public routes green at 390px.
 
 ## Next
-- Commit PR A; then branch `dev/2607-DEV-546` for PR B: move `@tailwindcss/oxide-linux-x64-gnu` + `lightningcss-linux-x64-gnu` devDeps → optionalDependencies (they hard-fail `npm ci` on Windows, EBADPLATFORM; added by 4f27d7a as a CI workaround) + ci.yml `npm install`→`npm ci` (must land together), verify/check:env scripts, Playwright mobile-390 smoke (navigation-only fence), preview-smoke.yml (advisory), turbopack root, env:worktree, .claude/settings.json
-- Both branches stay local until the user explicitly approves a push
+- User to approve push of `dev/2607-DEV-545` and `dev/2607-DEV-546`; open PRs (B based on A, retarget to main after A merges); confirm CI green + Vercel preview READY + preview-smoke run
+- Findings logged during smoke (pre-existing, not fixed here): anonymous visitors get a 401 + "Query data cannot be undefined" console error from the `profile-ui-prefs-font-size` query; radix-id hydration mismatch on `/`
 - Then: #547 local Supabase (priority:high)
 - (Parked milestone queue) merge-pending PRs #502/#504/#505/#506/#507/#508; #485; Phase 4: #490/#492/#489/#487/#488; Phase 5: #469/#486/#491/#493/#494/#495/#496/#497; #510 pickup
 

--- a/e2e/mobile-smoke.spec.ts
+++ b/e2e/mobile-smoke.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Navigation-only smoke over the public routes (see lib/public-routes.ts).
+ *
+ * PROD-DB FENCE: local dev and Vercel previews point at the PRODUCTION
+ * Supabase project until #547 (local Supabase) lands. Tests in this suite
+ * must only navigate and read — never submit forms, click mutating
+ * controls, or call write APIs.
+ *
+ * Failure policy: fails on HTTP >= 400, horizontal overflow at the
+ * project viewport, and uncaught page errors. console.error output is
+ * logged for diagnosis but is not fatal (third-party scripts are noisy
+ * in prod-like environments).
+ */
+
+const PUBLIC_ROUTES = ['/', '/about', '/calendar', '/trips', '/library', '/sign-in']
+
+for (const route of PUBLIC_ROUTES) {
+  test(`renders ${route} without overflow or page errors`, async ({ page }, testInfo) => {
+    const pageErrors: Error[] = []
+    page.on('pageerror', (err) => pageErrors.push(err))
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') console.log(`[console.error] ${route}: ${msg.text()}`)
+    })
+
+    const response = await page.goto(route)
+    expect(response, `no response for ${route}`).not.toBeNull()
+    expect(response!.status(), `HTTP status for ${route}`).toBeLessThan(400)
+
+    // Best-effort settle so hydration-induced layout shifts are included;
+    // never fails the test on slow background requests.
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {})
+    await expect(page.locator('body')).toBeVisible()
+
+    const viewport = testInfo.project.use.viewport
+    if (viewport != null) {
+      const scrollWidth = await page.evaluate(
+        () => document.scrollingElement?.scrollWidth ?? 0,
+      )
+      expect(
+        scrollWidth,
+        `horizontal overflow on ${route}: content is ${scrollWidth}px wide at a ${viewport.width}px viewport`,
+      ).toBeLessThanOrEqual(viewport.width)
+    }
+
+    expect(
+      pageErrors,
+      `uncaught page errors on ${route}: ${pageErrors.map((e) => e.message).join('; ')}`,
+    ).toHaveLength(0)
+  })
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,12 @@
+import path from 'path'
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  // Pin the project root so dev servers started inside git worktrees
+  // (.claude/worktrees/*) don't resolve the main checkout as root.
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
   experimental: {
     optimizePackageImports: ['lucide-react', '@tanstack/react-query'],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "vaul": "^1.1.2"
       },
       "devDependencies": {
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.1",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.2.1",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -56,11 +56,14 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "eslint-plugin-i18next": "^6.1.3",
-        "lightningcss-linux-x64-gnu": "1.31.1",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.1.10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.1",
+        "lightningcss-linux-x64-gnu": "1.31.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1016,6 +1019,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -2561,8 +2580,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -6779,8 +6798,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
       "os": [
         "linux"
       ],
@@ -7702,6 +7721,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "check-types": "tsc --noEmit",
     "test": "vitest run",
     "test:mock": "node scripts/run-e2e-tests.js --mock",
+    "test:e2e": "playwright test",
+    "test:mobile": "playwright test --project=mobile-390",
+    "verify": "npm run lint && npm run check-types && npm run test && npm run build",
+    "check:env": "node scripts/check-env.js",
+    "env:worktree": "node scripts/setup-worktree-env.js",
     "agentic:validate": "node scripts/validate-rules.js",
     "agentic:handoff": "node scripts/handoff.js",
     "agentic:bootstrap": "node scripts/bootstrap.js",
@@ -58,8 +63,12 @@
     "tailwind-merge": "^3.3.0",
     "vaul": "^1.1.2"
   },
-  "devDependencies": {
+  "optionalDependencies": {
     "@tailwindcss/oxide-linux-x64-gnu": "4.2.1",
+    "lightningcss-linux-x64-gnu": "1.31.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.2.1",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -67,7 +76,6 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-plugin-i18next": "^6.1.3",
-    "lightningcss-linux-x64-gnu": "1.31.1",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vite-tsconfig-paths": "^6.1.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// BASE_URL set (e.g. the preview-smoke workflow pointing at a Vercel preview)
+// -> test that deployment and start no local server.
+const baseURL = process.env.BASE_URL ?? 'http://localhost:3000'
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      // 390px is this repo's mobile-first hard constraint.
+      name: 'mobile-390',
+      use: { ...devices['iPhone 12'], viewport: { width: 390, height: 844 } },
+    },
+    {
+      name: 'desktop',
+      use: { viewport: { width: 1280, height: 800 } },
+    },
+  ],
+  webServer: process.env.BASE_URL
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: true,
+        timeout: 120_000,
+      },
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,8 +16,14 @@ export default defineConfig({
   projects: [
     {
       // 390px is this repo's mobile-first hard constraint.
+      // browserName pinned: devices['iPhone 12'] defaults to webkit, but CI
+      // (preview-smoke.yml) installs chromium only — keep local & CI identical.
       name: 'mobile-390',
-      use: { ...devices['iPhone 12'], viewport: { width: 390, height: 844 } },
+      use: {
+        ...devices['iPhone 12'],
+        browserName: 'chromium',
+        viewport: { width: 390, height: 844 },
+      },
     },
     {
       name: 'desktop',

--- a/scripts/check-env.js
+++ b/scripts/check-env.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that every variable listed in .env.example is available,
+ * reading .env.local directly (plain `node` does not auto-load env files —
+ * the PR #544 version checked process.env only and always failed).
+ *
+ * Sources, in order: .env.local values, then process.env (CI/exported shells).
+ * Empty values count as missing. Prints missing names only, never values.
+ *
+ * Vars listed below a `# --- optional ---` line in .env.example only warn.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const root = process.cwd()
+
+const OPTIONAL_DIVIDER = /^\s*#\s*-+\s*optional\s*-+/i
+
+function parseEnvFile(filePath) {
+  const vars = {}
+  const content = fs.readFileSync(filePath, 'utf8')
+  let optionalSection = false
+  for (const line of content.split(/\r?\n/)) {
+    if (OPTIONAL_DIVIDER.test(line)) {
+      optionalSection = true
+      continue
+    }
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/)
+    if (match === null) continue
+    let value = match[2]
+    if (
+      (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+      (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+    ) {
+      value = value.slice(1, -1)
+    }
+    vars[match[1]] = { value, optional: optionalSection }
+  }
+  return vars
+}
+
+const examplePath = path.join(root, '.env.example')
+if (!fs.existsSync(examplePath)) {
+  console.error(`check:env: ${examplePath} not found — run from the project root.`)
+  process.exit(1)
+}
+const example = parseEnvFile(examplePath)
+const required = Object.keys(example).filter((name) => !example[name].optional)
+const optional = Object.keys(example).filter((name) => example[name].optional)
+
+const localPath = path.join(root, '.env.local')
+let localVars = {}
+if (fs.existsSync(localPath)) {
+  localVars = parseEnvFile(localPath)
+} else {
+  console.warn(
+    'check:env: .env.local not found — checking process.env only.\n' +
+      '  Fresh clone: cp .env.example .env.local and fill in values.\n' +
+      '  Git worktree: npm run env:worktree',
+  )
+}
+
+function isMissing(name) {
+  const fromFile = localVars[name]
+  if (fromFile !== undefined && fromFile.value !== '') return false
+  const fromEnv = process.env[name]
+  return fromEnv === undefined || fromEnv === ''
+}
+
+const missingRequired = required.filter(isMissing)
+const missingOptional = optional.filter(isMissing)
+
+if (missingOptional.length > 0) {
+  console.warn('check:env: optional variables not set (app falls back to defaults):')
+  for (const name of missingOptional) console.warn(`  - ${name}`)
+}
+
+if (missingRequired.length > 0) {
+  console.error('check:env: missing required environment variables:')
+  for (const name of missingRequired) console.error(`  - ${name}`)
+  process.exit(1)
+}
+
+console.log(`check:env: all ${required.length} required variables are set.`)

--- a/scripts/setup-worktree-env.js
+++ b/scripts/setup-worktree-env.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+/**
+ * Copies the main checkout's .env.local into the current git worktree
+ * (worktrees under .claude/worktrees/ don't inherit untracked env files,
+ * so `npm run dev` fails there with "supabaseUrl is required").
+ *
+ * Refuses to overwrite an existing .env.local in the worktree.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const cwd = process.cwd()
+const segments = cwd.split(path.sep)
+const marker = segments.findIndex(
+  (seg, i) => seg === '.claude' && segments[i + 1] === 'worktrees',
+)
+
+if (marker === -1) {
+  console.error(
+    'env:worktree: current directory is not inside a .claude/worktrees worktree.\n' +
+      `  cwd: ${cwd}\n` +
+      '  In the main checkout, create .env.local from .env.example instead.',
+  )
+  process.exit(1)
+}
+
+const mainRoot = segments.slice(0, marker).join(path.sep)
+const source = path.join(mainRoot, '.env.local')
+const dest = path.join(cwd, '.env.local')
+
+if (!fs.existsSync(source)) {
+  console.error(
+    `env:worktree: ${source} not found — the main checkout has no .env.local to copy.`,
+  )
+  process.exit(1)
+}
+
+if (fs.existsSync(dest)) {
+  console.log('env:worktree: .env.local already exists in this worktree — leaving it untouched.')
+  console.log('  Delete it first if you want a fresh copy.')
+  process.exit(0)
+}
+
+fs.copyFileSync(source, dest)
+console.log(`env:worktree: copied ${source} -> ${dest}`)
+console.warn(
+  '\n⚠  WARNING: this file contains PRODUCTION credentials (Supabase service-role key).\n' +
+    '   Local dev writes hit live data until #547 (local Supabase) lands:\n' +
+    '   navigation-only testing — no form submits, no mutations, no destructive experiments.\n' +
+    '   Never commit or share this file (.env* is gitignored — keep it that way).',
+)


### PR DESCRIPTION
Closes #546. Part 2 of 2 of the dev-infrastructure refactor superseding #544. **Based on `dev/2607-DEV-545` (PR #548)** — retarget/rebase to `main` once that merges.

## What
- **Windows install fix**: `@tailwindcss/oxide-linux-x64-gnu` + `lightningcss-linux-x64-gnu` move devDependencies → `optionalDependencies`. Commit `4f27d7a` pinned them to fix native-binary resolution on Vercel/CI, but as direct devDeps they hard-fail `npm ci` on win32 (EBADPLATFORM) — which is why CI ran `npm install` and local checkouts had no reproducible installs. Lockfile verified to still carry all platform variants.
- **CI**: `npm install` → `npm ci` in all 5 jobs (safe now); drop `INSTAGRAM_ACCESS_TOKEN`/`FB_PAGE_*` placeholder env (dead — zero references in app or edge-function code).
- **`npm run verify`**: lint → check-types → test → build with visible output (replaces #544's output-swallowing orchestrator).
- **`npm run check:env`** (`scripts/check-env.js`): parses `.env.local` directly (plain `node` doesn't auto-load env files — #544's version could never pass), validates against `.env.example`; vars under the new `# --- optional ---` divider warn instead of fail. `.env.example` restructured accordingly; dead social tokens removed.
- **Playwright**: `@playwright/test` + `mobile-390` project (390×844) + `e2e/mobile-smoke.spec.ts` — navigation-only smoke over the public routes from `lib/public-routes.ts` (prod-DB fence: no writes/form submits until #547); asserts HTTP OK, no horizontal overflow at 390px, no uncaught page errors.
- **`preview-smoke.yml`**: runs the smoke against each Vercel preview on `deployment_status` success. **Advisory-only** — not a required check by default; wire into branch protection once trusted.
- **Worktrees**: `next.config.ts` pins `turbopack.root`; `npm run env:worktree` copies the main checkout's `.env.local` in (refuses overwrite, warns that it carries prod credentials).
- `.claude/settings.json`: read-only GitHub MCP allowlist.

## Verification (all on win32)
- `npm ci` (no `--force`) → `added 613 packages in 3m`, exit 0
- `npm run verify` → exit 0 (lint 0 errors · tsc clean · `Tests  82 passed (82)` · build `62/62` static pages)
- `npm run test:mobile` → `6 passed` (each public route, 390px, no overflow, no page errors)
- `npm run check:env` → fail-mode names missing vars; pass-mode `all 7 required variables are set`
- `npm run env:worktree` → copied into this worktree, dev server boots (Playwright webServer)

Pre-existing findings surfaced by the smoke (logged, out of scope): anonymous 401 + undefined-query-data from `profile-ui-prefs-font-size` on public pages; radix-id hydration mismatch on `/`.

## Session State
- **Agent Type:** Claude
- **Issue:** #546 · **Branch:** `dev/2607-DEV-546` (stacked on `dev/2607-DEV-545`, PR #548)
- **Status:** complete, verified locally; first `preview-smoke` run will trigger on this PR's Vercel preview
- **Next:** merge #548 → retarget this to main → merge; then #547 (local Supabase, priority:high) takes local dev off the production DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated mobile smoke checks for key public pages, including navigation, visibility, errors, and horizontal scrolling.
  - Added automated checks for preview deployments to catch navigation issues before release.
  - Added commands for end-to-end testing and comprehensive project verification.

- **Chores**
  - Improved environment-variable validation and local setup guidance.
  - Improved consistency of dependency installation in continuous integration.
  - Improved development reliability when working from alternate project directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->