### PR TITLE
chore: prune merged claims from CLAIMS.md

### DIFF
--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,3 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #605 | `dev/2607-DEV-605` | lib/server/event-shares.ts (new), lib/server/upline.ts (new), app/api/profile/event-shares/route.ts (GET only), app/api/profile/event-shares/export/route.ts, app/api/profile/route.ts, app/api/profile/upline/route.ts, app/(dashboard)/profile/page.tsx; migration: no | 2026-07-20T00:00Z |
-| #606 | `dev/2607-DEV-606` | app/(dashboard)/profile/components/InvitesSection.tsx, app/(dashboard)/profile/invites/page.tsx, lib/i18n/domains/profile.ts; migration: no | 2026-07-20T00:00Z |


### PR DESCRIPTION
Post-merge GCR cleanup: removes #605 and #606 rows from docs/CLAIMS.md (both merged: #618, #619). Doc-only, no code changes.