### PR TITLE
Fix mobile nav tap targets

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -147,7 +147,7 @@ export default function Header() {
         {/* Mobile/tablet drawer — visible below lg */}
         {mobileNavOpen && (
           <div
-            className="lg:hidden mt-2 rounded-2xl py-2 px-3"
+            className="lg:hidden mt-2 rounded-2xl py-2 px-3 flex flex-col gap-1"
             style={{
               backgroundColor: 'rgba(var(--bg-global-rgb), 0.97)',
               border: '1px solid var(--nav-border)',
@@ -160,7 +160,7 @@ export default function Header() {
                 key={href}
                 href={href}
                 onClick={() => setMobileNavOpen(false)}
-                className="interactive flex items-center pill-link-crimson text-xs font-semibold tracking-widest uppercase"
+                className="interactive flex items-center pill-link-crimson text-xs font-semibold tracking-widest uppercase w-full min-h-[44px] py-3"
                 style={isActive(href) ? { backgroundColor: 'rgba(188,71,73,0.12)' } : undefined}
               >
                 {labels[lang]}


### PR DESCRIPTION
## Summary
- Mobile hamburger drawer nav items (НАЧАЛО, ЗА НАС, КАЛЕНДАР, ПЪТУВАНИЯ, БИБЛИОТЕКА, РОЛИ, ПРОФИЛ) were rendered with only `.pill-link-crimson`'s padding (~4px/10px) + `text-xs` line-height, giving ~24-28px tall rows — under the WCAG/HIG/Material 44px minimum touch target, and easy to mis-tap.
- Each mobile item now gets `w-full min-h-[44px] py-3` (full-width row, real tap height) and the drawer container uses `flex flex-col gap-1` for spacing between rows.
- Scoped to `components/layout/Header.tsx`'s mobile-only markup — the shared `.pill-link-crimson` class and the desktop nav (same file) are untouched.
- Follow-up filed as #631: migrate the drawer from its custom `<div>` to the shadcn `Sheet` component (out of scope here, explicitly outside Milestone 3).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Verified at 390px viewport: drawer items measure 44px tall, 332px wide (full container width), evenly spaced, no overlap
- [x] Confirmed desktop nav (`lg:flex`) links unaffected (0-size when hidden, same pill styling when visible)
- [ ] Vercel preview READY + CI green (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the mobile navigation drawer layout.
  * Increased mobile navigation link width, minimum height, and vertical spacing for easier tapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->