### PR TITLE
Fix Agenda scroll landing under the fixed navbar on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ ds-bundle/
 .design-sync/.cache/
 .design-sync/learnings/
 .design-sync/node_modules
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/app/(dashboard)/calendar/components/AgendaView.tsx
+++ b/app/(dashboard)/calendar/components/AgendaView.tsx
@@ -96,7 +96,7 @@ export function AgendaView({
           <div
             key={dateKey}
             ref={dateKey === anchorDateKey ? anchorRef : null}
-            className="mb-6"
+            className="mb-6 scroll-mt-20 md:scroll-mt-0"
             style={{ opacity: isPast ? 0.5 : 1 }}
           >
             <div className="flex items-center gap-3 mb-2 py-2">
@@ -122,7 +122,7 @@ export function AgendaView({
                     key={ev.id}
                     ref={isHighlighted ? highlightRef : null}
                     onClick={() => onEventClick(ev.id)}
-                    className="w-full text-left rounded-xl border overflow-hidden hover:shadow-sm transition-shadow flex"
+                    className="w-full text-left rounded-xl border overflow-hidden hover:shadow-sm transition-shadow flex scroll-mt-20 md:scroll-mt-0"
                     style={{
                       backgroundColor: 'var(--bg-card)',
                       borderColor: isHighlighted ? 'var(--brand-crimson)' : 'rgba(0,0,0,0.05)',


### PR DESCRIPTION
## Summary
- Clicking the Agenda tab (or opening a deep-linked event) auto-scrolls via `scrollIntoView()`, which lands the target flush at the viewport top on mobile — where the fixed `Header` covers it, hiding the very content the scroll was meant to reveal.
- Adds `scroll-mt-20 md:scroll-mt-0` to the two scroll targets in `AgendaView.tsx` (the auto-scroll-to-today date group, and the deep-linked/highlighted event). This reuses the existing `pt-20` (80px) clearance already established elsewhere in the codebase for this same fixed header, applied only on mobile since desktop Agenda scrolls inside its own sized container below the header and isn't affected.
- Also adds a `.gitignore` entry for `/.clerk/` (local Clerk dev config, can include secrets) — picked up as a pre-existing uncommitted change on this branch.

## Test plan
- [ ] On a 390px-wide viewport, open `/calendar`, switch to Agenda, and confirm today's date group lands fully below the navbar (not hidden underneath it).
- [ ] Deep-link to a specific event (`?event=<id>`) on Agenda and confirm the highlighted event is not obscured by the navbar.
- [ ] Confirm desktop Agenda scrolling is unaffected (still scrolls flush within its own container).

Note: local browser verification was blocked this session by Docker Desktop instability preventing the local Supabase stack from starting; the fix is verified by code inspection against the codebase's existing header-offset convention (`pt-20` in `app/(dashboard)/layout.tsx`, `Header.tsx`'s `top-4` + `h-14` = 72px) but has not been click-tested live. Please verify visually on the preview deploy before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)