### PR TITLE
[2607-DEV-602] Calendar refactor 6: test coverage (date utils, ICS snapshot, calendar e2e)

### DIFF
--- a/app/(dashboard)/calendar/utils.test.ts
+++ b/app/(dashboard)/calendar/utils.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isoWeek,
+  startOfWeek,
+  addDays,
+  sameDaySofia,
+  toMonthParam,
+  formatTime,
+  formatShortDate,
+  eventMinutesFromMidnight,
+  eventDurationMinutes,
+} from '@/app/(dashboard)/calendar/utils'
+
+describe('isoWeek', () => {
+  it('returns ISO week 1 for the first Monday of the year', () => {
+    expect(isoWeek(new Date('2027-01-04T12:00:00Z'))).toBe(1)
+  })
+
+  it('returns week 53 for the last days of a 53-week year', () => {
+    expect(isoWeek(new Date('2026-12-31T12:00:00Z'))).toBe(53)
+  })
+})
+
+describe('startOfWeek', () => {
+  it('rolls a Wednesday back to the preceding Monday', () => {
+    const d = startOfWeek(new Date('2026-03-18T15:00:00'))
+    expect(d.getDay()).toBe(1)
+    expect(d.getDate()).toBe(16)
+  })
+
+  it('treats Sunday as the end of the week (rolls back 6 days)', () => {
+    const d = startOfWeek(new Date('2026-03-22T15:00:00'))
+    expect(d.getDay()).toBe(1)
+    expect(d.getDate()).toBe(16)
+  })
+})
+
+describe('addDays', () => {
+  it('adds a positive day count', () => {
+    const d = addDays(new Date('2026-03-18T00:00:00'), 5)
+    expect(d.getDate()).toBe(23)
+  })
+
+  it('subtracts with a negative day count', () => {
+    const d = addDays(new Date('2026-03-18T00:00:00'), -5)
+    expect(d.getDate()).toBe(13)
+  })
+
+  it('rolls across a month boundary', () => {
+    const d = addDays(new Date('2026-03-30T00:00:00'), 3)
+    expect(d.getMonth()).toBe(3)
+    expect(d.getDate()).toBe(2)
+  })
+})
+
+describe('sameDaySofia', () => {
+  // 2026-03-28T23:30:00Z is 2026-03-29 01:30 Sofia (EET +2, before spring-forward);
+  // 2026-03-29T00:30:00Z is 2026-03-29 02:30 Sofia (still the same Sofia calendar day).
+  it('treats two UTC instants as the same Sofia day across the DST spring-forward boundary', () => {
+    const a = new Date('2026-03-28T23:30:00.000Z')
+    const b = new Date('2026-03-29T00:30:00.000Z')
+    expect(sameDaySofia(a, b)).toBe(true)
+  })
+
+  // 2026-10-24T22:30:00Z is 2026-10-25 01:30 Sofia (EEST +3, before fall-back);
+  // 2026-10-25T21:30:00Z is 2026-10-25 23:30 Sofia — still the same Sofia day post fall-back.
+  it('treats two UTC instants as the same Sofia day across the DST fall-back boundary', () => {
+    const a = new Date('2026-10-24T22:30:00.000Z')
+    const b = new Date('2026-10-25T21:30:00.000Z')
+    expect(sameDaySofia(a, b)).toBe(true)
+  })
+
+  it('returns false for two different Sofia calendar days', () => {
+    const a = new Date('2026-03-18T12:00:00.000Z')
+    const b = new Date('2026-03-19T12:00:00.000Z')
+    expect(sameDaySofia(a, b)).toBe(false)
+  })
+})
+
+describe('toMonthParam', () => {
+  it('formats as YYYY-MM with zero-padded month', () => {
+    expect(toMonthParam(new Date('2026-03-18T00:00:00'))).toBe('2026-03')
+  })
+
+  it('zero-pads a single-digit month', () => {
+    expect(toMonthParam(new Date('2026-01-05T00:00:00'))).toBe('2026-01')
+  })
+})
+
+describe('formatTime', () => {
+  // 2026-03-18T12:00:00Z -> 14:00 Sofia (EET +2, before spring-forward)
+  it('formats as HH:mm in Europe/Sofia before spring-forward', () => {
+    expect(formatTime('2026-03-18T12:00:00.000Z')).toBe('14:00')
+  })
+
+  // 2026-07-18T12:00:00Z -> 15:00 Sofia (EEST +3, summer)
+  it('formats as HH:mm in Europe/Sofia during EEST', () => {
+    expect(formatTime('2026-07-18T12:00:00.000Z')).toBe('15:00')
+  })
+})
+
+describe('formatShortDate', () => {
+  it('formats as short weekday + day + month in Europe/Sofia', () => {
+    expect(formatShortDate(new Date('2026-03-18T12:00:00.000Z'))).toBe('Wed 18 Mar')
+  })
+})
+
+describe('eventMinutesFromMidnight', () => {
+  it('returns minutes elapsed since local midnight', () => {
+    const d = new Date()
+    d.setHours(9, 30, 0, 0)
+    expect(eventMinutesFromMidnight(d.toISOString())).toBe(9 * 60 + 30)
+  })
+
+  it('returns 0 at local midnight', () => {
+    const d = new Date()
+    d.setHours(0, 0, 0, 0)
+    expect(eventMinutesFromMidnight(d.toISOString())).toBe(0)
+  })
+})
+
+describe('eventDurationMinutes', () => {
+  it('returns the elapsed minutes between start and end', () => {
+    expect(eventDurationMinutes('2026-03-18T10:00:00Z', '2026-03-18T11:30:00Z')).toBe(90)
+  })
+
+  it('floors durations under 30 minutes to a 30-minute minimum', () => {
+    expect(eventDurationMinutes('2026-03-18T10:00:00Z', '2026-03-18T10:10:00Z')).toBe(30)
+  })
+})

--- a/app/(dashboard)/calendar/utils.test.ts
+++ b/app/(dashboard)/calendar/utils.test.ts
@@ -54,11 +54,11 @@ describe('addDays', () => {
 })
 
 describe('sameDaySofia', () => {
-  // 2026-03-28T23:30:00Z is 2026-03-29 01:30 Sofia (EET +2, before spring-forward);
-  // 2026-03-29T00:30:00Z is 2026-03-29 02:30 Sofia (still the same Sofia calendar day).
+  // 00:30Z is 02:30 EET (before the transition); 01:30Z is 04:30 EEST
+  // (after the skipped hour) — opposite sides of the spring-forward instant.
   it('treats two UTC instants as the same Sofia day across the DST spring-forward boundary', () => {
-    const a = new Date('2026-03-28T23:30:00.000Z')
-    const b = new Date('2026-03-29T00:30:00.000Z')
+    const a = new Date('2026-03-29T00:30:00.000Z')
+    const b = new Date('2026-03-29T01:30:00.000Z')
     expect(sameDaySofia(a, b)).toBe(true)
   })
 

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { createServiceClient } from '@/lib/supabase/service'
 import ical from 'ical-generator'
-import { listEventsForRole } from '@/lib/server/calendar'
+import { listEventsForRole, buildEventDescription } from '@/lib/server/calendar'
 import { verifyIcalToken, IcalTokenConfigError } from '@/lib/server/icalToken'
 
 const FEED_WINDOW_PAST_DAYS = 90
@@ -100,19 +100,7 @@ export async function GET(req: Request) {
   })
 
   for (const event of events ?? []) {
-    // Google Calendar (Android) and iOS Calendar don't surface the structured
-    // LOCATION/URL/CATEGORIES properties in their event view — append
-    // human-readable lines to the description so the info is visible there too,
-    // while keeping the structured properties for clients that do read them.
-    const detailLines = [
-      event.location != null && event.location !== '' ? `Location: ${event.location}` : undefined,
-      event.meeting_url != null && event.meeting_url !== '' ? `Meeting link: ${event.meeting_url}` : undefined,
-      event.category != null ? `Category: ${event.category}` : undefined,
-    ].filter((line): line is string => line !== undefined)
-    const baseDescription = event.description != null && event.description !== '' ? event.description : undefined
-    const description = [baseDescription, detailLines.length > 0 ? detailLines.join('\n') : undefined]
-      .filter((part): part is string => part !== undefined)
-      .join('\n\n')
+    const description = buildEventDescription(event)
 
     // For all-day events, ical-generator's VALUE=DATE truncates the Date to its
     // UTC date component — normalize to the UTC midnight boundary here so a

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -7,3 +7,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
 | #601 | `dev/2607-DEV-601` | `app/admin/calendar/components/AdminCalendarClient.tsx`, `app/admin/calendar/components/useAdminCalendarMutations.ts` (new), `app/admin/calendar/components/EventForm.tsx`, `app/admin/calendar/[id]/components/ReminderTable.tsx` — migration: no | 2026-07-23 |
+| #602 | `dev/2607-DEV-602` | `app/(dashboard)/calendar/utils.test.ts` (new), `lib/format.test.ts`, `lib/server/calendar.ts`, `lib/server/calendar.test.ts` (new), `app/api/calendar/feed.ics/route.ts`, `e2e/calendar.spec.ts` (new) — migration: no | 2026-07-23 |

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,3 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #601 | `dev/2607-DEV-601` | `app/admin/calendar/components/AdminCalendarClient.tsx`, `app/admin/calendar/components/useAdminCalendarMutations.ts` (new), `app/admin/calendar/components/EventForm.tsx`, `app/admin/calendar/[id]/components/ReminderTable.tsx` — migration: no | 2026-07-23 |
-| #602 | `dev/2607-DEV-602` | `app/(dashboard)/calendar/utils.test.ts` (new), `lib/format.test.ts`, `lib/server/calendar.ts`, `lib/server/calendar.test.ts` (new), `app/api/calendar/feed.ics/route.ts`, `e2e/calendar.spec.ts` (new) — migration: no | 2026-07-23 |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,14 +1,14 @@
 ## Goal
-Issue #601 (2607-DEV-601, branch `dev/2607-DEV-601`): Calendar refactor 5/8 — admin calendar consolidation (extract AdminCalendarClient mutations into a hook, adopt Phase-2 shared types, converge ReminderTable onto TanStack Query, i18n remaining hardcoded strings).
+Issue #602 (2607-DEV-602, branch `dev/2607-DEV-602`): Calendar refactor 6/8 — test coverage (Sofia-TZ date utils + `lib/format.ts` DST boundaries, ICS description snapshot, unauthenticated calendar e2e smoke).
 
 ## Now
-PR [#649](https://github.com/teamenjoyvd/tevd-portal/pull/649) open (ready for review, not draft). CI green (Build/Lint/Test/TypeCheck/SecurityAudit/migrations-replay/Vercel), CodeRabbit re-review clean after the GCR fix commit. GCR done: 4 findings (missing `onError` on delete/cancel/resend/reschedule mutations, NaN-date reschedule-validation bypass) fixed in commit `0769247`, all 4 threads resolved via GraphQL. Only `390px smoke vs preview` CI check still pending as of last poll.
+PR [#651](https://github.com/teamenjoyvd/tevd-portal/pull/651) open (ready for review, not draft). CI green (Build/Lint/Test/TypeCheck/SecurityAudit/migrations-replay/`390px smoke vs preview`/Vercel) as of the GCR fix commit `a2ba772`. CodeRabbit's re-review after that commit came back "rate limited" (not re-run) rather than clean — not yet a second genuine CodeRabbit pass.
 
 ## Next
-- Confirm `390px smoke vs preview` check passes
-- Manual 390px + desktop click-through: admin calendar CRUD, sync button, reminders toggle/cancel/resend/reschedule (Vercel Preview READY + CI green is the Done gate, not static analysis alone — CLAUDE.md hard constraint)
-- Merge PR #649 (squash, matches repo convention — no bare merge commits in `git log --merges`)
-- Post-merge tail: `migrate-prod` should auto-skip (no migrations in this PR); smoke-check `https://www.teamenjoyvd.com`; remove `#601` row from `docs/CLAIMS.md`; close issue #601 (PR body already has `Closes #601`)
+- Get a real CodeRabbit re-review on commit `a2ba772` (current one was rate-limited) or confirm no new findings another way before merging
+- Merge PR #651 (squash, matches repo convention)
+- Post-merge tail: `migrate-prod` should auto-skip (no migrations in this PR); smoke-check `https://www.teamenjoyvd.com`; issue #602 auto-closes via the PR's `Closes #602`. `#602`'s `docs/CLAIMS.md` row was removed ahead of merge per explicit user instruction (CI green, PR waiting on the cleanup merge) — not the normal post-merge-only rule
+- Separately outstanding: issue #601's post-merge tail was never finished last session (prod smoke-check / `migrate-prod` confirmation not verified) — worth a quick check next time prod state comes up, though its `docs/CLAIMS.md` row has now been pruned (issue closed, PR #649 merged 2026-07-23T11:27:39Z)
 
 ## Constraints
 - Never push directly to `main`; `dev/[YYMM]-DEV-[GH#]` branches only
@@ -16,24 +16,30 @@ PR [#649](https://github.com/teamenjoyvd/tevd-portal/pull/649) open (ready for r
 - No `git push` without the user explicitly asking for a push in-conversation (quote required)
 - No failing check gets weakened/skipped to pass
 - Never spin a solo cleanup-only PR just to prune a `docs/CLAIMS.md` row — fold it into the merging feature PR (repeat past mistake, see `feedback_no_standalone_claims_cleanup_pr` memory)
+- A `blocked` GitHub label is not authoritative — verify the actual named blocking issues before treating a ticket as blocked (2607-DEV-602's label was stale; #587-592 had all closed 2026-07-23)
 
 ## Decisions
-DECISION: #601's CodeRabbit-flagged mutation error-handling gaps (delete/cancel/resend/reschedule silently failing) fixed by adding `onError` + a visible error string near the action, matching the pattern `createMutation`/`updateMutation` already used.
-DECISION: `REMINDER_LABEL_SHORT` (`components/admin/reminder-shared.ts`, consumed only by `RemindersTab.tsx`) left hardcoded English — out of #601's affected-files scope. Only `REMINDER_LABEL_LONG` (consumed by `ReminderTable.tsx`, in scope) was converted to i18n, per explicit user instruction ("fix REMINDER_LABEL_LONG in this ticket").
+DECISION: #602's ICS-description logic (`feed.ics/route.ts`) extracted verbatim into `lib/server/calendar.ts`'s `buildEventDescription()` — additive, behavior-preserving — so the Phase 1c format is snapshot-testable without mocking Clerk/Supabase auth.
+DECISION: CodeRabbit's "seed deterministic event data" suggestion for the e2e popup-coverage gap was not implemented (heavy lift, no existing calendar-seed script, out of proportion for a test-coverage ticket); instead the silent `if (count > 0)` skip was converted to a hard `expect(...).toBeVisible()` so an empty month fails loudly instead of silently passing.
+DECISION: CodeRabbit's "use the `Personal` locator" finding was rejected as a false positive — `cal.inPerson`/"In-person" and `cal.personal`/"Personal" are two distinct real buttons; the PR's own live-Preview CI run had already passed using the original `'In-person'` locator. Replied on the thread, left unresolved (not applied).
 
 ## Facts
 - Hosted DEV Supabase project: `iymwxdewcpvpjgzewtzk`, prod: `ynykjpnetfwqzdnsgkkg`
-- CI's `Authenticated E2E (Clerk)` job is a ~5s gated skip (missing secrets) — does not run specs; not real coverage. Verify locally against DEV if a change touches an authenticated flow.
-- PR #649: `dev/2607-DEV-601` → `main`, title `[2607-DEV-601] Calendar refactor 5: admin calendar consolidation`, body has `Closes #601`.
-- New routes this ticket added: `GET /api/admin/calendar/[id]/reminders`, `PATCH|DELETE /api/admin/reminders/[reminderId]`.
+- CI's `Authenticated E2E (Clerk)` job is a ~5s gated skip (missing secrets) — does not run specs; not real coverage. `mobile-390`'s `390px smoke vs preview` job is real, runs against the live Vercel Preview, and did execute `e2e/calendar.spec.ts` (confirmed via job log: "1 [mobile-390] › e2e/calendar.spec.ts:21:7 ... (3.4s)").
+- This repo's local sandbox has a reproducible pre-existing Node-fetch flake reaching Supabase from the Next dev server under browser-driven (Playwright) load — confirmed present on a clean `main` checkout too (same failure line, same error), so it's environment-specific, not caused by any #602 change. Plain `curl` against the same route never reproduces it. Do not re-litigate this as a real bug without new evidence; the actual gate is CI/Preview, which passed.
+- PR #651: `dev/2607-DEV-602` → `main`, title `[2607-DEV-602] Calendar refactor 6: test coverage (date utils, ICS snapshot, calendar e2e)`, body has `Closes #602`.
+- No new routes, no schema/migration changes this ticket.
 
 ## Done
-#601 BUILD — RESULT: `useAdminCalendarMutations.ts` extracted (apiClient-based); `AdminCalendarEvent` shared type adopted (`types/calendar.ts`); `ReminderTable.tsx` converged onto TanStack Query via the two new API routes above, retiring its server-action + `router.refresh()` path (`app/admin/actions/reminders.ts` kept as-is — still used by `RemindersTab.tsx`); Upcoming/Past/All pills + all of `ReminderTable`'s strings + `REMINDER_LABEL_LONG` i18n'd. `tsc --noEmit`/`npm run lint`/`npm run build` clean throughout.
-#601 GCR — RESULT: CodeRabbit posted 4 findings (all real, all applied in commit `0769247`), all 4 threads resolved via GraphQL, re-review came back clean.
+#602 PLAN — RESULT: verdict READY; found the `blocked` label stale (dependencies #587-592 all closed).
+#602 CLAIM — RESULT: re-entry on existing issue #602 (label removed, Design Checklist completed in the issue body); branch `dev/2607-DEV-602` cut from `main`; `docs/CLAIMS.md` row added (no overlap with #601's then-in-flight row).
+#602 BUILD — RESULT: `app/(dashboard)/calendar/utils.test.ts` (new, 15 tests), `lib/format.test.ts` extended (`calMonth`/`calDay`/`formatDateMediumEn`/`formatDateLongEn`), `buildEventDescription()` extracted into `lib/server/calendar.ts` with `lib/server/calendar.test.ts` snapshot coverage, `e2e/calendar.spec.ts` (new, unauthenticated smoke). 51 unit tests / `tsc --noEmit` clean. PR #651 opened ready-for-review; CI green including the real `390px smoke vs preview` job.
+#602 GCR — RESULT: CodeRabbit posted 4 findings on commit `0639913`. 3 applied (DST test instants corrected; e2e popup-skip converted to a hard assertion; empty-string `category` handling made consistent with location/meeting_url, +1 new test) in commit `a2ba772`, threads resolved via GraphQL. 1 rejected as a false positive (filter-locator label mix-up), replied on-thread with reasoning, left unresolved.
 
 ## Open items
-- Issue #602 (calendar refactor 6/8: test coverage — date utils, ICS snapshot, calendar e2e) — not started
-- `REMINDER_LABEL_SHORT`/`RemindersTab.tsx` hardcoded English — noted, not fixed (out of #601 scope)
+- Get a genuine CodeRabbit re-review on `a2ba772` (last one was rate-limited) before merging PR #651
+- #601's post-merge tail (prod smoke-check, `migrate-prod` confirmation) was left unverified in a prior session — flag if prod state comes up again
+- Issue #603+ (calendar refactor phases 7-8, if any) — not investigated this session
 
 ## Failed attempts
 (none this session)

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect, type Locator, type Page } from '@playwright/test'
+
+/**
+ * Unauthenticated smoke over the public /calendar page (see lib/public-routes.ts).
+ * Covers: month load, month navigation, event popup, agenda view, category filter.
+ *
+ * Deliberately excluded from the `authenticated` Playwright project — that
+ * project is a CI skip when Clerk/Supabase seed secrets are absent (see
+ * project_ci_authenticated_e2e_is_a_skip); this spec needs no auth so it runs
+ * for real under `mobile-390`/`desktop` instead.
+ *
+ * CalendarClient renders both the mobile and desktop DOM trees at once (one
+ * hidden via CSS per breakpoint, not unmounted) — every role/text query below
+ * is narrowed to the one visible instance for the active viewport.
+ */
+function visible(page: Page, locator: Locator): Locator {
+  return locator.and(page.locator(':visible'))
+}
+
+test.describe('calendar', () => {
+  test('loads month view, navigates months, opens a popup, switches to agenda, and applies a filter', async ({ page }) => {
+    const response = await page.goto('/calendar')
+    expect(response, 'no response for /calendar').not.toBeNull()
+    expect(response!.status(), 'HTTP status for /calendar').toBeLessThan(400)
+
+    const grid = visible(page, page.getByRole('grid', { name: 'Month' }))
+    await expect(grid).toBeVisible()
+
+    const periodLabel = visible(page, page.getByText(/^[A-Z][a-z]+ \d{4}$/)).first()
+    const initialLabel = await periodLabel.textContent()
+
+    await visible(page, page.getByRole('button', { name: 'Next month' })).click()
+    await expect(periodLabel).not.toHaveText(initialLabel ?? '')
+
+    await visible(page, page.getByRole('button', { name: 'Previous month' })).click()
+    await expect(periodLabel).toHaveText(initialLabel ?? '')
+
+    const firstEvent = visible(page, page.locator('[role="gridcell"] button')).first()
+    if (await firstEvent.count() > 0) {
+      await firstEvent.click()
+      const dialog = page.getByRole('dialog')
+      await expect(dialog).toBeVisible()
+      await page.keyboard.press('Escape')
+      await expect(dialog).toBeHidden()
+    }
+
+    await visible(page, page.getByRole('button', { name: 'Agenda' })).click()
+    await expect(grid).not.toBeVisible()
+
+    const filterButton = visible(page, page.getByRole('button', { name: 'In-person' }))
+    await filterButton.click()
+    await expect(filterButton).toHaveAttribute('aria-pressed', 'true')
+  })
+})

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -35,14 +35,16 @@ test.describe('calendar', () => {
     await visible(page, page.getByRole('button', { name: 'Previous month' })).click()
     await expect(periodLabel).toHaveText(initialLabel ?? '')
 
+    // Fails loudly rather than silently skipping popup coverage — this repo's
+    // public calendar always has upcoming club events in the current month,
+    // so 0 here is itself a bug, not an empty fixture to route around.
     const firstEvent = visible(page, page.locator('[role="gridcell"] button')).first()
-    if (await firstEvent.count() > 0) {
-      await firstEvent.click()
-      const dialog = page.getByRole('dialog')
-      await expect(dialog).toBeVisible()
-      await page.keyboard.press('Escape')
-      await expect(dialog).toBeHidden()
-    }
+    await expect(firstEvent, 'no calendar events found in the current month view').toBeVisible()
+    await firstEvent.click()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(dialog).toBeHidden()
 
     await visible(page, page.getByRole('button', { name: 'Agenda' })).click()
     await expect(grid).not.toBeVisible()

--- a/lib/format.test.ts
+++ b/lib/format.test.ts
@@ -6,6 +6,10 @@ import {
   formatTime,
   formatDateTime,
   formatCurrency,
+  calMonth,
+  calDay,
+  formatDateMediumEn,
+  formatDateLongEn,
   toSofiaLocalInput,
   fromSofiaLocalInput,
   timeAgoMs,
@@ -41,6 +45,35 @@ describe('formatCurrency', () => {
 
   it('formats zero correctly', () => {
     expect(formatCurrency(0)).toBe('0,00\u00A0€')
+  })
+})
+
+describe('calMonth', () => {
+  it('formats as a 3-char uppercase month in Europe/Sofia', () => {
+    expect(calMonth(FIXED_ISO)).toBe('MAR')
+  })
+})
+
+describe('calDay', () => {
+  it('formats the day number with no leading zero in Europe/Sofia', () => {
+    expect(calDay(FIXED_ISO)).toBe('18')
+  })
+
+  it('has no leading zero for single-digit days', () => {
+    // 2026-03-05T22:00:00Z -> 2026-03-06 00:00 Sofia (EET+2)
+    expect(calDay('2026-03-05T22:00:00.000Z')).toBe('6')
+  })
+})
+
+describe('formatDateMediumEn', () => {
+  it('formats as "D MMM YYYY" in Europe/Sofia', () => {
+    expect(formatDateMediumEn(FIXED_ISO)).toBe('18 Mar 2026')
+  })
+})
+
+describe('formatDateLongEn', () => {
+  it('formats as "D Month YYYY" in Europe/Sofia', () => {
+    expect(formatDateLongEn(FIXED_ISO)).toBe('18 March 2026')
   })
 })
 

--- a/lib/server/calendar.test.ts
+++ b/lib/server/calendar.test.ts
@@ -65,4 +65,15 @@ describe('buildEventDescription', () => {
       Meeting link: https://meet.example.com/abc"
     `)
   })
+
+  it('omits the category line when category is an empty string', () => {
+    expect(
+      buildEventDescription({
+        description: 'Monthly N21 meetup',
+        location: null,
+        meeting_url: null,
+        category: '',
+      }),
+    ).toMatchInlineSnapshot(`"Monthly N21 meetup"`)
+  })
 })

--- a/lib/server/calendar.test.ts
+++ b/lib/server/calendar.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { buildEventDescription } from '@/lib/server/calendar'
+
+describe('buildEventDescription', () => {
+  it('returns undefined when no description or detail fields are set', () => {
+    expect(
+      buildEventDescription({ description: null, location: null, meeting_url: null, category: null }),
+    ).toMatchInlineSnapshot(`undefined`)
+  })
+
+  it('returns just the base description when no detail fields are set', () => {
+    expect(
+      buildEventDescription({
+        description: 'Monthly N21 meetup',
+        location: null,
+        meeting_url: null,
+        category: null,
+      }),
+    ).toMatchInlineSnapshot(`"Monthly N21 meetup"`)
+  })
+
+  it('returns just the detail lines when there is no base description', () => {
+    expect(
+      buildEventDescription({
+        description: null,
+        location: 'Sofia HQ',
+        meeting_url: 'https://meet.example.com/abc',
+        category: 'N21',
+      }),
+    ).toMatchInlineSnapshot(`
+      "Location: Sofia HQ
+      Meeting link: https://meet.example.com/abc
+      Category: N21"
+    `)
+  })
+
+  it('joins the base description and detail lines with a blank line (Phase 1c format)', () => {
+    expect(
+      buildEventDescription({
+        description: 'Monthly N21 meetup',
+        location: 'Sofia HQ',
+        meeting_url: 'https://meet.example.com/abc',
+        category: 'N21',
+      }),
+    ).toMatchInlineSnapshot(`
+      "Monthly N21 meetup
+
+      Location: Sofia HQ
+      Meeting link: https://meet.example.com/abc
+      Category: N21"
+    `)
+  })
+
+  it('omits a detail line whose field is an empty string', () => {
+    expect(
+      buildEventDescription({
+        description: 'Monthly N21 meetup',
+        location: '',
+        meeting_url: 'https://meet.example.com/abc',
+        category: null,
+      }),
+    ).toMatchInlineSnapshot(`
+      "Monthly N21 meetup
+
+      Meeting link: https://meet.example.com/abc"
+    `)
+  })
+})

--- a/lib/server/calendar.ts
+++ b/lib/server/calendar.ts
@@ -26,7 +26,7 @@ export function buildEventDescription(event: {
   const detailLines = [
     event.location != null && event.location !== '' ? `Location: ${event.location}` : undefined,
     event.meeting_url != null && event.meeting_url !== '' ? `Meeting link: ${event.meeting_url}` : undefined,
-    event.category != null ? `Category: ${event.category}` : undefined,
+    event.category != null && event.category !== '' ? `Category: ${event.category}` : undefined,
   ].filter((line): line is string => line !== undefined)
   const baseDescription = event.description != null && event.description !== '' ? event.description : undefined
   const description = [baseDescription, detailLines.length > 0 ? detailLines.join('\n') : undefined]

--- a/lib/server/calendar.ts
+++ b/lib/server/calendar.ts
@@ -9,6 +9,33 @@ const LIST_COLUMNS =
   'id, title, description, start_time, end_time, category, event_type, week_number, access_roles, is_all_day, location, meeting_url'
 
 /**
+ * Composes the ICS VEVENT description: the event's own description plus
+ * human-readable Location/Meeting link/Category lines. Google Calendar
+ * (Android) and iOS Calendar don't surface the structured LOCATION/URL/
+ * CATEGORIES properties in their event view, so this appends the same info
+ * as plain text — kept alongside the structured properties for clients that
+ * do read them. Extracted from feed.ics/route.ts so the composed format can
+ * be snapshot-tested without mocking auth/DB (Phase 1c format, #597).
+ */
+export function buildEventDescription(event: {
+  description: string | null
+  location: string | null
+  meeting_url: string | null
+  category: string | null
+}): string | undefined {
+  const detailLines = [
+    event.location != null && event.location !== '' ? `Location: ${event.location}` : undefined,
+    event.meeting_url != null && event.meeting_url !== '' ? `Meeting link: ${event.meeting_url}` : undefined,
+    event.category != null ? `Category: ${event.category}` : undefined,
+  ].filter((line): line is string => line !== undefined)
+  const baseDescription = event.description != null && event.description !== '' ? event.description : undefined
+  const description = [baseDescription, detailLines.length > 0 ? detailLines.join('\n') : undefined]
+    .filter((part): part is string => part !== undefined)
+    .join('\n\n')
+  return description || undefined
+}
+
+/**
  * Role-scoped calendar events, ordered by start_time.
  * `from`/`to` bound the window when provided.
  * `limit` is only applied when explicitly passed — with ascending start_time


### PR DESCRIPTION
## Summary
- Unit tests for `app/(dashboard)/calendar/utils.ts` + `lib/format.ts` Sofia-timezone helpers, including DST spring-forward/fall-back boundary cases.
- Extracted `buildEventDescription()` from `feed.ics/route.ts` into `lib/server/calendar.ts` (behavior-preserving) so the Phase 1c ICS description format can be snapshot-tested without mocking auth/DB.
- New `e2e/calendar.spec.ts`: unauthenticated smoke covering month load, month navigation, event popup, agenda view, and category filter — runs under `mobile-390`/`desktop`, not `authenticated`.

## Session State
**Status:** DONE
**Completed:**
- [x] `app/(dashboard)/calendar/utils.test.ts` — 15 tests, all passing
- [x] `lib/format.test.ts` extended — `calMonth`/`calDay`/`formatDateMediumEn`/`formatDateLongEn`
- [x] `lib/server/calendar.ts` — `buildEventDescription()` extracted
- [x] `lib/server/calendar.test.ts` — snapshot coverage of the Phase 1c format
- [x] `e2e/calendar.spec.ts` — unauthenticated smoke
**Next:** Confirm `mobile-390`/`desktop` e2e projects pass green on the Vercel Preview (`preview-smoke.yml`) — this repo's local sandbox has a reproducible pre-existing Node-fetch flake reaching Supabase from the Next dev server under browser-driven load (confirmed present on a clean `main` checkout too, unrelated to this diff); `curl` against the same route succeeds every time, so this is specific to this local sandbox's networking, not the app or this change.

## Test plan
- [x] `npx vitest run app/(dashboard)/calendar/utils.test.ts lib/format.test.ts lib/server/calendar.test.ts` — 3 files, 50 tests passed
- [x] `npx tsc --noEmit` — clean
- [ ] CI green + Vercel Preview READY (confirm `mobile-390` e2e project in `preview-smoke.yml` actually runs `e2e/calendar.spec.ts` and passes)

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar feed descriptions now consistently include available event details such as location, meeting link, and category.
  * Added calendar formatting support for month, day, and long- and medium-date displays.

* **Tests**
  * Expanded automated coverage for calendar navigation, event dialogs, agenda filtering, time-zone handling, date formatting, and calendar feed descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->