### PR TITLE
[2607-DEV-652] Calendar date correctness: ICS all-day export, overlap queries, Google sync hardening

### DIFF
--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -2,7 +2,7 @@ import { createServiceClient } from '@/lib/supabase/service'
 import { auth } from '@clerk/nextjs/server'
 import CalendarClient from './components/CalendarClient'
 import { listEventsForRole } from '@/lib/server/calendar'
-import { sofiaMidnightUtc } from '@/lib/calendar-dates'
+import { sofiaMidnightUtc, nextMonthKey } from '@/lib/calendar-dates'
 
 export const dynamic = 'force-dynamic'
 
@@ -15,10 +15,8 @@ export default async function CalendarPage({
 
   const now = new Date()
   const month = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
-  const nextMonth = now.getMonth() === 11 ? 1 : now.getMonth() + 2
-  const nextYear = now.getMonth() === 11 ? now.getFullYear() + 1 : now.getFullYear()
   const start = sofiaMidnightUtc(`${month}-01`).toISOString()
-  const end = sofiaMidnightUtc(`${nextYear}-${String(nextMonth).padStart(2, '0')}-01`).toISOString()
+  const end = sofiaMidnightUtc(`${nextMonthKey(month)}-01`).toISOString()
 
   let userId: string | null = null
   try {

--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -2,7 +2,7 @@ import { createServiceClient } from '@/lib/supabase/service'
 import { auth } from '@clerk/nextjs/server'
 import CalendarClient from './components/CalendarClient'
 import { listEventsForRole } from '@/lib/server/calendar'
-import { sofiaMidnightUtc, nextMonthKey } from '@/lib/calendar-dates'
+import { sofiaDateKey, sofiaMidnightUtc, nextMonthKey } from '@/lib/calendar-dates'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,7 +14,10 @@ export default async function CalendarPage({
   const { event: initialEventId = null } = await searchParams
 
   const now = new Date()
-  const month = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+  // Derive the month from the Sofia calendar day, not the server runtime's
+  // local time (Vercel runs UTC) — around Sofia midnight the two disagree,
+  // which would load the wrong month.
+  const month = sofiaDateKey(now.toISOString()).slice(0, 7)
   const start = sofiaMidnightUtc(`${month}-01`).toISOString()
   const end = sofiaMidnightUtc(`${nextMonthKey(month)}-01`).toISOString()
 

--- a/app/(dashboard)/calendar/page.tsx
+++ b/app/(dashboard)/calendar/page.tsx
@@ -2,6 +2,7 @@ import { createServiceClient } from '@/lib/supabase/service'
 import { auth } from '@clerk/nextjs/server'
 import CalendarClient from './components/CalendarClient'
 import { listEventsForRole } from '@/lib/server/calendar'
+import { sofiaMidnightUtc } from '@/lib/calendar-dates'
 
 export const dynamic = 'force-dynamic'
 
@@ -14,8 +15,10 @@ export default async function CalendarPage({
 
   const now = new Date()
   const month = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
-  const start = new Date(`${month}-01`).toISOString()
-  const end = new Date(now.getFullYear(), now.getMonth() + 1, 1).toISOString()
+  const nextMonth = now.getMonth() === 11 ? 1 : now.getMonth() + 2
+  const nextYear = now.getMonth() === 11 ? now.getFullYear() + 1 : now.getFullYear()
+  const start = sofiaMidnightUtc(`${month}-01`).toISOString()
+  const end = sofiaMidnightUtc(`${nextYear}-${String(nextMonth).padStart(2, '0')}-01`).toISOString()
 
   let userId: string | null = null
   try {

--- a/app/(dashboard)/calendar/utils.ts
+++ b/app/(dashboard)/calendar/utils.ts
@@ -15,17 +15,10 @@ export const CATEGORY_COLOR: Record<string, { bg: string; text: string }> = {
   Personal: { bg: 'var(--brand-sienna)', text: 'rgba(255,255,255,0.95)' },
 }
 
-// ── Module-level cached formatters ────────────────────────────────────────
-// Instantiating Intl.DateTimeFormat inside render functions or tight loops
-// is expensive. Cache at module scope — formatters are stateless and reusable.
-
-/** Sofia date formatter (YYYY-MM-DD via sv-SE). Used for day-key comparisons. */
-export const SOFIA_DATE_FMT = new Intl.DateTimeFormat('sv-SE', {
-  timeZone: 'Europe/Sofia',
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-})
+// Moved to lib/calendar-dates.ts (shared with app/api/calendar/feed.ics) —
+// re-exported here so existing importers are untouched.
+export { SOFIA_DATE_FMT } from '@/lib/calendar-dates'
+import { SOFIA_DATE_FMT } from '@/lib/calendar-dates'
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -1,17 +1,12 @@
 import { createHash } from 'node:crypto'
 import { createServiceClient } from '@/lib/supabase/service'
 import ical from 'ical-generator'
-import { listEventsForRole, buildEventDescription } from '@/lib/server/calendar'
+import { listEventsForRole, toVEventInput } from '@/lib/server/calendar'
 import { verifyIcalToken, IcalTokenConfigError } from '@/lib/server/icalToken'
 
 const FEED_WINDOW_PAST_DAYS = 90
 const FEED_WINDOW_FUTURE_DAYS = 365
 const FEED_LIMIT = 500
-
-function toUtcDateOnly(isoString: string): Date {
-  const d = new Date(isoString)
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
-}
 
 // RFC 7232 §3.2: If-None-Match may carry a comma-separated list of ETags, or
 // `*`. A plain `===` against the raw header would never match either form.
@@ -100,26 +95,7 @@ export async function GET(req: Request) {
   })
 
   for (const event of events ?? []) {
-    const description = buildEventDescription(event)
-
-    // For all-day events, ical-generator's VALUE=DATE truncates the Date to its
-    // UTC date component — normalize to the UTC midnight boundary here so a
-    // stored start_time/end_time that isn't exactly UTC midnight (e.g. legacy
-    // data) can't shift the displayed calendar day.
-    const start = event.is_all_day ? toUtcDateOnly(event.start_time) : new Date(event.start_time)
-    const end = event.is_all_day ? toUtcDateOnly(event.end_time) : new Date(event.end_time)
-
-    calendar.createEvent({
-      id: event.id,
-      summary: event.title,
-      description: description || undefined,
-      allDay: event.is_all_day,
-      start,
-      end,
-      location: event.location != null && event.location !== '' ? event.location : undefined,
-      url: event.meeting_url != null && event.meeting_url !== '' ? event.meeting_url : undefined,
-      categories: event.category != null ? [{ name: event.category }] : undefined,
-    })
+    calendar.createEvent(toVEventInput(event))
   }
 
   return new Response(calendar.toString(), {

--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -1,5 +1,6 @@
 import { getRoleForAccess } from '@/lib/server/guides'
 import { listEventsForRole } from '@/lib/server/calendar'
+import { sofiaMidnightUtc } from '@/lib/calendar-dates'
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
@@ -13,12 +14,11 @@ export async function GET(req: Request) {
   let to: string
 
   if (month) {
-    from = new Date(`${month}-01`).toISOString()
-    to = new Date(
-      new Date(`${month}-01`).getFullYear(),
-      new Date(`${month}-01`).getMonth() + 1,
-      1
-    ).toISOString()
+    const [year, monthNum] = month.split('-').map(Number)
+    const nextMonth = monthNum === 12 ? 1 : monthNum + 1
+    const nextYear = monthNum === 12 ? year + 1 : year
+    from = sofiaMidnightUtc(`${month}-01`).toISOString()
+    to = sofiaMidnightUtc(`${nextYear}-${String(nextMonth).padStart(2, '0')}-01`).toISOString()
   } else {
     // Agenda: bound to a window around today so the view stays cheap while
     // still covering recent past and upcoming events. Must always include

--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -1,6 +1,6 @@
 import { getRoleForAccess } from '@/lib/server/guides'
 import { listEventsForRole } from '@/lib/server/calendar'
-import { sofiaMidnightUtc } from '@/lib/calendar-dates'
+import { sofiaMidnightUtc, nextMonthKey } from '@/lib/calendar-dates'
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
@@ -14,11 +14,8 @@ export async function GET(req: Request) {
   let to: string
 
   if (month) {
-    const [year, monthNum] = month.split('-').map(Number)
-    const nextMonth = monthNum === 12 ? 1 : monthNum + 1
-    const nextYear = monthNum === 12 ? year + 1 : year
     from = sofiaMidnightUtc(`${month}-01`).toISOString()
-    to = sofiaMidnightUtc(`${nextYear}-${String(nextMonth).padStart(2, '0')}-01`).toISOString()
+    to = sofiaMidnightUtc(`${nextMonthKey(month)}-01`).toISOString()
   } else {
     // Agenda: bound to a window around today so the view stays cheap while
     // still covering recent past and upcoming events. Must always include

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,3 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
+| #652 | dev/2607-DEV-652 | lib/calendar-dates.ts (new), lib/server/calendar.ts, app/api/calendar/feed.ics/route.ts, app/api/calendar/route.ts, app/(dashboard)/calendar/{page.tsx,utils.ts}, supabase/functions/sync-google-calendar; migration: no | 2026-07-23 |

--- a/lib/calendar-dates.test.ts
+++ b/lib/calendar-dates.test.ts
@@ -74,9 +74,16 @@ describe('nextMonthKey', () => {
 describe('icsAllDayRange', () => {
   it('produces the correct exclusive DTEND for the real prod October row', () => {
     const { start, end } = icsAllDayRange('2026-10-22T22:00:00Z', '2026-10-24T22:00:00Z')
-    // Compare via the Sofia date key, not the raw UTC ISO date: a UTC-midnight
-    // Date representing Sofia midnight can fall on the previous UTC day.
-    expect(sofiaDateKey(start.toISOString())).toBe('2026-10-23')
-    expect(sofiaDateKey(end.toISOString())).toBe('2026-10-26')
+    // ical-generator serializes allDay dates via UTC getters (no calendar
+    // timezone set) — assert the UTC date components directly, matching
+    // what actually lands in DTSTART;VALUE=DATE / DTEND;VALUE=DATE.
+    expect(start.toISOString().slice(0, 10)).toBe('2026-10-23')
+    expect(end.toISOString().slice(0, 10)).toBe('2026-10-26')
+  })
+
+  it('rolls the exclusive end over a DST fall-back boundary without off-by-one', () => {
+    // Sofia day is 2026-10-25 (fall-back day, 25h long).
+    const { end } = icsAllDayRange('2026-10-24T21:00:00Z', '2026-10-24T21:00:00Z')
+    expect(end.toISOString().slice(0, 10)).toBe('2026-10-26')
   })
 })

--- a/lib/calendar-dates.test.ts
+++ b/lib/calendar-dates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sofiaDateKey, sofiaDateKeysBetween, sofiaMidnightUtc, icsAllDayRange } from '@/lib/calendar-dates'
+import { sofiaDateKey, sofiaDateKeysBetween, sofiaMidnightUtc, icsAllDayRange, nextMonthKey } from '@/lib/calendar-dates'
 
 describe('sofiaDateKeysBetween', () => {
   it('yields the correct 3-day span for the real prod October row', () => {
@@ -58,6 +58,16 @@ describe('sofiaMidnightUtc', () => {
 describe('sofiaDateKey', () => {
   it('reads the Sofia calendar day, not the UTC day', () => {
     expect(sofiaDateKey('2026-10-22T22:00:00Z')).toBe('2026-10-23')
+  })
+})
+
+describe('nextMonthKey', () => {
+  it('rolls over within a year', () => {
+    expect(nextMonthKey('2026-06')).toBe('2026-07')
+  })
+
+  it('rolls over the year at December', () => {
+    expect(nextMonthKey('2026-12')).toBe('2027-01')
   })
 })
 

--- a/lib/calendar-dates.test.ts
+++ b/lib/calendar-dates.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { sofiaDateKey, sofiaDateKeysBetween, sofiaMidnightUtc, icsAllDayRange } from '@/lib/calendar-dates'
+
+describe('sofiaDateKeysBetween', () => {
+  it('yields the correct 3-day span for the real prod October row', () => {
+    expect(sofiaDateKeysBetween('2026-10-22T22:00:00Z', '2026-10-24T22:00:00Z')).toEqual([
+      '2026-10-23',
+      '2026-10-24',
+      '2026-10-25',
+    ])
+  })
+
+  it('yields a 3-key span for the June prod row starting 2026-06-12', () => {
+    const keys = sofiaDateKeysBetween('2026-06-11T22:00:00Z', '2026-06-13T22:00:00Z')
+    expect(keys).toHaveLength(3)
+    expect(keys[0]).toBe('2026-06-12')
+  })
+
+  it('handles DST fall-back (25 Oct 2026)', () => {
+    // Sofia falls back to EET (+02:00) at 2026-10-25 04:00 local; start is
+    // pre-fallback EEST (Sofia 00:00), end is post-fallback EET (Sofia 23:00).
+    const keys = sofiaDateKeysBetween('2026-10-24T21:00:00Z', '2026-10-26T21:00:00Z')
+    expect(keys).toEqual(['2026-10-25', '2026-10-26'])
+  })
+
+  it('handles DST spring-forward (29 Mar 2026)', () => {
+    // Sofia springs forward to EEST (+03:00) at 2026-03-29 03:00 local.
+    const keys = sofiaDateKeysBetween('2026-03-28T22:00:00Z', '2026-03-30T21:00:00Z')
+    expect(keys).toEqual(['2026-03-29', '2026-03-30', '2026-03-31'])
+  })
+
+  it('is insensitive to the stored hour — Sofia 01:00 and Sofia 00:00 give the same day key', () => {
+    const a = sofiaDateKeysBetween('2026-10-22T22:00:00Z', '2026-10-22T22:00:00Z') // Sofia 01:00
+    const b = sofiaDateKeysBetween('2026-10-22T21:00:00Z', '2026-10-22T21:00:00Z') // Sofia 00:00
+    expect(a).toEqual(b)
+  })
+
+  it('yields 2 keys for a timed event spanning midnight (Fri 20:00 -> Sat 02:00)', () => {
+    const keys = sofiaDateKeysBetween('2026-06-19T17:00:00Z', '2026-06-19T23:00:00Z')
+    expect(keys).toHaveLength(2)
+  })
+
+  it('returns [startKey] when end < start', () => {
+    expect(sofiaDateKeysBetween('2026-06-15T00:00:00Z', '2026-06-10T00:00:00Z')).toEqual(['2026-06-15'])
+  })
+})
+
+describe('sofiaMidnightUtc', () => {
+  it('returns the DST-correct UTC instant for a summer date', () => {
+    expect(sofiaMidnightUtc('2026-07-01').toISOString()).toBe('2026-06-30T21:00:00.000Z')
+  })
+
+  it('returns the DST-correct UTC instant for a winter date', () => {
+    expect(sofiaMidnightUtc('2026-01-01').toISOString()).toBe('2025-12-31T22:00:00.000Z')
+  })
+})
+
+describe('sofiaDateKey', () => {
+  it('reads the Sofia calendar day, not the UTC day', () => {
+    expect(sofiaDateKey('2026-10-22T22:00:00Z')).toBe('2026-10-23')
+  })
+})
+
+describe('icsAllDayRange', () => {
+  it('produces the correct exclusive DTEND for the real prod October row', () => {
+    const { start, end } = icsAllDayRange('2026-10-22T22:00:00Z', '2026-10-24T22:00:00Z')
+    // Compare via the Sofia date key, not the raw UTC ISO date: a UTC-midnight
+    // Date representing Sofia midnight can fall on the previous UTC day.
+    expect(sofiaDateKey(start.toISOString())).toBe('2026-10-23')
+    expect(sofiaDateKey(end.toISOString())).toBe('2026-10-26')
+  })
+})

--- a/lib/calendar-dates.ts
+++ b/lib/calendar-dates.ts
@@ -1,0 +1,91 @@
+// ── lib/calendar-dates.ts ────────────────────────────────────────────────
+// Sofia-timezone date-key helpers shared by server routes (feed.ics) and
+// client components (calendar rendering). No `server-only`, no DB imports.
+import { TZ } from '@/lib/format'
+
+const MAX_SPAN_DAYS = 366
+
+/** Sofia date formatter (YYYY-MM-DD via sv-SE). Used for day-key comparisons. */
+export const SOFIA_DATE_FMT = new Intl.DateTimeFormat('sv-SE', {
+  timeZone: TZ,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+// Full wall-clock formatter (date + time) needed to measure the Sofia UTC
+// offset by round-trip — SOFIA_DATE_FMT alone loses the hour, which is the
+// entire quantity being measured.
+const SOFIA_DATETIME_FMT = new Intl.DateTimeFormat('sv-SE', {
+  timeZone: TZ,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+})
+
+/** 'YYYY-MM-DD' of the Sofia calendar day for a UTC ISO instant. */
+export function sofiaDateKey(iso: string): string {
+  return SOFIA_DATE_FMT.format(new Date(iso))
+}
+
+/**
+ * DST-correct UTC instant of Sofia 00:00 for a 'YYYY-MM-DD' date key.
+ * Measures the offset by round-tripping through Intl, mirroring the
+ * approach in lib/format.ts fromSofiaLocalInput.
+ */
+export function sofiaMidnightUtc(dateKey: string): Date {
+  const naiveDate = new Date(`${dateKey}T00:00:00Z`)
+  const sofiaWall = SOFIA_DATETIME_FMT.format(naiveDate).replace(' ', 'T')
+  const sofiaAsUtc = new Date(`${sofiaWall}Z`)
+  const offsetMs = naiveDate.getTime() - sofiaAsUtc.getTime()
+  return new Date(naiveDate.getTime() + offsetMs)
+}
+
+/**
+ * Inclusive list of 'YYYY-MM-DD' Sofia date keys covered by [startIso, endIso].
+ * Iterates on the date-key string, never the instant, so DST cannot add or
+ * drop a day. Returns [startKey] when end < start; clamps at MAX_SPAN_DAYS
+ * so a corrupt end_time can't hang a render loop.
+ */
+export function sofiaDateKeysBetween(startIso: string, endIso: string): string[] {
+  const startKey = sofiaDateKey(startIso)
+  const endKey = sofiaDateKey(endIso)
+  if (endKey <= startKey) return [startKey]
+
+  // Walk the 'YYYY-MM-DD' string via UTC calendar-date arithmetic — never
+  // via a fixed-duration instant step. A DST-transition day is 23h or 25h
+  // long, so stepping an instant by exactly 86400000ms can land on the same
+  // Sofia calendar day twice (fall-back) or skip one (spring-forward).
+  const keys: string[] = [startKey]
+  let cursor = new Date(`${startKey}T00:00:00Z`)
+  for (let i = 0; i < MAX_SPAN_DAYS && keys[keys.length - 1] < endKey; i++) {
+    cursor = new Date(cursor.getTime() + 86400000)
+    keys.push(cursor.toISOString().slice(0, 10))
+  }
+  return keys
+}
+
+/**
+ * ICS all-day VEVENT date range: start = UTC-midnight Date of the Sofia
+ * start day; end = UTC-midnight Date of the Sofia end day + 1 (VALUE=DATE
+ * DTEND is exclusive per RFC 5545 §3.8.2.2, while the DB stores the
+ * inclusive last day). Derived from date keys, so the stored Sofia-01:00
+ * hour (drift from the sync function's historical +02:00 hardcode) is
+ * irrelevant to the output.
+ */
+export function icsAllDayRange(startIso: string, endIso: string): { start: Date; end: Date } {
+  const start = sofiaMidnightUtc(sofiaDateKey(startIso))
+  const endKey = sofiaDateKey(endIso)
+  // +1 calendar day via UTC date-string arithmetic, then re-resolve through
+  // sofiaMidnightUtc — NOT +86400000ms on the instant, which under-shoots
+  // on a DST fall-back day (25h long) and would leave `end` on the same
+  // Sofia day as `endKey` instead of the next one.
+  const nextDay = new Date(`${endKey}T00:00:00Z`)
+  nextDay.setUTCDate(nextDay.getUTCDate() + 1)
+  const end = sofiaMidnightUtc(nextDay.toISOString().slice(0, 10))
+  return { start, end }
+}

--- a/lib/calendar-dates.ts
+++ b/lib/calendar-dates.ts
@@ -69,6 +69,14 @@ export function sofiaDateKeysBetween(startIso: string, endIso: string): string[]
   return keys
 }
 
+/** 'YYYY-MM' of the month following a 'YYYY-MM' month key, rolling the year over at December. */
+export function nextMonthKey(monthKey: string): string {
+  const [year, month] = monthKey.split('-').map(Number)
+  const nextMonth = month === 12 ? 1 : month + 1
+  const nextYear = month === 12 ? year + 1 : year
+  return `${nextYear}-${String(nextMonth).padStart(2, '0')}`
+}
+
 /**
  * ICS all-day VEVENT date range: start = UTC-midnight Date of the Sofia
  * start day; end = UTC-midnight Date of the Sofia end day + 1 (VALUE=DATE

--- a/lib/calendar-dates.ts
+++ b/lib/calendar-dates.ts
@@ -78,22 +78,23 @@ export function nextMonthKey(monthKey: string): string {
 }
 
 /**
- * ICS all-day VEVENT date range: start = UTC-midnight Date of the Sofia
- * start day; end = UTC-midnight Date of the Sofia end day + 1 (VALUE=DATE
- * DTEND is exclusive per RFC 5545 §3.8.2.2, while the DB stores the
- * inclusive last day). Derived from date keys, so the stored Sofia-01:00
- * hour (drift from the sync function's historical +02:00 hardcode) is
- * irrelevant to the output.
+ * ICS all-day VEVENT date range: start = a Date whose UTC Y/M/D equal the
+ * Sofia start day; end = a Date whose UTC Y/M/D equal the Sofia end day + 1
+ * (VALUE=DATE DTEND is exclusive per RFC 5545 §3.8.2.2, while the DB stores
+ * the inclusive last day).
+ *
+ * Deliberately NOT sofiaMidnightUtc: ical-generator serializes an allDay
+ * event's Date via its UTC getters when the calendar has no timezone set
+ * (our feed.ics case) — verified against ical-generator's source (the `l()`
+ * date formatter falls back to getUTCFullYear/getUTCMonth/getUTCDate). A
+ * real Sofia-midnight instant like sofiaMidnightUtc('2026-10-23') is
+ * 2026-10-22T21:00:00Z, whose UTC date is Oct 22 — one day early. The value
+ * ical-generator needs is a Date whose UTC fields literally spell out the
+ * target Sofia date, not a real instant at all.
  */
 export function icsAllDayRange(startIso: string, endIso: string): { start: Date; end: Date } {
-  const start = sofiaMidnightUtc(sofiaDateKey(startIso))
-  const endKey = sofiaDateKey(endIso)
-  // +1 calendar day via UTC date-string arithmetic, then re-resolve through
-  // sofiaMidnightUtc — NOT +86400000ms on the instant, which under-shoots
-  // on a DST fall-back day (25h long) and would leave `end` on the same
-  // Sofia day as `endKey` instead of the next one.
-  const nextDay = new Date(`${endKey}T00:00:00Z`)
-  nextDay.setUTCDate(nextDay.getUTCDate() + 1)
-  const end = sofiaMidnightUtc(nextDay.toISOString().slice(0, 10))
+  const start = new Date(`${sofiaDateKey(startIso)}T00:00:00Z`)
+  const end = new Date(`${sofiaDateKey(endIso)}T00:00:00Z`)
+  end.setUTCDate(end.getUTCDate() + 1)
   return { start, end }
 }

--- a/lib/server/calendar.test.ts
+++ b/lib/server/calendar.test.ts
@@ -6,7 +6,6 @@ vi.mock('@/lib/supabase/service', () => ({
 }))
 
 import { buildEventDescription, toVEventInput, listEventsForRole } from '@/lib/server/calendar'
-import { sofiaDateKey } from '@/lib/calendar-dates'
 
 describe('buildEventDescription', () => {
   it('returns undefined when no description or detail fields are set', () => {
@@ -98,9 +97,33 @@ describe('toVEventInput', () => {
       start_time: '2026-10-22T22:00:00Z',
       end_time: '2026-10-24T22:00:00Z',
     })
-    expect(sofiaDateKey((input.start as Date).toISOString())).toBe('2026-10-23')
-    expect(sofiaDateKey((input.end as Date).toISOString())).toBe('2026-10-26')
+    // ical-generator serializes allDay dates via UTC getters (no calendar
+    // timezone set) — assert the UTC date directly, matching what actually
+    // lands in DTSTART;VALUE=DATE / DTEND;VALUE=DATE.
+    expect((input.start as Date).toISOString().slice(0, 10)).toBe('2026-10-23')
+    expect((input.end as Date).toISOString().slice(0, 10)).toBe('2026-10-26')
     expect(input.allDay).toBe(true)
+  })
+
+  it('serializes to the exact expected VEVENT date-only lines (regression: ical-generator uses UTC getters for allDay)', async () => {
+    const ical = (await import('ical-generator')).default
+    const calendar = ical({ name: 'test' })
+    calendar.createEvent(
+      toVEventInput({
+        id: '5o3mircbst1a1v1mc4j1hrnirq',
+        title: 'WES event',
+        description: null,
+        location: null,
+        meeting_url: null,
+        category: null,
+        is_all_day: true,
+        start_time: '2026-10-22T22:00:00Z',
+        end_time: '2026-10-24T22:00:00Z',
+      }),
+    )
+    const output = calendar.toString()
+    expect(output).toContain('DTSTART;VALUE=DATE:20261023')
+    expect(output).toContain('DTEND;VALUE=DATE:20261026')
   })
 
   it('passes timed event start/end straight through as UTC instants', () => {

--- a/lib/server/calendar.test.ts
+++ b/lib/server/calendar.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from 'vitest'
-import { buildEventDescription } from '@/lib/server/calendar'
+import { describe, expect, it, vi } from 'vitest'
+
+const mockCreateServiceClient = vi.fn()
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: () => mockCreateServiceClient(),
+}))
+
+import { buildEventDescription, toVEventInput, listEventsForRole } from '@/lib/server/calendar'
+import { sofiaDateKey } from '@/lib/calendar-dates'
 
 describe('buildEventDescription', () => {
   it('returns undefined when no description or detail fields are set', () => {
@@ -75,5 +82,68 @@ describe('buildEventDescription', () => {
         category: '',
       }),
     ).toMatchInlineSnapshot(`"Monthly N21 meetup"`)
+  })
+})
+
+describe('toVEventInput', () => {
+  it('emits the correct all-day date range for the real prod October event', () => {
+    const input = toVEventInput({
+      id: '5o3mircbst1a1v1mc4j1hrnirq',
+      title: 'WES event',
+      description: null,
+      location: null,
+      meeting_url: null,
+      category: null,
+      is_all_day: true,
+      start_time: '2026-10-22T22:00:00Z',
+      end_time: '2026-10-24T22:00:00Z',
+    })
+    expect(sofiaDateKey((input.start as Date).toISOString())).toBe('2026-10-23')
+    expect(sofiaDateKey((input.end as Date).toISOString())).toBe('2026-10-26')
+    expect(input.allDay).toBe(true)
+  })
+
+  it('passes timed event start/end straight through as UTC instants', () => {
+    const input = toVEventInput({
+      id: 'timed-1',
+      title: 'Meeting',
+      description: null,
+      location: null,
+      meeting_url: null,
+      category: null,
+      is_all_day: false,
+      start_time: '2026-06-15T10:00:00Z',
+      end_time: '2026-06-15T11:00:00Z',
+    })
+    expect((input.start as Date).toISOString()).toBe('2026-06-15T10:00:00.000Z')
+    expect(input.allDay).toBe(false)
+  })
+})
+
+describe('listEventsForRole overlap semantics', () => {
+  it('includes an event that starts before the window but is still ongoing', async () => {
+    const gte = vi.fn().mockReturnThis()
+    const lt = vi.fn().mockReturnThis()
+    const chain: Record<string, unknown> = {}
+    const overlappingEvent = { id: 'e1', start_time: '2026-09-28T00:00:00Z', end_time: '2026-10-02T00:00:00Z' }
+    Object.assign(chain, {
+      contains: vi.fn().mockReturnValue(chain),
+      order: vi.fn().mockReturnValue(chain),
+      gte,
+      lt,
+      limit: vi.fn().mockReturnValue(chain),
+      then: (resolve: (v: unknown) => void) => resolve({ data: [overlappingEvent], error: null }),
+    })
+    gte.mockReturnValue(chain)
+    lt.mockReturnValue(chain)
+
+    mockCreateServiceClient.mockReturnValue({
+      from: () => ({ select: () => chain }),
+    })
+
+    const result = await listEventsForRole({ role: 'member', from: '2026-10-01T00:00:00Z', to: '2026-11-01T00:00:00Z' })
+    expect(result).toEqual([overlappingEvent])
+    expect(lt).toHaveBeenCalledWith('start_time', '2026-11-01T00:00:00Z')
+    expect(gte).toHaveBeenCalledWith('end_time', '2026-10-01T00:00:00Z')
   })
 })

--- a/lib/server/calendar.ts
+++ b/lib/server/calendar.ts
@@ -4,6 +4,8 @@
 // Server-only — never import from client components.
 import { createServiceClient } from '@/lib/supabase/service'
 import type { CalendarListEvent } from '@/types/calendar'
+import { icsAllDayRange } from '@/lib/calendar-dates'
+import type { ICalEventData } from 'ical-generator'
 
 const LIST_COLUMNS =
   'id, title, description, start_time, end_time, category, event_type, week_number, access_roles, is_all_day, location, meeting_url'
@@ -36,6 +38,44 @@ export function buildEventDescription(event: {
 }
 
 /**
+ * Builds the ical-generator input for a single VEVENT. Pure function —
+ * extracted from feed.ics/route.ts so ICS date output can be snapshot-tested
+ * without mocking auth/DB (the route itself needs Clerk + Supabase).
+ *
+ * All-day events use icsAllDayRange (Sofia date-key derived, DTEND exclusive
+ * per RFC 5545 §3.8.2.2); timed events pass start_time/end_time straight
+ * through — they're already +00 UTC strings from Supabase.
+ */
+export function toVEventInput(event: {
+  id: string
+  title: string
+  description: string | null
+  location: string | null
+  meeting_url: string | null
+  category: string | null
+  is_all_day: boolean
+  start_time: string
+  end_time: string
+}): ICalEventData {
+  const description = buildEventDescription(event)
+  const { start, end } = event.is_all_day
+    ? icsAllDayRange(event.start_time, event.end_time)
+    : { start: new Date(event.start_time), end: new Date(event.end_time) }
+
+  return {
+    id: event.id,
+    summary: event.title,
+    description: description || undefined,
+    allDay: event.is_all_day,
+    start,
+    end,
+    location: event.location != null && event.location !== '' ? event.location : undefined,
+    url: event.meeting_url != null && event.meeting_url !== '' ? event.meeting_url : undefined,
+    categories: event.category != null ? [{ name: event.category }] : undefined,
+  }
+}
+
+/**
  * Role-scoped calendar events, ordered by start_time.
  * `from`/`to` bound the window when provided.
  * `limit` is only applied when explicitly passed — with ascending start_time
@@ -62,8 +102,11 @@ export async function listEventsForRole({
     .contains('access_roles', [role])
     .order('start_time')
 
-  if (from) query = query.gte('start_time', from)
+  // Overlap semantics, not start-only: an event starting before `from` but
+  // still running (end_time >= from) must still match, or a multi-day span
+  // straddling a window boundary silently disappears from that window.
   if (to) query = query.lt('start_time', to)
+  if (from) query = query.gte('end_time', from)
   if (limit) query = query.limit(limit)
 
   const { data, error } = await query

--- a/lib/server/calendar.ts
+++ b/lib/server/calendar.ts
@@ -65,7 +65,7 @@ export function toVEventInput(event: {
   return {
     id: event.id,
     summary: event.title,
-    description: description || undefined,
+    description,
     allDay: event.is_all_day,
     start,
     end,
@@ -105,13 +105,13 @@ export async function listEventsForRole({
   // Overlap semantics, not start-only: an event starting before `from` but
   // still running (end_time >= from) must still match, or a multi-day span
   // straddling a window boundary silently disappears from that window.
-  if (to) query = query.lt('start_time', to)
-  if (from) query = query.gte('end_time', from)
-  if (limit) query = query.limit(limit)
+  if (to !== undefined) query = query.lt('start_time', to)
+  if (from !== undefined) query = query.gte('end_time', from)
+  if (limit !== undefined) query = query.limit(limit)
 
   const { data, error } = await query
   if (error) throw new Error(error.message)
-  if (limit && data && data.length === limit) {
+  if (limit !== undefined && data && data.length === limit) {
     console.warn(`listEventsForRole: hit limit (${limit}) for role "${role}" — results may be truncated`)
   }
   return (data ?? []) as CalendarListEvent[]

--- a/supabase/functions/sync-google-calendar/index.ts
+++ b/supabase/functions/sync-google-calendar/index.ts
@@ -96,6 +96,31 @@ function stripHtml(html: string): string {
 }
 
 /**
+ * DST-correct UTC instant of Sofia 00:00 for a 'YYYY-MM-DD' date string.
+ * Mirrors lib/calendar-dates.ts sofiaMidnightUtc — Deno Edge Functions
+ * cannot import from the repo, so the round-trip is duplicated here.
+ */
+function sofiaMidnightUtcFor(dateKey: string): Date {
+  const naiveDate = new Date(`${dateKey}T00:00:00Z`)
+  const sofiaWall = new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Europe/Sofia',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+    hour12: false,
+  }).format(naiveDate).replace(' ', 'T')
+  const sofiaAsUtc = new Date(`${sofiaWall}Z`)
+  const offsetMs = naiveDate.getTime() - sofiaAsUtc.getTime()
+  return new Date(naiveDate.getTime() + offsetMs)
+}
+
+/** Subtract one calendar day from a 'YYYY-MM-DD' string, returning a 'YYYY-MM-DD' string. */
+function previousDateKey(dateKey: string): string {
+  const d = new Date(`${dateKey}T00:00:00Z`)
+  d.setUTCDate(d.getUTCDate() - 1)
+  return d.toISOString().slice(0, 10)
+}
+
+/**
  * Resolve start/end times for a GCal event item.
  *
  * Google returns two distinct shapes:
@@ -103,17 +128,20 @@ function stripHtml(html: string): string {
  *   - All-day events: { start: { date: '2026-06-15' }, end: { date: '2026-06-16' } }
  *
  * The `date` form is a bare YYYY-MM-DD string. Passing it directly to
- * new Date(...) parses it as UTC midnight, which in Sofia (UTC+2) shifts
- * the event to the previous day at 22:00.
+ * new Date(...) parses it as UTC midnight, which in Sofia (UTC+2/+3) shifts
+ * the event to the previous day.
  *
- * Fix: detect all-day by absence of dateTime, then build an explicit
- * Sofia-midnight ISO string using the +02:00 offset. This produces the
- * correct UTC instant (e.g. 2026-06-14T22:00:00.000Z) while preserving
- * the correct calendar date when rendered in the Sofia timezone.
+ * Fix: detect all-day by absence of dateTime, then resolve the true,
+ * DST-correct Sofia-midnight UTC instant via sofiaMidnightUtcFor. This is
+ * correct year-round, unlike a hardcoded +02:00 offset which drifts 1h
+ * during EEST (May–Oct).
  *
  * Google's end.date is EXCLUSIVE (the day after the last day of the event).
- * We subtract one day so a single-day event stores start=Jun 15, end=Jun 15
- * and a two-day event stores start=Jun 15, end=Jun 16.
+ * We subtract one day on the YYYY-MM-DD string (not via runtime-local Date
+ * arithmetic, which on Deno Edge runs in UTC — safe here, but the string
+ * form keeps the operation explicit and TZ-independent) so a single-day
+ * event stores start=Jun 15, end=Jun 15 and a two-day event stores
+ * start=Jun 15, end=Jun 16.
  */
 function resolveTimes(item: Record<string, unknown>): {
   startIso: string
@@ -133,22 +161,8 @@ function resolveTimes(item: Record<string, unknown>): {
   }
 
   if (start?.date && end?.date) {
-    // All-day event — construct explicit Sofia midnight strings.
-    // +02:00 is Sofia standard time (EET). EEST (+03:00) applies May–Oct;
-    // using +02:00 year-round is a deliberate simplification: the stored
-    // UTC instant may be off by 1h during summer but the rendered Sofia
-    // calendar date will always be correct because the display layer reads
-    // back through the Europe/Sofia TZ (which applies DST automatically).
-    const startIso = new Date(`${start.date}T00:00:00+02:00`).toISOString()
-
-    // Subtract one day from Google's exclusive end date.
-    // exclusiveEnd is initialised as Sofia midnight (22:00 UTC); setDate adjusts
-    // the UTC date by -1, yielding the correct Sofia midnight for the inclusive
-    // end day. toISOString() on the resulting Date is the correct UTC instant.
-    const exclusiveEnd = new Date(`${end.date}T00:00:00+02:00`)
-    exclusiveEnd.setDate(exclusiveEnd.getDate() - 1)
-    const endIso = exclusiveEnd.toISOString()
-
+    const startIso = sofiaMidnightUtcFor(start.date).toISOString()
+    const endIso = sofiaMidnightUtcFor(previousDateKey(end.date)).toISOString()
     return { startIso, endIso, isAllDay: true }
   }
 


### PR DESCRIPTION
## Summary
- Fixes ICS all-day export (wrong day, dropped last day) via new Sofia-timezone date-key helpers in `lib/calendar-dates.ts`
- `listEventsForRole` now uses overlap semantics instead of start-only filtering, and month-window boundaries use Sofia midnight instead of UTC
- Hardens the Google Calendar sync Edge Function: removes hardcoded `+02:00` offset, uses DST-correct Sofia midnight resolution

Closes #652

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] `lib/calendar-dates.ts` with four Sofia date helpers, unit tested
- [x] `toVEventInput` extracted into `lib/server/calendar.ts`; `toUtcDateOnly` deleted
- [x] `listEventsForRole` overlap semantics; REFERENCE SWEEP done on all call sites
- [x] Month boundaries via `sofiaMidnightUtc` in both `app/api/calendar/route.ts` and `page.tsx`
- [x] `resolveTimes` hardened (no hardcoded offset, no runtime-local date arithmetic)
- [x] `npm run lint && npx tsc --noEmit && npx vitest run` all green (195 tests passing)
**Next:** Deploy Edge Function to DEV and verify; check Vercel preview `/api/calendar/feed.ics` output for the reported event

## Test plan
- [x] Unit tests: `lib/calendar-dates.test.ts` (DST fall-back/spring-forward, prod row spans, stored-hour insensitivity)
- [x] Unit tests: `lib/server/calendar.test.ts` (`toVEventInput` all-day/timed, `listEventsForRole` overlap)
- [ ] Deploy `sync-google-calendar` to DEV and verify via Management API / manual invoke
- [ ] Fetch `/api/calendar/feed.ics?token=…` on the Vercel preview and confirm `DTSTART;VALUE=DATE:20261023` / `DTEND;VALUE=DATE:20261026` for the reported event
- [ ] Vercel PR preview READY and CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar date handling across daylight-saving time changes.
  * Fixed calendar views and API results to include events that overlap the selected date range.
  * Corrected all-day event dates and exclusive end dates in calendar feeds and Google Calendar synchronization.
  * Improved month-boundary handling, including December-to-January transitions.

* **Tests**
  * Added coverage for time-zone conversions, daylight-saving transitions, date ranges, overlapping events, and calendar feed formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->