### PR TITLE
[2607-DEV-606] Invites 390px layout + i18n fixes (pre-T2)

### DIFF
--- a/app/(dashboard)/profile/components/InvitesSection.tsx
+++ b/app/(dashboard)/profile/components/InvitesSection.tsx
@@ -324,11 +324,11 @@ export function InvitesSection() {
                     </div>
 
                     {/* Guest cards — below sm */}
-                    <div className="sm:hidden divide-y" style={{ borderTop: '1px solid var(--border-default)' }}>
+                    <div className="sm:hidden">
                       {guests.map(g => {
                         const s = guestStatus(g)
                         return (
-                          <div key={g.id} className="px-4 py-3 space-y-1" style={{ borderColor: 'var(--border-default)' }}>
+                          <div key={g.id} className="px-4 py-3 space-y-1" style={{ borderTop: '1px solid var(--border-default)' }}>
                             <div className="flex items-center justify-between gap-2">
                               <p className="text-xs font-medium truncate" style={{ color: 'var(--text-primary)' }}>{g.name}</p>
                               <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold shrink-0"

--- a/app/(dashboard)/profile/components/InvitesSection.tsx
+++ b/app/(dashboard)/profile/components/InvitesSection.tsx
@@ -256,6 +256,7 @@ export function InvitesSection() {
                 {/* Event header */}
                 <button
                   onClick={() => toggleExpanded(link.id)}
+                  aria-expanded={isOpen}
                   className="w-full text-left px-4 py-3 flex flex-wrap items-start justify-between gap-3 hover:bg-black/[0.02] transition-colors"
                   style={{ backgroundColor: 'var(--bg-card)' }}
                 >

--- a/app/(dashboard)/profile/components/InvitesSection.tsx
+++ b/app/(dashboard)/profile/components/InvitesSection.tsx
@@ -256,7 +256,7 @@ export function InvitesSection() {
                 {/* Event header */}
                 <button
                   onClick={() => toggleExpanded(link.id)}
-                  className="w-full text-left px-4 py-3 flex items-start justify-between gap-3 hover:bg-black/[0.02] transition-colors"
+                  className="w-full text-left px-4 py-3 flex flex-wrap items-start justify-between gap-3 hover:bg-black/[0.02] transition-colors"
                   style={{ backgroundColor: 'var(--bg-card)' }}
                 >
                   <div className="flex-1 min-w-0">
@@ -272,7 +272,7 @@ export function InvitesSection() {
                     </p>
                   </div>
                   {/* Funnel summary */}
-                  <div className="flex items-center gap-3 flex-shrink-0 text-[10px] font-semibold" style={{ color: 'var(--text-secondary)' }}>
+                  <div className="flex items-center flex-wrap gap-3 text-[10px] font-semibold" style={{ color: 'var(--text-secondary)' }}>
                     <span>{link.click_count} {t('profile.invites.clicks')}</span>
                     <span>→</span>
                     <span>{guests.length} {t('profile.invites.registrations')}</span>
@@ -284,37 +284,67 @@ export function InvitesSection() {
                   </div>
                 </button>
 
-                {/* Guest table — expandable */}
+                {/* Guest table — sm+, expandable */}
                 {isOpen && guests.length > 0 && (
-                  <div className="overflow-x-auto">
-                    <table className="w-full text-xs" style={{ minWidth: 480 }}>
-                      <thead>
-                        <tr style={{ backgroundColor: 'rgba(0,0,0,0.03)', borderTop: '1px solid var(--border-default)' }}>
-                          {['Name', 'Email', 'Status', 'Registered', 'Attended'].map(h => (
-                            <th key={h} className="text-left px-4 py-2 font-semibold text-[10px] tracking-wider uppercase"
-                              style={{ color: 'var(--text-secondary)' }}>{h}</th>
-                          ))}
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {guests.map(g => {
-                          const s = guestStatus(g)
-                          return (
-                            <tr key={g.id} style={{ borderTop: '1px solid var(--border-default)' }}>
-                              <td className="px-4 py-2 font-medium" style={{ color: 'var(--text-primary)' }}>{g.name}</td>
-                              <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{g.email}</td>
-                              <td className="px-4 py-2">
-                                <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold"
-                                  style={STATUS_STYLE[s]}>{s}</span>
-                              </td>
-                              <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{fmt(g.created_at)}</td>
-                              <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{fmt(g.attended_at)}</td>
-                            </tr>
-                          )
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
+                  <>
+                    <div className="hidden sm:block overflow-x-auto">
+                      <table className="w-full text-xs" style={{ minWidth: 480 }}>
+                        <thead>
+                          <tr style={{ backgroundColor: 'rgba(0,0,0,0.03)', borderTop: '1px solid var(--border-default)' }}>
+                            {[
+                              t('profile.invites.col.name'),
+                              t('profile.invites.col.email'),
+                              t('profile.invites.col.status'),
+                              t('profile.invites.col.registered'),
+                              t('profile.invites.col.attended'),
+                            ].map(h => (
+                              <th key={h} className="text-left px-4 py-2 font-semibold text-[10px] tracking-wider uppercase"
+                                style={{ color: 'var(--text-secondary)' }}>{h}</th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {guests.map(g => {
+                            const s = guestStatus(g)
+                            return (
+                              <tr key={g.id} style={{ borderTop: '1px solid var(--border-default)' }}>
+                                <td className="px-4 py-2 font-medium" style={{ color: 'var(--text-primary)' }}>{g.name}</td>
+                                <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{g.email}</td>
+                                <td className="px-4 py-2">
+                                  <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold"
+                                    style={STATUS_STYLE[s]}>{s}</span>
+                                </td>
+                                <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{fmt(g.created_at)}</td>
+                                <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{fmt(g.attended_at)}</td>
+                              </tr>
+                            )
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+
+                    {/* Guest cards — below sm */}
+                    <div className="sm:hidden divide-y" style={{ borderTop: '1px solid var(--border-default)' }}>
+                      {guests.map(g => {
+                        const s = guestStatus(g)
+                        return (
+                          <div key={g.id} className="px-4 py-3 space-y-1" style={{ borderColor: 'var(--border-default)' }}>
+                            <div className="flex items-center justify-between gap-2">
+                              <p className="text-xs font-medium truncate" style={{ color: 'var(--text-primary)' }}>{g.name}</p>
+                              <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold shrink-0"
+                                style={STATUS_STYLE[s]}>{s}</span>
+                            </div>
+                            <p className="text-[11px] truncate" style={{ color: 'var(--text-secondary)' }}>{g.email}</p>
+                            <p className="text-[10px]" style={{ color: 'var(--text-secondary)' }}>
+                              {t('profile.invites.col.registered')} {fmt(g.created_at)}
+                              {' · '}
+                              {t('profile.invites.col.attended')} {fmt(g.attended_at)}
+                            </p>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </>
                 )}
                 {isOpen && guests.length === 0 && (
                   <p className="px-4 py-3 text-xs" style={{ color: 'var(--text-secondary)', borderTop: '1px solid var(--border-default)' }}>

--- a/app/(dashboard)/profile/invites/page.tsx
+++ b/app/(dashboard)/profile/invites/page.tsx
@@ -8,60 +8,26 @@ export default async function ProfileInvitesPage() {
   if (!userId) redirect('/sign-in')
 
   return (
-    <div className="py-8 pb-16">
+    <div className="py-8 pb-16 px-4 md:px-6 xl:px-8 md:max-w-[1280px] md:mx-auto">
+      {/* Back link */}
+      <Link
+        href="/profile"
+        className="inline-flex items-center gap-1 text-xs font-semibold mb-3 md:mb-5 hover:opacity-70 transition-opacity"
+        style={{ color: 'var(--text-secondary)' }}
+      >
+        ← Back to Profile
+      </Link>
 
-      {/* ════════════════════════════════════════════════════════════════════
-          DESKTOP layout (md+)
-          Single centred column, max-w-[1280px]
-          ════════════════════════════════════════════════════════════════════ */}
-      <div className="hidden md:block max-w-[1280px] mx-auto px-6 xl:px-8">
-        {/* Back link */}
-        <Link
-          href="/profile"
-          className="inline-flex items-center gap-1 text-xs font-semibold mb-5 hover:opacity-70 transition-opacity"
-          style={{ color: 'var(--text-secondary)' }}
-        >
-          ← Back to Profile
-        </Link>
-
-        {/* Full invites section — no bento wrapper */}
-        <div
-          className="rounded-2xl"
-          style={{
-            backgroundColor: 'var(--bg-card)',
-            border: '1px solid var(--border-default)',
-          }}
-        >
-          <InvitesSection />
-        </div>
+      {/* Full invites section */}
+      <div
+        className="rounded-2xl overflow-hidden"
+        style={{
+          backgroundColor: 'var(--bg-card)',
+          border: '1px solid var(--border-default)',
+        }}
+      >
+        <InvitesSection />
       </div>
-
-      {/* ════════════════════════════════════════════════════════════════════
-          MOBILE layout (< md)
-          Full-width, no horizontal padding on the card
-          ════════════════════════════════════════════════════════════════════ */}
-      <div className="md:hidden flex flex-col gap-3 px-4">
-        {/* Back link */}
-        <Link
-          href="/profile"
-          className="inline-flex items-center gap-1 text-xs font-semibold hover:opacity-70 transition-opacity"
-          style={{ color: 'var(--text-secondary)' }}
-        >
-          ← Back to Profile
-        </Link>
-
-        {/* Full invites section */}
-        <div
-          className="rounded-2xl overflow-hidden"
-          style={{
-            backgroundColor: 'var(--bg-card)',
-            border: '1px solid var(--border-default)',
-          }}
-        >
-          <InvitesSection />
-        </div>
-      </div>
-
     </div>
   )
 }

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -7,3 +7,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
 | #604 | `dev/2607-DEV-604` | app/api/profile/route.ts (GET column list), app/api/profile/payments/route.ts, app/api/profile/payments/upload-url/route.ts (+ any other 403-for-missing-profile spots from #603); migration: no | 2026-07-19T00:30Z |
+| #606 | `dev/2607-DEV-606` | app/(dashboard)/profile/components/InvitesSection.tsx, app/(dashboard)/profile/invites/page.tsx, lib/i18n/domains/profile.ts; migration: no | 2026-07-20T00:00Z |

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -163,6 +163,11 @@ export const profile = {
   'profile.invites.via':                  { en: 'via',                        bg: 'чрез'                                 },
   'profile.invites.direct':               { en: 'Direct',                     bg: 'Директно'                             },
   'profile.invites.registrations.tab':    { en: 'Registrations',              bg: 'Регистрации'                          },
+  'profile.invites.col.name':             { en: 'Name',                       bg: 'Име'                                  },
+  'profile.invites.col.email':            { en: 'Email',                      bg: 'Имейл'                                },
+  'profile.invites.col.status':           { en: 'Status',                     bg: 'Статус'                               },
+  'profile.invites.col.registered':       { en: 'Registered',                 bg: 'Регистриран'                          },
+  'profile.invites.col.attended':         { en: 'Attended',                   bg: 'Присъствал'                           },
   // InvitesBento
   'profile.invites.statLinks':            { en: 'invite links',               bg: 'покани'                               },
   'profile.invites.viewAll':              { en: 'View all invites',           bg: 'Виж всички покани'                    },


### PR DESCRIPTION
Closes #606.

## Summary
- Guest table hidden below `sm`, card list shown instead — fixes live 390px horizontal-scroll violation on `/profile/invites`.
- Funnel summary row wraps (`flex-wrap`) instead of forcing overflow.
- Table/card headers use `t()` via new `profile.invites.col.*` i18n keys, replacing hardcoded English strings.
- `invites/page.tsx`: collapsed duplicate desktop/mobile `InvitesSection` mounts into a single responsive wrapper.

Layout and strings only — no status/funnel logic changes (that consolidation is #610, gated on T2/T3).

## Test plan
- [x] `npx tsc --noEmit` clean on changed files
- [x] `/code-review low` run, 1 finding (dead inline style / wrong divide color) fixed
- [ ] Vercel PR preview: verify `/profile/invites` at 390×812 — no horizontal scroll, headers translated (EN/BG), funnel numbers/filter behavior unchanged, single `InvitesSection` instance in DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the invites view with responsive guest details: a table on larger screens and stacked cards on smaller screens.
  * Added localized column labels for guest name, email, status, registration, and attendance.
  * Updated invite page spacing, card styling, and navigation for a more consistent layout across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->