### PR TITLE
[2607-DEV-646] Add Details column to /roles table

### DIFF
--- a/app/(dashboard)/roles/components/RolesClient.tsx
+++ b/app/(dashboard)/roles/components/RolesClient.tsx
@@ -56,7 +56,7 @@ function OccupantCell({ name }: { name: string | null }) {
 }
 
 function DetailsCell({ description }: { description: string | null }) {
-  if (!description || description === '') {
+  if (description === null || description === '') {
     return (
       <span style={{ color: 'var(--text-secondary)' }}>—</span>
     )
@@ -64,7 +64,7 @@ function DetailsCell({ description }: { description: string | null }) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="block truncate cursor-default" style={{ color: 'var(--text-secondary)' }}>
+        <span tabIndex={0} className="block truncate cursor-default" style={{ color: 'var(--text-secondary)' }}>
           {description}
         </span>
       </TooltipTrigger>
@@ -197,7 +197,7 @@ function RolesCards({
                   </span>
                 </div>
               ))}
-              {event.description && (
+              {event.description !== null && event.description !== '' && (
                 <div className="flex items-start justify-between gap-2">
                   <span
                     className="text-[10px] font-semibold tracking-widest uppercase"

--- a/app/(dashboard)/roles/components/RolesClient.tsx
+++ b/app/(dashboard)/roles/components/RolesClient.tsx
@@ -12,6 +12,12 @@ import {
   SelectContent,
   SelectItem,
 } from '@/components/ui/select'
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from '@/components/ui/tooltip'
 import type { RoleEvent } from '@/lib/roles/types'
 import { Database } from '@/types/supabase'
 import { cn } from '@/lib/utils'
@@ -49,6 +55,26 @@ function OccupantCell({ name }: { name: string | null }) {
   )
 }
 
+function DetailsCell({ description }: { description: string | null }) {
+  if (!description || description === '') {
+    return (
+      <span style={{ color: 'var(--text-secondary)' }}>—</span>
+    )
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="block truncate cursor-default" style={{ color: 'var(--text-secondary)' }}>
+          {description}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="text-xs whitespace-pre-line" style={{ color: 'var(--text-primary)' }}>{description}</p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
 // ── Desktop table ────────────────────────────────────────────────────────────
 function RolesTable({
   events,
@@ -70,7 +96,7 @@ function RolesTable({
       <div
         className="grid text-[10px] font-semibold tracking-widest uppercase px-4 py-2.5"
         style={{
-          gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr 1fr',
+          gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr 1fr 1.5fr',
           borderBottom: '1px solid rgba(0,0,0,0.06)',
           color: 'var(--text-secondary)',
           backgroundColor: 'rgba(0,0,0,0.02)',
@@ -87,7 +113,7 @@ function RolesTable({
             key={event.id}
             className="grid items-center px-4 py-3 text-sm transition-all"
             style={{
-              gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr 1fr',
+              gridTemplateColumns: '2fr 1fr 1fr 1fr 1fr 1fr 1.5fr',
               borderTop: i === 0 ? undefined : '1px solid rgba(0,0,0,0.04)',
               opacity: isPast ? 0.6 : undefined,
               filter: isPast ? 'grayscale(0.5)' : undefined,
@@ -108,6 +134,7 @@ function RolesTable({
             <span className="text-xs"><OccupantCell name={event.slots.HOST} /></span>
             <span className="text-xs"><OccupantCell name={event.slots.SPEAKER} /></span>
             <span className="text-xs"><OccupantCell name={event.slots.PRODUCTS} /></span>
+            <span className="text-xs pr-2"><DetailsCell description={event.description} /></span>
           </div>
         )
       })}
@@ -119,11 +146,13 @@ function RolesTable({
 function RolesCards({
   events,
   slotLabels,
+  detailsLabel,
   currentTime,
   isCurrentQuarter,
 }: {
   events: RoleEvent[]
   slotLabels: Record<SlotLabel, string>
+  detailsLabel: string
   currentTime: string
   isCurrentQuarter: boolean
 }) {
@@ -168,6 +197,19 @@ function RolesCards({
                   </span>
                 </div>
               ))}
+              {event.description && (
+                <div className="flex items-start justify-between gap-2">
+                  <span
+                    className="text-[10px] font-semibold tracking-widest uppercase"
+                    style={{ color: 'var(--text-secondary)', minWidth: 72 }}
+                  >
+                    {detailsLabel}
+                  </span>
+                  <span className="text-xs text-right whitespace-pre-line" style={{ color: 'var(--text-secondary)' }}>
+                    {event.description}
+                  </span>
+                </div>
+              )}
             </div>
           </div>
         )
@@ -202,6 +244,7 @@ export default function RolesClient({
     t('event.roles.label.host'),
     t('event.roles.label.speaker'),
     t('event.roles.label.products'),
+    t('event.roles.col.details'),
   ]
 
   const slotLabels: Record<SlotLabel, string> = {
@@ -307,18 +350,21 @@ export default function RolesClient({
           <>
             {/* Desktop view */}
             <div className="hidden lg:block">
-              <RolesTable
-                events={quarterEvents}
-                headers={headers}
-                currentTime={currentTime}
-                isCurrentQuarter={isCurrentQuarter}
-              />
+              <TooltipProvider delayDuration={150}>
+                <RolesTable
+                  events={quarterEvents}
+                  headers={headers}
+                  currentTime={currentTime}
+                  isCurrentQuarter={isCurrentQuarter}
+                />
+              </TooltipProvider>
             </div>
             {/* Mobile view */}
             <div className="lg:hidden">
               <RolesCards
                 events={quarterEvents}
                 slotLabels={slotLabels}
+                detailsLabel={t('event.roles.col.details')}
                 currentTime={currentTime}
                 isCurrentQuarter={isCurrentQuarter}
               />

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+
+const TooltipProvider = TooltipPrimitive.Provider
+const Tooltip = TooltipPrimitive.Root
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+function TooltipContent({
+  children,
+  sideOffset = 6,
+  style,
+  className,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        sideOffset={sideOffset}
+        style={{
+          backgroundColor: 'var(--bg-global)',
+          border: '1px solid var(--border-default)',
+          borderRadius: '10px',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.06)',
+          outline: 'none',
+          maxWidth: '320px',
+          padding: '8px 10px',
+          ...style,
+        }}
+        className={className}
+        {...props}
+      >
+        {children}
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -7,3 +7,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
 | #596 | `dev/2607-DEV-596` | `supabase/functions/sync-google-calendar/index.ts`, `app/api/admin/calendar-sync/route.ts`, `app/admin/calendar/components/AdminCalendarClient.tsx` (status display only) — migration: no | 2026-07-22 |
+| #646 | `dev/2607-DEV-646` | `app/(dashboard)/roles/components/RolesClient.tsx`, `lib/roles/types.ts`, `lib/roles/queries.ts`, `lib/i18n/domains/events.ts`, `components/ui/tooltip.tsx` (new) — migration: yes, `supabase/migrations/20260723000000_add_description_to_v_roles_history.sql` | 2026-07-23 |

--- a/lib/i18n/domains/events.ts
+++ b/lib/i18n/domains/events.ts
@@ -25,6 +25,7 @@ export const events = {
   'event.roles.col.event':    { en: 'Event',    bg: 'Събитие'  },
   'event.roles.col.date':     { en: 'Date',     bg: 'Дата'     },
   'event.roles.col.time':     { en: 'Time',     bg: 'Час'      },
+  'event.roles.col.details':  { en: 'Details',  bg: 'Описание' },
 
   // roles page — slot role labels
   'event.roles.label.host':     { en: 'Host',     bg: 'Домакин'   },

--- a/lib/roles/queries.ts
+++ b/lib/roles/queries.ts
@@ -27,6 +27,7 @@ export async function getQuarterEvents(
     title: row.title ?? '',
     start_time: row.start_time ?? '',
     end_time: row.end_time ?? '',
+    description: row.description ?? null,
     slots: {
       HOST: row.host_name || null,
       SPEAKER: row.speaker_name || null,

--- a/lib/roles/types.ts
+++ b/lib/roles/types.ts
@@ -3,6 +3,7 @@ export type RoleEvent = {
   title: string
   start_time: string
   end_time: string
+  description: string | null
   slots: {
     HOST: string | null
     SPEAKER: string | null

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-select": "^2.2.4",
         "@radix-ui/react-tabs": "^1.1.3",
+        "@radix-ui/react-tooltip": "^1.2.14",
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.0.6",
         "@supabase/ssr": "^0.9.0",
@@ -1670,6 +1671,399 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.14.tgz",
+      "integrity": "sha512-C/JxCKJJac+wtHPW1yFBSN8Ssuaufy2jYQMgyiJYyW4Fw0WJfDWXQDAly1qsbd1YDznH+sYitaljhf8igPCvmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-context": "1.2.1",
+        "@radix-ui/react-dismissable-layer": "1.1.17",
+        "@radix-ui/react-id": "1.1.3",
+        "@radix-ui/react-popper": "1.3.5",
+        "@radix-ui/react-portal": "1.1.15",
+        "@radix-ui/react-presence": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-slot": "1.3.1",
+        "@radix-ui/react-use-controllable-state": "1.2.5",
+        "@radix-ui/react-use-layout-effect": "1.1.3",
+        "@radix-ui/react-visually-hidden": "1.2.9"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.13.tgz",
+      "integrity": "sha512-0Q310knIY0K+mkmncU9FxLggfW7V49Ok2oY+iu27KkERTsQXxYCIC8XW5QoK4w7Jp1z00vT5xj3oxTcn7QlcTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.8"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.4.tgz",
+      "integrity": "sha512-pWJo6lQAfR6uy1n7ii7PaCc9dLPwTXDYbQpORZU5B548Aqvl2pP1SM1vJGKyxIFqZMHRopRO4CQYX2iXAIB5jA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-context": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.1.tgz",
+      "integrity": "sha512-EraVbFjiIjibpLr6EjvEDmSCYJU2SlKDMiO+qEK/D9GOWnQoAQlpQo2occGYC1UM9MBeEx5Bek3UtW/Qi57vAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.17.tgz",
+      "integrity": "sha512-QAXwa38pG0xNAYh1pjdSaf86NrkqsMoDNmget/Y7X8O8E/C3Iqlj9GAPE4DfX9BPLXc7WH2TWSzMRnIoCdcjzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-use-callback-ref": "1.1.3",
+        "@radix-ui/react-use-effect-event": "0.0.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-id": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.3.tgz",
+      "integrity": "sha512-f/Wxm0ctyMymUJK0fqTSQlm85rbzdAkoNbPXJQ5+6caowVO8Yx+NWGjGz/oGhs/D+WIbbQpOrU0hU2Li2/42xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-popper": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.5.tgz",
+      "integrity": "sha512-6hLng2Rs45IZcvZ31BNvMeaFEMMEbtsog4xPcb8LZrGfyoV9fdAXqB9UKhLpTHtL0+E2DhSr6VW54Tehd6ksAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.13",
+        "@radix-ui/react-compose-refs": "1.1.4",
+        "@radix-ui/react-context": "1.2.1",
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-use-callback-ref": "1.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.3",
+        "@radix-ui/react-use-rect": "1.1.3",
+        "@radix-ui/react-use-size": "1.1.3",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.15.tgz",
+      "integrity": "sha512-kAfBVJUKNNKZuyGQXXG6rKolAV2KAmxxVkPXJgoq9dEFTl39286RufHQFNTL8rzha4vP8159BJ6hMGpB+bqv7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.8",
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.9.tgz",
+      "integrity": "sha512-LTi1v05bprIb8/GSY/GWusI0jfsYjQ3CD3Nin8o7jVxnpHzVQfzjOQJoJTQkE9bdmOnsS7SFdhkXiBv8PrYnxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.8.tgz",
+      "integrity": "sha512-DOlK1BdcIeYYUcFkSYFka4v1h95XTov93b0jCgW1EEiZuIhdwHY2NlE1teLIh+p0uBsuZI5A+voay+iVWpprfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.1.tgz",
+      "integrity": "sha512-Bu/aAQHFFh6/QAvXAeUMurJ9fbW0JUIqlojU/yBXZ7cAVqy75Y7JYYyuCr9zLNF0p4WWoJYV54CTUIf4l7FzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.3.tgz",
+      "integrity": "sha512-AUS7HoBBAncIsGMLNG+CcpLuJ+JIBbZzmyM8Qdb1eIThX0AlhSSC6wn40xfBlPE+ypx/vSSiRWnklUAjy3U3UA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.5.tgz",
+      "integrity": "sha512-UB1dXpxvHjR48poyKdKdTm7jT0kp3elkUKdKQiOkirlbYumqXinSJtrjDsr9maXNPvL12bKI4CDSmydms/9Aeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.4",
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.4.tgz",
+      "integrity": "sha512-XYcfa6wlXDCwQtePuEiPmXLSAhGL4DWtedSyRgGbG3y10mw+OnrLp6SyeY1gJFMiYF0Dx0nMAX9InylKbLEFQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.3.tgz",
+      "integrity": "sha512-rDiah9wvtqihWtWz02XreeRKIxt2EJF8y5D9rtY9l5A2zxePAtcPiOMpDugNRw5bFHz+1/8viVoc7ZVKiJknCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.3.tgz",
+      "integrity": "sha512-W0GSYZFKEfi6raMiMEfJSngvVbFDIyxtW5JuVg5NoQBY59l0dVQVGLbhog/tOdwq0qtZ+TXuX1ikSNan4/IZXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.3.tgz",
+      "integrity": "sha512-jJq6tQQLvO/z4uWbztjwPV+1a/+H4rCaWypasLB/ac8DEdd6+p7dIm7o3F6P2KZPGkPMqD4s5424EdAdoU+GLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.9.tgz",
+      "integrity": "sha512-seuZXNZVCz1kLSQMRO/TdNOSahBI3S5nXE4jzO7u7aFRWQlMAnwyrr8vKMkEU115fCLEyzR2YyjnP+aRMxK34w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.8"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-select": "^2.2.4",
     "@radix-ui/react-tabs": "^1.1.3",
+    "@radix-ui/react-tooltip": "^1.2.14",
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.6",
     "@supabase/ssr": "^0.9.0",

--- a/supabase/migrations/20260723000000_add_description_to_v_roles_history.sql
+++ b/supabase/migrations/20260723000000_add_description_to_v_roles_history.sql
@@ -1,0 +1,86 @@
+-- Up Migration: Add free-text description column to v_roles_history
+-- REPLACE only tolerates appended columns, so `e.description` is added LAST.
+
+CREATE OR REPLACE VIEW public.v_roles_history AS
+SELECT
+  e.id AS event_id,
+  e.title,
+  e.start_time,
+  e.end_time,
+  COALESCE(
+    (
+      SELECT p.first_name || ' ' || p.last_name
+      FROM public.event_role_requests r
+      JOIN public.profiles p ON p.id = r.profile_id
+      WHERE r.event_id = e.id AND r.role_label = 'HOST' AND r.status = 'approved'
+      LIMIT 1
+    ),
+    ''
+  ) AS host_name,
+  COALESCE(
+    (
+      SELECT p.first_name || ' ' || p.last_name
+      FROM public.event_role_requests r
+      JOIN public.profiles p ON p.id = r.profile_id
+      WHERE r.event_id = e.id AND r.role_label = 'SPEAKER' AND r.status = 'approved'
+      LIMIT 1
+    ),
+    ''
+  ) AS speaker_name,
+  COALESCE(
+    (
+      SELECT p.first_name || ' ' || p.last_name
+      FROM public.event_role_requests r
+      JOIN public.profiles p ON p.id = r.profile_id
+      WHERE r.event_id = e.id AND r.role_label = 'PRODUCTS' AND r.status = 'approved'
+      LIMIT 1
+    ),
+    ''
+  ) AS products_name,
+  e.description
+FROM public.calendar_events e
+WHERE EXISTS (
+  SELECT 1 FROM public.event_role_slots s WHERE s.event_id = e.id
+);
+
+-- ROLLBACK:
+-- CREATE OR REPLACE VIEW public.v_roles_history AS
+-- SELECT
+--   e.id AS event_id,
+--   e.title,
+--   e.start_time,
+--   e.end_time,
+--   COALESCE(
+--     (
+--       SELECT p.first_name || ' ' || p.last_name
+--       FROM public.event_role_requests r
+--       JOIN public.profiles p ON p.id = r.profile_id
+--       WHERE r.event_id = e.id AND r.role_label = 'HOST' AND r.status = 'approved'
+--       LIMIT 1
+--     ),
+--     ''
+--   ) AS host_name,
+--   COALESCE(
+--     (
+--       SELECT p.first_name || ' ' || p.last_name
+--       FROM public.event_role_requests r
+--       JOIN public.profiles p ON p.id = r.profile_id
+--       WHERE r.event_id = e.id AND r.role_label = 'SPEAKER' AND r.status = 'approved'
+--       LIMIT 1
+--     ),
+--     ''
+--   ) AS speaker_name,
+--   COALESCE(
+--     (
+--       SELECT p.first_name || ' ' || p.last_name
+--       FROM public.event_role_requests r
+--       JOIN public.profiles p ON p.id = r.profile_id
+--       WHERE r.event_id = e.id AND r.role_label = 'PRODUCTS' AND r.status = 'approved'
+--       LIMIT 1
+--     ),
+--     ''
+--   ) AS products_name
+-- FROM public.calendar_events e
+-- WHERE EXISTS (
+--   SELECT 1 FROM public.event_role_slots s WHERE s.event_id = e.id
+-- );

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -2095,6 +2095,7 @@ export type Database = {
       }
       v_roles_history: {
         Row: {
+          description: string | null
           end_time: string | null
           event_id: string | null
           host_name: string | null
@@ -2104,6 +2105,7 @@ export type Database = {
           title: string | null
         }
         Insert: {
+          description?: string | null
           end_time?: string | null
           event_id?: string | null
           host_name?: never
@@ -2113,6 +2115,7 @@ export type Database = {
           title?: string | null
         }
         Update: {
+          description?: string | null
           end_time?: string | null
           event_id?: string | null
           host_name?: never


### PR DESCRIPTION
## Summary
- Adds a "Details" column to /roles showing each event's free-text `description` (same text as the calendar EventPopup's last row) — not the `event_type` enum
- Extends `v_roles_history` view (additive, description appended last) and adds a shadcn Tooltip primitive (`@radix-ui/react-tooltip` was not yet in the repo) so long text truncates without breaking row height

## Files
- `supabase/migrations/20260723000000_add_description_to_v_roles_history.sql` (new)
- `lib/roles/types.ts`, `lib/roles/queries.ts`
- `lib/i18n/domains/events.ts` — `event.roles.col.details` (en/bg)
- `components/ui/tooltip.tsx` (new)
- `app/(dashboard)/roles/components/RolesClient.tsx`

## Test plan
- [x] Migration applied to hosted DEV (`iymwxdewcpvpjgzewtzk`) via `supabase db push`
- [x] `types/supabase.ts` regenerated, `v_roles_history.Row.description` present
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on touched files — 0 errors
- [x] `npm run build` — exit 0
- [ ] Vercel PR preview READY
- [ ] CI green

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Details column to the desktop roles table.
  * Role descriptions now appear in tooltips when available.
  * Mobile role cards can display event descriptions.
  * Added localized labels for the new Details field in English and Bulgarian.

* **Bug Fixes**
  * Roles now correctly handle events without descriptions, displaying an appropriate placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->