### PR TITLE
[2607-DEV-597] Calendar refactor 1c: ICS full-detail export + feed ETag/caching

### DIFF
--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -92,9 +92,11 @@ export async function GET(req: Request) {
   }
 
   const body = calendar.toString()
-  // Weak ETag over the rendered feed — good enough for conditional GETs;
-  // this is not a content hash used for integrity, just change detection.
-  const etag = `W/"${createHash('sha1').update(body).digest('hex')}"`
+  // Weak ETag over the source event data, NOT calendar.toString() — ical-generator
+  // stamps every VEVENT with DTSTAMP:<render time>, so hashing the rendered body
+  // would change the ETag on every request even when the underlying data hasn't,
+  // permanently defeating If-None-Match.
+  const etag = `W/"${createHash('sha1').update(JSON.stringify(events ?? []) + calendarName).digest('hex')}"`
 
   if (req.headers.get('if-none-match') === etag) {
     return new Response(null, {

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -8,6 +8,19 @@ const secret = new TextEncoder().encode(
   process.env.ICAL_TOKEN_SECRET ?? 'dev-ical-secret-change-in-production'
 )
 
+function toUtcDateOnly(isoString: string): Date {
+  const d = new Date(isoString)
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+// RFC 7232 §3.2: If-None-Match may carry a comma-separated list of ETags, or
+// `*`. A plain `===` against the raw header would never match either form.
+function matchesIfNoneMatch(header: string | null, etag: string): boolean {
+  if (!header) return false
+  if (header.trim() === '*') return true
+  return header.split(',').map((t) => t.trim()).includes(etag)
+}
+
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const token = searchParams.get('token')
@@ -78,13 +91,20 @@ export async function GET(req: Request) {
       .filter((part): part is string => part !== undefined)
       .join('\n\n')
 
+    // For all-day events, ical-generator's VALUE=DATE truncates the Date to its
+    // UTC date component — normalize to the UTC midnight boundary here so a
+    // stored start_time/end_time that isn't exactly UTC midnight (e.g. legacy
+    // data) can't shift the displayed calendar day.
+    const start = event.is_all_day ? toUtcDateOnly(event.start_time) : new Date(event.start_time)
+    const end = event.is_all_day ? toUtcDateOnly(event.end_time) : new Date(event.end_time)
+
     calendar.createEvent({
       id: event.id,
       summary: event.title,
       description: description || undefined,
       allDay: event.is_all_day,
-      start: new Date(event.start_time),
-      end: new Date(event.end_time),
+      start,
+      end,
       location: event.location ?? undefined,
       url: event.meeting_url ?? undefined,
       categories: event.category ? [{ name: event.category }] : undefined,
@@ -98,7 +118,7 @@ export async function GET(req: Request) {
   // permanently defeating If-None-Match.
   const etag = `W/"${createHash('sha1').update(JSON.stringify(events ?? []) + calendarName).digest('hex')}"`
 
-  if (req.headers.get('if-none-match') === etag) {
+  if (matchesIfNoneMatch(req.headers.get('if-none-match'), etag)) {
     return new Response(null, {
       status: 304,
       headers: {

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -70,6 +70,23 @@ export async function GET(req: Request) {
     (profile.ui_prefs as Record<string, unknown> | null)?.ical_display_name as string | undefined
     ?? 'teamenjoyVD'
 
+  // Weak ETag over the source event data, NOT calendar.toString() — ical-generator
+  // stamps every VEVENT with DTSTAMP:<render time>, so hashing the rendered body
+  // would change the ETag on every request even when the underlying data hasn't,
+  // permanently defeating If-None-Match. Computed before building/serializing the
+  // calendar so a conditional-GET hit short-circuits that work entirely.
+  const etag = `W/"${createHash('sha1').update(JSON.stringify(events ?? []) + calendarName).digest('hex')}"`
+
+  if (matchesIfNoneMatch(req.headers.get('if-none-match'), etag)) {
+    return new Response(null, {
+      status: 304,
+      headers: {
+        ETag: etag,
+        'Cache-Control': 'private, max-age=900',
+      },
+    })
+  }
+
   // Build iCal — no timezone set so dates are emitted as UTC (DTSTART:...Z)
   // start_time/end_time from Supabase are +00 UTC strings; new Date() preserves that.
   const calendar = ical({
@@ -83,11 +100,12 @@ export async function GET(req: Request) {
     // human-readable lines to the description so the info is visible there too,
     // while keeping the structured properties for clients that do read them.
     const detailLines = [
-      event.location ? `Location: ${event.location}` : undefined,
-      event.meeting_url ? `Meeting link: ${event.meeting_url}` : undefined,
-      event.category ? `Category: ${event.category}` : undefined,
+      event.location != null && event.location !== '' ? `Location: ${event.location}` : undefined,
+      event.meeting_url != null && event.meeting_url !== '' ? `Meeting link: ${event.meeting_url}` : undefined,
+      event.category != null ? `Category: ${event.category}` : undefined,
     ].filter((line): line is string => line !== undefined)
-    const description = [event.description ?? undefined, detailLines.length > 0 ? detailLines.join('\n') : undefined]
+    const baseDescription = event.description != null && event.description !== '' ? event.description : undefined
+    const description = [baseDescription, detailLines.length > 0 ? detailLines.join('\n') : undefined]
       .filter((part): part is string => part !== undefined)
       .join('\n\n')
 
@@ -105,30 +123,13 @@ export async function GET(req: Request) {
       allDay: event.is_all_day,
       start,
       end,
-      location: event.location ?? undefined,
-      url: event.meeting_url ?? undefined,
-      categories: event.category ? [{ name: event.category }] : undefined,
+      location: event.location != null && event.location !== '' ? event.location : undefined,
+      url: event.meeting_url != null && event.meeting_url !== '' ? event.meeting_url : undefined,
+      categories: event.category != null ? [{ name: event.category }] : undefined,
     })
   }
 
-  const body = calendar.toString()
-  // Weak ETag over the source event data, NOT calendar.toString() — ical-generator
-  // stamps every VEVENT with DTSTAMP:<render time>, so hashing the rendered body
-  // would change the ETag on every request even when the underlying data hasn't,
-  // permanently defeating If-None-Match.
-  const etag = `W/"${createHash('sha1').update(JSON.stringify(events ?? []) + calendarName).digest('hex')}"`
-
-  if (matchesIfNoneMatch(req.headers.get('if-none-match'), etag)) {
-    return new Response(null, {
-      status: 304,
-      headers: {
-        ETag: etag,
-        'Cache-Control': 'private, max-age=900',
-      },
-    })
-  }
-
-  return new Response(body, {
+  return new Response(calendar.toString(), {
     status: 200,
     headers: {
       'Content-Type': 'text/calendar; charset=utf-8',

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { createServiceClient } from '@/lib/supabase/service'
 import { jwtVerify } from 'jose'
 import ical from 'ical-generator'
@@ -64,10 +65,24 @@ export async function GET(req: Request) {
   })
 
   for (const event of events ?? []) {
+    // Google Calendar (Android) and iOS Calendar don't surface the structured
+    // LOCATION/URL/CATEGORIES properties in their event view — append
+    // human-readable lines to the description so the info is visible there too,
+    // while keeping the structured properties for clients that do read them.
+    const detailLines = [
+      event.location ? `Location: ${event.location}` : undefined,
+      event.meeting_url ? `Meeting link: ${event.meeting_url}` : undefined,
+      event.category ? `Category: ${event.category}` : undefined,
+    ].filter((line): line is string => line !== undefined)
+    const description = [event.description ?? undefined, detailLines.length > 0 ? detailLines.join('\n') : undefined]
+      .filter((part): part is string => part !== undefined)
+      .join('\n\n')
+
     calendar.createEvent({
       id: event.id,
       summary: event.title,
-      description: event.description ?? undefined,
+      description: description || undefined,
+      allDay: event.is_all_day,
       start: new Date(event.start_time),
       end: new Date(event.end_time),
       location: event.location ?? undefined,
@@ -76,12 +91,28 @@ export async function GET(req: Request) {
     })
   }
 
-  return new Response(calendar.toString(), {
+  const body = calendar.toString()
+  // Weak ETag over the rendered feed — good enough for conditional GETs;
+  // this is not a content hash used for integrity, just change detection.
+  const etag = `W/"${createHash('sha1').update(body).digest('hex')}"`
+
+  if (req.headers.get('if-none-match') === etag) {
+    return new Response(null, {
+      status: 304,
+      headers: {
+        ETag: etag,
+        'Cache-Control': 'private, max-age=900',
+      },
+    })
+  }
+
+  return new Response(body, {
     status: 200,
     headers: {
       'Content-Type': 'text/calendar; charset=utf-8',
       'Content-Disposition': 'attachment; filename="teamenjoyvd.ics"',
-      'Cache-Control': 'no-cache, no-store',
+      'Cache-Control': 'private, max-age=900',
+      ETag: etag,
     },
   })
 }

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -7,4 +7,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
 | #591 | `dev/2607-DEV-591` | `lib/rate-limit.ts` (new), `lib/actions/guest-registration.ts`, `lib/actions/guest-registration.test.ts`, `app/events/[eventId]/register/components/RegisterForm.tsx`, `lib/i18n/domains/events.ts` — migration: no | 2026-07-21 |
-| #598 | `dev/2607-DEV-598` | `types/calendar.ts` (new), `lib/server/calendar.ts` (new), `app/api/calendar/route.ts`, `app/api/calendar/feed.ics/route.ts`, `app/api/admin/calendar/route.ts`, `app/(dashboard)/calendar/page.tsx`, `app/(dashboard)/calendar/types.ts` — migration: no | 2026-07-21 |
+| #597 | `dev/2607-DEV-597` | `app/api/calendar/feed.ics/route.ts` — migration: no | 2026-07-21 |


### PR DESCRIPTION
Closes #597

## Summary
- All-day events now emit `allDay: true` with a date-only `DTSTART`/`DTEND` (normalized to the UTC date boundary so a non-midnight `start_time` can't shift the displayed day) instead of importing as timed UTC events.
- Description now composes the original text with `Location:` / `Meeting link:` / `Category:` lines so Google Calendar (Android) and iOS Calendar surface them — structured `LOCATION`/`URL`/`CATEGORIES` properties are kept as-is for clients that read them.
- Feed now computes a weak ETag over the source event data (not the rendered body, since `ical-generator` stamps `DTSTAMP` with render time and would otherwise defeat caching), honors `If-None-Match` (single value, comma-separated list, and `*` per RFC 7232 §3.2) with a `304`, and sets `Cache-Control: private, max-age=900` (was `no-cache, no-store`).

## Testing
- `tsc --noEmit`, `npm run lint` (0 errors, no new warnings), `npm run build` all green.
- Live-verified against hosted DEV (`iymwxdewcpvpjgzewtzk`) with a real profile/`ical_token`: `200` with correct feed body, stable ETag across repeated requests with unchanged data, `304` on matching `If-None-Match` (exact, list, and `*`), `200` on a stale ETag.
- `/code-review low` caught 2 real bugs before push (both fixed + re-verified live): the original ETag hashed the rendered body and never stabilized; `If-None-Match` used strict equality and never matched multi-valued/wildcard headers.
- All-day date-boundary normalization verified standalone (no all-day rows exist on DEV yet to hit end-to-end).

## Session State
**Status:** DONE
**Completed:**
- [x] `is_all_day` handling + date-boundary normalization
- [x] Composed description (location/meeting link/category)
- [x] Weak ETag + `If-None-Match` → 304 + `Cache-Control: private, max-age=900`
- [x] `/code-review low` findings fixed and re-verified live
**Next:** CI green + Vercel preview READY, then manual import into Google Calendar/a phone per the issue's own DoD (I verified via raw curl/VEVENT inspection against real DEV data, not an actual phone import).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar feeds now support ETags and conditional requests, reducing unnecessary data transfers.
  * Event descriptions include location, meeting links, and category details.
* **Bug Fixes**
  * All-day events now consistently display on the correct date across time zones.
* **Performance**
  * Calendar feed responses can be cached privately for up to 15 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->