### PR TITLE
[2607-DEV-599] Calendar refactor 4: CalendarClient dedupe + 390px + a11y

### DIFF
--- a/app/(dashboard)/calendar/components/CalendarClient.tsx
+++ b/app/(dashboard)/calendar/components/CalendarClient.tsx
@@ -8,7 +8,8 @@ import { Dialog, DialogContent, DialogOverlay, DialogPortal } from '@/components
 import { useCalendar } from '@/app/(dashboard)/calendar/components/useCalendar'
 import { MonthView } from '@/app/(dashboard)/calendar/components/MonthView'
 import { AgendaView } from '@/app/(dashboard)/calendar/components/AgendaView'
-import { type CalendarEvent, type View } from '@/app/(dashboard)/calendar/types'
+import { FilterControls } from '@/app/(dashboard)/calendar/components/FilterControls'
+import { type CalendarEvent } from '@/app/(dashboard)/calendar/types'
 
 const EventPopup = dynamic(() => import('@/app/(dashboard)/calendar/components/EventPopup'), { ssr: false })
 
@@ -19,7 +20,6 @@ type Props = {
   initialMonth: string
   initialEventId: string | null
   userRole: 'admin' | 'core' | 'member' | 'guest' | null
-  userProfileId: string | null
   isAuthenticated: boolean
   profileNameMissing: boolean
 }
@@ -31,7 +31,6 @@ export default function CalendarClient({
   initialMonth,
   initialEventId,
   userRole,
-  userProfileId: _userProfileId,
   isAuthenticated,
   profileNameMissing,
 }: Props) {
@@ -71,114 +70,26 @@ export default function CalendarClient({
     [current, MONTHS]
   )
 
-  const views: { key: View; label: string }[] = [
-    { key: 'agenda', label: t('cal.agenda') },
-    { key: 'month',  label: t('cal.month')  },
-  ]
-
-  const TYPE_FILTERS = ['in-person', 'online', 'hybrid'] as const
-
   return (
     <div className="w-full" style={{ backgroundColor: 'var(--bg-global)' }}>
 
       {/* ── MOBILE ──────────────────────────────────────────────────────────────── */}
       <div className="md:hidden">
-        <div className="flex-shrink-0 border-b" style={{ backgroundColor: 'var(--bg-global)', borderColor: 'var(--border-default)' }}>
-          <div className="max-w-[1024px] mx-auto px-4">
-
-            {/* Row 1: nav + period label (left) | view switcher (right) */}
-            <div className="flex items-center justify-between gap-2 py-2.5">
-              <div className="flex items-center gap-1 min-w-0">
-                <button onClick={() => navigate(-1)}
-                  className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-black/5 flex-shrink-0"
-                  style={{ color: 'var(--text-primary)' }}>
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
-                    stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <polyline points="15 18 9 12 15 6"/>
-                  </svg>
-                </button>
-                <button onClick={goToday}
-                  className="px-2.5 py-1 rounded-lg text-xs font-semibold border flex-shrink-0"
-                  style={{ borderColor: 'var(--crimson)', color: 'var(--crimson)' }}>
-                  {t('cal.today')}
-                </button>
-                <button onClick={() => navigate(1)}
-                  className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-black/5 flex-shrink-0"
-                  style={{ color: 'var(--text-primary)' }}>
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
-                    stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <polyline points="9 18 15 12 9 6"/>
-                  </svg>
-                </button>
-                <p className="text-sm font-semibold truncate ml-1" style={{ color: 'var(--text-primary)' }}>
-                  {periodLabel}
-                </p>
-              </div>
-              {/* View switcher — right side of Row 1 */}
-              <div className="flex gap-0.5 p-0.5 rounded-lg flex-shrink-0" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }}>
-                {views.map(v => (
-                  <button key={v.key} onClick={() => setView(v.key)}
-                    className="px-2.5 py-1 rounded-md text-xs font-medium transition-all"
-                    style={{
-                      backgroundColor: view === v.key ? 'white' : 'transparent',
-                      color: view === v.key ? 'var(--text-primary)' : 'var(--text-secondary)',
-                      boxShadow: view === v.key ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
-                    }}>
-                    {v.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Row 2: category + format filter chips */}
-            {/* sticky top-[60px]: top-4 + h-14 from Header.tsx */}
-            <div
-              className="flex items-center gap-1.5 pb-2.5 overflow-x-auto sticky top-[60px] z-10"
-              style={{ scrollbarWidth: 'none', backgroundColor: 'var(--bg-global)' }}
-            >
-              <button
-                onClick={() => setShowN21(v => !v)}
-                className="flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold flex-shrink-0 transition-all"
-                style={{
-                  backgroundColor: showN21 ? 'var(--forest)' : 'rgba(0,0,0,0.05)',
-                  color: showN21 ? 'white' : 'var(--text-secondary)',
-                }}
-              >
-                <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                  style={{ backgroundColor: showN21 ? 'rgba(255,255,255,0.6)' : 'var(--forest)' }} />
-                N21
-              </button>
-              {canSeePersonal && (
-                <button
-                  onClick={() => setShowPersonal(v => !v)}
-                  className="flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold flex-shrink-0 transition-all"
-                  style={{
-                    backgroundColor: showPersonal ? 'var(--sienna)' : 'rgba(0,0,0,0.05)',
-                    color: showPersonal ? 'white' : 'var(--text-secondary)',
-                  }}
-                >
-                  <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: showPersonal ? 'rgba(255,255,255,0.6)' : 'var(--sienna)' }} />
-                  {t('cal.personal')}
-                </button>
-              )}
-              <div className="w-px h-4 flex-shrink-0" style={{ backgroundColor: 'var(--border-default)' }} />
-              {TYPE_FILTERS.map(type => (
-                <button
-                  key={type}
-                  onClick={() => setFilterType(filterType === type ? null : type)}
-                  className="px-2.5 py-1 rounded-full text-xs font-semibold flex-shrink-0 transition-all"
-                  style={{
-                    backgroundColor: filterType === type ? 'var(--brand-teal)' : 'rgba(0,0,0,0.05)',
-                    color: filterType === type ? 'white' : 'var(--text-secondary)',
-                  }}
-                >
-                  {type === 'in-person' ? t('cal.inPerson') : type === 'online' ? t('cal.online') : t('cal.hybrid')}
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
+        <FilterControls
+          t={t}
+          periodLabel={periodLabel}
+          navigate={navigate}
+          goToday={goToday}
+          view={view}
+          setView={setView}
+          showN21={showN21}
+          setShowN21={setShowN21}
+          canSeePersonal={canSeePersonal}
+          showPersonal={showPersonal}
+          setShowPersonal={setShowPersonal}
+          filterType={filterType}
+          setFilterType={setFilterType}
+        />
 
         {/* Mobile: document scrolls — no scroll container */}
         <div className="max-w-[1024px] mx-auto">
@@ -202,101 +113,21 @@ export default function CalendarClient({
               alignItems: 'start',
             }}
           >
-            {/* col-2: left nav sidebar */}
-            <div
-              style={{ gridColumn: 'span 2', backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
-              className="rounded-2xl p-4 flex flex-col gap-4 sticky top-24"
-            >
-              <div>
-                <p className="font-display text-base font-semibold mb-1" style={{ color: 'var(--text-primary)' }}>
-                  {periodLabel}
-                </p>
-                <div className="flex gap-1 mt-2">
-                  <button onClick={() => navigate(-1)}
-                    className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-black/5 transition-colors flex-shrink-0"
-                    style={{ color: 'var(--text-primary)' }}>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-                      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <polyline points="15 18 9 12 15 6"/>
-                    </svg>
-                  </button>
-                  <button onClick={() => navigate(1)}
-                    className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-black/5 transition-colors flex-shrink-0"
-                    style={{ color: 'var(--text-primary)' }}>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-                      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <polyline points="9 18 15 12 9 6"/>
-                    </svg>
-                  </button>
-                </div>
-                <button onClick={goToday}
-                  className="mt-2 w-full px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors hover:bg-black/[0.02]"
-                  style={{ borderColor: 'var(--crimson)', color: 'var(--crimson)' }}>
-                  {t('cal.today')}
-                </button>
-              </div>
-
-              <div>
-                <p className="text-[10px] font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('cal.view')}</p>
-                <div className="flex flex-col gap-0.5">
-                  {views.map(v => (
-                    <button key={v.key} onClick={() => setView(v.key)}
-                      className="w-full text-left px-3 py-2 rounded-lg text-xs font-medium transition-all"
-                      style={{
-                        backgroundColor: view === v.key ? 'rgba(188,71,73,0.08)' : 'transparent',
-                        color: view === v.key ? 'var(--brand-crimson)' : 'var(--text-secondary)',
-                        fontWeight: view === v.key ? 600 : 400,
-                      }}>
-                      {v.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              <div>
-                <p className="text-[10px] font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('cal.category')}</p>
-                <div className="flex flex-col gap-1.5">
-                  <button onClick={() => setShowN21(v => !v)}
-                    className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-semibold transition-all"
-                    style={{
-                      backgroundColor: showN21 ? 'var(--forest)' : 'rgba(0,0,0,0.04)',
-                      color: showN21 ? 'white' : 'var(--text-secondary)',
-                    }}>
-                    <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                      style={{ backgroundColor: showN21 ? 'rgba(255,255,255,0.6)' : 'var(--forest)' }} />
-                    N21
-                  </button>
-                  {canSeePersonal && (
-                    <button onClick={() => setShowPersonal(v => !v)}
-                      className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-semibold transition-all"
-                      style={{
-                        backgroundColor: showPersonal ? 'var(--sienna)' : 'rgba(0,0,0,0.04)',
-                        color: showPersonal ? 'white' : 'var(--text-secondary)',
-                      }}>
-                      <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                        style={{ backgroundColor: showPersonal ? 'rgba(255,255,255,0.6)' : 'var(--sienna)' }} />
-                      {t('cal.personal')}
-                    </button>
-                  )}
-                </div>
-              </div>
-
-              <div>
-                <p className="text-[10px] font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('cal.format')}</p>
-                <div className="flex flex-col gap-1">
-                  {TYPE_FILTERS.map(type => (
-                    <button key={type} onClick={() => setFilterType(filterType === type ? null : type)}
-                      className="w-full text-left px-3 py-2 rounded-lg text-xs font-semibold transition-all"
-                      style={{
-                        backgroundColor: filterType === type ? 'var(--brand-teal)' : 'rgba(0,0,0,0.04)',
-                        color: filterType === type ? 'white' : 'var(--text-secondary)',
-                      }}>
-                      {type === 'in-person' ? t('cal.inPerson') : type === 'online' ? t('cal.online') : t('cal.hybrid')}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
+            <FilterControls
+              t={t}
+              periodLabel={periodLabel}
+              navigate={navigate}
+              goToday={goToday}
+              view={view}
+              setView={setView}
+              showN21={showN21}
+              setShowN21={setShowN21}
+              canSeePersonal={canSeePersonal}
+              showPersonal={showPersonal}
+              setShowPersonal={setShowPersonal}
+              filterType={filterType}
+              setFilterType={setFilterType}
+            />
 
             {/* col-10: calendar */}
             <div
@@ -325,42 +156,34 @@ export default function CalendarClient({
             </div>
           </div>
         </div>
-
-        {/* Desktop event modal */}
-        <Dialog open={!!selectedEventId} onOpenChange={open => { if (!open) handleClose() }}>
-          <DialogPortal>
-            <DialogOverlay
-              style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
-            />
-            <DialogContent
-              style={{
-                position: 'fixed',
-                top: '50%',
-                left: '50%',
-                transform: 'translate(-50%, -50%)',
-                width: 360,
-                maxHeight: '80vh',
-                display: 'flex',
-                flexDirection: 'column',
-                borderRadius: '1rem',
-                backgroundColor: 'var(--bg-global)',
-                boxShadow: '0 8px 40px rgba(0,0,0,0.22)',
-                overflow: 'hidden',
-                padding: 0,
-              }}
-            >
-              {selectedEventId && (
-                <EventPopup
-                  eventId={selectedEventId}
-                  onClose={handleClose}
-                  userRole={userRole}
-                  profileNameMissing={profileNameMissing}
-                />
-              )}
-            </DialogContent>
-          </DialogPortal>
-        </Dialog>
       </div>
+
+      {/* Event modal — mobile: bottom sheet; desktop: centered card */}
+      <Dialog open={!!selectedEventId} onOpenChange={open => { if (!open) handleClose() }}>
+        <DialogPortal>
+          <DialogOverlay
+            style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+          />
+          <DialogContent
+            className="fixed flex flex-col overflow-hidden p-0
+              inset-x-0 bottom-0 w-full max-h-[85vh] rounded-t-2xl
+              md:inset-x-auto md:bottom-auto md:top-1/2 md:left-1/2 md:w-[360px] md:max-h-[80vh] md:rounded-2xl md:-translate-x-1/2 md:-translate-y-1/2"
+            style={{
+              backgroundColor: 'var(--bg-global)',
+              boxShadow: '0 8px 40px rgba(0,0,0,0.22)',
+            }}
+          >
+            {selectedEventId && (
+              <EventPopup
+                eventId={selectedEventId}
+                onClose={handleClose}
+                userRole={userRole}
+                profileNameMissing={profileNameMissing}
+              />
+            )}
+          </DialogContent>
+        </DialogPortal>
+      </Dialog>
     </div>
   )
 }

--- a/app/(dashboard)/calendar/components/FilterControls.tsx
+++ b/app/(dashboard)/calendar/components/FilterControls.tsx
@@ -1,0 +1,240 @@
+'use client'
+
+import { type View } from '@/app/(dashboard)/calendar/types'
+import { type TranslationKey } from '@/lib/i18n'
+
+// ── Module-scope constants (shared with CalendarClient) ─────────────────────
+export const VIEWS: { key: View; label: (t: (key: TranslationKey) => string) => string }[] = [
+  { key: 'agenda', label: t => t('cal.agenda') },
+  { key: 'month',  label: t => t('cal.month')  },
+]
+
+export const TYPE_FILTERS = ['in-person', 'online', 'hybrid'] as const
+
+type FilterType = (typeof TYPE_FILTERS)[number] | null
+
+type Props = {
+  t: (key: TranslationKey) => string
+  periodLabel: string
+  navigate: (dir: 1 | -1) => void
+  goToday: () => void
+  view: View
+  setView: (v: View) => void
+  showN21: boolean
+  setShowN21: (fn: (v: boolean) => boolean) => void
+  canSeePersonal: boolean
+  showPersonal: boolean
+  setShowPersonal: (fn: (v: boolean) => boolean) => void
+  filterType: FilterType
+  setFilterType: (v: FilterType) => void
+}
+
+function typeLabel(type: (typeof TYPE_FILTERS)[number], t: (key: TranslationKey) => string) {
+  return type === 'in-person' ? t('cal.inPerson') : type === 'online' ? t('cal.online') : t('cal.hybrid')
+}
+
+// ── Responsive filter/nav controls ───────────────────────────────────────────
+// Renders the mobile top bar (<md) and the desktop sidebar (md+) from one
+// component so the nav/view-switcher/filter state and markup only exist once.
+export function FilterControls({
+  t, periodLabel, navigate, goToday, view, setView,
+  showN21, setShowN21, canSeePersonal, showPersonal, setShowPersonal,
+  filterType, setFilterType,
+}: Props) {
+  return (
+    <>
+      {/* ── MOBILE ──────────────────────────────────────────────────────── */}
+      <div className="md:hidden flex-shrink-0 border-b" style={{ backgroundColor: 'var(--bg-global)', borderColor: 'var(--border-default)' }}>
+        <div className="max-w-[1024px] mx-auto px-4">
+          <div className="flex items-center justify-between gap-2 py-2.5">
+            <div className="flex items-center gap-1 min-w-0">
+              <button onClick={() => navigate(-1)} aria-label={t('cal.prevMonth')}
+                className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-black/5 flex-shrink-0"
+                style={{ color: 'var(--text-primary)' }}>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="15 18 9 12 15 6"/>
+                </svg>
+              </button>
+              <button onClick={goToday}
+                className="px-2.5 py-1 rounded-lg text-xs font-semibold border flex-shrink-0"
+                style={{ borderColor: 'var(--crimson)', color: 'var(--crimson)' }}>
+                {t('cal.today')}
+              </button>
+              <button onClick={() => navigate(1)} aria-label={t('cal.nextMonth')}
+                className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-black/5 flex-shrink-0"
+                style={{ color: 'var(--text-primary)' }}>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="9 18 15 12 9 6"/>
+                </svg>
+              </button>
+              <p className="text-sm font-semibold truncate ml-1" style={{ color: 'var(--text-primary)' }}>
+                {periodLabel}
+              </p>
+            </div>
+            <div className="flex gap-0.5 p-0.5 rounded-lg flex-shrink-0" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }}>
+              {VIEWS.map(v => (
+                <button key={v.key} onClick={() => setView(v.key)}
+                  className="px-2.5 py-1 rounded-md text-xs font-medium transition-all"
+                  style={{
+                    backgroundColor: view === v.key ? 'white' : 'transparent',
+                    color: view === v.key ? 'var(--text-primary)' : 'var(--text-secondary)',
+                    boxShadow: view === v.key ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
+                  }}>
+                  {v.label(t)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* sticky top-[60px]: top-4 + h-14 from Header.tsx */}
+          <div
+            className="flex items-center gap-1.5 pb-2.5 overflow-x-auto sticky top-[60px] z-10"
+            style={{ scrollbarWidth: 'none', backgroundColor: 'var(--bg-global)' }}
+          >
+            <button
+              onClick={() => setShowN21(v => !v)}
+              aria-pressed={showN21}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold flex-shrink-0 transition-all"
+              style={{
+                backgroundColor: showN21 ? 'var(--forest)' : 'rgba(0,0,0,0.05)',
+                color: showN21 ? 'white' : 'var(--text-secondary)',
+              }}
+            >
+              <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: showN21 ? 'rgba(255,255,255,0.6)' : 'var(--forest)' }} />
+              N21
+            </button>
+            {canSeePersonal && (
+              <button
+                onClick={() => setShowPersonal(v => !v)}
+                aria-pressed={showPersonal}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold flex-shrink-0 transition-all"
+                style={{
+                  backgroundColor: showPersonal ? 'var(--sienna)' : 'rgba(0,0,0,0.05)',
+                  color: showPersonal ? 'white' : 'var(--text-secondary)',
+                }}
+              >
+                <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: showPersonal ? 'rgba(255,255,255,0.6)' : 'var(--sienna)' }} />
+                {t('cal.personal')}
+              </button>
+            )}
+            <div className="w-px h-4 flex-shrink-0" style={{ backgroundColor: 'var(--border-default)' }} />
+            {TYPE_FILTERS.map(type => (
+              <button
+                key={type}
+                onClick={() => setFilterType(filterType === type ? null : type)}
+                aria-pressed={filterType === type}
+                className="px-2.5 py-1 rounded-full text-xs font-semibold flex-shrink-0 transition-all"
+                style={{
+                  backgroundColor: filterType === type ? 'var(--brand-teal)' : 'rgba(0,0,0,0.05)',
+                  color: filterType === type ? 'white' : 'var(--text-secondary)',
+                }}
+              >
+                {typeLabel(type, t)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ── DESKTOP ─────────────────────────────────────────────────────── */}
+      <div
+        style={{ gridColumn: 'span 2', backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+        className="hidden md:flex rounded-2xl p-4 flex-col gap-4 sticky top-24"
+      >
+        <div>
+          <p className="font-display text-base font-semibold mb-1" style={{ color: 'var(--text-primary)' }}>
+            {periodLabel}
+          </p>
+          <div className="flex gap-1 mt-2">
+            <button onClick={() => navigate(-1)} aria-label={t('cal.prevMonth')}
+              className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-black/5 transition-colors flex-shrink-0"
+              style={{ color: 'var(--text-primary)' }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="15 18 9 12 15 6"/>
+              </svg>
+            </button>
+            <button onClick={() => navigate(1)} aria-label={t('cal.nextMonth')}
+              className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-black/5 transition-colors flex-shrink-0"
+              style={{ color: 'var(--text-primary)' }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="9 18 15 12 9 6"/>
+              </svg>
+            </button>
+          </div>
+          <button onClick={goToday}
+            className="mt-2 w-full px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors hover:bg-black/[0.02]"
+            style={{ borderColor: 'var(--crimson)', color: 'var(--crimson)' }}>
+            {t('cal.today')}
+          </button>
+        </div>
+
+        <div>
+          <p className="text-[10px] font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('cal.view')}</p>
+          <div className="flex flex-col gap-0.5">
+            {VIEWS.map(v => (
+              <button key={v.key} onClick={() => setView(v.key)}
+                className="w-full text-left px-3 py-2 rounded-lg text-xs font-medium transition-all"
+                style={{
+                  backgroundColor: view === v.key ? 'rgba(188,71,73,0.08)' : 'transparent',
+                  color: view === v.key ? 'var(--brand-crimson)' : 'var(--text-secondary)',
+                  fontWeight: view === v.key ? 600 : 400,
+                }}>
+                {v.label(t)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <p className="text-[10px] font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('cal.category')}</p>
+          <div className="flex flex-col gap-1.5">
+            <button onClick={() => setShowN21(v => !v)} aria-pressed={showN21}
+              className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-semibold transition-all"
+              style={{
+                backgroundColor: showN21 ? 'var(--forest)' : 'rgba(0,0,0,0.04)',
+                color: showN21 ? 'white' : 'var(--text-secondary)',
+              }}>
+              <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: showN21 ? 'rgba(255,255,255,0.6)' : 'var(--forest)' }} />
+              N21
+            </button>
+            {canSeePersonal && (
+              <button onClick={() => setShowPersonal(v => !v)} aria-pressed={showPersonal}
+                className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-semibold transition-all"
+                style={{
+                  backgroundColor: showPersonal ? 'var(--sienna)' : 'rgba(0,0,0,0.04)',
+                  color: showPersonal ? 'white' : 'var(--text-secondary)',
+                }}>
+                <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: showPersonal ? 'rgba(255,255,255,0.6)' : 'var(--sienna)' }} />
+                {t('cal.personal')}
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <p className="text-[10px] font-semibold tracking-widest uppercase mb-2" style={{ color: 'var(--text-secondary)' }}>{t('cal.format')}</p>
+          <div className="flex flex-col gap-1">
+            {TYPE_FILTERS.map(type => (
+              <button key={type} onClick={() => setFilterType(filterType === type ? null : type)} aria-pressed={filterType === type}
+                className="w-full text-left px-3 py-2 rounded-lg text-xs font-semibold transition-all"
+                style={{
+                  backgroundColor: filterType === type ? 'var(--brand-teal)' : 'rgba(0,0,0,0.04)',
+                  color: filterType === type ? 'white' : 'var(--text-secondary)',
+                }}>
+                {typeLabel(type, t)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/(dashboard)/calendar/components/MonthView.tsx
+++ b/app/(dashboard)/calendar/components/MonthView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { DAYS_I18N } from '@/lib/i18n/translations'
 import { type CalendarEvent } from '@/app/(dashboard)/calendar/types'
@@ -48,10 +48,36 @@ export function MonthView({
     return eventsBySofiaDate[dateKey] ?? []
   }
 
+  const todayIndex = useMemo(() => {
+    const i = cells.findIndex(d => sameDaySofia(d, today))
+    return i === -1 ? 0 : i
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [current])
+
+  const [focusIndex, setFocusIndex] = useState(todayIndex)
+  const cellRefs = useRef<(HTMLDivElement | null)[]>([])
+
+  const focusCell = (index: number) => {
+    const clamped = Math.max(0, Math.min(41, index))
+    setFocusIndex(clamped)
+    cellRefs.current[clamped]?.focus()
+  }
+
+  const handleGridKeyDown = (e: KeyboardEvent<HTMLDivElement>, index: number, date: Date) => {
+    switch (e.key) {
+      case 'ArrowRight': e.preventDefault(); focusCell(index + 1); break
+      case 'ArrowLeft':  e.preventDefault(); focusCell(index - 1); break
+      case 'ArrowDown':  e.preventDefault(); focusCell(index + 7); break
+      case 'ArrowUp':    e.preventDefault(); focusCell(index - 7); break
+      case 'Enter':
+      case ' ':          e.preventDefault(); onDayClick(date); break
+    }
+  }
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <div className="grid grid-cols-[40px_repeat(7,1fr)] border-b border-black/5 flex-shrink-0">
-        <div />
+      <div className="grid grid-cols-7 md:grid-cols-[40px_repeat(7,1fr)] border-b border-black/5 flex-shrink-0">
+        <div className="hidden md:block" />
         {DAYS.map(d => (
           <div key={d} className="py-2 text-center text-xs font-semibold tracking-wide"
             style={{ color: 'var(--text-secondary)' }}>
@@ -59,28 +85,35 @@ export function MonthView({
           </div>
         ))}
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto" role="grid" aria-label={t('cal.month')}>
         {Array.from({ length: 6 }, (_, week) => {
           const weekDays = cells.slice(week * 7, week * 7 + 7)
           return (
-            <div key={week}
-              className="grid grid-cols-[40px_repeat(7,1fr)] border-b border-black/5"
+            <div key={week} role="row"
+              className="grid grid-cols-7 md:grid-cols-[40px_repeat(7,1fr)] border-b border-black/5"
               style={{ minHeight: 90 }}>
-              <div className="flex items-start justify-center pt-2 flex-shrink-0">
+              <div className="hidden md:flex items-start justify-center pt-2 flex-shrink-0">
                 <span className="text-[10px] font-semibold" style={{ color: 'var(--text-secondary)' }}>
                   W{isoWeek(weekDays[0])}
                 </span>
               </div>
               {weekDays.map((date, di) => {
+                const index = week * 7 + di
                 const isToday = sameDaySofia(date, today)
                 const isCurrentMonth = date.getMonth() === current.getMonth()
                 const dayEvents = eventsOnDay(date)
                 return (
                   <div
                     key={di}
-                    onClick={() => onDayClick(date)}
-                    className="border-l border-black/5 p-1 cursor-pointer hover:bg-black/[0.02] transition-colors overflow-hidden"
-                    style={{ minHeight: 90 }}
+                    ref={el => { cellRefs.current[index] = el }}
+                    role="gridcell"
+                    aria-current={isToday ? 'date' : undefined}
+                    tabIndex={index === focusIndex ? 0 : -1}
+                    onClick={() => { setFocusIndex(index); onDayClick(date) }}
+                    onKeyDown={e => handleGridKeyDown(e, index, date)}
+                    onFocus={() => setFocusIndex(index)}
+                    className="border-l border-black/5 p-1 cursor-pointer hover:bg-black/[0.02] transition-colors overflow-hidden focus:outline-none focus:ring-2 focus:ring-inset"
+                    style={{ minHeight: 90, ['--tw-ring-color' as string]: 'var(--brand-teal)' }}
                   >
                     <div className="flex justify-center mb-1">
                       <span

--- a/app/(dashboard)/calendar/components/useCalendar.ts
+++ b/app/(dashboard)/calendar/components/useCalendar.ts
@@ -50,7 +50,7 @@ export function useCalendar({
   const { data: agendaEvents = [], isPending: agendaPending } = useQuery<CalendarEvent[]>({
     queryKey: ['events-agenda'],
     queryFn: () => apiClient<CalendarEvent[]>('/api/calendar'),
-    staleTime: 0,
+    staleTime: 60_000,
     enabled: view === 'agenda',
   })
 

--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -31,7 +31,6 @@ export default async function CalendarPage({
   // Unauthenticated and authenticated-but-no-profile both resolve to 'guest'.
   let resolvedRole: 'admin' | 'core' | 'member' | 'guest' = 'guest'
   let userRole: 'admin' | 'core' | 'member' | 'guest' | null = null
-  let userProfileId: string | null = null
   let profileNameMissing = false
 
   if (userId) {
@@ -44,7 +43,6 @@ export default async function CalendarPage({
     if (profile) {
       resolvedRole  = profile.role
       userRole      = profile.role
-      userProfileId = profile.id
 
       // display_names is JSONB — cast to known shape.
       // BG name fields are stored as bg_first / bg_last (see PersonalDetailsContent).
@@ -67,7 +65,6 @@ export default async function CalendarPage({
       initialMonth={month}
       initialEventId={initialEventId}
       userRole={userRole}
-      userProfileId={userProfileId}
       isAuthenticated={!!userId}
       profileNameMissing={profileNameMissing}
     />

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -8,3 +8,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 |---|---|---|---|
 | #596 | `dev/2607-DEV-596` | `supabase/functions/sync-google-calendar/index.ts`, `app/api/admin/calendar-sync/route.ts`, `app/admin/calendar/components/AdminCalendarClient.tsx` (status display only) — migration: no | 2026-07-22 |
 | #646 | `dev/2607-DEV-646` | `app/(dashboard)/roles/components/RolesClient.tsx`, `lib/roles/types.ts`, `lib/roles/queries.ts`, `lib/i18n/domains/events.ts`, `components/ui/tooltip.tsx` (new) — migration: yes, `supabase/migrations/20260723000000_add_description_to_v_roles_history.sql` | 2026-07-23 |
+| #599 | `dev/2607-DEV-599` | `app/(dashboard)/calendar/components/CalendarClient.tsx`, `app/(dashboard)/calendar/components/FilterControls.tsx` (new), `app/(dashboard)/calendar/components/MonthView.tsx`, `app/(dashboard)/calendar/components/useCalendar.ts`, `app/(dashboard)/calendar/page.tsx` — migration: no | 2026-07-23 |

--- a/lib/i18n/domains/calendar.ts
+++ b/lib/i18n/domains/calendar.ts
@@ -1,5 +1,7 @@
 export const calendar = {
   'cal.today':              { en: 'Today',                    bg: 'Днес'                          },
+  'cal.prevMonth':          { en: 'Previous month',           bg: 'Предходен месец'               },
+  'cal.nextMonth':          { en: 'Next month',               bg: 'Следващ месец'                 },
   'cal.month':              { en: 'Month',                    bg: 'Месец'                         },
   'cal.week':               { en: 'Week',                     bg: 'Седмица'                       },
   'cal.day':                { en: 'Day',                      bg: 'Ден'                           },


### PR DESCRIPTION
## Summary
- Extracted `FilterControls.tsx` from `CalendarClient.tsx` — mobile top-bar and desktop sidebar nav/filter UI was fully duplicated (~150 redundant lines); now one component, both layouts.
- Hoisted `views`/`TYPE_FILTERS` to module scope (`FilterControls.tsx` as `VIEWS`/`TYPE_FILTERS`); dropped dead `userProfileId` prop from `page.tsx` -> `CalendarClient`.
- Agenda query `staleTime` was `0` (refetched every mount) -> `60_000`.
- MonthView: week-number gutter (`grid-cols-[40px_repeat(7,1fr)]`) now only renders at `md+`; below `md` it's a plain 7-col grid. Nav arrows enlarged 32px -> 44px touch targets.
- A11y: `role="grid"`/`row`/`gridcell` + `aria-current="date"` on MonthView, roving-tabindex arrow-key day navigation (Enter/Space opens the day), `aria-pressed` on filter chips.
- Event popup dialog previously only rendered inside the desktop (`hidden md:block`) branch — on mobile, clicking an event set `selectedEventId` but nothing displayed it. Moved the `Dialog` to component root so it renders on both breakpoints: bottom sheet on mobile, centered card on desktop (unchanged visual). Radix's built-in focus trap + return-focus now applies on both.

## Not done (out of ticket scope, noted for a follow-up)
- `EventPopupShell.tsx`'s dialog has no `DialogTitle` (Radix a11y warning) — pre-existing, not introduced/fixed here.

Closes #599

## Session State
**Status:** DONE
**Completed:**
- [x] FilterControls extraction + dedupe
- [x] views/TYPE_FILTERS hoisted, dead userProfileId prop dropped
- [x] agenda staleTime fix
- [x] MonthView 390px gutter + 44px nav targets
- [x] MonthView ARIA grid + arrow-key nav
- [x] Event dialog renders on mobile (bug fix) + aria-pressed chips
**Next:** wait for CI green + Vercel preview READY, then verify 390px + keyboard walkthrough per DoD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added unified calendar controls for navigation, view selection, and event-category filtering across mobile and desktop.
  - Improved event details presentation with a mobile bottom-sheet layout and a compact desktop dialog.
  - Added keyboard navigation and accessibility support to the month view.

- **Improvements**
  - Calendar agenda data remains fresh for up to 60 seconds.
  - Added English and Bulgarian labels for previous and next month navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->