### PR TITLE
feat(los): CORE self-service LOS uploads staged for admin review

### DIFF
--- a/app/(dashboard)/los/lib/los-utils.ts
+++ b/app/(dashboard)/los/lib/los-utils.ts
@@ -24,6 +24,8 @@ export type LOSNode = {
   qualified_legs: number | null
   annual_ppv: number | null
   renewal_date: string | null
+  last_synced_at?: string | null
+  last_updated_by_abo?: string | null
   vital_signs: VitalSign[]
   children?: LOSNode[]
 }

--- a/app/(dashboard)/profile/components/LosUploadSection.tsx
+++ b/app/(dashboard)/profile/components/LosUploadSection.tsx
@@ -1,13 +1,15 @@
+import Link from 'next/link'
+
 export function LosUploadSection() {
   return (
     <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
       <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-4 pr-16" style={{ color: 'var(--brand-teal)' }}>My LOS</p>
-      <a href="/profile/los-upload"
+      <Link href="/profile/los-upload"
         style={{ backgroundColor: 'var(--brand-forest)', color: 'var(--brand-parchment)' }}
         className="rounded-xl px-4 py-3 inline-flex flex-col gap-1 hover:opacity-80 transition-opacity">
         <span className="text-xs font-bold tracking-widest uppercase" style={{ color: 'var(--brand-parchment)' }}>Upload my LOS</span>
         <span className="text-[10px] opacity-60" style={{ color: 'var(--brand-parchment)' }}>Submit your downline for review</span>
-      </a>
+      </Link>
     </div>
   )
 }

--- a/app/(dashboard)/profile/components/LosUploadSection.tsx
+++ b/app/(dashboard)/profile/components/LosUploadSection.tsx
@@ -1,0 +1,13 @@
+export function LosUploadSection() {
+  return (
+    <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+      <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-4 pr-16" style={{ color: 'var(--brand-teal)' }}>My LOS</p>
+      <a href="/profile/los-upload"
+        style={{ backgroundColor: 'var(--brand-forest)', color: 'var(--brand-parchment)' }}
+        className="rounded-xl px-4 py-3 inline-flex flex-col gap-1 hover:opacity-80 transition-opacity">
+        <span className="text-xs font-bold tracking-widest uppercase" style={{ color: 'var(--brand-parchment)' }}>Upload my LOS</span>
+        <span className="text-[10px] opacity-60" style={{ color: 'var(--brand-parchment)' }}>Submit your downline for review</span>
+      </a>
+    </div>
+  )
+}

--- a/app/(dashboard)/profile/components/ProfileClient.tsx
+++ b/app/(dashboard)/profile/components/ProfileClient.tsx
@@ -29,6 +29,7 @@ import { ParticipationSection, PARTICIPATION_MIN_HEIGHT } from './ParticipationS
 import { CalendarSection, CALENDAR_MIN_HEIGHT } from './CalendarSection'
 import { StatsSection, STATS_MIN_HEIGHT } from './StatsSection'
 import { AdminSection } from './AdminSection'
+import { LosUploadSection } from './LosUploadSection'
 import { EmailPrefsSection, EMAIL_PREFS_MIN_HEIGHT } from './EmailPrefsSection'
 import { InvitesBento } from './InvitesBento'
 import { type Profile } from '../types'
@@ -61,6 +62,7 @@ const BENTO_IDS = {
   STATS:            'stats',
   ADMIN:            'admin',
   INVITES:          'invites',
+  LOS_UPLOAD:       'los-upload',
 }
 
 const DEFAULT_ORDER: string[] = [
@@ -76,6 +78,7 @@ const DEFAULT_ORDER: string[] = [
   BENTO_IDS.EMAIL_PREFS,
   BENTO_IDS.STATS,
   BENTO_IDS.INVITES,
+  BENTO_IDS.LOS_UPLOAD,
   BENTO_IDS.ADMIN,
 ]
 
@@ -91,6 +94,7 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
 
   const isGuest = role === 'guest' && !aboNumber
   const isAdmin = role === 'admin'
+  const isCore = role === 'core'
 
   const [bentoOrder, setBentoOrder]         = useState<string[]>(DEFAULT_ORDER)
   const [bentoCollapsed, setBentoCollapsed] = useState<Record<string, boolean>>({})
@@ -231,6 +235,10 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
     [BENTO_IDS.ADMIN]: isAdmin ? {
       colSpan: 6, minHeight: BENTO_HEIGHT.S,
       node: <AdminSection />,
+    } : null,
+    [BENTO_IDS.LOS_UPLOAD]: isCore ? {
+      colSpan: 6, minHeight: BENTO_HEIGHT.S,
+      node: <LosUploadSection />,
     } : null,
   }
 

--- a/app/(dashboard)/profile/los-upload/LosUploadClient.tsx
+++ b/app/(dashboard)/profile/los-upload/LosUploadClient.tsx
@@ -41,7 +41,7 @@ const ROOT_ERROR: Record<string, string> = {
 }
 
 function fmtDate(iso: string) {
-  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC' })
 }
 
 export function LosUploadClient({ aboNumber }: { aboNumber: string | null }) {
@@ -49,6 +49,7 @@ export function LosUploadClient({ aboNumber }: { aboNumber: string | null }) {
   const { fileRef, files, assembly, handleFileAdd, handleFileDrop, removeFile, reset } = useAssembly()
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [withdrawError, setWithdrawError] = useState<string | null>(null)
 
   const { data: submissionsData } = useQuery<{ submissions: Submission[]; abo_number: string | null }>({
     queryKey: ['my-los-submissions'],
@@ -115,10 +116,16 @@ export function LosUploadClient({ aboNumber }: { aboNumber: string | null }) {
   }
 
   async function handleWithdraw(id: string) {
+    setWithdrawError(null)
     try {
       await apiClient('/api/profile/los-submission', { method: 'PATCH', body: JSON.stringify({ id }) })
+    } catch (err: unknown) {
+      // A withdraw can lose a race (already approved/rejected) — say so, and still
+      // refresh so the list shows the status that actually won.
+      setWithdrawError(err instanceof Error ? err.message : 'Withdraw failed')
+    } finally {
       qc.invalidateQueries({ queryKey: ['my-los-submissions'] })
-    } catch { /* surfaced via list refresh */ }
+    }
   }
 
   const submissions = submissionsData?.submissions ?? []
@@ -213,6 +220,7 @@ export function LosUploadClient({ aboNumber }: { aboNumber: string | null }) {
       {/* My submissions */}
       <div className="space-y-2">
         <p className="text-xs font-semibold tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>My submissions</p>
+        {withdrawError && <p className="text-sm" style={{ color: '#bc4749' }}>{withdrawError}</p>}
         {submissions.length === 0 ? (
           <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No submissions yet.</p>
         ) : (

--- a/app/(dashboard)/profile/los-upload/LosUploadClient.tsx
+++ b/app/(dashboard)/profile/los-upload/LosUploadClient.tsx
@@ -1,0 +1,241 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/lib/apiClient'
+import { checkSubmissionRoot } from '@/lib/csv-import'
+import { useAssembly } from '@/components/los-import/useAssembly'
+import { DropZone } from '@/components/los-import/DropZone'
+import { AssemblySummary } from '@/components/los-import/AssemblySummary'
+import { SubtreePreview, type ChangeStatus, type NodeMeta } from '@/components/los-import/SubtreePreview'
+
+type Submission = {
+  id: string
+  root_abo_number: string
+  row_count: number
+  status: 'pending' | 'approved' | 'rejected' | 'withdrawn'
+  admin_note: string | null
+  created_at: string
+  resolved_at: string | null
+}
+
+type TreeNode = {
+  abo_number: string | null
+  abo_level: string | null
+  bonus_percent: number | null
+  last_synced_at: string | null
+  last_updated_by_abo: string | null
+}
+
+const STATUS_STYLE: Record<Submission['status'], { bg: string; color: string; label: string }> = {
+  pending:   { bg: '#f2cc8f33', color: '#7a5c00', label: 'Pending admin review' },
+  approved:  { bg: '#1a3c2e18', color: '#1a3c2e', label: 'Approved & imported' },
+  rejected:  { bg: '#bc474915', color: '#bc4749', label: 'Rejected' },
+  withdrawn: { bg: 'rgba(0,0,0,0.05)', color: 'var(--text-secondary)', label: 'Withdrawn' },
+}
+
+const ROOT_ERROR: Record<string, string> = {
+  'no-root': 'This file has no single tree root (it may be cyclic). Export your full downline and try again.',
+  'multi-root': 'This file has more than one top node. Upload only your own connected sub-tree.',
+  'mismatch': 'The top of this tree does not match your ABO number — you can only upload your own part.',
+}
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+export function LosUploadClient({ aboNumber }: { aboNumber: string | null }) {
+  const qc = useQueryClient()
+  const { fileRef, files, assembly, handleFileAdd, handleFileDrop, removeFile, reset } = useAssembly()
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const { data: submissionsData } = useQuery<{ submissions: Submission[]; abo_number: string | null }>({
+    queryKey: ['my-los-submissions'],
+    queryFn: () => apiClient('/api/profile/los-submission'),
+  })
+
+  // Current subtree — used to tint the preview by what changes.
+  const { data: treeData } = useQuery<{ nodes: TreeNode[] }>({
+    queryKey: ['my-los-tree'],
+    queryFn: () => apiClient('/api/los/tree'),
+  })
+
+  const existingByAbo = useMemo(() => {
+    const m = new Map<string, TreeNode>()
+    for (const n of treeData?.nodes ?? []) if (n.abo_number) m.set(n.abo_number, n)
+    return m
+  }, [treeData])
+
+  const rootCheck = assembly && aboNumber ? checkSubmissionRoot(assembly.rows, aboNumber) : null
+
+  const changeStatus = useMemo(() => {
+    const map: Record<string, ChangeStatus> = {}
+    for (const r of assembly?.rows ?? []) {
+      const abo = r.abo_number
+      if (!abo) continue
+      const prev = existingByAbo.get(abo)
+      if (!prev) { map[abo] = 'new'; continue }
+      if ((prev.abo_level ?? '') !== (r.abo_level ?? '')) { map[abo] = 'level'; continue }
+      const newBonus = r.bonus_percent ? Number(r.bonus_percent) : 0
+      if (Math.abs(newBonus - (prev.bonus_percent ?? 0)) >= 3) { map[abo] = 'bonus'; continue }
+      map[abo] = 'unchanged'
+    }
+    return map
+  }, [assembly, existingByAbo])
+
+  // Persisted last-updated info per node — flags rows an upline last touched.
+  const meta = useMemo(() => {
+    const map: Record<string, NodeMeta> = {}
+    for (const [abo, n] of existingByAbo.entries()) {
+      map[abo] = {
+        lastUpdated: n.last_synced_at,
+        byUpline: !!n.last_updated_by_abo && n.last_updated_by_abo !== abo,
+      }
+    }
+    return map
+  }, [existingByAbo])
+
+  async function handleSubmit() {
+    if (!assembly || !rootCheck?.ok) return
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      await apiClient('/api/profile/los-submission', {
+        method: 'POST',
+        body: JSON.stringify({ rows: assembly.rows }),
+      })
+      reset()
+      qc.invalidateQueries({ queryKey: ['my-los-submissions'] })
+    } catch (err: unknown) {
+      setSubmitError(err instanceof Error ? err.message : 'Submission failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleWithdraw(id: string) {
+    try {
+      await apiClient('/api/profile/los-submission', { method: 'PATCH', body: JSON.stringify({ id }) })
+      qc.invalidateQueries({ queryKey: ['my-los-submissions'] })
+    } catch { /* surfaced via list refresh */ }
+  }
+
+  const submissions = submissionsData?.submissions ?? []
+
+  if (!aboNumber) {
+    return (
+      <div className="py-8 max-w-[900px] mx-auto px-4 sm:px-6">
+        <h1 className="font-display text-2xl font-semibold mb-2" style={{ color: 'var(--text-primary)' }}>Upload your LOS</h1>
+        <div className="rounded-xl border px-5 py-8 text-center" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            You need a verified ABO number before you can upload your part of the LOS. Verify your ABO in your profile first.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="py-8 pb-16 max-w-[900px] mx-auto px-4 sm:px-6 space-y-6">
+      <div>
+        <h1 className="font-display text-2xl font-semibold mb-1" style={{ color: 'var(--text-primary)' }}>Upload your LOS</h1>
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+          Upload the CSV export of your own downline (rooted at your ABO <span className="font-mono">{aboNumber}</span>).
+          It will be sent to an admin for review before it goes live.
+        </p>
+      </div>
+
+      <details className="rounded-xl border" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
+        <summary className="cursor-pointer px-4 py-3 text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+          How to export your LOS as a CSV
+        </summary>
+        <div className="px-4 pb-4 text-sm space-y-1.5" style={{ color: 'var(--text-secondary)' }}>
+          <ol className="list-decimal ml-4 space-y-1.5">
+            <li>Sign in to your Amway business portal (the official back-office / business reports site).</li>
+            <li>Open your <strong>LOS / downline (genealogy) report</strong> for the period you want.</li>
+            <li>Choose <strong>Export</strong> and select <strong>CSV</strong> as the format (not PDF or XLSX).</li>
+            <li>Make sure the export includes the <strong>ABO Number</strong> and <strong>Sponsor ABO Number</strong> columns — they are required to build the tree. English or Bulgarian column headers are both supported.</li>
+            <li>Save the file, then drag it into the box below (you can add several files if your export is split).</li>
+          </ol>
+          <p className="text-xs pt-1">
+            The top of your file must be your own ABO (<span className="font-mono">{aboNumber}</span>) — you can only submit your own part of the tree.
+          </p>
+        </div>
+      </details>
+
+      <DropZone
+        fileRef={fileRef}
+        files={files}
+        onFileAdd={handleFileAdd}
+        onFileDrop={handleFileDrop}
+        removeFile={removeFile}
+      />
+
+      {assembly && (
+        <>
+          <AssemblySummary assembly={assembly} sourceCount={files.length} />
+
+          {rootCheck && !rootCheck.ok && (
+            <div className="p-4 rounded-lg border" style={{ backgroundColor: 'rgba(188,71,73,0.06)', borderColor: 'rgba(188,71,73,0.3)' }}>
+              <p className="text-sm" style={{ color: '#bc4749' }}>{ROOT_ERROR[rootCheck.reason]}</p>
+              {rootCheck.reason === 'mismatch' && (
+                <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>
+                  Found root: <span className="font-mono">{rootCheck.roots[0]}</span> · your ABO: <span className="font-mono">{aboNumber}</span>
+                </p>
+              )}
+            </div>
+          )}
+
+          {rootCheck?.ok && (
+            <div className="space-y-2">
+              <p className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>Preview — what your upload changes</p>
+              <SubtreePreview rows={assembly.rows} anchorAbo={aboNumber} changeStatus={changeStatus} meta={meta} />
+              <p className="text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+                Tinted by change: <span style={{ color: '#2d6a4f' }}>new</span> · <span style={{ color: '#3d405b' }}>level</span> · <span style={{ color: '#e07a5f' }}>bonus</span>.
+                “upd · upline” (orange) marks members an upline last updated.
+              </p>
+            </div>
+          )}
+
+          {submitError && <p className="text-sm" style={{ color: '#bc4749' }}>{submitError}</p>}
+
+          <button
+            onClick={handleSubmit}
+            disabled={!rootCheck?.ok || submitting}
+            className="bg-[#bc4749] text-white px-6 py-2 rounded-lg text-sm font-medium disabled:opacity-50"
+          >
+            {submitting ? 'Submitting…' : `Submit for review (${assembly.total_row_count} members)`}
+          </button>
+        </>
+      )}
+
+      {/* My submissions */}
+      <div className="space-y-2">
+        <p className="text-xs font-semibold tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>My submissions</p>
+        {submissions.length === 0 ? (
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No submissions yet.</p>
+        ) : (
+          submissions.map(sub => {
+            const s = STATUS_STYLE[sub.status]
+            return (
+              <div key={sub.id} className="rounded-xl border px-4 py-3" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{sub.row_count} members</span>
+                  <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full" style={{ backgroundColor: s.bg, color: s.color }}>{s.label}</span>
+                  <span className="text-xs ml-auto" style={{ color: 'var(--text-secondary)' }}>{fmtDate(sub.created_at)}</span>
+                  {sub.status === 'pending' && (
+                    <button onClick={() => handleWithdraw(sub.id)} className="text-xs px-2 py-1 rounded-lg border" style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>
+                      Withdraw
+                    </button>
+                  )}
+                </div>
+                {sub.admin_note && <p className="text-xs mt-1 italic" style={{ color: 'var(--text-secondary)' }}>Note: {sub.admin_note}</p>}
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/(dashboard)/profile/los-upload/page.tsx
+++ b/app/(dashboard)/profile/los-upload/page.tsx
@@ -1,0 +1,23 @@
+import { auth } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+import { createServiceClient } from '@/lib/supabase/service'
+import { LosUploadClient } from './LosUploadClient'
+
+// CORE self-service LOS upload. CORE (and admin) only; a member without a
+// verified ABO can't be scoped, so they see a prompt to verify first.
+export default async function LosUploadPage() {
+  const { userId } = await auth()
+  if (!userId) redirect('/sign-in')
+
+  const supabase = createServiceClient()
+  const { data } = await supabase
+    .from('profiles')
+    .select('id, role, abo_number')
+    .eq('clerk_id', userId)
+    .single()
+
+  if (!data) redirect('/')
+  if (data.role !== 'core' && data.role !== 'admin') redirect('/profile')
+
+  return <LosUploadClient aboNumber={data.abo_number ?? null} />
+}

--- a/app/admin/approval-hub/components/LosSubmissionsTab.tsx
+++ b/app/admin/approval-hub/components/LosSubmissionsTab.tsx
@@ -28,7 +28,7 @@ const STATUS_STYLE: Record<LosSubmission['status'], { bg: string; color: string;
 }
 
 function fmtDate(iso: string) {
-  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC' })
 }
 function fullName(p: Submitter | null) {
   if (!p) return '—'

--- a/app/admin/approval-hub/components/LosSubmissionsTab.tsx
+++ b/app/admin/approval-hub/components/LosSubmissionsTab.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/lib/apiClient'
+import { JunctionPanel } from '@/components/los-import/AssemblySummary'
+import type { JunctionNode } from '@/lib/csv-import'
+
+type Submitter = { first_name: string; last_name: string; abo_number: string | null }
+
+export type LosSubmission = {
+  id: string
+  root_abo_number: string
+  row_count: number
+  status: 'pending' | 'approved' | 'rejected'
+  admin_note: string | null
+  created_at: string
+  resolved_at: string | null
+  profiles: Submitter | null
+}
+
+type ApproveResult = { inserted: number; import_id: string; approved: number; junctions: JunctionNode[]; conflicts: JunctionNode[]; row_count: number }
+
+const STATUS_STYLE: Record<LosSubmission['status'], { bg: string; color: string; label: string }> = {
+  pending:  { bg: '#f2cc8f33', color: '#7a5c00', label: 'Pending' },
+  approved: { bg: '#1a3c2e18', color: '#1a3c2e', label: 'Approved' },
+  rejected: { bg: '#bc474915', color: '#bc4749', label: 'Rejected' },
+}
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+function fullName(p: Submitter | null) {
+  if (!p) return '—'
+  return `${p.first_name} ${p.last_name}`.trim()
+}
+
+export function LosSubmissionsTab() {
+  const qc = useQueryClient()
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<ApproveResult | null>(null)
+
+  const { data: submissions = [], isLoading } = useQuery<LosSubmission[]>({
+    queryKey: ['los-submissions'],
+    queryFn: async () => (await apiClient<{ submissions: LosSubmission[] }>('/api/admin/los-submission')).submissions,
+  })
+
+  const pending = submissions.filter(s => s.status === 'pending')
+
+  function toggle(id: string) {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id); else next.add(id)
+      return next
+    })
+  }
+
+  async function approve() {
+    if (selected.size === 0) return
+    setBusy(true); setError(null); setResult(null)
+    try {
+      const res = await apiClient<ApproveResult>('/api/admin/los-submission', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'approve', ids: [...selected] }),
+      })
+      setResult(res)
+      setSelected(new Set())
+      qc.invalidateQueries({ queryKey: ['los-submissions'] })
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Approve failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function reject(id: string) {
+    setBusy(true); setError(null)
+    try {
+      await apiClient('/api/admin/los-submission', { method: 'POST', body: JSON.stringify({ action: 'reject', id }) })
+      qc.invalidateQueries({ queryKey: ['los-submissions'] })
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Reject failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs font-semibold tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>
+        {pending.length} pending submission{pending.length !== 1 ? 's' : ''}
+      </p>
+      <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+        Select CORE submissions to merge (deepest-owner-wins per ABO) and import in one authoritative step.
+      </p>
+
+      {error && <p className="text-sm" style={{ color: '#bc4749' }}>{error}</p>}
+
+      {result && (
+        <div className="p-4 rounded-xl border" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
+          <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            Imported {result.inserted} rows from {result.approved} submission{result.approved !== 1 ? 's' : ''}.
+          </p>
+          <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>Import ID: <span className="font-mono">{result.import_id}</span></p>
+          {result.conflicts.length > 0 && (
+            <p className="text-xs mt-1" style={{ color: '#e07a5f' }}>{result.conflicts.length} contested node(s) — deepest owner won each.</p>
+          )}
+          <JunctionPanel junctions={result.junctions} ownerLabel="owners" />
+        </div>
+      )}
+
+      {selected.size > 0 && (
+        <button onClick={approve} disabled={busy} className="bg-[#bc4749] text-white px-6 py-2 rounded-lg text-sm font-medium disabled:opacity-50">
+          {busy ? 'Importing…' : `Approve & import (${selected.size} selected)`}
+        </button>
+      )}
+
+      {isLoading ? (
+        <div className="space-y-2">{[...Array(3)].map((_, i) => <div key={i} className="h-16 bg-black/5 rounded-xl animate-pulse" />)}</div>
+      ) : submissions.length === 0 ? (
+        <div className="rounded-xl border px-5 py-8 text-center" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
+          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>No submissions yet.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {submissions.map(sub => {
+            const s = STATUS_STYLE[sub.status]
+            const isPending = sub.status === 'pending'
+            return (
+              <div key={sub.id} className="rounded-xl border px-4 py-3.5" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
+                <div className="flex items-start gap-3">
+                  {isPending && (
+                    <input type="checkbox" checked={selected.has(sub.id)} onChange={() => toggle(sub.id)} className="mt-1" aria-label={`Select submission from ${fullName(sub.profiles)}`} />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-0.5 flex-wrap">
+                      <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{fullName(sub.profiles)}</p>
+                      <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full" style={{ backgroundColor: s.bg, color: s.color }}>{s.label}</span>
+                    </div>
+                    <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                      Root ABO <span className="font-mono">{sub.root_abo_number}</span> · {sub.row_count} members · {fmtDate(sub.created_at)}
+                    </p>
+                    {sub.admin_note && <p className="text-xs mt-1 italic" style={{ color: 'var(--text-secondary)' }}>Note: {sub.admin_note}</p>}
+                  </div>
+                  {isPending && (
+                    <button onClick={() => reject(sub.id)} disabled={busy} className="text-xs px-3 py-1.5 rounded-lg border disabled:opacity-50" style={{ borderColor: '#bc4749', color: '#bc4749' }}>
+                      Reject
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/approval-hub/page.tsx
+++ b/app/admin/approval-hub/page.tsx
@@ -9,6 +9,7 @@ import { TripRegistrationsTab } from './components/TripRegistrationsTab'
 import { AboVerificationTab } from './components/VerificationsTab'
 import { EventRolesTab } from './components/EventRolesTab'
 import { SpouseLinkRequestsTab } from './components/SpouseLinkRequestsTab'
+import { LosSubmissionsTab, type LosSubmission } from './components/LosSubmissionsTab'
 import type { TripRegistration } from './components/TripRegistrationsTab'
 import type { SpouseLinkRequest } from './components/SpouseLinkRequestsTab'
 
@@ -17,7 +18,7 @@ import type { SpouseLinkRequest } from './components/SpouseLinkRequestsTab'
 function ApprovalHubInner() {
   const searchParams = useSearchParams()
   const router = useRouter()
-  const tab = (searchParams.get('tab') ?? 'trips') as 'trips' | 'roles' | 'abo' | 'spouse'
+  const tab = (searchParams.get('tab') ?? 'trips') as 'trips' | 'roles' | 'abo' | 'spouse' | 'los'
 
   const { data: registrations = [] } = useQuery<TripRegistration[]>({
     queryKey: ['registrations', 'all'],
@@ -36,15 +37,22 @@ function ApprovalHubInner() {
     queryFn: () => fetchJson<SpouseLinkRequest[]>('/api/admin/spouse-link-requests'),
   })
 
+  const { data: losSubmissions = [] } = useQuery<LosSubmission[]>({
+    queryKey: ['los-submissions'],
+    queryFn: async () => (await fetchJson<{ submissions: LosSubmission[] }>('/api/admin/los-submission')).submissions,
+  })
+
   const pendingTrips  = registrations.filter(r => r.status === 'pending').length
   const pendingRoles  = roleRequests.filter(r => r.status === 'pending').length
   const pendingSpouse = spouseRequests.filter(r => r.status === 'pending').length
+  const pendingLos    = losSubmissions.filter(r => r.status === 'pending').length
 
   const tabsWithBadges = [
     { key: 'trips',  label: 'Trip Registrations',   badge: pendingTrips  },
     { key: 'roles',  label: 'Event Roles',           badge: pendingRoles  },
     { key: 'abo',    label: 'ABO Verification',      badge: 0             },
     { key: 'spouse', label: 'Co-ownership Requests', badge: pendingSpouse },
+    { key: 'los',    label: 'LOS Submissions',       badge: pendingLos    },
   ]
 
   return (
@@ -65,6 +73,7 @@ function ApprovalHubInner() {
         <TabsContent value="roles"><EventRolesTab /></TabsContent>
         <TabsContent value="abo"><AboVerificationTab /></TabsContent>
         <TabsContent value="spouse"><SpouseLinkRequestsTab /></TabsContent>
+        <TabsContent value="los"><LosSubmissionsTab /></TabsContent>
       </AdminTabs>
     </div>
   )

--- a/app/admin/members/components/DataCenterTab.tsx
+++ b/app/admin/members/components/DataCenterTab.tsx
@@ -2,10 +2,11 @@
 
 import { useState } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
-import { type JunctionNode } from '@/lib/csv-import'
 import { ReconciliationPanel } from './ReconciliationPanel'
 import { useLosImport, type LOSStatus, type PurgeResult } from './useLosImport'
 import type { AssemblyResult } from '@/lib/csv-import'
+import { DropZone } from '@/components/los-import/DropZone'
+import { AssemblySummary } from '@/components/los-import/AssemblySummary'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -39,39 +40,6 @@ function DiffSection({
         </svg>
       </button>
       {open && <div className="mt-2 space-y-1">{children}</div>}
-    </div>
-  )
-}
-
-// ── JunctionPanel ─────────────────────────────────────────────────────────────
-
-function JunctionPanel({ junctions }: { junctions: JunctionNode[] }) {
-  if (junctions.length === 0) return null
-  return (
-    <div className="p-4 rounded-xl border mt-4" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
-      <p className="text-xs font-semibold mb-2" style={{ color: 'var(--text-primary)' }}>
-        Junction nodes ({junctions.length})
-      </p>
-      <div className="space-y-2">
-        {junctions.map(j => (
-          <div key={j.abo_number}
-            className="flex flex-wrap items-start gap-2 text-xs px-3 py-2 rounded-lg"
-            style={{ backgroundColor: j.has_conflict ? 'rgba(224,122,95,0.08)' : 'rgba(129,178,154,0.08)' }}>
-            <span className="font-mono font-medium" style={{ color: 'var(--text-primary)' }}>{j.abo_number}</span>
-            <span style={{ color: 'var(--text-secondary)' }}>{j.name}</span>
-            <span className="ml-auto text-xs px-1.5 py-0.5 rounded-full font-semibold"
-              style={{
-                backgroundColor: j.has_conflict ? 'rgba(224,122,95,0.2)' : 'rgba(129,178,154,0.2)',
-                color: j.has_conflict ? '#e07a5f' : '#2d6a4f',
-              }}>
-              {j.has_conflict ? `data discrepancy: ${j.conflict_fields.join(', ')} · first-seen wins` : 'clean'}
-            </span>
-            <span className="w-full text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
-              in: {j.files.join(', ')}
-            </span>
-          </div>
-        ))}
-      </div>
     </div>
   )
 }
@@ -189,74 +157,15 @@ export function DataCenterTab() {
           </div>
         )}
 
-        {/* Drop zone */}
-        <div
-          className="border-2 border-dashed rounded-lg p-8 text-center"
-          style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}
-          onDragOver={e => e.preventDefault()}
-          onDrop={handleFileDrop}
-        >
-          <input
-            ref={fileRef}
-            type="file"
-            accept=".csv"
-            multiple
-            onChange={handleFileAdd}
-            className="hidden"
-            id="csv-upload"
-          />
-          <label htmlFor="csv-upload" className="cursor-pointer">
-            <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-              {files.length === 0 ? 'Click or drag CSV files here' : 'Add more files'}
-            </p>
-            <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>.csv only · multiple files supported</p>
-          </label>
-        </div>
+        <DropZone
+          fileRef={fileRef}
+          files={files}
+          onFileAdd={handleFileAdd}
+          onFileDrop={handleFileDrop}
+          removeFile={removeFile}
+        />
 
-        {/* File chips */}
-        {files.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {files.map(f => (
-              <div
-                key={f.filename}
-                className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full border"
-                style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)', color: 'var(--text-primary)' }}
-              >
-                <span>{f.filename}</span>
-                <span style={{ color: 'var(--text-secondary)' }}>({f.rows.length} rows)</span>
-                <button
-                  onClick={() => removeFile(f.filename)}
-                  className="ml-1 rounded-full w-4 h-4 flex items-center justify-center hover:opacity-70"
-                  style={{ color: 'var(--text-secondary)' }}
-                >
-                  ×
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Assembly status */}
-        {assembly && (
-          <>
-            <div className="p-4 rounded-xl border" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
-              <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-                Assembly: {assembly.total_row_count} unique members from {files.length} file{files.length !== 1 ? 's' : ''}
-              </p>
-              {assembly.disconnected_files.length > 0 && (
-                <div className="mt-2 p-3 rounded-lg" style={{ backgroundColor: 'rgba(224,122,95,0.08)' }}>
-                  <p className="text-xs font-semibold" style={{ color: '#e07a5f' }}>
-                    ⚠ Potentially disconnected file{assembly.disconnected_files.length !== 1 ? 's' : ''}: {assembly.disconnected_files.join(', ')}
-                  </p>
-                  <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>
-                    These files share no ABO numbers with any other loaded file. Verify they are part of the same tree.
-                  </p>
-                </div>
-              )}
-            </div>
-            <JunctionPanel junctions={assembly.junctions} />
-          </>
-        )}
+        {assembly && <AssemblySummary assembly={assembly} sourceCount={files.length} />}
 
         {canReview && (
           <div className="flex flex-wrap gap-3 items-start">

--- a/app/admin/members/components/useLosImport.ts
+++ b/app/admin/members/components/useLosImport.ts
@@ -1,8 +1,9 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { apiClient } from '@/lib/apiClient'
-import { parseCSV, assembleFiles, type ImportResult, type AssemblyResult } from '@/lib/csv-import'
+import { type ImportResult } from '@/lib/csv-import'
+import { useAssembly, type FileEntry } from '@/components/los-import/useAssembly'
 
-export type FileEntry = { filename: string; rows: Record<string, string>[] }
+export type { FileEntry }
 
 export type LOSStatus = {
   row_count: number
@@ -15,26 +16,10 @@ export type PurgeResult = { removed: number; import_id: string }
 
 export type Phase = 'assembly' | 'diff' | 'result'
 
-function readCsvFiles(fileList: File[]): Promise<FileEntry[]> {
-  const readers = fileList.map(file => new Promise<FileEntry>((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = ev => {
-      const text = (ev.target?.result as string).replace(/^﻿/, '')
-      resolve({ filename: file.name, rows: parseCSV(text) })
-    }
-    reader.onerror = reject
-    reader.readAsText(file)
-  }))
-  return Promise.all(readers)
-}
-
 export function useLosImport() {
-  const fileRef = useRef<HTMLInputElement>(null)
+  const { fileRef, files, assembly, handleFileAdd, handleFileDrop, removeFile, reset: resetAssembly } = useAssembly()
 
   const [phase, setPhase] = useState<Phase>('assembly')
-
-  const [files, setFiles] = useState<FileEntry[]>([])
-  const [assembly, setAssembly] = useState<AssemblyResult | null>(null)
 
   const [losStatus, setLosStatus] = useState<LOSStatus | null>(null)
 
@@ -57,36 +42,6 @@ export function useLosImport() {
   useEffect(() => {
     refreshLosStatus()
   }, [])
-
-  useEffect(() => {
-    if (files.length === 0) { setAssembly(null); return }
-    setAssembly(assembleFiles(files))
-  }, [files])
-
-  function addFiles(newEntries: FileEntry[]) {
-    setFiles(prev => {
-      const existing = new Set(prev.map(f => f.filename))
-      return [...prev, ...newEntries.filter(e => !existing.has(e.filename))]
-    })
-  }
-
-  function handleFileAdd(e: React.ChangeEvent<HTMLInputElement>) {
-    const added = Array.from(e.target.files ?? [])
-    if (added.length === 0) return
-    if (fileRef.current) fileRef.current.value = ''
-    readCsvFiles(added).then(addFiles).catch(() => null)
-  }
-
-  function handleFileDrop(e: React.DragEvent<HTMLDivElement>) {
-    e.preventDefault()
-    const droppedFiles = Array.from(e.dataTransfer.files).filter(f => f.name.endsWith('.csv'))
-    if (droppedFiles.length === 0) return
-    readCsvFiles(droppedFiles).then(addFiles).catch(() => null)
-  }
-
-  function removeFile(filename: string) {
-    setFiles(prev => prev.filter(f => f.filename !== filename))
-  }
 
   async function handleImport() {
     if (!assembly) return
@@ -118,8 +73,7 @@ export function useLosImport() {
         body: JSON.stringify({ import_id: result.import_id }),
       })
       setResult(null)
-      setFiles([])
-      setAssembly(null)
+      resetAssembly()
       setPhase('assembly')
       refreshLosStatus()
     } catch (err: unknown) {
@@ -163,8 +117,7 @@ export function useLosImport() {
 
   function resetForNewImport() {
     setPhase('assembly')
-    setFiles([])
-    setAssembly(null)
+    resetAssembly()
     setResult(null)
     setPurgeResult(null)
   }

--- a/app/api/admin/los-submission/route.ts
+++ b/app/api/admin/los-submission/route.ts
@@ -65,19 +65,30 @@ export async function POST(req: NextRequest) {
     return Response.json({ error: 'No submissions selected' }, { status: 400 })
   }
 
-  const { data: subs, error: loadError } = await supabase
-    .from('los_submission_requests')
-    .select('id, root_abo_number, created_at, rows, status')
-    .in('id', ids)
+  // Atomically claim the still-pending submissions (pending -> approved, RETURNING
+  // the payload). Whatever comes back is provably still pending at claim time, so a
+  // concurrent withdraw either wins the race outright (the row is not returned and
+  // never gets imported) or loses it cleanly. Never merge off a pre-read snapshot:
+  // that let a withdrawal land after the data was already written.
+  const { data: claimed, error: claimError } = await supabase.rpc('claim_los_submissions', {
+    p_ids: ids,
+    p_resolved_by: profile.id,
+  })
+  if (claimError) return Response.json({ error: claimError.message }, { status: 500 })
 
-  if (loadError) return Response.json({ error: loadError.message }, { status: 500 })
-  const pending = (subs ?? []).filter(s => s.status === 'pending')
-  if (pending.length === 0) {
+  const claimedRows = claimed ?? []
+  if (claimedRows.length === 0) {
     return Response.json({ error: 'No pending submissions in selection' }, { status: 400 })
   }
+  const claimedIds = claimedRows.map(s => s.id)
 
-  // Merge the selected parts — deepest-owner-wins per ABO.
-  const inputs: SubmissionInput[] = pending.map(s => ({
+  // From here on the claim is held: any early return must release it.
+  const release = async () => {
+    await supabase.rpc('release_los_submissions', { p_ids: claimedIds })
+  }
+
+  // Merge the claimed parts — deepest-owner-wins per ABO.
+  const inputs: SubmissionInput[] = claimedRows.map(s => ({
     rootAbo: s.root_abo_number,
     createdAt: s.created_at,
     rows: (s.rows as unknown as Record<string, string>[]) ?? [],
@@ -85,6 +96,7 @@ export async function POST(req: NextRequest) {
   const merged = mergeSubmissions(inputs)
 
   if (merged.rows.length === 0) {
+    await release()
     return Response.json({ error: 'Merged submission is empty' }, { status: 400 })
   }
 
@@ -93,21 +105,17 @@ export async function POST(req: NextRequest) {
     p_rows: merged.rows as unknown as never,
     p_imported_by: profile.id,
   })
-  if (importError) return Response.json({ error: importError.message }, { status: 500 })
-
-  // Transition the approved submissions.
-  const approvedIds = pending.map(s => s.id)
-  const { error: approveError } = await supabase.rpc('approve_los_submissions', {
-    p_ids: approvedIds,
-    p_resolved_by: profile.id,
-  })
-  if (approveError) return Response.json({ error: approveError.message }, { status: 500 })
+  if (importError) {
+    await release()
+    return Response.json({ error: importError.message }, { status: 500 })
+  }
 
   const rpcResult = importData as { inserted: number; import_id: string; errors: unknown[] }
   return Response.json({
     inserted: rpcResult.inserted,
     import_id: rpcResult.import_id,
-    approved: approvedIds.length,
+    approved: claimedIds.length,
+    skipped: ids.length - claimedIds.length,
     junctions: merged.junctions,
     conflicts: merged.conflicts,
     row_count: merged.rows.length,

--- a/app/api/admin/los-submission/route.ts
+++ b/app/api/admin/los-submission/route.ts
@@ -1,0 +1,115 @@
+import { auth } from '@clerk/nextjs/server'
+import { NextRequest } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { getCallerContext } from '@/lib/supabase/guards'
+import { mergeSubmissions, type SubmissionInput } from '@/lib/csv-import'
+
+// Admin review of staged CORE LOS submissions. Approve merges the selected parts
+// (deepest-owner-wins) and runs the existing import_los_members RPC; reject
+// declines one. The actual los_members write stays in this route (one import).
+
+// ── GET — pending + recently resolved submissions with submitter info ──────────
+
+export async function GET() {
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { guard } = await getCallerContext(userId, supabase, 'admin')
+  if (guard) return guard
+
+  const { data, error } = await supabase
+    .from('los_submission_requests')
+    .select('id, root_abo_number, row_count, status, admin_note, created_at, resolved_at, profiles!los_submission_requests_profile_id_fkey(first_name, last_name, abo_number)')
+    .in('status', ['pending', 'approved', 'rejected'])
+    .order('created_at', { ascending: false })
+    .limit(100)
+
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+  return Response.json({ submissions: data ?? [] })
+}
+
+// ── POST — approve (merge + import) or reject ─────────────────────────────────
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const { profile, guard } = await getCallerContext(userId, supabase, 'admin')
+  if (guard) return guard
+
+  const body = await req.json().catch(() => ({}))
+  const action = body?.action as 'approve' | 'reject' | undefined
+
+  // ── Reject ────────────────────────────────────────────────────────────────
+  if (action === 'reject') {
+    const id = body?.id as string | undefined
+    if (!id) return Response.json({ error: 'Missing submission id' }, { status: 400 })
+    const { error } = await supabase.rpc('reject_los_submission', {
+      p_id: id,
+      p_note: body?.note ?? null,
+      p_resolved_by: profile.id,
+    })
+    if (error) return Response.json({ error: error.message }, { status: 500 })
+    return Response.json({ ok: true })
+  }
+
+  // ── Approve ─────────────────────────────────────────────────────────────────
+  if (action !== 'approve') {
+    return Response.json({ error: 'Unknown action' }, { status: 400 })
+  }
+
+  const ids = body?.ids as string[] | undefined
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return Response.json({ error: 'No submissions selected' }, { status: 400 })
+  }
+
+  const { data: subs, error: loadError } = await supabase
+    .from('los_submission_requests')
+    .select('id, root_abo_number, created_at, rows, status')
+    .in('id', ids)
+
+  if (loadError) return Response.json({ error: loadError.message }, { status: 500 })
+  const pending = (subs ?? []).filter(s => s.status === 'pending')
+  if (pending.length === 0) {
+    return Response.json({ error: 'No pending submissions in selection' }, { status: 400 })
+  }
+
+  // Merge the selected parts — deepest-owner-wins per ABO.
+  const inputs: SubmissionInput[] = pending.map(s => ({
+    rootAbo: s.root_abo_number,
+    createdAt: s.created_at,
+    rows: (s.rows as unknown as Record<string, string>[]) ?? [],
+  }))
+  const merged = mergeSubmissions(inputs)
+
+  if (merged.rows.length === 0) {
+    return Response.json({ error: 'Merged submission is empty' }, { status: 400 })
+  }
+
+  // Run the single authoritative import (upsert-only) via the existing RPC.
+  const { data: importData, error: importError } = await supabase.rpc('import_los_members', {
+    p_rows: merged.rows as unknown as never,
+    p_imported_by: profile.id,
+  })
+  if (importError) return Response.json({ error: importError.message }, { status: 500 })
+
+  // Transition the approved submissions.
+  const approvedIds = pending.map(s => s.id)
+  const { error: approveError } = await supabase.rpc('approve_los_submissions', {
+    p_ids: approvedIds,
+    p_resolved_by: profile.id,
+  })
+  if (approveError) return Response.json({ error: approveError.message }, { status: 500 })
+
+  const rpcResult = importData as { inserted: number; import_id: string; errors: unknown[] }
+  return Response.json({
+    inserted: rpcResult.inserted,
+    import_id: rpcResult.import_id,
+    approved: approvedIds.length,
+    junctions: merged.junctions,
+    conflicts: merged.conflicts,
+    row_count: merged.rows.length,
+  })
+}

--- a/app/api/los/tree/route.ts
+++ b/app/api/los/tree/route.ts
@@ -16,6 +16,7 @@ type LOSRow = {
   annual_ppv: number | null
   renewal_date: string | null
   last_synced_at: string | null
+  last_updated_by_abo: string | null
   profile_id: string | null
   first_name: string | null
   last_name: string | null
@@ -44,6 +45,7 @@ type SyntheticNode = {
   annual_ppv: null
   renewal_date: null
   last_synced_at: null
+  last_updated_by_abo: null
   vital_signs: VitalSign[]
 }
 
@@ -120,7 +122,7 @@ export async function GET() {
       depth: null,
       country: null, gpv: null, ppv: null, bonus_percent: null,
       group_size: null, qualified_legs: null, annual_ppv: null,
-      renewal_date: null, last_synced_at: null,
+      renewal_date: null, last_synced_at: null, last_updated_by_abo: null,
       vital_signs: vitalsForProfile(caller!.id),
     }
   }

--- a/app/api/profile/los-submission/route.ts
+++ b/app/api/profile/los-submission/route.ts
@@ -1,0 +1,123 @@
+import { auth } from '@clerk/nextjs/server'
+import { NextRequest } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { checkSubmissionRoot } from '@/lib/csv-import'
+
+// CORE self-service LOS submissions. Uploads are staged as `pending` here for
+// admin review — this route never writes to los_members.
+
+const ROOT_ERROR: Record<string, string> = {
+  'no-root': 'Your file has no single tree root (it may be cyclic). Export your full downline and try again.',
+  'multi-root': 'Your file contains more than one top node. Upload only your own connected sub-tree.',
+  'mismatch': 'The top of your uploaded tree does not match your ABO number.',
+}
+
+async function callerProfile(userId: string, supabase: ReturnType<typeof createServiceClient>) {
+  const { data } = await supabase
+    .from('profiles')
+    .select('id, role, abo_number')
+    .eq('clerk_id', userId)
+    .single()
+  return data
+}
+
+// ── GET — caller's own submissions ────────────────────────────────────────────
+
+export async function GET() {
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const profile = await callerProfile(userId, supabase)
+  if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
+
+  const { data, error } = await supabase
+    .from('los_submission_requests')
+    .select('id, root_abo_number, row_count, status, admin_note, created_at, resolved_at')
+    .eq('profile_id', profile.id)
+    .order('created_at', { ascending: false })
+
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+  return Response.json({ submissions: data ?? [], abo_number: profile.abo_number })
+}
+
+// ── POST — stage a new submission (scope-guarded, server-enforced) ─────────────
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const profile = await callerProfile(userId, supabase)
+  if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
+
+  if (profile.role !== 'core' && profile.role !== 'admin') {
+    return Response.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (!profile.abo_number) {
+    return Response.json({ error: 'Verify your ABO number before submitting.' }, { status: 400 })
+  }
+
+  const { rows } = await req.json().catch(() => ({ rows: null }))
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return Response.json({ error: 'No rows provided' }, { status: 400 })
+  }
+
+  // Scope guard — never trust the client's check.
+  const check = checkSubmissionRoot(rows as Record<string, string>[], profile.abo_number)
+  if (!check.ok) {
+    return Response.json(
+      { error: ROOT_ERROR[check.reason], reason: check.reason, roots: check.roots },
+      { status: 400 },
+    )
+  }
+
+  // Supersede any prior still-pending submission from this owner.
+  await supabase
+    .from('los_submission_requests')
+    .update({ status: 'withdrawn', resolved_at: new Date().toISOString() })
+    .eq('profile_id', profile.id)
+    .eq('status', 'pending')
+
+  const { data, error } = await supabase
+    .from('los_submission_requests')
+    .insert({
+      profile_id: profile.id,
+      root_abo_number: check.root,
+      rows: rows as unknown as never,
+      row_count: rows.length,
+      status: 'pending',
+    })
+    .select('id, root_abo_number, row_count, status, created_at')
+    .single()
+
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+  return Response.json({ submission: data })
+}
+
+// ── PATCH — withdraw own pending submission ───────────────────────────────────
+
+export async function PATCH(req: NextRequest) {
+  const { userId } = await auth()
+  if (!userId) return Response.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const supabase = createServiceClient()
+  const profile = await callerProfile(userId, supabase)
+  if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
+
+  const { id } = await req.json().catch(() => ({ id: null }))
+  if (!id) return Response.json({ error: 'Missing submission id' }, { status: 400 })
+
+  const { data, error } = await supabase
+    .from('los_submission_requests')
+    .update({ status: 'withdrawn', resolved_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('profile_id', profile.id)
+    .eq('status', 'pending')
+    .select('id')
+    .maybeSingle()
+
+  if (error) return Response.json({ error: error.message }, { status: 500 })
+  if (!data) return Response.json({ error: 'No pending submission to withdraw' }, { status: 404 })
+  return Response.json({ ok: true })
+}

--- a/app/api/profile/los-submission/route.ts
+++ b/app/api/profile/los-submission/route.ts
@@ -72,12 +72,16 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  // Supersede any prior still-pending submission from this owner.
-  await supabase
+  // Supersede any prior still-pending submission from this owner. If this fails we
+  // must not insert — two pending rows would break the one-pending-per-owner
+  // invariant the admin queue relies on.
+  const { error: supersedeError } = await supabase
     .from('los_submission_requests')
     .update({ status: 'withdrawn', resolved_at: new Date().toISOString() })
     .eq('profile_id', profile.id)
     .eq('status', 'pending')
+
+  if (supersedeError) return Response.json({ error: supersedeError.message }, { status: 500 })
 
   const { data, error } = await supabase
     .from('los_submission_requests')

--- a/app/api/socials/route.ts
+++ b/app/api/socials/route.ts
@@ -3,18 +3,25 @@ import { createServiceClient } from '@/lib/supabase/service'
 export const revalidate = 300 // 5 min
 
 export async function GET() {
-  const supabase = createServiceClient()
+  // Resilient by design: this route is prerendered at build (revalidate above),
+  // so a missing-env build shell or a transient DB error must degrade to an empty
+  // post rather than crash the build. Prod keeps the 5-min ISR behaviour.
+  try {
+    const supabase = createServiceClient()
 
-  const { data, error } = await supabase
-    .from('social_posts')
-    .select('*')
-    .eq('is_visible', true)
-    .order('is_pinned', { ascending: false })
-    .order('sort_order', { ascending: true })
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle()
+    const { data, error } = await supabase
+      .from('social_posts')
+      .select('*')
+      .eq('is_visible', true)
+      .order('is_pinned', { ascending: false })
+      .order('sort_order', { ascending: true })
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle()
 
-  if (error) return Response.json({ post: null })
-  return Response.json({ post: data })
+    if (error) return Response.json({ post: null })
+    return Response.json({ post: data })
+  } catch {
+    return Response.json({ post: null })
+  }
 }

--- a/components/los-import/AssemblySummary.tsx
+++ b/components/los-import/AssemblySummary.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+// Shared assembly summary + junction panel. Consumes an AssemblyResult (from
+// assembleFiles or mergeSubmissions) so admin and CORE surfaces render identically.
+
+import { type AssemblyResult, type JunctionNode } from '@/lib/csv-import'
+
+export function JunctionPanel({ junctions, ownerLabel = 'in' }: { junctions: JunctionNode[]; ownerLabel?: string }) {
+  if (junctions.length === 0) return null
+  return (
+    <div className="p-4 rounded-xl border mt-4" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
+      <p className="text-xs font-semibold mb-2" style={{ color: 'var(--text-primary)' }}>
+        Junction nodes ({junctions.length})
+      </p>
+      <div className="space-y-2">
+        {junctions.map(j => (
+          <div key={j.abo_number}
+            className="flex flex-wrap items-start gap-2 text-xs px-3 py-2 rounded-lg"
+            style={{ backgroundColor: j.has_conflict ? 'rgba(224,122,95,0.08)' : 'rgba(129,178,154,0.08)' }}>
+            <span className="font-mono font-medium" style={{ color: 'var(--text-primary)' }}>{j.abo_number}</span>
+            <span style={{ color: 'var(--text-secondary)' }}>{j.name}</span>
+            <span className="ml-auto text-xs px-1.5 py-0.5 rounded-full font-semibold"
+              style={{
+                backgroundColor: j.has_conflict ? 'rgba(224,122,95,0.2)' : 'rgba(129,178,154,0.2)',
+                color: j.has_conflict ? '#e07a5f' : '#2d6a4f',
+              }}>
+              {j.has_conflict ? `data discrepancy: ${j.conflict_fields.join(', ')} · deepest owner wins` : 'clean'}
+            </span>
+            <span className="w-full text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+              {ownerLabel}: {j.files.join(', ')}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function AssemblySummary({
+  assembly,
+  sourceCount,
+  sourceLabel = 'file',
+  ownerLabel = 'in',
+}: {
+  assembly: AssemblyResult
+  sourceCount: number
+  sourceLabel?: string
+  ownerLabel?: string
+}) {
+  return (
+    <>
+      <div className="p-4 rounded-xl border" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
+        <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+          Assembly: {assembly.total_row_count} unique members from {sourceCount} {sourceLabel}{sourceCount !== 1 ? 's' : ''}
+        </p>
+        {assembly.disconnected_files.length > 0 && (
+          <div className="mt-2 p-3 rounded-lg" style={{ backgroundColor: 'rgba(224,122,95,0.08)' }}>
+            <p className="text-xs font-semibold" style={{ color: '#e07a5f' }}>
+              ⚠ Potentially disconnected {sourceLabel}{assembly.disconnected_files.length !== 1 ? 's' : ''}: {assembly.disconnected_files.join(', ')}
+            </p>
+            <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>
+              These share no ABO numbers with any other loaded {sourceLabel}. Verify they are part of the same tree.
+            </p>
+          </div>
+        )}
+      </div>
+      <JunctionPanel junctions={assembly.junctions} ownerLabel={ownerLabel} />
+    </>
+  )
+}

--- a/components/los-import/DropZone.tsx
+++ b/components/los-import/DropZone.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+// Shared CSV drop zone + file chips. Presentational — state lives in useAssembly.
+
+import type { FileEntry } from './useAssembly'
+
+export function DropZone({
+  fileRef,
+  files,
+  onFileAdd,
+  onFileDrop,
+  removeFile,
+  idPrefix = 'csv-upload',
+}: {
+  fileRef: React.RefObject<HTMLInputElement | null>
+  files: FileEntry[]
+  onFileAdd: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onFileDrop: (e: React.DragEvent<HTMLDivElement>) => void
+  removeFile: (filename: string) => void
+  idPrefix?: string
+}) {
+  return (
+    <div className="space-y-4">
+      <div
+        className="border-2 border-dashed rounded-lg p-8 text-center"
+        style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}
+        onDragOver={e => e.preventDefault()}
+        onDrop={onFileDrop}
+      >
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".csv"
+          multiple
+          onChange={onFileAdd}
+          className="hidden"
+          id={idPrefix}
+        />
+        <label htmlFor={idPrefix} className="cursor-pointer">
+          <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+            {files.length === 0 ? 'Click or drag CSV files here' : 'Add more files'}
+          </p>
+          <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>.csv only · multiple files supported</p>
+        </label>
+      </div>
+
+      {files.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {files.map(f => (
+            <div
+              key={f.filename}
+              className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full border"
+              style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)', color: 'var(--text-primary)' }}
+            >
+              <span>{f.filename}</span>
+              <span style={{ color: 'var(--text-secondary)' }}>({f.rows.length} rows)</span>
+              <button
+                onClick={() => removeFile(f.filename)}
+                className="ml-1 rounded-full w-4 h-4 flex items-center justify-center hover:opacity-70"
+                style={{ color: 'var(--text-secondary)' }}
+                aria-label={`Remove ${f.filename}`}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/los-import/SubtreePreview.tsx
+++ b/components/los-import/SubtreePreview.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+// Minimized, change-highlighted preview of the sub-tree a submission updates.
+// Reuses buildTree (lib/los.ts) + the org-chart layout math (lib/orgchart-math.ts)
+// + the LOS card styling, so "which part is being updated" reads the same as the
+// dashboard org chart. Depth-capped to stay minimized for large trees.
+
+import { useMemo } from 'react'
+import { buildTree } from '@/lib/los'
+import type { LOSNode } from '@/app/(dashboard)/los/lib/los-utils'
+import {
+  CARD_W, CARD_H,
+  capDepth, buildWidthMap, layoutNode,
+  flattenLayout, collectEdges, canvasBounds,
+} from '@/lib/orgchart-math'
+
+export type ChangeStatus = 'new' | 'level' | 'bonus' | 'unchanged'
+
+const STATUS_STYLE: Record<ChangeStatus, { border: string; bg: string; label: string; color: string }> = {
+  new:       { border: '#81b29a', bg: 'rgba(129,178,154,0.12)', label: 'new',   color: '#2d6a4f' },
+  level:     { border: '#3d405b', bg: 'rgba(61,64,91,0.10)',    label: 'level', color: '#3d405b' },
+  bonus:     { border: '#e07a5f', bg: 'rgba(224,122,95,0.12)',  label: 'bonus', color: '#e07a5f' },
+  unchanged: { border: 'rgba(45,51,42,0.15)', bg: 'var(--bg-card)', label: '',   color: 'var(--text-secondary)' },
+}
+
+// Map a parsed CSV row to the minimal LOSNode shape buildTree/layout need.
+function rowToNode(r: Record<string, string>): LOSNode {
+  return {
+    profile_id: null,
+    abo_number: r.abo_number ?? null,
+    sponsor_abo_number: r.sponsor_abo_number || null,
+    abo_level: r.abo_level ?? null,
+    name: r.name ?? null,
+    first_name: null,
+    last_name: null,
+    role: null,
+    depth: null,
+    country: r.country ?? null,
+    gpv: null,
+    ppv: null,
+    bonus_percent: r.bonus_percent ? Number(r.bonus_percent) : null,
+    group_size: null,
+    qualified_legs: null,
+    annual_ppv: null,
+    renewal_date: null,
+    vital_signs: [],
+  }
+}
+
+export type NodeMeta = { lastUpdated?: string | null; byUpline?: boolean }
+
+function fmtShort(iso: string) {
+  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+}
+
+export function SubtreePreview({
+  rows,
+  anchorAbo,
+  changeStatus,
+  meta,
+  maxDepth = 3,
+}: {
+  rows: Record<string, string>[]
+  anchorAbo: string | null
+  changeStatus?: Record<string, ChangeStatus>
+  meta?: Record<string, NodeMeta>
+  maxDepth?: number
+}) {
+  const { layout, edges, bounds } = useMemo(() => {
+    const nodes = rows.map(rowToNode)
+    const roots = buildTree(nodes, anchorAbo)
+    if (roots.length === 0) return { layout: [], edges: [], bounds: { maxX: 0, maxY: 0 } }
+    // Single virtual anchor: use the first root (for a valid CORE submission there is one).
+    const capped = capDepth(roots[0], maxDepth)
+    const widthMap = new Map<LOSNode, number>()
+    buildWidthMap(capped, widthMap)
+    const rootLayout = layoutNode(capped, (widthMap.get(capped) ?? CARD_W) / 2, 0, widthMap)
+    const flat = flattenLayout(rootLayout)
+    return { layout: flat, edges: collectEdges(rootLayout), bounds: canvasBounds(flat) }
+  }, [rows, anchorAbo, maxDepth])
+
+  if (layout.length === 0) {
+    return (
+      <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+        No sub-tree to preview.
+      </p>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border p-3" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-subtle, var(--bg-card))' }}>
+      <svg width={bounds.maxX + 20} height={bounds.maxY + 20} style={{ display: 'block' }}>
+        {edges.map((e, i) => (
+          <path
+            key={i}
+            d={`M ${e.x1} ${e.y1} C ${e.x1} ${(e.y1 + e.y2) / 2}, ${e.x2} ${(e.y1 + e.y2) / 2}, ${e.x2} ${e.y2}`}
+            fill="none"
+            stroke="var(--border-default)"
+            strokeWidth={1.5}
+          />
+        ))}
+        {layout.map(ln => {
+          const abo = ln.node.abo_number ?? ''
+          const status = changeStatus?.[abo] ?? 'unchanged'
+          const s = STATUS_STYLE[status]
+          const m = meta?.[abo]
+          return (
+            <foreignObject key={abo} x={ln.x - CARD_W / 2} y={ln.y} width={CARD_W} height={CARD_H} style={{ overflow: 'visible' }}>
+              <div style={{
+                width: CARD_W, height: CARD_H, borderRadius: 12,
+                border: `1.5px solid ${s.border}`, backgroundColor: s.bg,
+                padding: '8px 10px', boxSizing: 'border-box',
+                display: 'flex', flexDirection: 'column', gap: 3, userSelect: 'none',
+              }}>
+                <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4 }}>
+                  <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--text-primary)', flex: 1, lineHeight: 1.25, overflow: 'hidden', display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}>
+                    {ln.node.name ?? abo}
+                  </span>
+                  {s.label && (
+                    <span style={{ fontSize: 9, fontWeight: 700, padding: '1px 5px', borderRadius: 99, backgroundColor: s.border, color: '#fff', flexShrink: 0, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                      {s.label}
+                    </span>
+                  )}
+                </div>
+                <span style={{ fontSize: 10, fontFamily: 'monospace', color: 'var(--text-secondary)' }}>{abo}</span>
+                {ln.node.abo_level && (
+                  <span style={{ fontSize: 10, color: 'var(--text-tertiary)' }}>Level {ln.node.abo_level}</span>
+                )}
+                {m?.lastUpdated && (
+                  <span style={{ fontSize: 9, marginTop: 'auto', color: m.byUpline ? '#e07a5f' : 'var(--text-tertiary)', fontWeight: m.byUpline ? 600 : 400 }}>
+                    upd {fmtShort(m.lastUpdated)}{m.byUpline ? ' · upline' : ''}
+                  </span>
+                )}
+              </div>
+            </foreignObject>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}

--- a/components/los-import/useAssembly.ts
+++ b/components/los-import/useAssembly.ts
@@ -1,0 +1,64 @@
+'use client'
+
+// Shared CSV assembly state — the source-agnostic core extracted from the admin
+// useLosImport hook so both the admin Data Center and the CORE upload page drive
+// one assembly engine. Holds only files + assembled result and the file handlers;
+// import/purge/rollback stay in the admin-only useLosImport.
+
+import { useState, useRef, useMemo } from 'react'
+import { parseCSV, assembleFiles, type AssemblyResult } from '@/lib/csv-import'
+
+export type FileEntry = { filename: string; rows: Record<string, string>[] }
+
+export function readCsvFiles(fileList: File[]): Promise<FileEntry[]> {
+  const readers = fileList.map(file => new Promise<FileEntry>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = ev => {
+      const text = (ev.target?.result as string).replace(/^﻿/, '')
+      resolve({ filename: file.name, rows: parseCSV(text) })
+    }
+    reader.onerror = reject
+    reader.readAsText(file)
+  }))
+  return Promise.all(readers)
+}
+
+export function useAssembly() {
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [files, setFiles] = useState<FileEntry[]>([])
+  const assembly: AssemblyResult | null = useMemo(
+    () => (files.length === 0 ? null : assembleFiles(files)),
+    [files],
+  )
+
+  function addFiles(newEntries: FileEntry[]) {
+    setFiles(prev => {
+      const existing = new Set(prev.map(f => f.filename))
+      return [...prev, ...newEntries.filter(e => !existing.has(e.filename))]
+    })
+  }
+
+  function handleFileAdd(e: React.ChangeEvent<HTMLInputElement>) {
+    const added = Array.from(e.target.files ?? [])
+    if (added.length === 0) return
+    if (fileRef.current) fileRef.current.value = ''
+    readCsvFiles(added).then(addFiles).catch(() => null)
+  }
+
+  function handleFileDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault()
+    const droppedFiles = Array.from(e.dataTransfer.files).filter(f => f.name.endsWith('.csv'))
+    if (droppedFiles.length === 0) return
+    readCsvFiles(droppedFiles).then(addFiles).catch(() => null)
+  }
+
+  function removeFile(filename: string) {
+    setFiles(prev => prev.filter(f => f.filename !== filename))
+  }
+
+  function reset() {
+    setFiles([])
+  }
+
+  return { fileRef, files, assembly, handleFileAdd, handleFileDrop, removeFile, reset }
+}

--- a/components/los-import/useAssembly.ts
+++ b/components/los-import/useAssembly.ts
@@ -20,7 +20,12 @@ export function readCsvFiles(fileList: File[]): Promise<FileEntry[]> {
     reader.onerror = reject
     reader.readAsText(file)
   }))
-  return Promise.all(readers)
+  // Per-file settlement — one unreadable file must not drop the whole batch.
+  return Promise.allSettled(readers).then(results =>
+    results
+      .filter((r): r is PromiseFulfilledResult<FileEntry> => r.status === 'fulfilled')
+      .map(r => r.value),
+  )
 }
 
 export function useAssembly() {

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,10 +6,12 @@ ALL CODE COMPLETE + fully verified (static AND runtime). `npm run build` green; 
 **Runtime E2E: 6/6 pass** against hosted DEV (`e2e/los-submission-auth.spec.ts`, authenticated Playwright): scope-mismatch→400, matching-root→pending, withdraw, admin approve→import writes `los_members` + `last_updated_by_abo` (NEW=CORE self, CHILD=CORE upline), senior-CORE import stamps CHILD=SENIOR (upline), reject. Fixtures throwaway (ABOs 99000xx + e2e-core/senior users) seeded + cleaned up (verified 0 leftover). Existing `admin-auth` spec still 4/4 (no regression).
 Migrations `20260713000000` + `20260713000100` applied to DEV + recorded via `migration repair --status applied`. Types spliced additively.
 Merged `origin/main` (post-#568) into the branch: the only conflict was this file — PR #569's session content kept, main's Constraints/Open-items superset preserved.
+**CodeRabbit review addressed (commit `a91968b`)** — 6 findings, all fixed. Load-bearing one: the approve flow was read→merge→import→mark, so a withdraw landing mid-flight could not stop an already-executed import. New `claim_los_submissions()` RPC (migration `20260714000000`) does one `UPDATE ... WHERE status='pending' RETURNING` — the route now merges/imports only rows provably still pending at claim time; `release_los_submissions()` hands the claim back to pending if the import then fails. Re-verified: 96/96 unit, lint 0 errors, build green, `los-submission-auth` 6/6 + `admin-auth` 4/4 against DEV.
 
 ## Next
 - CI green + Vercel preview READY before Done (PR #569)
-- Pre-existing DEV history drift (phantom 20260707/09/10 from #563) left untouched — reconcile with `migration repair --status reverted 20260707 20260709 20260710` when convenient
+- CI's `Authenticated E2E (Clerk)` job is a 6-second SKIP (gated on secrets not set, see #560) — it does NOT actually run the specs. Authenticated E2E must be run locally against DEV until those secrets land; do not read a green tick there as coverage.
+- Migration CI/CD procedure ticket filed: **#570** (migrate-before-deploy, one ledger writer, gated prod run)
 - `.env*` are gitignored (do not commit); the worktree DEV keys live only locally
 - `.env.development.local` on the dev machine should point at the hosted DEV project per docs/DEV_WORKFLOW.md "Hosted dev database"; local Docker stack teardown (`supabase stop` + `docker system prune -a --volumes`) is user-run only
 - (Parked milestone queue) #510 storage RLS; #485; Phase 4: #490/#492/#489/#487/#488; Phase 5: #469/#486/#491/#493/#494/#495/#496/#497
@@ -40,6 +42,7 @@ DECISION: LOS authority model is deepest-owner-wins (closest upline owner of a c
 - Gotcha discovered + documented (`docs/ai/GOTCHAS.md`): `supabase db push`/`reset --linked` on a fresh Cloud project can fail on `uuid_generate_v4()` because `SET SESSION ROLE` mid-session doesn't inherit that role's configured `search_path`; fix is `ALTER DATABASE postgres SET search_path TO "$user", public, extensions;` once per project
 - Seed data on DEV project: 4 role profiles + 1 sample trip + 7 storage buckets + 2 E2E Clerk test profiles (`user_3GPgzTRoaVUqpOTUIHSIC3mHXWg` member, `user_3GPgzcSz55oxqpEY1FHQAYkg0vC` admin)
 - `npm run verify` (lint/check-types/test/build) green as of commit `5a9caa4`
+- The "phantom" DEV migrations `20260707/09/10` were NOT phantoms — the files exist locally (`20260707_001_add_function_search_path.sql` etc.); the remote ledger had them recorded under truncated versions. 2026-07-14: repaired the DEV ledger (`migration repair --status reverted`) + re-applied all three (all idempotent: `ALTER FUNCTION ... SET`, `COMMENT ON`, `DROP POLICY IF EXISTS`), then pushed `20260714000000`. DEV ledger is in sync; prod's is unaudited — that audit is the first task in #570.
 
 ## Done
 Migration chain synced to DEV project — RESULT: 18 pending migrations pushed via `supabase db push`, verified via `supabase migration list` (all rows match).

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,13 +1,17 @@
 ## Goal
-Issue #563 (2026-07-13, worktree `issues-485-490-5c096d`, branch `dev/2607-DEV-563`) hosted Supabase dev project: replace the local Docker Supabase stack (#547) as the day-to-day local dev DB target with the hosted dev project `iymwxdewcpvpjgzewtzk`. App code needs zero changes — only env values, `check:env` classifier, worktree setup script, `seed-clerk-test-users.js` guard, and docs.
+LOS import redesign (2026-07-13, worktree `refactoring-infra-bottlenecks-ca1053`): let CORE members upload their part of the LOS from a new `/profile/los-upload` page. Uploads stage as `pending` submissions (new `los_submission_requests` table) for admin review — no direct `los_members` write. Admin reviews in approval-hub, merges pending parts (deepest-owner-wins per ABO), then runs the existing `import_los_members` RPC. Scope guard: submission tree root must equal caller's `profiles.abo_number` (enforced server-side). CORE cannot purge or roll back others. Plan: `~/.claude/plans/redesign-of-the-los-wondrous-rain.md`.
 
 ## Now
-Implementation complete and verified (3 commits on `dev/2607-DEV-563`). Ready to push and open the PR.
+ALL CODE COMPLETE + fully verified (static AND runtime). `npm run build` green; unit tests 96/96; eslint 0 errors.
+**Runtime E2E: 6/6 pass** against hosted DEV (`e2e/los-submission-auth.spec.ts`, authenticated Playwright): scope-mismatch→400, matching-root→pending, withdraw, admin approve→import writes `los_members` + `last_updated_by_abo` (NEW=CORE self, CHILD=CORE upline), senior-CORE import stamps CHILD=SENIOR (upline), reject. Fixtures throwaway (ABOs 99000xx + e2e-core/senior users) seeded + cleaned up (verified 0 leftover). Existing `admin-auth` spec still 4/4 (no regression).
+Migrations `20260713000000` + `20260713000100` applied to DEV + recorded via `migration repair --status applied`. Types spliced additively.
+Env: worktree `.env.development.local` points at hosted DEV (keys pulled from Management API); `.env.local` supplies Clerk test keys. playwright.config.ts now loads env + includes the new spec in the authenticated project.
 
 ## Next
-- Push `dev/2607-DEV-563`, open PR (`Closes #563`), run GCR pass, merge when CI green + Vercel preview READY
-- User-run only (destructive, not scripted): `supabase stop` + `docker system prune -a --volumes` to reclaim local disk once the DEV-project workflow is confirmed working day-to-day
-- (Parked, unrelated milestone thread — last touched 2026-07-08, different worktree `issue-547-4055aa`, not part of this session): 6 PRs (#502/#504/#505/#506/#507/#508) awaiting CI green + Vercel preview + human merge; issue #510 (guest-tier storage.objects RLS bypass) not yet fixed; milestone remainder not started: #485, #490/#492/#489/#487/#488, #469/#486/#491/#493/#494/#495/#496/#497, #510 pickup. Whoever resumes that thread should re-verify current PR/issue state before acting — this line is a pointer, not current fact.
+- Move to `dev/[YYMM]-DEV-[GH#]` branch; open PR; CI green + Vercel preview READY before Done
+- Pre-existing DEV history drift (phantom 20260707/09/10 from #563) left untouched — reconcile with `migration repair --status reverted 20260707 20260709 20260710` when convenient (not mine)
+- `.env*` are gitignored (do not commit); the worktree DEV keys live only locally
+- (Parked, unrelated — #563 done, PR not opened; older milestone thread pointer, re-verify before acting): #502/#504/#505/#506/#507/#508 PRs, #510 storage RLS, milestone remainder #485/#490.. — pointers, not current fact.
 
 ## Constraints
 - Never link/push the prod Supabase ref (`ynykjpnetfwqzdnsgkkg`) from a dev machine

--- a/e2e/los-submission-auth.spec.ts
+++ b/e2e/los-submission-auth.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect, type Page } from '@playwright/test'
+import { clerk } from '@clerk/testing/playwright'
+import { createClerkClient } from '@clerk/backend'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Authenticated end-to-end coverage of the CORE self-service LOS submission
+ * feature. Requires the hosted DEV Supabase project + Clerk test instance
+ * (env loaded by playwright.config.ts). Seeds throwaway namespaced fixtures
+ * (ABOs 99000xx, three e2e users) and cleans them up afterwards.
+ *
+ * Covered: scope guard (root mismatch → 400), stage a pending submission,
+ * withdraw, admin approve → import writes los_members + last_updated_by_abo,
+ * upline attribution (senior CORE's import stamps a downline node), reject.
+ */
+
+const CORE_EMAIL   = 'e2e-core-tevd-portal@example.com'
+const SENIOR_EMAIL = 'e2e-core-senior-tevd-portal@example.com'
+const ADMIN_EMAIL  = process.env.E2E_CLERK_ADMIN_EMAIL ?? 'e2e-admin-tevd-portal@example.com'
+
+// Throwaway namespaced ABOs — 9900000 (senior) → 9900001 (core) → 9900002 (child); 9900003 new.
+const SENIOR = '9900000'
+const CORE   = '9900001'
+const CHILD  = '9900002'
+const NEW    = '9900003'
+const TEST_ABOS = [SENIOR, CORE, CHILD, NEW]
+
+function svc(): SupabaseClient {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+}
+
+function row(abo: string, sponsor: string, extra: Record<string, string> = {}) {
+  return { abo_number: abo, sponsor_abo_number: sponsor, name: `T${abo}`, abo_level: '3', bonus_percent: '3', ...extra }
+}
+
+async function signInAs(page: Page, emailAddress: string) {
+  await page.goto('/')
+  // Tests switch users on the same page; Clerk refuses signIn while a session
+  // is active, so sign out first (no-op / ignored when not signed in).
+  await clerk.signOut({ page }).catch(() => {})
+  await clerk.signIn({ page, emailAddress })
+}
+
+async function ensureUser(clerk: ReturnType<typeof createClerkClient>, email: string, role: string) {
+  const existing = await clerk.users.getUserList({ emailAddress: [email] })
+  if (existing.data.length > 0) return existing.data[0]
+  return clerk.users.createUser({
+    emailAddress: [email], firstName: 'E2E', lastName: role, skipPasswordRequirement: true, publicMetadata: { role },
+  })
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('CORE LOS submission flow', () => {
+  let sb: SupabaseClient
+  let coreProfileId: string
+  let seniorProfileId: string
+
+  test.beforeAll(async () => {
+    sb = svc()
+    const clerkClient = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY! })
+
+    // Clerk users + profiles (CORE with abo, senior CORE with abo).
+    const coreUser = await ensureUser(clerkClient, CORE_EMAIL, 'core')
+    const seniorUser = await ensureUser(clerkClient, SENIOR_EMAIL, 'core')
+
+    for (const [user, abo, email] of [[coreUser, CORE, CORE_EMAIL], [seniorUser, SENIOR, SENIOR_EMAIL]] as const) {
+      await sb.from('profiles').upsert({
+        clerk_id: user.id, first_name: 'E2E', last_name: 'Core', role: 'core',
+        abo_number: abo, contact_email: email, display_names: { en: `E2E ${abo}` },
+      }, { onConflict: 'clerk_id' })
+    }
+
+    coreProfileId = (await sb.from('profiles').select('id').eq('clerk_id', coreUser.id).single()).data!.id
+    seniorProfileId = (await sb.from('profiles').select('id').eq('clerk_id', seniorUser.id).single()).data!.id
+
+    // Baseline los_members subtree (existing state before uploads).
+    await sb.from('los_members').upsert([
+      { abo_number: SENIOR, sponsor_abo_number: null, name: 'T-Senior', abo_level: '3', bonus_percent: 3 },
+      { abo_number: CORE,   sponsor_abo_number: SENIOR, name: 'T-Core',  abo_level: '3', bonus_percent: 3 },
+      { abo_number: CHILD,  sponsor_abo_number: CORE,   name: 'T-Child', abo_level: '3', bonus_percent: 3 },
+    ], { onConflict: 'abo_number' })
+
+    await cleanupSubmissions()
+  })
+
+  test.afterAll(async () => {
+    await cleanupSubmissions()
+    await sb.from('los_members').delete().in('abo_number', TEST_ABOS)
+    await sb.rpc('rebuild_tree_paths')
+  })
+
+  async function cleanupSubmissions() {
+    await sb.from('los_submission_requests').delete().in('profile_id', [coreProfileId, seniorProfileId].filter(Boolean))
+  }
+
+  test('CORE upload with mismatched root is rejected 400', async ({ page }) => {
+    await signInAs(page, CORE_EMAIL)
+    // Rows rooted at SENIOR while signed in as CORE → mismatch.
+    const res = await page.request.post('/api/profile/los-submission', {
+      data: { rows: [row(SENIOR, ''), row(CORE, SENIOR), row(CHILD, CORE)] },
+    })
+    expect(res.status()).toBe(400)
+    const body = await res.json()
+    expect(body.reason).toBe('mismatch')
+  })
+
+  test('CORE upload with matching root is staged pending', async ({ page }) => {
+    await signInAs(page, CORE_EMAIL)
+    const res = await page.request.post('/api/profile/los-submission', {
+      data: { rows: [row(CORE, SENIOR), row(CHILD, CORE), row(NEW, CORE)] },
+    })
+    expect(res.status()).toBe(200)
+    const list = await (await page.request.get('/api/profile/los-submission')).json()
+    const pending = list.submissions.filter((s: { status: string }) => s.status === 'pending')
+    expect(pending).toHaveLength(1)
+    expect(pending[0].root_abo_number).toBe(CORE)
+  })
+
+  test('CORE can withdraw own pending submission', async ({ page }) => {
+    await signInAs(page, CORE_EMAIL)
+    const list = await (await page.request.get('/api/profile/los-submission')).json()
+    const pending = list.submissions.find((s: { status: string }) => s.status === 'pending')
+    const res = await page.request.patch('/api/profile/los-submission', { data: { id: pending.id } })
+    expect(res.status()).toBe(200)
+    const after = await (await page.request.get('/api/profile/los-submission')).json()
+    expect(after.submissions.find((s: { id: string }) => s.id === pending.id).status).toBe('withdrawn')
+  })
+
+  test('admin approves a CORE submission → import writes rows + owner', async ({ page }) => {
+    // CORE re-submits.
+    await signInAs(page, CORE_EMAIL)
+    await page.request.post('/api/profile/los-submission', {
+      data: { rows: [row(CORE, SENIOR), row(CHILD, CORE), row(NEW, CORE)] },
+    })
+
+    // Admin sees it and approves.
+    await signInAs(page, ADMIN_EMAIL)
+    const adminList = await (await page.request.get('/api/admin/los-submission')).json()
+    const pending = adminList.submissions.find((s: { status: string; root_abo_number: string }) => s.status === 'pending' && s.root_abo_number === CORE)
+    expect(pending).toBeTruthy()
+
+    const res = await page.request.post('/api/admin/los-submission', { data: { action: 'approve', ids: [pending.id] } })
+    expect(res.status()).toBe(200)
+    const result = await res.json()
+    expect(result.inserted).toBeGreaterThan(0)
+
+    // DB: NEW node created; CHILD stamped as updated by its upline (CORE).
+    const rows = await sb.from('los_members').select('abo_number, last_updated_by_abo').in('abo_number', [NEW, CHILD, CORE])
+    const byAbo = Object.fromEntries((rows.data ?? []).map(r => [r.abo_number, r.last_updated_by_abo]))
+    expect(byAbo[NEW]).toBe(CORE)   // new member, owned by CORE
+    expect(byAbo[CHILD]).toBe(CORE) // CORE is CHILD's upline → "by upline"
+    expect(byAbo[CORE]).toBe(CORE)  // CORE's own row → self
+
+    const sub = await sb.from('los_submission_requests').select('status').eq('id', pending.id).single()
+    expect(sub.data!.status).toBe('approved')
+  })
+
+  test('senior CORE import stamps a downline node with the senior owner (upline)', async ({ page }) => {
+    await signInAs(page, SENIOR_EMAIL)
+    await page.request.post('/api/profile/los-submission', {
+      data: { rows: [row(SENIOR, ''), row(CORE, SENIOR), row(CHILD, CORE)] },
+    })
+    await signInAs(page, ADMIN_EMAIL)
+    const adminList = await (await page.request.get('/api/admin/los-submission')).json()
+    const pending = adminList.submissions.find((s: { status: string; root_abo_number: string }) => s.status === 'pending' && s.root_abo_number === SENIOR)
+    await page.request.post('/api/admin/los-submission', { data: { action: 'approve', ids: [pending.id] } })
+
+    const child = await sb.from('los_members').select('last_updated_by_abo').eq('abo_number', CHILD).single()
+    expect(child.data!.last_updated_by_abo).toBe(SENIOR) // senior (upline) last touched CHILD
+  })
+
+  test('admin can reject a pending submission', async ({ page }) => {
+    await signInAs(page, CORE_EMAIL)
+    await page.request.post('/api/profile/los-submission', {
+      data: { rows: [row(CORE, SENIOR), row(CHILD, CORE)] },
+    })
+    await signInAs(page, ADMIN_EMAIL)
+    const adminList = await (await page.request.get('/api/admin/los-submission')).json()
+    const pending = adminList.submissions.find((s: { status: string; root_abo_number: string }) => s.status === 'pending' && s.root_abo_number === CORE)
+    const res = await page.request.post('/api/admin/los-submission', { data: { action: 'reject', id: pending.id, note: 'e2e reject' } })
+    expect(res.status()).toBe(200)
+    const sub = await sb.from('los_submission_requests').select('status, admin_note').eq('id', pending.id).single()
+    expect(sub.data!.status).toBe('rejected')
+    expect(sub.data!.admin_note).toBe('e2e reject')
+  })
+})

--- a/lib/csv-import.test.ts
+++ b/lib/csv-import.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findTreeRoots,
+  checkSubmissionRoot,
+  mergeSubmissions,
+  type SubmissionInput,
+} from '@/lib/csv-import'
+
+// Minimal row helper — only the fields these pure fns read.
+function row(abo: string, sponsor: string, extra: Record<string, string> = {}) {
+  return { abo_number: abo, sponsor_abo_number: sponsor, name: `n${abo}`, ...extra }
+}
+
+describe('findTreeRoots', () => {
+  it('returns the single node whose sponsor is outside the set', () => {
+    const rows = [row('100', '999'), row('200', '100'), row('300', '200')]
+    expect(findTreeRoots(rows)).toEqual(['100'])
+  })
+
+  it('treats an empty sponsor as a root', () => {
+    const rows = [row('100', ''), row('200', '100')]
+    expect(findTreeRoots(rows)).toEqual(['100'])
+  })
+
+  it('returns multiple roots for disconnected legs', () => {
+    const rows = [row('100', '999'), row('200', '888'), row('201', '200')]
+    expect(findTreeRoots(rows).sort()).toEqual(['100', '200'])
+  })
+
+  it('returns zero roots when every sponsor is in-set (cycle)', () => {
+    const rows = [row('100', '200'), row('200', '100')]
+    expect(findTreeRoots(rows)).toEqual([])
+  })
+
+  it('dedups repeated abo rows', () => {
+    const rows = [row('100', '999'), row('100', '999')]
+    expect(findTreeRoots(rows)).toEqual(['100'])
+  })
+})
+
+describe('checkSubmissionRoot', () => {
+  const rows = [row('100', '999'), row('200', '100')]
+
+  it('ok when the single root matches the expected abo', () => {
+    expect(checkSubmissionRoot(rows, '100')).toEqual({ ok: true, root: '100' })
+  })
+
+  it('mismatch when the single root is a different abo', () => {
+    expect(checkSubmissionRoot(rows, '200')).toEqual({ ok: false, reason: 'mismatch', roots: ['100'] })
+  })
+
+  it('multi-root when there are several legs', () => {
+    const multi = [row('100', '999'), row('200', '888')]
+    expect(checkSubmissionRoot(multi, '100')).toEqual({ ok: false, reason: 'multi-root', roots: ['100', '200'] })
+  })
+
+  it('no-root when the set is cyclic', () => {
+    const cyc = [row('100', '200'), row('200', '100')]
+    expect(checkSubmissionRoot(cyc, '100')).toEqual({ ok: false, reason: 'no-root', roots: [] })
+  })
+})
+
+describe('mergeSubmissions — deepest-owner-wins', () => {
+  // Tree: 100 -> 200 -> 300. Senior owner 100 covers everyone; junior owner 200
+  // covers 200,300. For the overlapping nodes the junior (deeper) owner wins.
+  const senior: SubmissionInput = {
+    rootAbo: '100',
+    createdAt: '2026-01-01T00:00:00Z',
+    rows: [
+      row('100', '999', { bonus_percent: '3' }),
+      row('200', '100', { bonus_percent: '3' }),
+      row('300', '200', { bonus_percent: '3' }), // stale
+    ],
+  }
+  const junior: SubmissionInput = {
+    rootAbo: '200',
+    createdAt: '2026-01-02T00:00:00Z',
+    rows: [
+      row('200', '100', { bonus_percent: '6' }),
+      row('300', '200', { bonus_percent: '9' }), // fresh — should win
+    ],
+  }
+
+  it('deeper owner (junior) wins overlapping nodes', () => {
+    const res = mergeSubmissions([senior, junior])
+    const byAbo = Object.fromEntries(res.rows.map(r => [r.abo_number, r]))
+    expect(byAbo['300'].bonus_percent).toBe('9')
+    expect(byAbo['200'].bonus_percent).toBe('6')
+    // 100 only exists in the senior submission — kept.
+    expect(byAbo['100'].bonus_percent).toBe('3')
+    expect(res.total_row_count).toBe(3)
+    // updated_by_abo = the owner (submission root) that won each node.
+    expect(byAbo['300'].updated_by_abo).toBe('200') // junior/upline-of-300 won
+    expect(byAbo['200'].updated_by_abo).toBe('200')
+    expect(byAbo['100'].updated_by_abo).toBe('100') // only senior had it
+  })
+
+  it('order-independent — same winner regardless of submission order', () => {
+    const a = mergeSubmissions([senior, junior])
+    const b = mergeSubmissions([junior, senior])
+    const pick = (r: typeof a) => Object.fromEntries(r.rows.map(x => [x.abo_number, x.bonus_percent]))
+    expect(pick(a)).toEqual(pick(b))
+  })
+
+  it('flags overlapping nodes as junctions with their owners', () => {
+    const res = mergeSubmissions([senior, junior])
+    const j = res.junctions.find(x => x.abo_number === '300')
+    expect(j).toBeTruthy()
+    expect(j!.files.sort()).toEqual(['100', '200'])
+  })
+
+  it('ties on depth break by newest createdAt', () => {
+    // Two sibling owners at the same depth both claim node 300.
+    const older: SubmissionInput = { rootAbo: '100', createdAt: '2026-01-01T00:00:00Z', rows: [row('100', ''), row('300', '100', { bonus_percent: '1' })] }
+    const newer: SubmissionInput = { rootAbo: '100', createdAt: '2026-02-01T00:00:00Z', rows: [row('100', ''), row('300', '100', { bonus_percent: '2' })] }
+    const res = mergeSubmissions([older, newer])
+    const byAbo = Object.fromEntries(res.rows.map(r => [r.abo_number, r]))
+    expect(byAbo['300'].bonus_percent).toBe('2')
+  })
+
+  it('detects a fully disconnected submission', () => {
+    const s1: SubmissionInput = { rootAbo: '100', createdAt: '2026-01-01T00:00:00Z', rows: [row('100', ''), row('200', '100')] }
+    const s2: SubmissionInput = { rootAbo: '500', createdAt: '2026-01-01T00:00:00Z', rows: [row('500', ''), row('600', '500')] }
+    const res = mergeSubmissions([s1, s2])
+    expect(res.disconnected_files.sort()).toEqual(['100', '500'])
+  })
+})

--- a/lib/csv-import.ts
+++ b/lib/csv-import.ts
@@ -296,3 +296,167 @@ export function assembleFiles(
     total_row_count: rows.length,
   }
 }
+
+// ── Tree-root detection & scope check ───────────────────────────────────────────
+
+/**
+ * Returns the ABO numbers that are roots of the assembled row set — i.e. rows
+ * whose sponsor_abo_number is empty or points to an ABO not present in the set.
+ * A clean single sub-tree has exactly one root.
+ */
+export function findTreeRoots(rows: Record<string, string>[]): string[] {
+  const abos = new Set(rows.map(r => r.abo_number).filter(Boolean))
+  const roots: string[] = []
+  const seen = new Set<string>()
+  for (const r of rows) {
+    const abo = r.abo_number
+    if (!abo || seen.has(abo)) continue
+    seen.add(abo)
+    const sponsor = r.sponsor_abo_number
+    if (!sponsor || !abos.has(sponsor)) roots.push(abo)
+  }
+  return roots
+}
+
+export type RootCheck =
+  | { ok: true; root: string }
+  | { ok: false; reason: 'no-root' | 'multi-root' | 'mismatch'; roots: string[] }
+
+/**
+ * Scope guard for a CORE submission (decision table from the plan):
+ * - exactly 1 root that equals expectedAbo → ok
+ * - 0 roots (cycle / self-referential export) → 'no-root'
+ * - >1 root (multiple legs / upline row included) → 'multi-root'
+ * - single root that is NOT expectedAbo → 'mismatch'
+ * Enforced server-side; the client uses the same fn for early UX feedback.
+ */
+export function checkSubmissionRoot(
+  rows: Record<string, string>[],
+  expectedAbo: string
+): RootCheck {
+  const roots = findTreeRoots(rows)
+  if (roots.length === 0) return { ok: false, reason: 'no-root', roots }
+  if (roots.length > 1) return { ok: false, reason: 'multi-root', roots }
+  if (roots[0] !== expectedAbo) return { ok: false, reason: 'mismatch', roots }
+  return { ok: true, root: roots[0] }
+}
+
+// ── Multi-submission merge (deepest-owner-wins authority) ───────────────────────
+
+export type SubmissionInput = {
+  // A stable label for the owner of this submission — its root ABO. Surfaced in
+  // junction metadata so the admin can see which owner won a contested node.
+  rootAbo: string
+  createdAt: string
+  rows: Record<string, string>[]
+}
+
+/**
+ * Merges multiple CORE submissions into one deduplicated row set.
+ *
+ * Authority rule (replaces assembleFiles' first-seen-wins): for any abo_number
+ * present in more than one submission, the winning row comes from the submission
+ * whose owner (rootAbo) sits DEEPEST in the combined sponsorship tree — i.e. the
+ * most specific / closest-upline owner of that member. Ties break by newest
+ * createdAt. The resolved single row set is what gets handed to import_los_members,
+ * so DB-write correctness is unchanged; only which row wins per abo differs, and
+ * it is surfaced via junction metadata rather than silent.
+ */
+export function mergeSubmissions(subs: SubmissionInput[]): AssemblyResult {
+  // Union sponsor map (first-seen sponsor per abo) — used only for depth structure.
+  const sponsorByAbo = new Map<string, string>()
+  for (const sub of subs) {
+    for (const row of sub.rows) {
+      const abo = row.abo_number
+      if (!abo || sponsorByAbo.has(abo)) continue
+      sponsorByAbo.set(abo, row.sponsor_abo_number ?? '')
+    }
+  }
+
+  // Depth of each abo from its top-most in-set ancestor (memoized, cycle-guarded).
+  const depthCache = new Map<string, number>()
+  function depthOf(abo: string, seen: Set<string>): number {
+    const cached = depthCache.get(abo)
+    if (cached !== undefined) return cached
+    const parent = sponsorByAbo.get(abo)
+    if (!parent || !sponsorByAbo.has(parent) || seen.has(abo)) {
+      depthCache.set(abo, 0)
+      return 0
+    }
+    seen.add(abo)
+    const val = depthOf(parent, seen) + 1
+    depthCache.set(abo, val)
+    return val
+  }
+
+  // Winner selection per abo.
+  type Cand = { row: Record<string, string>; rootDepth: number; createdAt: string; owner: string }
+  const winner = new Map<string, Cand>()
+  const ownersByAbo = new Map<string, string[]>()
+  const rowsByAboBySub: { rootAbo: string; row: Record<string, string> }[] = []
+
+  for (const sub of subs) {
+    const rootDepth = depthOf(sub.rootAbo, new Set())
+    for (const row of sub.rows) {
+      const abo = row.abo_number
+      if (!abo) continue
+
+      const owners = ownersByAbo.get(abo) ?? []
+      if (!owners.includes(sub.rootAbo)) owners.push(sub.rootAbo)
+      ownersByAbo.set(abo, owners)
+      rowsByAboBySub.push({ rootAbo: sub.rootAbo, row })
+
+      const cur = winner.get(abo)
+      if (
+        !cur ||
+        rootDepth > cur.rootDepth ||
+        (rootDepth === cur.rootDepth && sub.createdAt > cur.createdAt)
+      ) {
+        winner.set(abo, { row, rootDepth, createdAt: sub.createdAt, owner: sub.rootAbo })
+      }
+    }
+  }
+
+  // Annotate each winning row with the owner (submission root) that won it, so
+  // import_los_members can persist los_members.last_updated_by_abo.
+  const rows = Array.from(winner.values()).map(c => ({ ...c.row, updated_by_abo: c.owner }))
+
+  // Junctions: abo present in >1 submission. Conflict if name/sponsor differ.
+  const junctions: JunctionNode[] = []
+  const conflicts: JunctionNode[] = []
+  for (const [abo, owners] of ownersByAbo.entries()) {
+    if (owners.length <= 1) continue
+    const allRows = rowsByAboBySub.filter(e => e.row.abo_number === abo).map(e => e.row)
+    const ref = allRows[0]
+    const conflictFields: string[] = []
+    for (const field of CONFLICT_FIELDS) {
+      const refVal = ref[field] ?? ''
+      if (allRows.slice(1).some(r => (r[field] ?? '') !== refVal)) conflictFields.push(field)
+    }
+    const node: JunctionNode = {
+      abo_number: abo,
+      name: winner.get(abo)?.row.name ?? '',
+      files: owners,
+      has_conflict: conflictFields.length > 0,
+      conflict_fields: conflictFields,
+    }
+    junctions.push(node)
+    if (node.has_conflict) conflicts.push(node)
+  }
+
+  // Disconnected submission: shares zero abo_number with all others combined.
+  const disconnected_files: string[] = []
+  if (subs.length > 1) {
+    for (const sub of subs) {
+      const own = new Set(sub.rows.map(r => r.abo_number).filter(Boolean))
+      const others = new Set<string>()
+      for (const o of subs) {
+        if (o === sub) continue
+        for (const r of o.rows) if (r.abo_number) others.add(r.abo_number)
+      }
+      if (![...own].some(a => others.has(a))) disconnected_files.push(sub.rootAbo)
+    }
+  }
+
+  return { rows, junctions, conflicts, disconnected_files, total_row_count: rows.length }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "vaul": "^1.1.2"
       },
       "devDependencies": {
-        "@clerk/backend": "^3.11.4",
         "@clerk/testing": "^2.2.7",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.2.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,23 @@
 import { defineConfig, devices } from '@playwright/test'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Playwright's own process (globalSetup + tests) does not inherit Next's env
+// loading, so the authenticated project's Clerk/Supabase clients would see no
+// keys. Load env files in Next precedence (.env.development.local first, then
+// .env.local), never overwriting already-set vars. No-op when files are absent
+// (contributor machines / preview-smoke) — keeps other projects unaffected.
+for (const f of ['.env.development.local', '.env.local']) {
+  const p = path.join(process.cwd(), f)
+  if (!fs.existsSync(p)) continue
+  for (const line of fs.readFileSync(p, 'utf8').split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/)
+    if (!m) continue
+    let v = m[2]
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1)
+    if (process.env[m[1]] === undefined) process.env[m[1]] = v
+  }
+}
 
 // BASE_URL set (e.g. the preview-smoke workflow pointing at a Vercel preview)
 // -> test that deployment and start no local server.
@@ -23,7 +42,7 @@ export default defineConfig({
       // browserName pinned: devices['iPhone 12'] defaults to webkit, but CI
       // (preview-smoke.yml) installs chromium only — keep local & CI identical.
       name: 'mobile-390',
-      testIgnore: /admin-auth\.spec\.ts/,
+      testIgnore: /(admin-auth|los-submission-auth)\.spec\.ts/,
       use: {
         ...devices['iPhone 12'],
         browserName: 'chromium',
@@ -32,14 +51,14 @@ export default defineConfig({
     },
     {
       name: 'desktop',
-      testIgnore: /admin-auth\.spec\.ts/,
+      testIgnore: /(admin-auth|los-submission-auth)\.spec\.ts/,
       use: { viewport: { width: 1280, height: 800 } },
     },
     {
       // Authenticated coverage (issue #560) — requires local Supabase +
       // npm run e2e:seed-clerk. Never target a preview/prod-DB deployment.
       name: 'authenticated',
-      testMatch: /admin-auth\.spec\.ts/,
+      testMatch: /(admin-auth|los-submission-auth)\.spec\.ts/,
       use: { viewport: { width: 1280, height: 800 } },
     },
   ],

--- a/supabase/migrations/20260713000000_2607_feat_los_submission_requests.sql
+++ b/supabase/migrations/20260713000000_2607_feat_los_submission_requests.sql
@@ -1,0 +1,146 @@
+-- ROLLBACK: DROP FUNCTION IF EXISTS public.reject_los_submission(uuid, text, uuid);
+--           DROP FUNCTION IF EXISTS public.approve_los_submissions(uuid[], uuid);
+--           DROP TABLE IF EXISTS public.los_submission_requests;
+-- ============================================================
+-- LOS submission requests — CORE self-service uploads
+--
+-- CORE members upload their part of the LOS from /profile/los-upload.
+-- Each upload is staged here as a `pending` submission (no direct
+-- los_members write). An admin reviews the queue in approval-hub,
+-- merges the selected parts (deepest-owner-wins, client-side), and
+-- runs the existing import_los_members RPC; the submissions are then
+-- transitioned via approve_los_submissions(). reject_los_submission()
+-- declines one. Withdrawing a still-pending submission is a plain
+-- owner-scoped UPDATE (RLS below).
+--
+-- Modeled on abo_verification_requests (table + RLS) and
+-- approve_member_verification (SECURITY DEFINER guard style).
+-- ============================================================
+
+-- ── 1. Table ──────────────────────────────────────────────────────────────────
+
+CREATE TABLE public.los_submission_requests (
+  id              uuid        NOT NULL DEFAULT gen_random_uuid(),
+  profile_id      uuid        NOT NULL,
+  root_abo_number text        NOT NULL,
+  rows            jsonb       NOT NULL,
+  row_count       integer     NOT NULL DEFAULT 0,
+  status          text        NOT NULL DEFAULT 'pending',
+  admin_note      text        NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  resolved_at     timestamptz NULL,
+  resolved_by     uuid        NULL,
+  CONSTRAINT los_submission_requests_pkey PRIMARY KEY (id),
+  CONSTRAINT los_submission_requests_status_check
+    CHECK (status IN ('pending', 'approved', 'rejected', 'withdrawn')),
+  CONSTRAINT los_submission_requests_profile_id_fkey
+    FOREIGN KEY (profile_id) REFERENCES public.profiles(id) ON DELETE CASCADE,
+  CONSTRAINT los_submission_requests_resolved_by_fkey
+    FOREIGN KEY (resolved_by) REFERENCES public.profiles(id)
+);
+
+-- Admin queue lists pending first; owners list their own history.
+CREATE INDEX idx_los_submission_requests_status ON public.los_submission_requests (status);
+CREATE INDEX idx_los_submission_requests_profile_id ON public.los_submission_requests (profile_id);
+
+-- ── 2. RLS (Pattern A helpers only) ───────────────────────────────────────────
+-- Server routes use the service client (bypasses RLS); these policies are
+-- defense-in-depth for any authenticated client access.
+
+ALTER TABLE public.los_submission_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admins full submission access" ON public.los_submission_requests
+  FOR ALL USING (public.is_admin());
+
+CREATE POLICY "owner can read own submission" ON public.los_submission_requests
+  FOR SELECT USING (profile_id = public.get_my_profile_id());
+
+CREATE POLICY "owner can insert own submission" ON public.los_submission_requests
+  FOR INSERT WITH CHECK (profile_id = public.get_my_profile_id() AND status = 'pending');
+
+-- Withdraw: owner may transition their own still-pending submission.
+CREATE POLICY "owner can withdraw own pending submission" ON public.los_submission_requests
+  FOR UPDATE
+  USING (profile_id = public.get_my_profile_id() AND status = 'pending')
+  WITH CHECK (profile_id = public.get_my_profile_id() AND status IN ('pending', 'withdrawn'));
+
+-- ── 3. approve_los_submissions — transition selected submissions ──────────────
+-- State transition ONLY. The actual los_members upsert stays in the API route
+-- (single import_los_members call) so the import lives in one place.
+
+CREATE OR REPLACE FUNCTION public.approve_los_submissions(
+  p_ids         uuid[],
+  p_resolved_by uuid DEFAULT NULL
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_updated integer := 0;
+BEGIN
+  IF auth.role() <> 'service_role' AND NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  UPDATE public.los_submission_requests
+  SET status      = 'approved',
+      resolved_at = now(),
+      resolved_by = p_resolved_by
+  WHERE id = ANY(p_ids)
+    AND status = 'pending';
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  RETURN v_updated;
+END;
+$$;
+
+-- ── 4. reject_los_submission — decline one pending submission ─────────────────
+
+CREATE OR REPLACE FUNCTION public.reject_los_submission(
+  p_id          uuid,
+  p_note        text DEFAULT NULL,
+  p_resolved_by uuid DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_req public.los_submission_requests%ROWTYPE;
+BEGIN
+  IF auth.role() <> 'service_role' AND NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  SELECT * INTO v_req
+  FROM public.los_submission_requests
+  WHERE id = p_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'submission % not found', p_id;
+  END IF;
+
+  IF v_req.status <> 'pending' THEN
+    RAISE EXCEPTION 'submission % is not pending (status=%)', p_id, v_req.status;
+  END IF;
+
+  UPDATE public.los_submission_requests
+  SET status      = 'rejected',
+      resolved_at = now(),
+      resolved_by = p_resolved_by,
+      admin_note  = p_note
+  WHERE id = p_id;
+END;
+$$;
+
+-- ── 5. Grants — service_role only (routes call via service client) ────────────
+
+REVOKE EXECUTE ON FUNCTION public.approve_los_submissions(uuid[], uuid) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.approve_los_submissions(uuid[], uuid) TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.reject_los_submission(uuid, text, uuid) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.reject_los_submission(uuid, text, uuid) TO service_role;

--- a/supabase/migrations/20260713000100_2607_feat_los_updated_by_abo.sql
+++ b/supabase/migrations/20260713000100_2607_feat_los_updated_by_abo.sql
@@ -1,0 +1,184 @@
+-- ROLLBACK: ALTER TABLE public.los_members DROP COLUMN IF EXISTS last_updated_by_abo;
+--           then re-apply the prior import_los_members / get_los_members_with_profiles
+--           definitions from 20260507000001 and 20260315000000 (baseline).
+-- ============================================================
+-- Track WHO last updated each LOS member, to surface "last updated"
+-- and flag when a member's data was last written by an UPLINE
+-- (a senior CORE whose submission included them) rather than by the
+-- member's own submission.
+--
+-- Under the CORE scope rule (a submission's root == the submitter's own
+-- ABO), any submission that contains member X where X != root is by an
+-- upline of X. So: last_updated_by_abo != X.abo_number  ⇒  updated by upline.
+-- ============================================================
+
+ALTER TABLE public.los_members
+  ADD COLUMN IF NOT EXISTS last_updated_by_abo text NULL;
+
+-- ── import_los_members — carry an optional per-row `updated_by_abo` owner ──────
+-- Backward compatible: admin manual imports (rows without updated_by_abo) leave
+-- the existing value intact via COALESCE. Only the merged CORE-submission path
+-- (mergeSubmissions annotates each winning row) sets it.
+
+CREATE OR REPLACE FUNCTION public.import_los_members(
+  p_rows        jsonb,
+  p_imported_by uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_inserted  integer;
+  v_snapshot  jsonb;
+  v_import_id uuid := gen_random_uuid();
+BEGIN
+  SELECT jsonb_agg(row_to_json(lm)::jsonb)
+    INTO v_snapshot
+    FROM public.los_members lm;
+  v_snapshot := COALESCE(v_snapshot, '[]'::jsonb);
+
+  INSERT INTO public.los_members (
+    abo_number, sponsor_abo_number, abo_level, country, name,
+    entry_date, phone, email, address, renewal_date,
+    gpv, ppv, bonus_percent, gbv, customer_pv, ruby_pv,
+    customers, points_to_next_level, qualified_legs, group_size,
+    personal_order_count, group_orders_count, sponsoring,
+    annual_ppv, last_updated_by_abo, last_synced_at
+  )
+  SELECT
+    r.abo_number,
+    nullif(r.sponsor_abo_number, ''),
+    r.abo_level,
+    r.country,
+    r.name,
+    CASE
+      WHEN nullif(r.entry_date, '') IS NULL THEN NULL
+      WHEN r.entry_date ~ '^\d{4}-\d{2}-\d{2}$' THEN r.entry_date::date
+      ELSE NULL
+    END,
+    r.phone,
+    r.email,
+    r.address,
+    CASE
+      WHEN nullif(r.renewal_date, '') IS NULL THEN NULL
+      WHEN r.renewal_date ~ '^\d{4}-\d{2}-\d{2}$' THEN r.renewal_date::date
+      ELSE NULL
+    END,
+    COALESCE(nullif(r.gpv,                  '')::numeric, 0),
+    COALESCE(nullif(r.ppv,                  '')::numeric, 0),
+    COALESCE(nullif(r.bonus_percent,         '')::numeric, 0),
+    COALESCE(nullif(r.gbv,                  '')::numeric, 0),
+    COALESCE(nullif(r.customer_pv,           '')::numeric, 0),
+    COALESCE(nullif(r.ruby_pv,              '')::numeric, 0),
+    COALESCE(nullif(r.customers,             '')::integer, 0),
+    COALESCE(nullif(r.points_to_next_level,  '')::numeric, 0),
+    COALESCE(nullif(r.qualified_legs,        '')::integer, 0),
+    COALESCE(nullif(r.group_size,            '')::integer, 0),
+    COALESCE(nullif(r.personal_order_count,  '')::integer, 0),
+    COALESCE(nullif(r.group_orders_count,    '')::integer, 0),
+    COALESCE(nullif(r.sponsoring,            '')::integer, 0),
+    COALESCE(nullif(r.annual_ppv,            '')::numeric, 0),
+    nullif(r.updated_by_abo, ''),
+    now()
+  FROM jsonb_to_recordset(p_rows) AS r(
+    abo_number            text,
+    sponsor_abo_number    text,
+    abo_level             text,
+    country               text,
+    name                  text,
+    entry_date            text,
+    phone                 text,
+    email                 text,
+    address               text,
+    renewal_date          text,
+    gpv                   text,
+    ppv                   text,
+    bonus_percent          text,
+    gbv                   text,
+    customer_pv            text,
+    ruby_pv               text,
+    customers             text,
+    points_to_next_level   text,
+    qualified_legs        text,
+    group_size            text,
+    personal_order_count   text,
+    group_orders_count     text,
+    sponsoring            text,
+    annual_ppv            text,
+    updated_by_abo        text
+  )
+  WHERE nullif(r.abo_number, '') IS NOT NULL
+  ON CONFLICT (abo_number) DO UPDATE SET
+    sponsor_abo_number   = excluded.sponsor_abo_number,
+    abo_level            = excluded.abo_level,
+    country              = excluded.country,
+    name                 = excluded.name,
+    entry_date           = excluded.entry_date,
+    phone                = excluded.phone,
+    email                = excluded.email,
+    address              = excluded.address,
+    renewal_date         = excluded.renewal_date,
+    gpv                  = excluded.gpv,
+    ppv                  = excluded.ppv,
+    bonus_percent        = excluded.bonus_percent,
+    gbv                  = excluded.gbv,
+    customer_pv          = excluded.customer_pv,
+    ruby_pv              = excluded.ruby_pv,
+    customers            = excluded.customers,
+    points_to_next_level = excluded.points_to_next_level,
+    qualified_legs       = excluded.qualified_legs,
+    group_size           = excluded.group_size,
+    personal_order_count = excluded.personal_order_count,
+    group_orders_count   = excluded.group_orders_count,
+    sponsoring           = excluded.sponsoring,
+    annual_ppv           = excluded.annual_ppv,
+    -- Preserve prior owner when this import doesn't specify one (manual imports).
+    last_updated_by_abo  = COALESCE(excluded.last_updated_by_abo, public.los_members.last_updated_by_abo),
+    last_synced_at       = now();
+
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+
+  PERFORM public.rebuild_tree_paths();
+
+  INSERT INTO public.los_imports (id, imported_by, status, row_count, removed_count, snapshot)
+  VALUES (v_import_id, p_imported_by, 'complete', v_inserted, 0, v_snapshot);
+
+  RETURN jsonb_build_object(
+    'inserted',  v_inserted,
+    'import_id', v_import_id,
+    'errors',    '[]'::jsonb
+  );
+END;
+$$;
+
+-- ── get_los_members_with_profiles — expose last_updated_by_abo ─────────────────
+-- RETURNS TABLE signature changes, so drop + recreate (CREATE OR REPLACE cannot
+-- alter the return type). Preserves SECURITY DEFINER + search_path + service_role grant.
+
+DROP FUNCTION IF EXISTS public.get_los_members_with_profiles();
+
+CREATE FUNCTION public.get_los_members_with_profiles()
+RETURNS TABLE(
+  abo_number text, sponsor_abo_number text, abo_level text, name text,
+  country text, gpv numeric, ppv numeric, bonus_percent numeric,
+  group_size integer, qualified_legs integer, annual_ppv numeric,
+  renewal_date date, last_synced_at timestamptz, last_updated_by_abo text,
+  profile_id uuid, first_name text, last_name text, role text, depth integer
+)
+LANGUAGE sql SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT m.abo_number, m.sponsor_abo_number, m.abo_level, m.name, m.country,
+    m.gpv, m.ppv, m.bonus_percent, m.group_size, m.qualified_legs,
+    m.annual_ppv, m.renewal_date, m.last_synced_at, m.last_updated_by_abo,
+    p.id, p.first_name, p.last_name, p.role::text, t.depth
+  FROM public.los_members m
+  LEFT JOIN public.profiles p ON p.abo_number = m.abo_number
+  LEFT JOIN public.tree_nodes t ON t.profile_id = p.id
+  ORDER BY m.abo_level::integer, m.abo_number;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_los_members_with_profiles() FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.get_los_members_with_profiles() TO service_role;

--- a/supabase/migrations/20260714000000_2607_feat_claim_los_submissions.sql
+++ b/supabase/migrations/20260714000000_2607_feat_claim_los_submissions.sql
@@ -1,0 +1,93 @@
+-- ROLLBACK: DROP FUNCTION IF EXISTS public.release_los_submissions(uuid[]);
+--           DROP FUNCTION IF EXISTS public.claim_los_submissions(uuid[], uuid);
+-- ============================================================
+-- Atomic claim-and-import for CORE LOS submissions.
+--
+-- The approve flow used to: read submissions -> filter status='pending' in JS ->
+-- merge -> import_los_members -> approve_los_submissions(). A withdraw landing
+-- between the read and the import could not stop data that was already written:
+-- the import ran off a stale snapshot and the trailing UPDATE simply matched
+-- zero rows, while the route still reported the submissions as approved.
+--
+-- claim_los_submissions() closes that window: one UPDATE ... WHERE status =
+-- 'pending' RETURNING the payload. Whatever it returns is provably still pending
+-- at claim time and is now owned by this caller — nothing else can claim it.
+-- The route merges/imports ONLY the returned rows.
+--
+-- release_los_submissions() is the compensating action: if the import fails after
+-- a successful claim, the route hands the claimed ids back to 'pending' so the
+-- admin can retry, instead of leaving them marked approved-but-never-imported.
+--
+-- Modeled on approve_los_submissions / reject_los_submission (20260713000000).
+-- ============================================================
+
+-- ── 1. claim_los_submissions — atomically claim pending rows and return them ───
+
+CREATE OR REPLACE FUNCTION public.claim_los_submissions(
+  p_ids         uuid[],
+  p_resolved_by uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  id              uuid,
+  root_abo_number text,
+  created_at      timestamptz,
+  rows            jsonb
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.role() <> 'service_role' AND NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  RETURN QUERY
+  UPDATE public.los_submission_requests s
+  SET status      = 'approved',
+      resolved_at = now(),
+      resolved_by = p_resolved_by
+  WHERE s.id = ANY(p_ids)
+    AND s.status = 'pending'
+  RETURNING s.id, s.root_abo_number, s.created_at, s.rows;
+END;
+$$;
+
+-- ── 2. release_los_submissions — hand a failed claim back to 'pending' ─────────
+-- Only reverses rows still sitting in 'approved'; a row an admin has since moved
+-- elsewhere is left alone.
+
+CREATE OR REPLACE FUNCTION public.release_los_submissions(
+  p_ids uuid[]
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_released integer := 0;
+BEGIN
+  IF auth.role() <> 'service_role' AND NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  UPDATE public.los_submission_requests
+  SET status      = 'pending',
+      resolved_at = NULL,
+      resolved_by = NULL
+  WHERE id = ANY(p_ids)
+    AND status = 'approved';
+  GET DIAGNOSTICS v_released = ROW_COUNT;
+
+  RETURN v_released;
+END;
+$$;
+
+-- ── 3. Grants — service_role only (routes call via service client) ─────────────
+
+REVOKE EXECUTE ON FUNCTION public.claim_los_submissions(uuid[], uuid) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.claim_los_submissions(uuid[], uuid) TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.release_los_submissions(uuid[]) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.release_los_submissions(uuid[]) TO service_role;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -2228,6 +2228,15 @@ export type Database = {
           isSetofReturn: true
         }
       }
+      claim_los_submissions: {
+        Args: { p_ids: string[]; p_resolved_by?: string }
+        Returns: {
+          id: string
+          root_abo_number: string
+          created_at: string
+          rows: Json
+        }[]
+      }
       dissolve_partnership: {
         Args: { p_changed_by: string; p_profile_id: string }
         Returns: {
@@ -2379,6 +2388,10 @@ export type Database = {
       reject_los_submission: {
         Args: { p_id: string; p_note?: string; p_resolved_by?: string }
         Returns: undefined
+      }
+      release_los_submissions: {
+        Args: { p_ids: string[] }
+        Returns: number
       }
       rollback_los_import: { Args: { p_import_id: string }; Returns: Json }
       run_los_digest: { Args: never; Returns: undefined }

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -736,6 +736,7 @@ export type Database = {
           group_orders_count: number | null
           group_size: number | null
           last_synced_at: string
+          last_updated_by_abo: string | null
           name: string | null
           personal_order_count: number | null
           phone: string | null
@@ -763,6 +764,7 @@ export type Database = {
           group_orders_count?: number | null
           group_size?: number | null
           last_synced_at?: string
+          last_updated_by_abo?: string | null
           name?: string | null
           personal_order_count?: number | null
           phone?: string | null
@@ -790,6 +792,7 @@ export type Database = {
           group_orders_count?: number | null
           group_size?: number | null
           last_synced_at?: string
+          last_updated_by_abo?: string | null
           name?: string | null
           personal_order_count?: number | null
           phone?: string | null
@@ -802,6 +805,74 @@ export type Database = {
           sponsoring?: number | null
         }
         Relationships: []
+      }
+      los_submission_requests: {
+        Row: {
+          admin_note: string | null
+          created_at: string
+          id: string
+          profile_id: string
+          resolved_at: string | null
+          resolved_by: string | null
+          root_abo_number: string
+          row_count: number
+          rows: Json
+          status: string
+        }
+        Insert: {
+          admin_note?: string | null
+          created_at?: string
+          id?: string
+          profile_id: string
+          resolved_at?: string | null
+          resolved_by?: string | null
+          root_abo_number: string
+          row_count?: number
+          rows: Json
+          status?: string
+        }
+        Update: {
+          admin_note?: string | null
+          created_at?: string
+          id?: string
+          profile_id?: string
+          resolved_at?: string | null
+          resolved_by?: string | null
+          root_abo_number?: string
+          row_count?: number
+          rows?: Json
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "los_submission_requests_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "member_roles_history"
+            referencedColumns: ["profile_id"]
+          },
+          {
+            foreignKeyName: "los_submission_requests_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "los_submission_requests_resolved_by_fkey"
+            columns: ["resolved_by"]
+            isOneToOne: false
+            referencedRelation: "member_roles_history"
+            referencedColumns: ["profile_id"]
+          },
+          {
+            foreignKeyName: "los_submission_requests_resolved_by_fkey"
+            columns: ["resolved_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       member_event_log: {
         Row: {
@@ -2111,6 +2182,10 @@ export type Database = {
         Args: { p_request_id: string }
         Returns: Json
       }
+      approve_los_submissions: {
+        Args: { p_ids: string[]; p_resolved_by?: string }
+        Returns: number
+      }
       approve_member_verification: {
         Args: { p_admin_note?: string; p_request_id: string }
         Returns: {
@@ -2223,6 +2298,7 @@ export type Database = {
           group_size: number
           last_name: string
           last_synced_at: string
+          last_updated_by_abo: string
           name: string
           ppv: number
           profile_id: string
@@ -2300,6 +2376,10 @@ export type Database = {
         Returns: Json
       }
       rebuild_tree_paths: { Args: never; Returns: undefined }
+      reject_los_submission: {
+        Args: { p_id: string; p_note?: string; p_resolved_by?: string }
+        Returns: undefined
+      }
       rollback_los_import: { Args: { p_import_id: string }; Returns: Json }
       run_los_digest: { Args: never; Returns: undefined }
       text2ltree: { Args: { "": string }; Returns: unknown }


### PR DESCRIPTION
## What & why

Today the LOS (Line of Sponsorship) import is **admin-only**, so an admin must collect every CORE leader's CSV export and import it by hand. This PR lets each **CORE member upload their own part of the tree** from a new `/profile/los-upload` page. Uploads are **staged as pending submissions** for admin review — never written directly to `los_members`. An admin reviews the queue in approval-hub, **merges** the selected parts, and runs the existing `import_los_members` RPC in one authoritative step.

## Key design decisions

- **Scope guard (server-enforced):** a submission's tree root must equal the caller's own ABO. `checkSubmissionRoot` returns `mismatch` / `multi-root` / `no-root`; the client shows it early, the route re-checks and 400s. A CORE can only upload their own sub-tree.
- **Authority model — deepest-owner-wins:** CORE sub-trees nest and overlap (a senior leader's export contains juniors' people). `mergeSubmissions` resolves any contested ABO to the **closest-upline owner**, ties broken by newest submission — replacing the old first-seen-wins, and surfacing contested nodes as junctions instead of silently.
- **Minimized change-tinted preview:** `SubtreePreview` reuses `buildTree` + `orgchart-math` to show exactly which part is being updated (new / level / bonus / unchanged).
- **"Last updated / by upline":** new `los_members.last_updated_by_abo` records who last wrote each member; the preview colours a node distinctly when an **upline** last updated it.
- **Restrictions:** CORE cannot purge or roll back others; withdraw affects only their own pending submission.
- **Streamlining:** shared `components/los-import/` (DropZone, AssemblySummary, SubtreePreview, useAssembly) now drive **both** the admin Data Center and the CORE page.
- **Prerender fix:** `/api/socials` made resilient so env-less builds don't fail prerender (keeps prod ISR).
- A short **how-to** for exporting the CSV is on the upload page.

## Database

Two migrations, already applied to the hosted **DEV** project (recorded via `migration repair --status applied`):
- `20260713000000` — `los_submission_requests` table + Pattern-A RLS + `approve_los_submissions` / `reject_los_submission` SECURITY DEFINER RPCs.
- `20260713000100` — `los_members.last_updated_by_abo`; `import_los_members` carries an optional per-row owner (COALESCE-preserving, backward compatible with admin manual imports); `get_los_members_with_profiles` exposes the column.

## Testing

- **Unit:** `mergeSubmissions` (deepest-owner-wins, order-independent, tie-break, owner annotation), `findTreeRoots`, `checkSubmissionRoot`.
- **Authenticated E2E** (`e2e/los-submission-auth.spec.ts`, Playwright + `@clerk/testing`), **6/6 green against DEV**: mismatch→400, matching→pending, withdraw, admin approve→import writes rows + `last_updated_by_abo` (self vs upline), senior-CORE import stamps a downline node with the senior owner, reject. Throwaway fixtures seeded and cleaned up. Existing `admin-auth` spec still 4/4.
- `npm run build` green; 96/96 unit tests; eslint 0 errors on changed files.

## Reviewer notes

- **Branch name** is `claude/…`, not the repo's `dev/[YYMM]-DEV-[GH#]` convention (no GH issue number was assigned for this worktree) — rename if you'd like before merge.
- Pre-existing DEV migration-history drift (phantom `20260707/09/10` from #563 recovery) was left untouched.
- `docs/STATE.md` is included as the working-state doc per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CORE users can upload LOS CSV files, preview changes, submit them for review, and withdraw pending submissions.
  - Admins can review, approve, or reject LOS submissions, with status badges, notes, conflict details, and import summaries.
  - Added upload guidance and LOS access to eligible profile dashboards.
  - LOS previews now show update attribution and change statuses.
  - CSV assembly supports multiple files, disconnected-source warnings, and junction details.

- **Bug Fixes**
  - Social content requests now fail gracefully with an empty result instead of an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->