### PR TITLE
[2607-DEV-595] chore: remove merged claim row from CLAIMS.md

### DIFF
--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -7,4 +7,3 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
 | #592 | `dev/2607-DEV-592` | `lib/notifications/guest-event-changes.ts` (new), `app/api/admin/calendar/[id]/route.ts`, admin calendar edit/delete confirm dialog components, `e2e/guest-invite.spec.ts`, `scripts/seed-guest-test-user.js`/seed:smoke-guest — migration: no | 2026-07-22 |
-| #595 | `dev/2607-DEV-595` | `app/api/calendar/feed.ics/route.ts`, `app/api/calendar/feed-token/route.ts`, `app/api/admin/calendar/route.ts`, `lib/server/icalToken.ts` (new) — migration: no | 2026-07-22 |


### PR DESCRIPTION
Post-merge tail for #595 (PR #635, merged) — removes the now-stale claim row per the GCR workflow. Docs-only, no code changes.