### PR TITLE
[2607-DEV-582] test(e2e): graduate preview-smoke to a real guest library flow

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -26,12 +26,6 @@ jobs:
       github.event.deployment_status.state == 'success' &&
       startsWith(github.event.deployment.environment, 'Preview')
     runs-on: ubuntu-latest
-    # Surfaced as env so steps can guard on presence (the `secrets` context
-    # is not usable directly in a step `if:`). Absent -> seeding is skipped
-    # and the guest flow skips gracefully.
-    env:
-      DEV_SUPABASE_URL: ${{ secrets.DEV_SUPABASE_URL }}
-      DEV_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.DEV_SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,17 +36,6 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
-      # Ensure the guest-visible fixture guide exists in DEV so the
-      # library-guide flow runs (not skips). Self-healing: re-seeds on every
-      # run, so a DEV re-mirror from prod can't leave the flow un-exercised.
-      # Requires DEV_SUPABASE_URL + DEV_SUPABASE_SERVICE_ROLE_KEY secrets;
-      # the seed script's own guard refuses any non-DEV/local target.
-      - name: Seed guest smoke guide into DEV
-        if: env.DEV_SUPABASE_URL != ''
-        run: npm run seed:smoke-guide
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ env.DEV_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ env.DEV_SUPABASE_SERVICE_ROLE_KEY }}
       - run: npx playwright install --with-deps chromium
       # VERCEL_AUTOMATION_BYPASS_SECRET: Vercel project -> Settings ->
       # Deployment Protection -> Protection Bypass for Automation, mirrored

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -1,16 +1,13 @@
 name: Preview Smoke
 
-# Runs the navigation-only Playwright smoke against each Vercel PREVIEW
-# deployment once Vercel reports it ready.
+# Runs the Playwright smoke against each Vercel PREVIEW deployment once
+# Vercel reports it ready: public-route navigation plus one real guest flow
+# (e2e/library-guide.spec.ts). Previews use the DEV Supabase project
+# (Pre-Production-scoped Vercel env vars) since 2026-07-16.
 #
 # Advisory-only for now: deployment_status-triggered runs are not attached
 # to the PR as required checks by default. Once trusted, add the "smoke"
 # job as a required status check in branch protection.
-#
-# The suite is navigation-only for historical reasons: previews used to hit
-# the production Supabase project. Since 2026-07-16 previews use the DEV
-# project (Pre-Production-scoped Vercel env vars), so this can graduate to
-# real flows — see docs/DEV_WORKFLOW.md.
 
 on:
   deployment_status:
@@ -29,6 +26,12 @@ jobs:
       github.event.deployment_status.state == 'success' &&
       startsWith(github.event.deployment.environment, 'Preview')
     runs-on: ubuntu-latest
+    # Surfaced as env so steps can guard on presence (the `secrets` context
+    # is not usable directly in a step `if:`). Absent -> seeding is skipped
+    # and the guest flow skips gracefully.
+    env:
+      DEV_SUPABASE_URL: ${{ secrets.DEV_SUPABASE_URL }}
+      DEV_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.DEV_SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,6 +42,17 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
+      # Ensure the guest-visible fixture guide exists in DEV so the
+      # library-guide flow runs (not skips). Self-healing: re-seeds on every
+      # run, so a DEV re-mirror from prod can't leave the flow un-exercised.
+      # Requires DEV_SUPABASE_URL + DEV_SUPABASE_SERVICE_ROLE_KEY secrets;
+      # the seed script's own guard refuses any non-DEV/local target.
+      - name: Seed guest smoke guide into DEV
+        if: env.DEV_SUPABASE_URL != ''
+        run: npm run seed:smoke-guide
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ env.DEV_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ env.DEV_SUPABASE_SERVICE_ROLE_KEY }}
       - run: npx playwright install --with-deps chromium
       # VERCEL_AUTOMATION_BYPASS_SECRET: Vercel project -> Settings ->
       # Deployment Protection -> Protection Bypass for Automation, mirrored

--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -77,7 +77,7 @@ CI (`e2e-authenticated` job in `ci.yml`) does the same against a fresh local Sup
 5. Push (agents: only with an explicit user go-ahead) → PR opens → automatically:
    - **GitHub Actions**: typecheck, lint, test, build, audit ([ci.yml](../.github/workflows/ci.yml))
    - **Vercel**: preview deployment (~2 min), URL in the PR comment
-   - **preview-smoke**: Playwright 390px smoke against the preview URL once the deployment is READY — advisory (not a required check) for now. Covers navigation over the public routes plus one real guest flow (`e2e/library-guide.spec.ts`: open `/library` → click a guide card → detail page). That flow needs a stable guest-visible guide in DEV — run `npm run seed:smoke-guide` once against DEV (and after any DEV re-mirror from prod); it skips with a pointer when the guide is absent.
+   - **preview-smoke**: Playwright 390px smoke against the preview URL once the deployment is READY — advisory (not a required check) for now. Covers navigation over the public routes plus one real guest flow (`e2e/library-guide.spec.ts`: open `/library` → click a guide card → detail page). That flow needs a stable guest-visible guide in DEV; the workflow re-seeds it every run via `npm run seed:smoke-guide` (guarded by the `DEV_SUPABASE_URL` / `DEV_SUPABASE_SERVICE_ROLE_KEY` Actions secrets), so a DEV re-mirror from prod can't leave it un-seeded. To seed manually against a DEV-configured env, run `npm run seed:smoke-guide`; the spec skips with a pointer when the guide is absent.
    - **CodeRabbit** review; review-bot fixes are applied via the `GCR` (General Code Review) workflow command
 6. Merge only when CI is green **and** the Vercel preview is READY (never mark work Done on static analysis alone).
 

--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -77,7 +77,7 @@ CI (`e2e-authenticated` job in `ci.yml`) does the same against a fresh local Sup
 5. Push (agents: only with an explicit user go-ahead) → PR opens → automatically:
    - **GitHub Actions**: typecheck, lint, test, build, audit ([ci.yml](../.github/workflows/ci.yml))
    - **Vercel**: preview deployment (~2 min), URL in the PR comment
-   - **preview-smoke**: Playwright 390px smoke against the preview URL once the deployment is READY — advisory (not a required check) for now
+   - **preview-smoke**: Playwright 390px smoke against the preview URL once the deployment is READY — advisory (not a required check) for now. Covers navigation over the public routes plus one real guest flow (`e2e/library-guide.spec.ts`: open `/library` → click a guide card → detail page). That flow needs a stable guest-visible guide in DEV — run `npm run seed:smoke-guide` once against DEV (and after any DEV re-mirror from prod); it skips with a pointer when the guide is absent.
    - **CodeRabbit** review; review-bot fixes are applied via the `GCR` (General Code Review) workflow command
 6. Merge only when CI is green **and** the Vercel preview is READY (never mark work Done on static analysis alone).
 

--- a/docs/DEV_WORKFLOW.md
+++ b/docs/DEV_WORKFLOW.md
@@ -77,7 +77,7 @@ CI (`e2e-authenticated` job in `ci.yml`) does the same against a fresh local Sup
 5. Push (agents: only with an explicit user go-ahead) → PR opens → automatically:
    - **GitHub Actions**: typecheck, lint, test, build, audit ([ci.yml](../.github/workflows/ci.yml))
    - **Vercel**: preview deployment (~2 min), URL in the PR comment
-   - **preview-smoke**: Playwright 390px smoke against the preview URL once the deployment is READY — advisory (not a required check) for now. Covers navigation over the public routes plus one real guest flow (`e2e/library-guide.spec.ts`: open `/library` → click a guide card → detail page). That flow needs a stable guest-visible guide in DEV; the workflow re-seeds it every run via `npm run seed:smoke-guide` (guarded by the `DEV_SUPABASE_URL` / `DEV_SUPABASE_SERVICE_ROLE_KEY` Actions secrets), so a DEV re-mirror from prod can't leave it un-seeded. To seed manually against a DEV-configured env, run `npm run seed:smoke-guide`; the spec skips with a pointer when the guide is absent.
+   - **preview-smoke**: Playwright 390px smoke against the preview URL once the deployment is READY — advisory (not a required check) for now. Covers navigation over the public routes plus one real guest flow (`e2e/library-guide.spec.ts`: open `/library` → click a guide card → detail page). That flow needs a stable guest-visible guide in DEV (`npm run seed:smoke-guide`, seeded once — see the Database section); the spec skips with a pointer when the guide is absent, so an unseeded DB never fails the run.
    - **CodeRabbit** review; review-bot fixes are applied via the `GCR` (General Code Review) workflow command
 6. Merge only when CI is green **and** the Vercel preview is READY (never mark work Done on static analysis alone).
 
@@ -94,6 +94,7 @@ Agent sessions run in worktrees under `.claude/worktrees/`. Two things make them
 - **Expand/contract (hard constraint)**: migrations merged with code must be backward-compatible with the currently deployed code; destructive changes (drops/renames) ship in a later PR after no code references the old shape. Vercel deploys on merge while the migration awaits approval, so both orderings must be safe.
 - Refs: dev `iymwxdewcpvpjgzewtzk` (`tevd-portal-dev`, the default link in `supabase/config.toml`, also the day-to-day local dev target per #563), prod `ynykjpnetfwqzdnsgkkg`. Never link/push prod from a dev machine without an explicit ticket.
 - Local Supabase stack (Docker, #547): superseded by the hosted DEV project (#563) for all local dev, including the authenticated E2E suite — see "Authenticated E2E (Clerk)" above. Keep the local stack option only if you specifically need per-machine data isolation.
+- **preview-smoke fixture**: the guest flow needs one published, guest-visible guide (`slug=e2e-smoke-guide`) in DEV. Seed it with `npm run seed:smoke-guide` against a DEV-configured env (the script refuses any non-DEV/local target). It persists — the only thing that drops it is **reloading/re-mirroring DEV from prod**, so make re-seeding the final step of any such reset. If it's ever missing, the `library-guide` spec skips (with a pointer) rather than failing.
 
 ## Troubleshooting
 

--- a/e2e/library-guide.spec.ts
+++ b/e2e/library-guide.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Real guest flow (issue #582): open the library, click a guide card, and
+ * land on its detail page. Graduates preview-smoke beyond navigation-only
+ * now that previews use the DEV Supabase project (PR #579).
+ *
+ * Depends on a stable guest-visible guide seeded by scripts/seed-smoke-guide.js
+ * (npm run seed:smoke-guide, DEV/local only). When that guide is absent — an
+ * unseeded local DB, or DEV freshly re-mirrored from prod — the flow can't
+ * run, so it skips with a pointer to the seed command rather than failing on
+ * missing fixture data. In CI (seeded DEV preview) it runs for real.
+ */
+
+// Kept in sync with scripts/seed-smoke-guide.js (SMOKE_GUIDE_SLUG / title).
+const SMOKE_GUIDE_SLUG = 'e2e-smoke-guide'
+const SMOKE_GUIDE_TITLE = 'E2E Smoke Guide'
+
+test(`guest opens /library and clicks through to the ${SMOKE_GUIDE_SLUG} guide`, async ({
+  page,
+}, testInfo) => {
+  const pageErrors: Error[] = []
+  page.on('pageerror', (err) => pageErrors.push(err))
+
+  await page.goto('/library?type=guides')
+
+  const card = page.locator(`a[href="/library/${SMOKE_GUIDE_SLUG}"]`)
+  const seeded = (await card.count()) > 0
+  test.skip(
+    !seeded,
+    `smoke guide "${SMOKE_GUIDE_SLUG}" not present in this DB — run: npm run seed:smoke-guide (DEV/local)`,
+  )
+
+  await card.first().click()
+
+  await expect(page).toHaveURL(new RegExp(`/library/${SMOKE_GUIDE_SLUG}$`))
+  await expect(page.locator('h1')).toHaveText(SMOKE_GUIDE_TITLE)
+  // The detail page renders a back link to the library index.
+  await expect(page.locator('a[href="/library"]')).toBeVisible()
+
+  const viewport = testInfo.project.use.viewport
+  if (viewport != null) {
+    const scrollWidth = await page.evaluate(
+      () => document.scrollingElement?.scrollWidth ?? 0,
+    )
+    expect(
+      scrollWidth,
+      `horizontal overflow on the guide detail: content is ${scrollWidth}px wide at a ${viewport.width}px viewport`,
+    ).toBeLessThanOrEqual(viewport.width)
+  }
+
+  expect(
+    pageErrors,
+    `uncaught page errors: ${pageErrors.map((e) => e.message).join('; ')}`,
+  ).toHaveLength(0)
+})

--- a/e2e/library-guide.spec.ts
+++ b/e2e/library-guide.spec.ts
@@ -27,7 +27,7 @@ test(`guest opens /library and clicks through to the ${SMOKE_GUIDE_SLUG} guide`,
   const card = page.locator(`a[href="/library/${SMOKE_GUIDE_SLUG}"]`)
   const seeded = (await card.count()) > 0
   test.skip(
-    !seeded,
+    seeded === false,
     `smoke guide "${SMOKE_GUIDE_SLUG}" not present in this DB — run: npm run seed:smoke-guide (DEV/local)`,
   )
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:mobile": "playwright test --project=mobile-390",
     "test:e2e:auth": "playwright test --project=authenticated",
     "e2e:seed-clerk": "node scripts/seed-clerk-test-users.js",
+    "seed:smoke-guide": "node scripts/seed-smoke-guide.js",
     "verify": "npm run lint && npm run check-types && npm run test && npm run build",
     "check:env": "node scripts/check-env.js",
     "env:worktree": "node scripts/setup-worktree-env.js",

--- a/scripts/seed-smoke-guide.js
+++ b/scripts/seed-smoke-guide.js
@@ -22,7 +22,7 @@ const { createClient } = require('@supabase/supabase-js')
 // Loaded in Next.js precedence order: .env.development.local first (higher
 // priority — already-set vars are never overwritten), then .env.local.
 function loadEnvFile(filePath) {
-  if (!fs.existsSync(filePath)) return
+  if (fs.existsSync(filePath) === false) return
   const content = fs.readFileSync(filePath, 'utf8')
   for (const line of content.split(/\r?\n/)) {
     const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/)
@@ -71,8 +71,8 @@ function isSafeSupabaseTarget(url) {
 }
 
 async function main() {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
-  if (!isSafeSupabaseTarget(supabaseUrl)) {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+  if (isSafeSupabaseTarget(supabaseUrl) === false) {
     console.error(
       `seed-smoke-guide: refusing to run — NEXT_PUBLIC_SUPABASE_URL ("${supabaseUrl}") ` +
         'is not a local instance or the hosted DEV project. This script must never write to prod/preview Supabase.',
@@ -82,7 +82,7 @@ async function main() {
   }
 
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-  if (!serviceRoleKey) {
+  if (serviceRoleKey === undefined || serviceRoleKey === '') {
     console.error('seed-smoke-guide: SUPABASE_SERVICE_ROLE_KEY is not set.')
     process.exitCode = 1
     return
@@ -92,7 +92,7 @@ async function main() {
   const { error } = await supabase
     .from('guides')
     .upsert(SMOKE_GUIDE, { onConflict: 'slug' })
-  if (error) throw new Error(`guides upsert failed for ${SMOKE_GUIDE_SLUG}: ${error.message}`)
+  if (error !== null) throw new Error(`guides upsert failed for ${SMOKE_GUIDE_SLUG}: ${error.message}`)
   console.log(`seed-smoke-guide: ready — /library/${SMOKE_GUIDE_SLUG} (guest-visible, published)`)
 }
 

--- a/scripts/seed-smoke-guide.js
+++ b/scripts/seed-smoke-guide.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+/**
+ * Seeds one stable, guest-visible published guide for the preview-smoke
+ * click-through flow (e2e/library-guide.spec.ts): guest opens /library,
+ * clicks this guide's card, and lands on /library/<slug>.
+ *
+ * Idempotent: upserts on the fixed slug, so re-running never accumulates
+ * rows. Re-run after any DEV re-mirror from prod (which drops this row).
+ *
+ * SAFETY: refuses to run unless NEXT_PUBLIC_SUPABASE_URL points at a local
+ * instance (127.0.0.1/localhost) or the hosted DEV project
+ * (iymwxdewcpvpjgzewtzk) — this must never write to prod/preview Supabase.
+ * (Mirrors scripts/seed-clerk-test-users.js.)
+ */
+
+const fs = require('fs')
+const path = require('path')
+const { createClient } = require('@supabase/supabase-js')
+
+// Plain `node` does not auto-load env files — mirrors scripts/seed-clerk-test-users.js.
+// Loaded in Next.js precedence order: .env.development.local first (higher
+// priority — already-set vars are never overwritten), then .env.local.
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) return
+  const content = fs.readFileSync(filePath, 'utf8')
+  for (const line of content.split(/\r?\n/)) {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/)
+    if (match === null) continue
+    let value = match[2]
+    if (
+      (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+      (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+    ) {
+      value = value.slice(1, -1)
+    }
+    if (process.env[match[1]] === undefined) process.env[match[1]] = value
+  }
+}
+
+const root = process.cwd()
+loadEnvFile(path.join(root, '.env.development.local'))
+loadEnvFile(path.join(root, '.env.local'))
+
+const DEV_PROJECT_REF = 'iymwxdewcpvpjgzewtzk'
+
+// Kept in sync with e2e/library-guide.spec.ts (SMOKE_GUIDE_SLUG).
+const SMOKE_GUIDE_SLUG = 'e2e-smoke-guide'
+
+// Minimal valid Tiptap JSONContent doc — the detail page runs generateHTML()
+// over body_en, which must not throw on a malformed node tree.
+function tiptapDoc(text) {
+  return {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  }
+}
+
+const SMOKE_GUIDE = {
+  slug: SMOKE_GUIDE_SLUG,
+  title: { en: 'E2E Smoke Guide', bg: 'E2E Smoke Guide' },
+  body_en: tiptapDoc('Fixture guide for the preview-smoke click-through. Safe to leave in DEV.'),
+  body_bg: tiptapDoc('Fixture guide for the preview-smoke click-through. Safe to leave in DEV.'),
+  access_roles: ['guest', 'member', 'core', 'admin'],
+  is_published: true,
+}
+
+function isSafeSupabaseTarget(url) {
+  if (/^https?:\/\/(127\.0\.0\.1|localhost)(:|\/|$)/.test(url)) return true
+  return url.includes(DEV_PROJECT_REF)
+}
+
+async function main() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+  if (!isSafeSupabaseTarget(supabaseUrl)) {
+    console.error(
+      `seed-smoke-guide: refusing to run — NEXT_PUBLIC_SUPABASE_URL ("${supabaseUrl}") ` +
+        'is not a local instance or the hosted DEV project. This script must never write to prod/preview Supabase.',
+    )
+    process.exitCode = 1
+    return
+  }
+
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!serviceRoleKey) {
+    console.error('seed-smoke-guide: SUPABASE_SERVICE_ROLE_KEY is not set.')
+    process.exitCode = 1
+    return
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey)
+  const { error } = await supabase
+    .from('guides')
+    .upsert(SMOKE_GUIDE, { onConflict: 'slug' })
+  if (error) throw new Error(`guides upsert failed for ${SMOKE_GUIDE_SLUG}: ${error.message}`)
+  console.log(`seed-smoke-guide: ready — /library/${SMOKE_GUIDE_SLUG} (guest-visible, published)`)
+}
+
+main().catch((err) => {
+  console.error('seed-smoke-guide: failed —', err)
+  process.exitCode = 1
+})


### PR DESCRIPTION
Closes #582

## What
Graduates preview-smoke beyond navigation-only (the goal of #582, unblocked now that previews use the DEV Supabase project — #579) by adding one real guest flow: open `/library`, click a guide card, land on the guide detail page.

- **e2e/library-guide.spec.ts** — the click-through flow (mobile-390 + desktop). Asserts the URL becomes `/library/<slug>`, the detail `<h1>` shows the guide title, the back-link renders, no overflow at the viewport, no page errors.
- **scripts/seed-smoke-guide.js** + `npm run seed:smoke-guide` — idempotently upserts one stable guest-visible published guide (`e2e-smoke-guide`). Reuses the `seed-clerk-test-users.js` safety guard: refuses any target except local or the DEV project — **never prod/preview**.
- **docs/DEV_WORKFLOW.md** — documents the new flow + seed step.

## Design decisions (from #582's open questions)
- **Guest-only** — no authenticated coverage here (that stays in the local-only `authenticated` project, #560).
- **Advisory** — the smoke job stays non-required for now.
- **Seed once, locally** — no DEV service-role key added to CI. The guide persists in DEV; re-run the seed after any DEV re-mirror.

## Required before this proves anything
DEV must be seeded or the flow **skips** (and a skipped test would pass vacuously — the exact anti-pattern #581 just fixed). Run once against DEV:
```
npm run seed:smoke-guide
```
Then preview-smoke exercises the real click-through. The spec skips with a pointer when the guide is absent, so unseeded local runs stay green without false failures.

## Verification
- `npx eslint` on both new files → clean.
- Spec vs prod (guide absent) → `1 skipped` with the seed pointer (skip path works).
- Seed guard: prod URL → refuses, exit 1, no write.
- Real click-through: this PR's preview-smoke run **after DEV is seeded** — must show the library-guide test *passed*, not skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for opening a published library guide, verifying navigation, page content, back-link visibility, layout behavior, and runtime errors.

* **Chores**
  * Added a repeatable command to seed a guest-visible smoke-test guide for local and development environments.
  * Seed now includes an environment safety check before writing and uses an idempotent upsert to avoid duplicate rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->