### PR TITLE
[2607-DEV-555] Align local settings RLS policies with prod (is_admin read/write)

### DIFF
--- a/lib/hooks/useNotifications.ts
+++ b/lib/hooks/useNotifications.ts
@@ -5,7 +5,7 @@ export type Notification = {
   id: string
   profile_id: string
   is_read: boolean
-  type: 'role_request' | 'trip_request' | 'trip_created' | 'event_fetched' | 'doc_expiry' | 'los_digest' | 'trip_message' | 'trip_attachment'
+  type: 'role_request' | 'trip_request' | 'trip_created' | 'event_fetched' | 'doc_expiry' | 'los_digest' | 'trip_message' | 'trip_attachment' | 'spouse_link_request'
   title: string
   message: string
   action_url: string | null

--- a/supabase/migrations/20260514000200_reminder_config.sql
+++ b/supabase/migrations/20260514000200_reminder_config.sql
@@ -18,22 +18,11 @@ CREATE TABLE IF NOT EXISTS public.settings (
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 
--- RLS with the same two Pattern-A policies prod has (verified 2026-07-12,
--- #555): admins may read/write via the Data API; anon/authenticated
--- non-admins get nothing. App server code uses the service-role client
--- (bypasses RLS) either way. Idempotent.
+-- Deny-all posture: RLS enabled with no policies. All app reads/writes of
+-- settings go through the server-side service-role client (bypasses RLS);
+-- anon/authenticated must not reach it via the Data API. Idempotent.
+-- (Prod's admin policies are added by 20260712000200 — forward-fix, #555.)
 ALTER TABLE public.settings ENABLE ROW LEVEL SECURITY;
-
-DROP POLICY IF EXISTS "Admin read settings" ON public.settings;
-CREATE POLICY "Admin read settings"
-  ON public.settings FOR SELECT
-  USING (is_admin());
-
-DROP POLICY IF EXISTS "Admin write settings" ON public.settings;
-CREATE POLICY "Admin write settings"
-  ON public.settings FOR ALL
-  USING (is_admin())
-  WITH CHECK (is_admin());
 
 INSERT INTO public.settings (key, value)
 VALUES

--- a/supabase/migrations/20260514000200_reminder_config.sql
+++ b/supabase/migrations/20260514000200_reminder_config.sql
@@ -18,10 +18,22 @@ CREATE TABLE IF NOT EXISTS public.settings (
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Deny-all posture: RLS enabled with no policies. All app reads/writes of
--- settings go through the server-side service-role client (bypasses RLS);
--- anon/authenticated must not reach it via the Data API. Idempotent.
+-- RLS with the same two Pattern-A policies prod has (verified 2026-07-12,
+-- #555): admins may read/write via the Data API; anon/authenticated
+-- non-admins get nothing. App server code uses the service-role client
+-- (bypasses RLS) either way. Idempotent.
 ALTER TABLE public.settings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admin read settings" ON public.settings;
+CREATE POLICY "Admin read settings"
+  ON public.settings FOR SELECT
+  USING (is_admin());
+
+DROP POLICY IF EXISTS "Admin write settings" ON public.settings;
+CREATE POLICY "Admin write settings"
+  ON public.settings FOR ALL
+  USING (is_admin())
+  WITH CHECK (is_admin());
 
 INSERT INTO public.settings (key, value)
 VALUES

--- a/supabase/migrations/20260712000100_repair_prod_schema_drift.sql
+++ b/supabase/migrations/20260712000100_repair_prod_schema_drift.sql
@@ -1,0 +1,15 @@
+-- #555: repair prod schema drift found while mirroring prod data for #547.
+-- Two objects exist in prod but were created by no migration (same drift
+-- class as settings/email_log). Definitions copied verbatim from prod
+-- catalogs (2026-07-12). IF NOT EXISTS makes both no-ops if applied to prod.
+-- Full-catalog diff (prod vs fresh local replay) showed exactly these two;
+-- all other tables/columns/enum values match.
+
+-- 1. profiles.notification_prefs — read/written by /api/profile and the
+--    profile EmailPrefsSection.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS notification_prefs jsonb NOT NULL
+  DEFAULT '{"payment_status": true, "document_expiring_soon": true, "abo_verification_result": true, "trip_registration_status": true, "event_role_request_result": true}'::jsonb;
+
+-- 2. notification_type value used by prod rows in member_notifications.
+ALTER TYPE public.notification_type ADD VALUE IF NOT EXISTS 'spouse_link_request';

--- a/supabase/migrations/20260712000200_add_settings_rls_policies.sql
+++ b/supabase/migrations/20260712000200_add_settings_rls_policies.sql
@@ -1,0 +1,20 @@
+-- #555: add the two Pattern-A RLS policies public.settings has in prod
+-- (verified 2026-07-12 via Management API: relrowsecurity=true, 2 policies).
+-- Forward-fix migration so existing local databases pick the policies up
+-- without a destructive reset; idempotent and a net no-op on prod, where the
+-- identical policies already exist. Admins may read/write settings via the
+-- Data API; anon/authenticated non-admins get nothing. App server code uses
+-- the service-role client (bypasses RLS) either way.
+
+ALTER TABLE public.settings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Admin read settings" ON public.settings;
+CREATE POLICY "Admin read settings"
+  ON public.settings FOR SELECT
+  USING (is_admin());
+
+DROP POLICY IF EXISTS "Admin write settings" ON public.settings;
+CREATE POLICY "Admin write settings"
+  ON public.settings FOR ALL
+  USING (is_admin())
+  WITH CHECK (is_admin());

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -2336,6 +2336,9 @@ export type Database = {
         | "event_fetched"
         | "doc_expiry"
         | "los_digest"
+        | "trip_message"
+        | "trip_attachment"
+        | "spouse_link_request"
       registration_status: "pending" | "approved" | "denied"
       reminder_type: "1_hour" | "15_min"
       user_role: "admin" | "core" | "member" | "guest"
@@ -2936,6 +2939,9 @@ export const Constants = {
         "event_fetched",
         "doc_expiry",
         "los_digest",
+        "trip_message",
+        "trip_attachment",
+        "spouse_link_request",
       ],
       registration_status: ["pending", "approved", "denied"],
       reminder_type: ["1_hour", "15_min"],


### PR DESCRIPTION
Closes #555. Follow-up to #547 / PR #554.

Prod's `public.settings` has RLS with two permissive Pattern-A policies (verified 2026-07-12 against prod: `relrowsecurity=true`, `policy_count=2`, anon Data API probe returns `[]` while service role returns 3 rows). The #547 guard produced deny-all on fresh replays — residual drift in the opposite direction. This adds the same two policies (`"Admin read settings"` SELECT USING `is_admin()`; `"Admin write settings"` ALL USING/WITH CHECK `is_admin()`) to the guarded block so a fresh local replay matches prod, and corrects the comment.

No prod action: the migration is stamped as applied there; prod already has both policies. `is_admin()` is defined in the baseline, so ordering is safe.

## Verification
- `supabase db reset` → exit 0 (full 110-migration chain + seed)
- `pg_policy` on `public.settings` → `Admin read settings`, `Admin write settings`; `rls: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin-only access controls for application settings.
  * Added configurable notification preferences to user profiles.
  * Added support for spouse link request notifications.
  * Added reminder settings for calendar events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->