### PR TITLE
[2607-DEV-570] fix: migrate-prod connects via IPv4 session pooler

### DIFF
--- a/.github/workflows/migrate-prod.yml
+++ b/.github/workflows/migrate-prod.yml
@@ -13,6 +13,9 @@ name: Migrate Prod
 on:
   push:
     branches: [main]
+  # Manual re-run path: when a run fails after merge (or a fix PR without
+  # migrations needs to re-trigger the apply), dispatch it by hand.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -34,6 +37,10 @@ jobs:
       - name: Check whether this push touched supabase/migrations
         id: diff
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "has_migrations=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           BEFORE="${{ github.event.before }}"
           # New branch or force push: fall back to running the gated job.
           if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BEFORE" 2>/dev/null; then
@@ -53,18 +60,23 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     env:
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD_PROD }}
     steps:
       - uses: actions/checkout@v4
       - uses: supabase/setup-cli@v3
         with:
           version: latest
-      - name: Link production project
-        run: supabase link --project-ref ynykjpnetfwqzdnsgkkg
+      # GitHub-hosted runners have no IPv6 route and the direct DB host
+      # (db.<ref>.supabase.co) is IPv6-only, so `supabase link` cannot
+      # connect from CI. Connect explicitly through the IPv4 session pooler.
+      - name: Build pooler connection string
+        run: |
+          ENC_PW=$(jq -rn --arg p "$SUPABASE_DB_PASSWORD" '$p|@uri')
+          echo "::add-mask::$ENC_PW"
+          echo "DB_URL=postgresql://postgres.ynykjpnetfwqzdnsgkkg:${ENC_PW}@aws-1-eu-west-2.pooler.supabase.com:5432/postgres" >> "$GITHUB_ENV"
       - name: Log ledger state before push
-        run: supabase migration list --linked
+        run: supabase migration list --db-url "$DB_URL"
       - name: Apply pending migrations
-        run: supabase db push --linked
+        run: supabase db push --db-url "$DB_URL"
       - name: Log ledger state after push
-        run: supabase migration list --linked
+        run: supabase migration list --db-url "$DB_URL"

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -59,4 +59,5 @@ Recovered a live incident — RESULT: `supabase db reset --linked` wiped the DEV
 - NOTED (not done): untracked June-orchestration leftovers in main checkout root (`.agents/` dirs, `convert.js`, `test_out.txt`) — user call whether to archive/delete; pre-existing April stash `stash@{1}` on main; guest-visitor console error `Query data cannot be undefined ["profile-ui-prefs-font-size"]` (pre-existing app behavior, UI-prefs query returns undefined for signed-out users); Playwright `webServer.timeout` 120s < cold worktree compile ~5min (warm the cache first)
 
 ## Failed attempts
-(none — the `db reset --linked` incident above was diagnosed and recovered in the same session, not abandoned)
+ATTEMPT 1 [L1] (migrate-prod.yml, run 29491753945): `supabase link` + `migration list --linked` from a GitHub-hosted runner -> "failed to connect to postgres: effect/sql/SqlError: PgClient: Failed to connect" — direct DB host is IPv6-only, runners have no IPv6. Fix: explicit `--db-url` via the IPv4 session pooler (aws-1-eu-west-2), no link.
+(previous task: none — the `db reset --linked` incident was diagnosed and recovered in the same session, not abandoned)

--- a/scripts/claude-hooks/dispatch.js
+++ b/scripts/claude-hooks/dispatch.js
@@ -56,14 +56,18 @@ function commandSkeleton(command) {
 /** Blocking checks for a Bash command. */
 function bashViolation(command) {
   const cmd = commandSkeleton(command);
-  // Never push to main (covers "push origin main", "push -f", "HEAD:main").
-  if (/\bgit\s+push\b/.test(cmd) && /(\s|:)(main|master)\b/.test(cmd)) {
-    return "BLOCKED: pushing to main is forbidden. Use a dev/[YYMM]-DEV-[GH#] branch and open a PR (CLAUDE.md hard constraint).";
-  }
-  // Branch naming at creation time.
-  const m = cmd.match(/\bgit\s+(?:checkout\s+-b|switch\s+-c)\s+["']?([^\s"']+)/);
-  if (m && !rules.isValidBranchName(m[1])) {
-    return `BLOCKED: branch "${m[1]}" violates naming. Use dev/[YYMM]-DEV-[GH#] (e.g. dev/2607-DEV-572) or claude/*.`;
+  // Evaluate per shell clause so `git checkout main && git push origin dev/x`
+  // is not misread as a push to main.
+  for (const clause of cmd.split(/&&|\|\||[;|\n]/)) {
+    // Never push to main (covers "push origin main", "push -f", "HEAD:main").
+    if (/\bgit\s+push\b/.test(clause) && /(\s|:)(main|master)\b/.test(clause)) {
+      return "BLOCKED: pushing to main is forbidden. Use a dev/[YYMM]-DEV-[GH#] branch and open a PR (CLAUDE.md hard constraint).";
+    }
+    // Branch naming at creation time.
+    const m = clause.match(/\bgit\s+(?:checkout\s+-b|switch\s+-c)\s+["']?([^\s"']+)/);
+    if (m && !rules.isValidBranchName(m[1])) {
+      return `BLOCKED: branch "${m[1]}" violates naming. Use dev/[YYMM]-DEV-[GH#] (e.g. dev/2607-DEV-572) or claude/*.`;
+    }
   }
   return null;
 }

--- a/scripts/claude-hooks/dispatch.test.js
+++ b/scripts/claude-hooks/dispatch.test.js
@@ -99,6 +99,8 @@ describe('legitimate operations pass (exit 0)', () => {
       // Text inside quotes/heredocs that merely MENTIONS forbidden commands
       pre('Bash', { command: 'gh pr create --title "t" --body "$(cat <<\'EOF\'\nBlocks `git push` to main and prod db push (ynykjpnetfwqzdnsgkkg).\nEOF\n)"' }),
       pre('Bash', { command: 'git commit -m "docs: never git push origin main"' }),
+      // main in one clause, push in another — must not cross-contaminate
+      pre('Bash', { command: 'git checkout main && git pull && git checkout -b dev/2607-DEV-570-fix && git push -u origin dev/2607-DEV-570-fix' }),
       pre('mcp__github-tevd__create_branch', { branch: 'dev/2607-DEV-design-sync' }),
     ]
     for (const p of allowed) {


### PR DESCRIPTION
## Summary

The first gated migrate-prod run (29491753945) failed at connection: GitHub-hosted runners have no IPv6 route and the direct DB host is IPv6-only, so `supabase link`/`--linked` cannot connect from CI. Fix: explicit `--db-url` via the `aws-1-eu-west-2` session pooler (URI-encoded, masked password); no `link` step. Adds `workflow_dispatch` so the still-pending `20260716000100` apply can be re-triggered without a new migration push. Also fixes a hook-dispatcher false positive on compound shell commands.

## Checklist
- [ ] CI green and Vercel preview READY
- [x] 390px — N/A, no UI changes
- [x] Migrations expand-only — N/A, no migrations
- [x] ROLLBACK comment — N/A
- [ ] CLAIMS.md — N/A (infra)

## Session State
**Status:** DONE
**Next:** merge -> workflow_dispatch Migrate Prod -> approve gate -> verify ledger + inventory diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for manually rerunning production database migrations.
  * Improved migration execution and status reporting using a direct production database connection.

* **Bug Fixes**
  * Improved command validation so chained shell commands are evaluated independently, reducing incorrect blocks of legitimate operations.

* **Tests**
  * Added coverage for chained Git operations that should be permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->