### PR TITLE
[2607-DEV-570] fix: rename prod constraint instead of re-adopting its index

### DIFF
--- a/supabase/migrations/20260716000100_normalize_prod_schema_drift.sql
+++ b/supabase/migrations/20260716000100_normalize_prod_schema_drift.sql
@@ -90,6 +90,17 @@ BEGIN
       AND conrelid = 'public.spouse_link_requests'::regclass
   ) THEN
     IF EXISTS (
+      -- prod: the invariant already exists as a CONSTRAINT under the
+      -- MCP-era name (its index is constraint-owned, so USING INDEX would
+      -- fail with SQLSTATE 55000) — rename it to the canonical name.
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'spouse_link_requests_requester_unique'
+        AND conrelid = 'public.spouse_link_requests'::regclass
+    ) THEN
+      ALTER TABLE public.spouse_link_requests
+        RENAME CONSTRAINT spouse_link_requests_requester_unique
+        TO uq_spouse_link_requester;
+    ELSIF EXISTS (
       SELECT 1 FROM pg_indexes
       WHERE schemaname = 'public'
         AND indexname = 'spouse_link_requests_requester_unique'


### PR DESCRIPTION
## Summary

Third and final prod-apply fix: prod's unique index is constraint-owned under the MCP-era name, so the adopt-by-USING-INDEX branch raised SQLSTATE 55000 and the migration rolled back (recorded nowhere — in-place edit is safe). New first branch: RENAME CONSTRAINT to canonical `uq_spouse_link_requester`. Merging this triggers the gated run directly (migration path changed), no manual dispatch.

## Checklist
- [ ] CI green (migrations-check replays incl. this file)
- [x] Expand-only — metadata rename, no data shape change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database consistency across environments.
  * Prevented invalid profile records from being created or updated.
  * Enforced one active spouse-link request per requester.
  * Strengthened safeguards for pinned social posts and primary profiles.

* **Performance**
  * Added and restored indexes to improve tree, notification, and profile lookups.

* **Security**
  * Standardized access controls for spouse-link requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->