### PR TITLE
chore: explicit type check for reschedule send_at (post-#601 nitpick)

### DIFF
--- a/app/api/admin/reminders/[reminderId]/route.ts
+++ b/app/api/admin/reminders/[reminderId]/route.ts
@@ -26,8 +26,11 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ remind
   }
 
   // reschedule
+  if (typeof body.send_at !== 'string') {
+    return Response.json({ error: 'Rescheduled time must be in the future' }, { status: 400 })
+  }
   const rescheduledAt = new Date(body.send_at)
-  if (!body.send_at || Number.isNaN(rescheduledAt.getTime()) || rescheduledAt <= new Date()) {
+  if (Number.isNaN(rescheduledAt.getTime()) || rescheduledAt <= new Date()) {
     return Response.json({ error: 'Rescheduled time must be in the future' }, { status: 400 })
   }
   const { error } = await supabase


### PR DESCRIPTION
## Summary
Fast-follow to #601/PR#649: CodeRabbit's final re-review (after that PR had already merged) flagged the reschedule endpoint's `send_at` validation as a truthy-check rather than an explicit type check — `''`, `0`, `false` all fell through to `new Date(...)`, relying only on the subsequent `Number.isNaN` guard. Reject non-string values explicitly first.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on the touched file
- [ ] CI green

Resolves the outstanding review thread on PR #649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)