### PR TITLE
[2607-DEV-570] Retire the never-write-from-preview constraint

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -7,8 +7,10 @@ name: Preview Smoke
 # to the PR as required checks by default. Once trusted, add the "smoke"
 # job as a required status check in branch protection.
 #
-# The suite is navigation-only because preview deployments hit the
-# production Supabase project (see docs/DEV_WORKFLOW.md and issue #547).
+# The suite is navigation-only for historical reasons: previews used to hit
+# the production Supabase project. Since 2026-07-16 previews use the DEV
+# project (Pre-Production-scoped Vercel env vars), so this can graduate to
+# real flows — see docs/DEV_WORKFLOW.md.
 
 on:
   deployment_status:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Violation = immediate stop, no exceptions.
 - **NEVER expose `SUPABASE_SERVICE_ROLE_KEY` to the client.**
 - **NEVER bypass Clerk auth on a protected route.**
 - **NEVER mark Done on static analysis alone.** Vercel PR preview must be READY and CI green.
-- **NEVER write data to Supabase from a Preview URL** — preview URLs hit production DB.
+- **Preview deployments use the DEV Supabase project** (Pre-Production-scoped Vercel env vars, verified 2026-07-16). Writes from a preview land in the shared DEV DB — same etiquette as local dev. Production-scoped vars still hold prod credentials; never copy them to other scopes.
 - **390px mobile-first.** Every new UI surface must render correctly at 390px.
 - **RLS policies use Pattern A helpers only** — `is_admin()`, `get_my_role()`, `get_my_profile_id()`, `get_my_clerk_id()`. Never raw `auth.jwt()`.
 - **NEVER introduce a Clerk JWT Supabase client on the server.** All server DB access uses `createServiceClient()` (service role); a JWT client requires a ticket explicitly scoping it (ADR-002/ADR-011).

--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -47,7 +47,7 @@ Local dev runs against the **hosted Supabase dev project** `iymwxdewcpvpjgzewtzk
 
 **Local stack decommission** (optional, reclaims disk): `supabase stop` to tear down the Docker containers, then `docker system prune -a --volumes` to reclaim images/volumes — **destructive to all unused Docker data on the machine**, run it yourself, don't script it into anything automated.
 
-**Prod credentials** serve only explicitly prod-targeted work (deploys, prod data checks). Vercel **preview URLs still hit prod** — the never-write-from-preview rule stands.
+**Prod credentials** serve only explicitly prod-targeted work (deploys, prod data checks). Vercel **preview deployments hit the DEV project** since 2026-07-16 (Pre-Production-scoped env vars in the Vercel dashboard hold the `iymwxdewcpvpjgzewtzk` URL + keys); preview writes land in the shared DEV DB. Only the Production environment carries prod credentials.
 
 ## Authenticated E2E (Clerk)
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -28,7 +28,7 @@ Merged `origin/main` (post-#568) into the branch: the only conflict was this fil
 - `.env.development.local` never committed (gitignored, real DEV-project credentials after the #563 switch)
 - Docker teardown (`docker system prune`) is user-run only, never scripted/automated
 - Milestone touches Supabase RLS/grants/security-definer functions — Pattern A helpers only, never raw auth.jwt() (CLAUDE.md hard constraint)
-- Never write data to Supabase from a Preview URL (preview hits prod DB)
+- Never write data to Supabase from a Preview URL (preview hits prod DB) — OBSOLETE 2026-07-16: previews now use the DEV project (Pre-Production-scoped Vercel env vars); constraint retired with the user's confirmation
 - Never push directly to `main`; `dev/[YYMM]-DEV-[GH#]` branches only
 - Never mark Done on static analysis alone — Vercel PR preview must be READY and CI green
 - CLAUDE.md hard stop: no `git push` without the user explicitly asking for a push in-conversation (quote required)


### PR DESCRIPTION
## Summary

Previews now run against the DEV Supabase project (Pre-Production-scoped Vercel env vars, values verified against `iymwxdewcpvpjgzewtzk`). This PR retires the "never write from a preview URL" hard constraint across CLAUDE.md / DEV_WORKFLOW / preview-smoke header. Merge only after this PR's own preview is runtime-verified to call the DEV host (verification in progress).

Follow-up (separate ticket): graduate preview-smoke from navigation-only to real flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)