### PR TITLE
[2607-DEV-594] Adopt lib/utils/base-url.ts in feed-token and spouse-link routes

### DIFF
--- a/app/api/calendar/feed-token/route.ts
+++ b/app/api/calendar/feed-token/route.ts
@@ -1,6 +1,7 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { signIcalToken, IcalTokenConfigError } from '@/lib/server/icalToken'
+import { getBaseUrl } from '@/lib/utils/base-url'
 
 export async function GET() {
   const { userId } = await auth()
@@ -17,7 +18,7 @@ export async function GET() {
 
   // Return existing token if already generated
   if (profile.ical_token) {
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://tevd-portal.vercel.app'
+    const baseUrl = await getBaseUrl()
     return Response.json({
       token: profile.ical_token,
       url: `${baseUrl}/api/calendar/feed.ics?token=${profile.ical_token}`,
@@ -41,7 +42,7 @@ export async function GET() {
     .update({ ical_token: token })
     .eq('id', profile.id)
 
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://tevd-portal.vercel.app'
+  const baseUrl = await getBaseUrl()
   return Response.json({
     token,
     url: `${baseUrl}/api/calendar/feed.ics?token=${token}`,
@@ -77,7 +78,7 @@ export async function POST() {
     .update({ ical_token: token })
     .eq('id', profile.id)
 
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://tevd-portal.vercel.app'
+  const baseUrl = await getBaseUrl()
   return Response.json({
     token,
     url: `${baseUrl}/api/calendar/feed.ics?token=${token}`,

--- a/app/api/profile/spouse-link/route.ts
+++ b/app/api/profile/spouse-link/route.ts
@@ -2,6 +2,7 @@ import { withProfile } from '@/lib/supabase/with-profile'
 import { sendNotificationEmail } from '@/lib/email/send'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { SpouseLinkRequestEmail } from '@/lib/email/templates/SpouseLinkRequestEmail'
+import { getBaseUrl } from '@/lib/utils/base-url'
 
 // GET — return own pending/denied spouse_link_requests row, or null
 export async function GET() {
@@ -134,12 +135,13 @@ export async function POST(req: Request) {
 
   // Email notification for primary — best-effort
   if (primary.contact_email) {
+    const baseUrl = await getBaseUrl()
     renderEmailTemplate(
       SpouseLinkRequestEmail({
         primaryFirstName: primary.first_name ?? 'Member',
         requesterFirstName: profile.first_name ?? '',
         requesterLastName: profile.last_name ?? '',
-        actionUrl: `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://portal.teamenjoyvd.com'}/profile/spouse-link`,
+        actionUrl: `${baseUrl}/profile/spouse-link`,
       })
     ).then(html =>
       sendNotificationEmail({

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -8,3 +8,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 |---|---|---|---|
 | #592 | `dev/2607-DEV-592` | `lib/notifications/guest-event-changes.ts` (new), `app/api/admin/calendar/[id]/route.ts`, admin calendar edit/delete confirm dialog components, `e2e/guest-invite.spec.ts`, `scripts/seed-guest-test-user.js`/seed:smoke-guest — migration: no | 2026-07-22 |
 | #596 | `dev/2607-DEV-596` | `supabase/functions/sync-google-calendar/index.ts`, `app/api/admin/calendar-sync/route.ts`, `app/admin/calendar/components/AdminCalendarClient.tsx` (status display only) — migration: no | 2026-07-22 |
+| #594 | `dev/2607-DEV-594` | `app/api/calendar/feed-token/route.ts`, `app/api/profile/spouse-link/route.ts` — migration: no | 2026-07-22 |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,10 +1,9 @@
-## Goal (issue #594)
-Issue #594 (2026-07-22, branch `dev/2607-DEV-594`): follow-up to #587 — adopt the shared `lib/utils/base-url.ts` (`getBaseUrl()`) in `app/api/calendar/feed-token/route.ts` (3 call sites) and `app/api/profile/spouse-link/route.ts` (1 call site), replacing duplicated inline `process.env.NEXT_PUBLIC_APP_URL ?? '<literal>'` fallbacks (the two routes previously had two different hardcoded fallback hosts).
+### Prior task (#594)
+Issue #594 (2026-07-22, branch `dev/2607-DEV-594`): follow-up to #587 — adopted shared `lib/utils/base-url.ts` (`getBaseUrl()`) in `feed-token/route.ts` (3 sites) and `spouse-link/route.ts` (1 site), replacing two different duplicated hardcoded fallback hosts.
 
 ## Now (issue #594)
-PLAN → CLAIM → BUILD in one session (user: "CLAIM ISSUE 594", then "BUILD #594"). PLAN: no gotchas found, no migration, no E2E needed (pure internal refactor, env var always set in deployed environments). CLAIM: no overlap in `docs/CLAIMS.md`, issue got Design Checklist + `## Branch`, cut `dev/2607-DEV-594`, registered claim row. BUILD: swapped all 4 call sites for `await getBaseUrl()` — 3 in feed-token (both GET branches + POST), 1 in spouse-link's best-effort email notification (hoisted `const baseUrl = await getBaseUrl()` before the template call since it was previously inlined synchronously inside `renderEmailTemplate(...)`).
-Verified: `npx tsc --noEmit` clean, `npm run build` green, `npx eslint` on both changed files 0 issues, `npx vitest run` 151/151 (no regressions). Committed `9a3fc16`. Not pushed (user hasn't asked).
-Next: user-approved push → draft PR → CI green + Vercel preview READY before Done.
+PLAN → CLAIM → BUILD → self-review → draft PR → ready-for-review all done in one session (user: "CLAIM ISSUE 594", "BUILD #594", "/code-review low", "once done open a PR and mark it ready for review"). Verified: `tsc --noEmit` clean, `npm run build` green, `eslint` 0 issues, `vitest run` 151/151. Manual self-review (`/code-review low` not invocable programmatically) — no findings. Pushed, opened PR [#638](https://github.com/teamenjoyvd/tevd-portal/pull/638), all CI green (Build/Lint/Test/TypeCheck/SecurityAudit/migrations-replay/390px-smoke) + Vercel preview READY. PR was already flipped out of draft (by `teamenjoyvd` directly, same pattern as prior PRs) by the time `gh pr ready` ran.
+Next: waiting on CodeRabbit's pass (rate-limited when last checked) — GCR once it posts, then merge + post-merge tail (prod migration gate auto-skip since no migration, smoke-check prod, remove `docs/CLAIMS.md` #594 row, close issue).
 
 ## Goal (issue #596)
 Issue #596 (2026-07-22, branch `dev/2607-DEV-596`): Calendar refactor 1b/8 — `supabase/functions/sync-google-calendar/index.ts` overhaul (fail-closed 401, pagination, N+1→upsert, deletions/reconciliation, observability). Phase 1b, lands before #587-592, isolated from 1a (security hardening, already merged #635) so a revert doesn't take that back out.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,3 +1,11 @@
+## Goal (issue #594)
+Issue #594 (2026-07-22, branch `dev/2607-DEV-594`): follow-up to #587 — adopt the shared `lib/utils/base-url.ts` (`getBaseUrl()`) in `app/api/calendar/feed-token/route.ts` (3 call sites) and `app/api/profile/spouse-link/route.ts` (1 call site), replacing duplicated inline `process.env.NEXT_PUBLIC_APP_URL ?? '<literal>'` fallbacks (the two routes previously had two different hardcoded fallback hosts).
+
+## Now (issue #594)
+PLAN → CLAIM → BUILD in one session (user: "CLAIM ISSUE 594", then "BUILD #594"). PLAN: no gotchas found, no migration, no E2E needed (pure internal refactor, env var always set in deployed environments). CLAIM: no overlap in `docs/CLAIMS.md`, issue got Design Checklist + `## Branch`, cut `dev/2607-DEV-594`, registered claim row. BUILD: swapped all 4 call sites for `await getBaseUrl()` — 3 in feed-token (both GET branches + POST), 1 in spouse-link's best-effort email notification (hoisted `const baseUrl = await getBaseUrl()` before the template call since it was previously inlined synchronously inside `renderEmailTemplate(...)`).
+Verified: `npx tsc --noEmit` clean, `npm run build` green, `npx eslint` on both changed files 0 issues, `npx vitest run` 151/151 (no regressions). Committed `9a3fc16`. Not pushed (user hasn't asked).
+Next: user-approved push → draft PR → CI green + Vercel preview READY before Done.
+
 ## Goal (issue #596)
 Issue #596 (2026-07-22, branch `dev/2607-DEV-596`): Calendar refactor 1b/8 — `supabase/functions/sync-google-calendar/index.ts` overhaul (fail-closed 401, pagination, N+1→upsert, deletions/reconciliation, observability). Phase 1b, lands before #587-592, isolated from 1a (security hardening, already merged #635) so a revert doesn't take that back out.
 


### PR DESCRIPTION
## Summary
- Replace duplicated inline `process.env.NEXT_PUBLIC_APP_URL ?? '<literal>'` fallback logic in `app/api/calendar/feed-token/route.ts` (3 call sites) and `app/api/profile/spouse-link/route.ts` (1 call site) with the shared `getBaseUrl()` util from `lib/utils/base-url.ts` (already used by `lib/actions/guest-registration.ts`, introduced in #587).
- **Behavior note:** the two routes previously had two different hardcoded fallback hosts (`tevd-portal.vercel.app` vs `portal.teamenjoyvd.com`) for when `NEXT_PUBLIC_APP_URL` is unset. Both now fall back to `getBaseUrl()`'s host-header derivation instead. `NEXT_PUBLIC_APP_URL` is set in every deployed environment (prod/preview/DEV), so this only changes behavior for local dev without that env var configured.

Closes #594

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` green
- [x] `npx eslint` on both changed files — 0 issues
- [x] `npx vitest run` — 151/151, no regressions
- [x] Manual self-review of diff (`/code-review low` not invocable programmatically this session) — no findings
- [ ] CI green + Vercel preview READY

## Session State
**Status:** DONE
**Completed:**
- [x] Both routes migrated to `getBaseUrl()`
**Next:** none — ready for CI/preview verification then merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar feed links now consistently use the application’s configured base URL.
  * Spouse-link request emails now include correctly generated action links.
  * Improved link reliability across existing, newly generated, and regenerated calendar feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->