### PR TITLE
[2607-DEV-605] Profile refactor 2: shared event-shares query builder + resolveUpline helper

### DIFF
--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -8,9 +8,12 @@ export default async function ProfilePage() {
   if (!userId) redirect('/sign-in')
 
   const supabase = createServiceClient()
+  // Single embedded-count query replaces the prior profile-row + separate
+  // event_share_links count round-trip: event_share_links has one FK to
+  // profiles (profile_id, unambiguous), so PostgREST's embedded count works.
   const { data } = await supabase
     .from('profiles')
-    .select('id, role, abo_number')
+    .select('id, role, abo_number, event_share_links(count)')
     .eq('clerk_id', userId)
     .single()
 
@@ -18,18 +21,14 @@ export default async function ProfilePage() {
   // Redirect rather than rendering a skeleton that never resolves.
   if (!data) redirect('/')
 
-  // Gate InvitesSection: cheap count query — avoids client-side fetch-then-hide.
-  const { count } = await supabase
-    .from('event_share_links')
-    .select('id', { count: 'exact', head: true })
-    .eq('profile_id', data.id)
+  const invitesCount = data.event_share_links?.[0]?.count ?? 0
 
   return (
     <ProfileClient
       profileId={data.id}
       role={data.role}
       aboNumber={data.abo_number ?? null}
-      hasInvites={(count ?? 0) > 0}
+      hasInvites={invitesCount > 0}
     />
   )
 }

--- a/app/api/profile/event-shares/export/route.ts
+++ b/app/api/profile/event-shares/export/route.ts
@@ -4,6 +4,7 @@
 // to avoid pdfkit/fontkit Turbopack ESM incompatibility.
 
 import { withProfile } from '@/lib/supabase/with-profile'
+import { fetchEventShares } from '@/lib/server/event-shares'
 import { NextRequest } from 'next/server'
 
 function toISODate(d: string | null): string {
@@ -31,40 +32,10 @@ export async function GET(req: NextRequest): Promise<Response> {
   const to      = searchParams.get('to')
   const q       = searchParams.get('q')
 
-  let query = supabase
-    .from('event_share_links')
-    .select(`
-      id,
-      token,
-      share_method,
-      click_count,
-      created_at,
-      event:calendar_events ( id, title, start_time ),
-      guests:guest_registrations (
-        id, name, email, status, attended_at, created_at
-      )
-    `)
-    .eq('profile_id', profile.id)
-    .order('created_at', { ascending: false })
-
-  if (eventId) query = query.eq('event_id', eventId)
-  if (method)  query = query.eq('share_method', method)
-  if (from)    query = query.gte('created_at', from)
-  if (to)      query = query.lte('created_at', to)
-
-  const { data: links, error } = await query
+  const { data: filtered, error } = await fetchEventShares(supabase, profile.id, {
+    eventId, status, method, from, to, q,
+  })
   if (error) return Response.json({ error: error.message }, { status: 500 })
-
-  // Apply guest-level filters
-  const filtered = (links ?? []).map(link => ({
-    ...link,
-    guests: (link.guests as any[]).filter(g => {
-      const guestStatus = g.attended_at ? 'attended' : g.status
-      const matchStatus = status ? guestStatus === status : true
-      const matchQ      = q ? (g.name as string).toLowerCase().includes(q.toLowerCase()) : true
-      return matchStatus && matchQ
-    }),
-  }))
 
   // ── CSV ────────────────────────────────────────────────────────────────────
   const rows: string[] = [
@@ -72,7 +43,7 @@ export async function GET(req: NextRequest): Promise<Response> {
      'Guest Name', 'Guest Email', 'Status', 'Attended'].join(','),
   ]
 
-  for (const link of filtered) {
+  for (const link of filtered ?? []) {
     const ev        = link.event as any
     const eventTitle = `"${(ev?.title ?? '').replace(/"/g, '""')}"`
     const eventDate  = toISODate(ev?.start_time ?? null)

--- a/app/api/profile/event-shares/export/route.ts
+++ b/app/api/profile/event-shares/export/route.ts
@@ -44,25 +44,25 @@ export async function GET(req: NextRequest): Promise<Response> {
   ]
 
   for (const link of filtered ?? []) {
-    const ev        = link.event as any
+    const ev        = link.event
     const eventTitle = `"${(ev?.title ?? '').replace(/"/g, '""')}"`
     const eventDate  = toISODate(ev?.start_time ?? null)
     const sharedAt   = toLocalDateTime(link.created_at)
 
-    if ((link.guests as any[]).length === 0) {
+    if (link.guests.length === 0) {
       rows.push([
         eventTitle, eventDate, link.share_method, `"${sharedAt}"`,
         String(link.click_count), '', '', '', '',
       ].join(','))
     } else {
-      for (const g of link.guests as any[]) {
+      for (const g of link.guests) {
         const gStatus    = g.attended_at ? 'attended' : g.status
         const attendedAt = g.attended_at ? toLocalDateTime(g.attended_at) : ''
         rows.push([
           eventTitle, eventDate, link.share_method, `"${sharedAt}"`,
           String(link.click_count),
-          `"${(g.name as string).replace(/"/g, '""')}"`,
-          `"${(g.email as string).replace(/"/g, '""')}"`,
+          `"${g.name.replace(/"/g, '""')}"`,
+          `"${g.email.replace(/"/g, '""')}"`,
           gStatus,
           `"${attendedAt}"`,
         ].join(','))

--- a/app/api/profile/event-shares/route.ts
+++ b/app/api/profile/event-shares/route.ts
@@ -3,6 +3,7 @@
 // GET   — return all share links with nested guest data, supports filtering
 
 import { requireAuth, withProfile } from '@/lib/supabase/with-profile'
+import { fetchEventShares } from '@/lib/server/event-shares'
 import { randomBytes } from 'crypto'
 import { z } from 'zod'
 import { NextRequest } from 'next/server'
@@ -94,51 +95,11 @@ export async function GET(req: NextRequest): Promise<Response> {
   const to       = searchParams.get('to')       // ISO date
   const q        = searchParams.get('q')        // guest name search
 
-  let query = supabase
-    .from('event_share_links')
-    .select(`
-      id,
-      token,
-      share_method,
-      click_count,
-      created_at,
-      event:calendar_events ( id, title, start_time ),
-      guests:guest_registrations (
-        id,
-        name,
-        email,
-        status,
-        attended_at,
-        created_at
-      )
-    `)
-    .eq('profile_id', profile.id)
-    .order('created_at', { ascending: false })
-
-  if (eventId) query = query.eq('event_id', eventId)
-  if (method)  query = query.eq('share_method', method)
-  if (from)    query = query.gte('created_at', from)
-  if (to)      query = query.lte('created_at', to)
-
-  const { data: links, error } = await query
+  const { data: result, error } = await fetchEventShares(supabase, profile.id, {
+    eventId, status, method, from, to, q,
+  })
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
 
-  // Post-process: apply status and guest name filters in-memory
-  // (these filter on nested guest rows — not straightforward in PostgREST)
-  let result = links ?? []
-
-  if (status || q) {
-    result = result.map(link => ({
-      ...link,
-      guests: (link.guests as any[]).filter(g => {
-        const guestStatus = g.attended_at ? 'attended' : g.status
-        const matchStatus = status ? guestStatus === status : true
-        const matchQ      = q ? (g.name as string).toLowerCase().includes(q.toLowerCase()) : true
-        return matchStatus && matchQ
-      }),
-    }))
-  }
-
-  return Response.json({ links: result, total: result.length })
+  return Response.json({ links: result, total: (result ?? []).length })
 }

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,5 +1,6 @@
 import { createServiceClient } from '@/lib/supabase/service'
 import { requireAuth, withProfile } from '@/lib/supabase/with-profile'
+import { resolveUpline } from '@/lib/server/upline'
 import type { Tables } from '@/types/supabase'
 
 // Explicit column list — never '*'. Every field here is read by at least one
@@ -76,46 +77,9 @@ export async function GET() {
   const [upline, verRequest, spouse, pendingSpouseLinkCount] = await Promise.all([
     // Resolve upline for any verified member (own account, or via the primary
     // profile's shared ABO when this is a spouse-linked secondary).
-    // Standard path: abo_number set — look up sponsor via los_members tree.
-    // Manual path: abo_number null but upline_abo_number set — resolve name directly.
-    effectiveAboNumber
-      ? (async () => {
-          const { data: losMember } = await supabase
-            .from('los_members')
-            .select('sponsor_abo_number')
-            .eq('abo_number', effectiveAboNumber)
-            .single()
-
-          if (!losMember?.sponsor_abo_number) {
-            return { upline_name: null, upline_abo_number: null }
-          }
-
-          const { data: uplineMember } = await supabase
-            .from('los_members')
-            .select('abo_number, name')
-            .eq('abo_number', losMember.sponsor_abo_number)
-            .single()
-
-          return {
-            upline_name: uplineMember?.name ?? null,
-            upline_abo_number: uplineMember?.abo_number ?? null,
-          }
-        })()
-      : effectiveUplineAboNumber
-        ? (async () => {
-            // Manual path: upline ABO already known, just resolve the name
-            const { data: uplineMember } = await supabase
-              .from('los_members')
-              .select('abo_number, name')
-              .eq('abo_number', effectiveUplineAboNumber)
-              .single()
-
-            return {
-              upline_name: uplineMember?.name ?? null,
-              upline_abo_number: uplineMember?.abo_number ?? effectiveUplineAboNumber,
-            }
-          })()
-        : Promise.resolve(null),
+    (effectiveAboNumber || effectiveUplineAboNumber)
+      ? resolveUpline(supabase, effectiveAboNumber, effectiveUplineAboNumber)
+      : Promise.resolve(null),
     role === 'guest'
       ? (async () => {
           const { data: req } = await supabase

--- a/app/api/profile/upline/route.ts
+++ b/app/api/profile/upline/route.ts
@@ -1,4 +1,5 @@
 import { withProfile } from '@/lib/supabase/with-profile'
+import { resolveUpline } from '@/lib/server/upline'
 
 export async function GET() {
   const ctx = await withProfile<{ abo_number: string | null; upline_abo_number: string | null; primary_profile_id: string | null }>(
@@ -15,41 +16,8 @@ export async function GET() {
   const memberAbo = profile?.abo_number ?? null
   const directUplineAbo = profile?.upline_abo_number ?? null
 
-  if (memberAbo) {
-    const { data: losMember } = await supabase
-      .from('los_members')
-      .select('sponsor_abo_number')
-      .eq('abo_number', memberAbo)
-      .single()
-
-    if (!losMember?.sponsor_abo_number) {
-      return Response.json({ upline_name: null, upline_abo_number: null })
-    }
-
-    const { data: upline } = await supabase
-      .from('los_members')
-      .select('abo_number, name')
-      .eq('abo_number', losMember.sponsor_abo_number)
-      .single()
-
-    return Response.json({
-      upline_name: upline?.name ?? null,
-      upline_abo_number: upline?.abo_number ?? losMember.sponsor_abo_number,
-    })
-  }
-
-  if (directUplineAbo) {
-    const { data: upline } = await supabase
-      .from('los_members')
-      .select('abo_number, name')
-      .eq('abo_number', directUplineAbo)
-      .single()
-
-    return Response.json({
-      upline_name: upline?.name ?? null,
-      upline_abo_number: upline?.abo_number ?? directUplineAbo,
-    })
-  }
-
-  return Response.json({ upline_name: null, upline_abo_number: null })
+  const result = await resolveUpline(supabase, memberAbo, directUplineAbo, {
+    fallbackStandardToSponsorAbo: true,
+  })
+  return Response.json(result)
 }

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #604 | `dev/2607-DEV-604` | app/api/profile/route.ts (GET column list), app/api/profile/payments/route.ts, app/api/profile/payments/upload-url/route.ts (+ any other 403-for-missing-profile spots from #603); migration: no | 2026-07-19T00:30Z |
+| #605 | `dev/2607-DEV-605` | lib/server/event-shares.ts (new), lib/server/upline.ts (new), app/api/profile/event-shares/route.ts (GET only), app/api/profile/event-shares/export/route.ts, app/api/profile/route.ts, app/api/profile/upline/route.ts, app/(dashboard)/profile/page.tsx; migration: no | 2026-07-20T00:00Z |

--- a/lib/server/event-shares.ts
+++ b/lib/server/event-shares.ts
@@ -1,0 +1,86 @@
+import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js'
+
+export interface EventShareFilters {
+  eventId?: string | null
+  status?: string | null
+  method?: string | null
+  from?: string | null
+  to?: string | null
+  q?: string | null
+}
+
+export interface EventShareGuest {
+  id: string
+  name: string
+  email: string
+  status: string
+  attended_at: string | null
+  created_at: string
+}
+
+export interface EventShareLink {
+  id: string
+  token: string
+  share_method: string
+  click_count: number
+  created_at: string
+  event: { id: string; title: string; start_time: string } | null
+  guests: EventShareGuest[]
+}
+
+/**
+ * Nested event_share_links query + in-memory guest filter (status/name-search
+ * filter on the nested guest rows, not straightforward in PostgREST) shared by
+ * app/api/profile/event-shares/route.ts (GET) and .../export/route.ts, which
+ * previously duplicated this verbatim.
+ */
+export async function fetchEventShares(
+  supabase: SupabaseClient,
+  profileId: string,
+  filters: EventShareFilters
+): Promise<{ data: EventShareLink[] | null; error: PostgrestError | null }> {
+  let query = supabase
+    .from('event_share_links')
+    .select(`
+      id,
+      token,
+      share_method,
+      click_count,
+      created_at,
+      event:calendar_events ( id, title, start_time ),
+      guests:guest_registrations (
+        id,
+        name,
+        email,
+        status,
+        attended_at,
+        created_at
+      )
+    `)
+    .eq('profile_id', profileId)
+    .order('created_at', { ascending: false })
+
+  if (filters.eventId) query = query.eq('event_id', filters.eventId)
+  if (filters.method) query = query.eq('share_method', filters.method)
+  if (filters.from) query = query.gte('created_at', filters.from)
+  if (filters.to) query = query.lte('created_at', filters.to)
+
+  const { data: links, error } = await query
+  if (error) return { data: null, error }
+
+  // PostgREST resolves `event:calendar_events(...)` to a single object at
+  // runtime (profile_id/event_id are both plain FKs, no ambiguity), but the
+  // untyped query builder infers it as an array — cast through `unknown` to
+  // the known runtime shape rather than fight the inferred type.
+  const result = (links ?? []).map(link => ({
+    ...link,
+    guests: (link.guests as EventShareGuest[]).filter(g => {
+      const guestStatus = g.attended_at ? 'attended' : g.status
+      const matchStatus = filters.status ? guestStatus === filters.status : true
+      const matchQ = filters.q ? g.name.toLowerCase().includes(filters.q.toLowerCase()) : true
+      return matchStatus && matchQ
+    }),
+  })) as unknown as EventShareLink[]
+
+  return { data: result, error: null }
+}

--- a/lib/server/upline.ts
+++ b/lib/server/upline.ts
@@ -1,0 +1,70 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export interface UplineResult {
+  upline_name: string | null
+  upline_abo_number: string | null
+}
+
+export interface ResolveUplineOptions {
+  /**
+   * Standard path only: when the sponsor ABO has no matching los_members row,
+   * upline_abo_number falls back to the known sponsor ABO instead of null.
+   * app/api/profile/upline/route.ts does this; app/api/profile/route.ts does
+   * not (falls back to null) — a pre-existing divergence between the two
+   * routes, preserved here rather than silently unified.
+   */
+  fallbackStandardToSponsorAbo?: boolean
+}
+
+/**
+ * Standard path (abo_number set): resolve sponsor via the los_members tree,
+ * then the sponsor's display name. Manual path (upline_abo_number set,
+ * no abo_number): resolve the upline's name directly. Shared by
+ * app/api/profile/upline/route.ts and app/api/profile/route.ts, whose
+ * branching was previously duplicated verbatim.
+ */
+export async function resolveUpline(
+  supabase: SupabaseClient,
+  aboNumber: string | null,
+  uplineAboNumber: string | null,
+  options: ResolveUplineOptions = {}
+): Promise<UplineResult> {
+  if (aboNumber) {
+    const { data: losMember } = await supabase
+      .from('los_members')
+      .select('sponsor_abo_number')
+      .eq('abo_number', aboNumber)
+      .single()
+
+    if (!losMember?.sponsor_abo_number) {
+      return { upline_name: null, upline_abo_number: null }
+    }
+
+    const { data: upline } = await supabase
+      .from('los_members')
+      .select('abo_number, name')
+      .eq('abo_number', losMember.sponsor_abo_number)
+      .single()
+
+    return {
+      upline_name: upline?.name ?? null,
+      upline_abo_number:
+        upline?.abo_number ?? (options.fallbackStandardToSponsorAbo ? losMember.sponsor_abo_number : null),
+    }
+  }
+
+  if (uplineAboNumber) {
+    const { data: upline } = await supabase
+      .from('los_members')
+      .select('abo_number, name')
+      .eq('abo_number', uplineAboNumber)
+      .single()
+
+    return {
+      upline_name: upline?.name ?? null,
+      upline_abo_number: upline?.abo_number ?? uplineAboNumber,
+    }
+  }
+
+  return { upline_name: null, upline_abo_number: null }
+}


### PR DESCRIPTION
## Summary
- New `lib/server/event-shares.ts` (`fetchEventShares`): dedupes the nested `event_share_links` query + in-memory guest filter previously copy-pasted between `app/api/profile/event-shares/route.ts` (GET) and `.../export/route.ts`.
- New `lib/server/upline.ts` (`resolveUpline`): dedupes the two-hop `los_members` sponsor lookup duplicated between `app/api/profile/upline/route.ts` and `GET /api/profile`. Preserved a real pre-existing fallback divergence between the two call sites via an explicit `fallbackStandardToSponsorAbo` option rather than silently unifying it.
- `app/(dashboard)/profile/page.tsx`: replaced two sequential queries (profile row, then a separate `event_share_links` count) with one PostgREST embedded-count query (`event_share_links(count)`) — `event_share_links` has a single unambiguous FK to `profiles`.

No response-shape or status-code changes anywhere in this diff.

## Verification
- Byte-identical parity verified via a throwaway vitest spec (deleted, never committed) comparing the new helpers against the reconstructed pre-refactor logic on seeded DEV fixtures: 5 event-shares filter combinations + both upline call sites (including the fallback divergence and the sponsor-not-in-`los_members` edge case) — all matched.
- `tsc --noEmit` clean, `npm run lint` 0 errors (514 pre-existing warnings, none new in touched files), `npm run build` green, `vitest run` 112/112.
- Confirmed unauthenticated `/profile` still redirects to sign-in with no server errors (dev server against hosted DEV).

## Session State
**Status:** DONE
**Completed:**
- [x] `lib/server/event-shares.ts` + `lib/server/upline.ts` extracted
- [x] All 4 consumer routes + `profile/page.tsx` wired, zero shape changes
- [x] DoD parity verified against hosted DEV (byte-identical)
- [x] Static verification (tsc, lint, build, vitest) green
- [x] Self-review (in place of `/code-review low`, a user-only slash command)
**Next:** CI green + Vercel preview READY, then mark ready for review

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Event share history and CSV exports now support consistent filtering by event, status, sharing method, date range, and guest name.
  - Profile and upline information now resolves more consistently, including sponsor details and fallback handling.

- **Bug Fixes**
  - Improved profile invite detection.
  - Standardized behavior when profile data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->