### PR TITLE
[2607-DEV-595] Calendar refactor 1a: ICS/admin security hardening

### DIFF
--- a/app/api/admin/calendar/route.ts
+++ b/app/api/admin/calendar/route.ts
@@ -76,7 +76,7 @@ export async function POST(req: Request): Promise<Response> {
   const caller = ctx.profile
 
   const body = await req.json().catch(() => null)
-  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+  if (body === null || body === undefined || typeof body !== 'object' || Array.isArray(body)) {
     return Response.json({ error: 'Invalid or empty request body' }, { status: 400 })
   }
 
@@ -94,11 +94,19 @@ export async function POST(req: Request): Promise<Response> {
     return Response.json({ error: 'title, start_time, and end_time are required' }, { status: 400 })
   }
 
-  // Auto-compute week_number from start_time if not provided
-  if (!picked.week_number) {
-    const d = new Date(picked.start_time)
-    const startOfYear = new Date(d.getFullYear(), 0, 1)
-    picked.week_number = Math.ceil(((d.getTime() - startOfYear.getTime()) / 86400000 + startOfYear.getDay() + 1) / 7)
+  const startDate = new Date(picked.start_time)
+  const endDate = new Date(picked.end_time)
+  if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+    return Response.json({ error: 'start_time and end_time must be valid dates' }, { status: 400 })
+  }
+
+  // Auto-compute week_number only when the field is genuinely absent (not merely falsy — 0 is a valid value)
+  if (picked.week_number === null || picked.week_number === undefined) {
+    const startOfYear = new Date(startDate.getFullYear(), 0, 1)
+    picked.week_number = Math.ceil(((startDate.getTime() - startOfYear.getTime()) / 86400000 + startOfYear.getDay() + 1) / 7)
+  }
+  if (typeof picked.week_number !== 'number' || !Number.isInteger(picked.week_number)) {
+    return Response.json({ error: 'week_number must be an integer' }, { status: 400 })
   }
 
   const insertData: Database['public']['Tables']['calendar_events']['Insert'] = {
@@ -106,7 +114,7 @@ export async function POST(req: Request): Promise<Response> {
     title: picked.title,
     start_time: picked.start_time,
     end_time: picked.end_time,
-    week_number: picked.week_number as number,
+    week_number: picked.week_number,
     created_by: caller.id,
   }
 

--- a/app/api/admin/calendar/route.ts
+++ b/app/api/admin/calendar/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { requireAdmin, getCallerContext } from '@/lib/supabase/guards'
+import type { Database } from '@/types/supabase'
 
 type CategoryFilter = 'N21' | 'Personal'
 
@@ -74,16 +75,42 @@ export async function POST(req: Request): Promise<Response> {
   if (ctx.guard) return ctx.guard
   const caller = ctx.profile
 
-  const body = await req.json()
-  // Auto-compute week_number from start_time if not provided
-  if (!body.week_number && body.start_time) {
-    const d = new Date(body.start_time)
-    const startOfYear = new Date(d.getFullYear(), 0, 1)
-    body.week_number = Math.ceil(((d.getTime() - startOfYear.getTime()) / 86400000 + startOfYear.getDay() + 1) / 7)
+  const body = await req.json().catch(() => null)
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return Response.json({ error: 'Invalid or empty request body' }, { status: 400 })
   }
-  body.created_by = caller.id
 
-  const { data, error } = await supabase.from('calendar_events').insert(body).select().single()
+  const allowed = [
+    'title', 'description', 'start_time', 'end_time', 'category',
+    'event_type', 'meeting_url', 'access_roles', 'available_roles',
+    'allow_guest_registration', 'guest_capacity', 'week_number',
+  ] as const
+  const picked: Record<string, unknown> = {}
+  for (const key of allowed) {
+    if (key in body) picked[key] = (body as Record<string, unknown>)[key]
+  }
+
+  if (typeof picked.title !== 'string' || typeof picked.start_time !== 'string' || typeof picked.end_time !== 'string') {
+    return Response.json({ error: 'title, start_time, and end_time are required' }, { status: 400 })
+  }
+
+  // Auto-compute week_number from start_time if not provided
+  if (!picked.week_number) {
+    const d = new Date(picked.start_time)
+    const startOfYear = new Date(d.getFullYear(), 0, 1)
+    picked.week_number = Math.ceil(((d.getTime() - startOfYear.getTime()) / 86400000 + startOfYear.getDay() + 1) / 7)
+  }
+
+  const insertData: Database['public']['Tables']['calendar_events']['Insert'] = {
+    ...picked,
+    title: picked.title,
+    start_time: picked.start_time,
+    end_time: picked.end_time,
+    week_number: picked.week_number as number,
+    created_by: caller.id,
+  }
+
+  const { data, error } = await supabase.from('calendar_events').insert(insertData).select().single()
   if (error) return Response.json({ error: error.message }, { status: 500 })
 
   // Seed role slots for the new event

--- a/app/api/calendar/feed-token/route.ts
+++ b/app/api/calendar/feed-token/route.ts
@@ -1,10 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
-import { SignJWT } from 'jose'
-
-const secret = new TextEncoder().encode(
-  process.env.ICAL_TOKEN_SECRET ?? 'dev-ical-secret-change-in-production'
-)
+import { signIcalToken, IcalTokenConfigError } from '@/lib/server/icalToken'
 
 export async function GET() {
   const { userId } = await auth()
@@ -29,9 +25,15 @@ export async function GET() {
   }
 
   // Generate new signed JWT — no expiry, permanent subscription URL
-  const token = await new SignJWT({ profile_id: profile.id, role: profile.role })
-    .setProtectedHeader({ alg: 'HS256' })
-    .sign(secret)
+  let token: string
+  try {
+    token = await signIcalToken({ profile_id: profile.id, role: profile.role })
+  } catch (err) {
+    if (err instanceof IcalTokenConfigError) {
+      return Response.json({ error: 'Calendar service unavailable' }, { status: 503 })
+    }
+    throw err
+  }
 
   // Store token in profile
   await supabase
@@ -60,9 +62,15 @@ export async function POST() {
 
   if (error || !profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
-  const token = await new SignJWT({ profile_id: profile.id, role: profile.role })
-    .setProtectedHeader({ alg: 'HS256' })
-    .sign(secret)
+  let token: string
+  try {
+    token = await signIcalToken({ profile_id: profile.id, role: profile.role })
+  } catch (err) {
+    if (err instanceof IcalTokenConfigError) {
+      return Response.json({ error: 'Calendar service unavailable' }, { status: 503 })
+    }
+    throw err
+  }
 
   await supabase
     .from('profiles')

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -1,12 +1,12 @@
 import { createHash } from 'node:crypto'
 import { createServiceClient } from '@/lib/supabase/service'
-import { jwtVerify } from 'jose'
 import ical from 'ical-generator'
 import { listEventsForRole } from '@/lib/server/calendar'
+import { verifyIcalToken, IcalTokenConfigError } from '@/lib/server/icalToken'
 
-const secret = new TextEncoder().encode(
-  process.env.ICAL_TOKEN_SECRET ?? 'dev-ical-secret-change-in-production'
-)
+const FEED_WINDOW_PAST_DAYS = 90
+const FEED_WINDOW_FUTURE_DAYS = 365
+const FEED_LIMIT = 500
 
 function toUtcDateOnly(isoString: string): Date {
   const d = new Date(isoString)
@@ -33,9 +33,11 @@ export async function GET(req: Request) {
   // live from the DB below to avoid stale-token promotion issues
   let payload: { profile_id: string }
   try {
-    const { payload: p } = await jwtVerify(token, secret)
-    payload = p as { profile_id: string }
-  } catch {
+    payload = await verifyIcalToken(token)
+  } catch (err) {
+    if (err instanceof IcalTokenConfigError) {
+      return new Response('Calendar service unavailable', { status: 503 })
+    }
     return new Response('Invalid or expired token', { status: 401 })
   }
 
@@ -58,7 +60,10 @@ export async function GET(req: Request) {
   // matching the prior inline query's behavior (errors were not checked there either).
   let events: Awaited<ReturnType<typeof listEventsForRole>> = []
   try {
-    events = await listEventsForRole({ role: profile.role })
+    const now = Date.now()
+    const from = new Date(now - FEED_WINDOW_PAST_DAYS * 86400000).toISOString()
+    const to = new Date(now + FEED_WINDOW_FUTURE_DAYS * 86400000).toISOString()
+    events = await listEventsForRole({ role: profile.role, from, to, limit: FEED_LIMIT })
   } catch (err) {
     console.error('feed.ics: listEventsForRole failed', err)
   }

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -7,3 +7,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
 | #592 | `dev/2607-DEV-592` | `lib/notifications/guest-event-changes.ts` (new), `app/api/admin/calendar/[id]/route.ts`, admin calendar edit/delete confirm dialog components, `e2e/guest-invite.spec.ts`, `scripts/seed-guest-test-user.js`/seed:smoke-guest — migration: no | 2026-07-22 |
+| #595 | `dev/2607-DEV-595` | `app/api/calendar/feed.ics/route.ts`, `app/api/calendar/feed-token/route.ts`, `app/api/admin/calendar/route.ts`, `lib/server/icalToken.ts` (new) — migration: no | 2026-07-22 |

--- a/lib/server/icalToken.ts
+++ b/lib/server/icalToken.ts
@@ -1,0 +1,23 @@
+// ── lib/server/icalToken.ts ──────────────────────────────────────────────────
+// Shared ICAL_TOKEN_SECRET + JWT sign/verify for the iCal feed subscription.
+// Used by: app/api/calendar/feed.ics/route.ts, app/api/calendar/feed-token/route.ts.
+// Fails closed: throws IcalTokenConfigError when ICAL_TOKEN_SECRET is unset,
+// instead of falling back to a hardcoded dev secret.
+import { SignJWT, jwtVerify } from 'jose'
+
+export class IcalTokenConfigError extends Error {}
+
+function getSecret(): Uint8Array {
+  const raw = process.env.ICAL_TOKEN_SECRET
+  if (!raw) throw new IcalTokenConfigError('ICAL_TOKEN_SECRET is not set')
+  return new TextEncoder().encode(raw)
+}
+
+export async function signIcalToken(payload: { profile_id: string; role: string }): Promise<string> {
+  return new SignJWT(payload).setProtectedHeader({ alg: 'HS256' }).sign(getSecret())
+}
+
+export async function verifyIcalToken(token: string): Promise<{ profile_id: string }> {
+  const { payload } = await jwtVerify(token, getSecret())
+  return payload as { profile_id: string }
+}

--- a/lib/server/icalToken.ts
+++ b/lib/server/icalToken.ts
@@ -9,7 +9,9 @@ export class IcalTokenConfigError extends Error {}
 
 function getSecret(): Uint8Array {
   const raw = process.env.ICAL_TOKEN_SECRET
-  if (!raw) throw new IcalTokenConfigError('ICAL_TOKEN_SECRET is not set')
+  if (raw === undefined || raw === '') {
+    throw new IcalTokenConfigError('ICAL_TOKEN_SECRET is not set')
+  }
   return new TextEncoder().encode(raw)
 }
 


### PR DESCRIPTION
## Summary
- Fail-closed `ICAL_TOKEN_SECRET`: new `lib/server/icalToken.ts` (shared sign/verify helper) replaces the duplicated `dev-ical-secret-change-in-production` fallback in `feed.ics` and `feed-token` routes; missing secret now returns 503 instead of silently signing/verifying with a known dev string.
- ICS feed query bounded to `-90d..+365d` window with `.limit(500)` (was unbounded).
- `POST /api/admin/calendar` now applies the same field allow-list `PATCH [id]` already uses (was inserting raw `req.json()` — mass assignment).

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `npm run build` — TypeScript + build pass
- [x] Local curl: missing token → 400, invalid token → 401
- [ ] Local curl: unset secret → 503 (blocked locally by an unrelated pre-existing `next dev` instance already holding this repo's dev lock; verify on preview or after that process is cleared)
- [ ] Preview: valid token → 200 ICS download
- [ ] Preview: admin event create via `POST /api/admin/calendar` works end-to-end
- [ ] No `dev-ical-secret-change-in-production` string remains in repo (confirmed via grep, re-check after review)

Closes #595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar feeds now support secure token generation and verification.
  * iCal feeds are limited to events from 90 days ago through 365 days ahead, with a maximum of 500 events.

* **Bug Fixes**
  * Improved calendar event validation and filtering when creating events.
  * Invalid calendar feed tokens and unavailable calendar services now return clearer error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->