### PR TITLE
[2607-DEV-653] Calendar multi-day rendering: month spanning bars, agenda per-day rows, popup date range

### DIFF
--- a/app/(dashboard)/calendar/components/AgendaView.tsx
+++ b/app/(dashboard)/calendar/components/AgendaView.tsx
@@ -4,6 +4,9 @@ import { useMemo, useRef, useEffect } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { type CalendarEvent } from '@/app/(dashboard)/calendar/types'
 import { CATEGORY_COLOR, SOFIA_DATE_FMT, isoWeek, formatTime, formatShortDate } from '@/app/(dashboard)/calendar/utils'
+import { sofiaDateKeysBetween } from '@/lib/calendar-dates'
+
+type AgendaRow = { event: CalendarEvent; dayNum: number; totalDays: number }
 
 export function AgendaView({
   events,
@@ -24,14 +27,16 @@ export function AgendaView({
   const todaySofia = SOFIA_DATE_FMT.format(new Date())
 
   const grouped = useMemo(() => {
-    const map: Record<string, CalendarEvent[]> = {}
+    const map: Record<string, AgendaRow[]> = {}
     events
       .slice()
       .sort((a, b) => a.start_time.localeCompare(b.start_time))
       .forEach(e => {
-        const key = SOFIA_DATE_FMT.format(new Date(e.start_time))
-        if (!map[key]) map[key] = []
-        map[key].push(e)
+        const keys = sofiaDateKeysBetween(e.start_time, e.end_time)
+        keys.forEach((key, i) => {
+          if (!map[key]) map[key] = []
+          map[key].push({ event: e, dayNum: i + 1, totalDays: keys.length })
+        })
       })
     return map
   }, [events])
@@ -114,12 +119,12 @@ export function AgendaView({
               </span>
             </div>
             <div className="space-y-2">
-              {grouped[dateKey].map(ev => {
+              {grouped[dateKey].map(({ event: ev, dayNum, totalDays }) => {
                 const c = CATEGORY_COLOR[ev.category]
                 const isHighlighted = ev.id === highlightId
                 return (
                   <button
-                    key={ev.id}
+                    key={`${ev.id}-${dateKey}`}
                     ref={isHighlighted ? highlightRef : null}
                     onClick={() => onEventClick(ev.id)}
                     className="w-full text-left rounded-xl border overflow-hidden hover:shadow-sm transition-shadow flex scroll-mt-20 md:scroll-mt-0"
@@ -134,6 +139,11 @@ export function AgendaView({
                       <div className="flex items-start justify-between gap-2">
                         <p className="text-sm font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
                           {ev.title}
+                          {totalDays > 1 && (
+                            <span className="ml-1.5 text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>
+                              {t('cal.dayOf').replace('{n}', String(dayNum)).replace('{m}', String(totalDays))}
+                            </span>
+                          )}
                         </p>
                         <span className="text-xs flex-shrink-0 font-medium"
                           style={{ color: 'var(--text-secondary)' }}>

--- a/app/(dashboard)/calendar/components/EventPill.tsx
+++ b/app/(dashboard)/calendar/components/EventPill.tsx
@@ -21,6 +21,10 @@ export function EventPill({
         e.stopPropagation()
         onClick()
       }}
+      // compact pills are the Month-view spanning bars, rendered inside an
+      // aria-hidden wrapper — a <button> is tabbable regardless of an
+      // ancestor's tabIndex, so it must be excluded from the tab order here too.
+      tabIndex={compact ? -1 : 0}
       className="w-full text-left px-1.5 transition-opacity hover:opacity-80 active:opacity-60"
       style={{
         backgroundColor: c.bg,

--- a/app/(dashboard)/calendar/components/EventPill.tsx
+++ b/app/(dashboard)/calendar/components/EventPill.tsx
@@ -5,10 +5,14 @@ export function EventPill({
   event,
   onClick,
   compact = false,
+  continuesLeft = false,
+  continuesRight = false,
 }: {
   event: CalendarEvent
   onClick: () => void
   compact?: boolean
+  continuesLeft?: boolean
+  continuesRight?: boolean
 }) {
   const c = CATEGORY_COLOR[event.category]
   return (
@@ -17,7 +21,7 @@ export function EventPill({
         e.stopPropagation()
         onClick()
       }}
-      className="w-full text-left rounded-md px-1.5 transition-opacity hover:opacity-80 active:opacity-60"
+      className="w-full text-left px-1.5 transition-opacity hover:opacity-80 active:opacity-60"
       style={{
         backgroundColor: c.bg,
         color: c.text,
@@ -30,6 +34,10 @@ export function EventPill({
         textOverflow: 'ellipsis',
         display: 'block',
         maxWidth: '100%',
+        borderTopLeftRadius: continuesLeft ? 0 : 6,
+        borderBottomLeftRadius: continuesLeft ? 0 : 6,
+        borderTopRightRadius: continuesRight ? 0 : 6,
+        borderBottomRightRadius: continuesRight ? 0 : 6,
       }}
     >
       {compact ? event.title : `${formatTime(event.start_time)} ${event.title}`}

--- a/app/(dashboard)/calendar/components/MonthView.tsx
+++ b/app/(dashboard)/calendar/components/MonthView.tsx
@@ -11,7 +11,14 @@ import {
   addDays,
   sameDaySofia,
 } from '@/app/(dashboard)/calendar/utils'
+import { sofiaDateKeysBetween } from '@/lib/calendar-dates'
+import { packWeek, MAX_LANES } from '@/lib/calendar-layout'
 import { EventPill } from '@/app/(dashboard)/calendar/components/EventPill'
+
+const LANE_HEIGHT = 20
+const DAY_NUMBER_ROW_HEIGHT = 28
+const OVERFLOW_ROW_HEIGHT = 14
+const ROW_PADDING = 8
 
 export function MonthView({
   current,
@@ -27,26 +34,23 @@ export function MonthView({
   const { lang, t } = useLanguage()
   const DAYS = DAYS_I18N[lang]
   const today = new Date()
-  const firstOfMonth = new Date(current.getFullYear(), current.getMonth(), 1)
-  const gridStart = startOfWeek(firstOfMonth)
+  const gridStart = startOfWeek(current)
   const cells = Array.from({ length: 42 }, (_, i) => addDays(gridStart, i))
+  const cellDateKeys = useMemo(() => cells.map(d => SOFIA_DATE_FMT.format(d)), [cells])
+  const currentMonthKey = SOFIA_DATE_FMT.format(current).slice(0, 7)
 
-  // Pre-compute a map of Sofia-date-key → events to avoid O(N×M) filtering
-  // inside the 42-cell render loop.
-  const eventsBySofiaDate = useMemo(() => {
+  // Events covering a given Sofia date key — used for aria-labels and the
+  // overflow count, independent of the week-level bar packing.
+  const eventsByDateKey = useMemo(() => {
     const map: Record<string, CalendarEvent[]> = {}
     events.forEach(e => {
-      const key = SOFIA_DATE_FMT.format(new Date(e.start_time))
-      if (!map[key]) map[key] = []
-      map[key].push(e)
+      sofiaDateKeysBetween(e.start_time, e.end_time).forEach(key => {
+        if (!map[key]) map[key] = []
+        map[key].push(e)
+      })
     })
     return map
   }, [events])
-
-  const eventsOnDay = (date: Date) => {
-    const dateKey = SOFIA_DATE_FMT.format(date)
-    return eventsBySofiaDate[dateKey] ?? []
-  }
 
   const todayIndex = useMemo(() => {
     const i = cells.findIndex(d => sameDaySofia(d, today))
@@ -88,34 +92,61 @@ export function MonthView({
       <div className="flex-1 overflow-y-auto" role="grid" aria-label={t('cal.month')}>
         {Array.from({ length: 6 }, (_, week) => {
           const weekDays = cells.slice(week * 7, week * 7 + 7)
+          const weekDateKeys = cellDateKeys.slice(week * 7, week * 7 + 7)
+          const { segments, overflowByCol } = packWeek(weekDateKeys, events)
+          const visibleLanes = Math.min(
+            segments.reduce((max, s) => Math.max(max, s.lane + 1), 0),
+            MAX_LANES
+          )
+          const rowMinHeight = Math.max(
+            90,
+            DAY_NUMBER_ROW_HEIGHT + visibleLanes * LANE_HEIGHT + OVERFLOW_ROW_HEIGHT + ROW_PADDING
+          )
           return (
             <div key={week} role="row"
-              className="grid grid-cols-7 md:grid-cols-[40px_repeat(7,1fr)] border-b border-black/5"
-              style={{ minHeight: 90 }}>
-              <div className="hidden md:flex items-start justify-center pt-2 flex-shrink-0">
+              className="grid grid-cols-7 md:grid-cols-[40px_repeat(7,1fr)] border-b border-black/5 [--col-offset:0] md:[--col-offset:1]"
+              style={{
+                minHeight: rowMinHeight,
+                gridTemplateRows: `${DAY_NUMBER_ROW_HEIGHT}px repeat(${visibleLanes}, ${LANE_HEIGHT}px) ${OVERFLOW_ROW_HEIGHT}px`,
+              }}
+            >
+              <div className="hidden md:flex items-start justify-center pt-2 flex-shrink-0" style={{ gridRow: '1 / -1' }}>
                 <span className="text-[10px] font-semibold" style={{ color: 'var(--text-secondary)' }}>
                   W{isoWeek(weekDays[0])}
                 </span>
               </div>
               {weekDays.map((date, di) => {
                 const index = week * 7 + di
+                const dateKey = weekDateKeys[di]
                 const isToday = sameDaySofia(date, today)
-                const isCurrentMonth = date.getMonth() === current.getMonth()
-                const dayEvents = eventsOnDay(date)
+                const isCurrentMonth = dateKey.slice(0, 7) === currentMonthKey
+                const dayNumber = Number(dateKey.slice(8, 10))
+                const dayEvents = eventsByDateKey[dateKey] ?? []
+                const droppedCount = overflowByCol[di]
+                const ariaLabel = dayEvents.length === 0
+                  ? undefined
+                  : dayEvents
+                      .map(ev => {
+                        const keys = sofiaDateKeysBetween(ev.start_time, ev.end_time)
+                        const dayNum = keys.indexOf(dateKey) + 1
+                        return keys.length > 1 ? `${ev.title} (Day ${dayNum}/${keys.length})` : ev.title
+                      })
+                      .join(', ')
                 return (
                   <div
                     key={di}
                     ref={el => { cellRefs.current[index] = el }}
                     role="gridcell"
                     aria-current={isToday ? 'date' : undefined}
+                    aria-label={ariaLabel}
                     tabIndex={index === focusIndex ? 0 : -1}
                     onClick={() => { setFocusIndex(index); onDayClick(date) }}
                     onKeyDown={e => handleGridKeyDown(e, index, date)}
                     onFocus={() => setFocusIndex(index)}
                     className="border-l border-black/5 p-1 cursor-pointer hover:bg-black/[0.02] transition-colors overflow-hidden focus:outline-none focus:ring-2 focus:ring-inset"
-                    style={{ minHeight: 90, ['--tw-ring-color' as string]: 'var(--brand-teal)' }}
+                    style={{ gridRow: '1 / -1', ['--tw-ring-color' as string]: 'var(--brand-teal)' }}
                   >
-                    <div className="flex justify-center mb-1">
+                    <div className="flex justify-center">
                       <span
                         className="w-6 h-6 flex items-center justify-center rounded-full text-xs font-medium flex-shrink-0"
                         style={{
@@ -124,28 +155,37 @@ export function MonthView({
                           opacity: isCurrentMonth ? 1 : 0.4,
                         }}
                       >
-                        {date.getDate()}
+                        {dayNumber}
                       </span>
                     </div>
-                    <div className="space-y-0.5 overflow-hidden">
-                      {dayEvents.slice(0, 3).map(ev => (
-                        <EventPill
-                          key={ev.id}
-                          event={ev}
-                          compact
-                          onClick={() => onEventClick(ev.id)}
-                        />
-                      ))}
-                      {dayEvents.length > 3 && (
-                        <p className="text-[10px] font-medium pl-1 truncate"
-                          style={{ color: 'var(--text-secondary)' }}>
-                          +{dayEvents.length - 3} {t('cal.moreEvents')}
-                        </p>
-                      )}
-                    </div>
+                    {droppedCount > 0 && (
+                      <p className="text-[10px] font-medium pl-1 truncate" style={{ color: 'var(--text-secondary)' }}>
+                        +{droppedCount} {t('cal.moreEvents')}
+                      </p>
+                    )}
                   </div>
                 )
               })}
+              {segments.map(seg => (
+                <div
+                  key={seg.event.id}
+                  aria-hidden="true"
+                  tabIndex={-1}
+                  style={{
+                    gridColumn: `calc(var(--col-offset) + ${seg.startCol + 1}) / span ${seg.span}`,
+                    gridRow: seg.lane + 2,
+                    minWidth: 0,
+                  }}
+                >
+                  <EventPill
+                    event={seg.event}
+                    compact
+                    continuesLeft={seg.continuesLeft}
+                    continuesRight={seg.continuesRight}
+                    onClick={() => onEventClick(seg.event.id)}
+                  />
+                </div>
+              ))}
             </div>
           )
         })}

--- a/app/(dashboard)/calendar/components/MonthView.tsx
+++ b/app/(dashboard)/calendar/components/MonthView.tsx
@@ -11,7 +11,7 @@ import {
   addDays,
   sameDaySofia,
 } from '@/app/(dashboard)/calendar/utils'
-import { sofiaDateKeysBetween } from '@/lib/calendar-dates'
+import { sofiaDateKeysBetween, monthKeyToDate } from '@/lib/calendar-dates'
 import { packWeek, MAX_LANES } from '@/lib/calendar-layout'
 import { EventPill } from '@/app/(dashboard)/calendar/components/EventPill'
 
@@ -39,7 +39,7 @@ export function MonthView({
   // Sofia month key, not from `current` directly (noon-UTC anchor keeps this
   // Sofia-safe rather than reading current.getFullYear()/getMonth() locally).
   const currentMonthKey = SOFIA_DATE_FMT.format(current).slice(0, 7)
-  const firstOfMonth = new Date(`${currentMonthKey}-01T12:00:00Z`)
+  const firstOfMonth = monthKeyToDate(currentMonthKey)
   const gridStart = startOfWeek(firstOfMonth)
   const cells = Array.from({ length: 42 }, (_, i) => addDays(gridStart, i))
   const cellDateKeys = useMemo(() => cells.map(d => SOFIA_DATE_FMT.format(d)), [cells])

--- a/app/(dashboard)/calendar/components/MonthView.tsx
+++ b/app/(dashboard)/calendar/components/MonthView.tsx
@@ -34,10 +34,15 @@ export function MonthView({
   const { lang, t } = useLanguage()
   const DAYS = DAYS_I18N[lang]
   const today = new Date()
-  const gridStart = startOfWeek(current)
+  // `current` is not guaranteed to be the 1st — handleDayClick sets it to
+  // whatever day was clicked — so the grid start must be re-derived from the
+  // Sofia month key, not from `current` directly (noon-UTC anchor keeps this
+  // Sofia-safe rather than reading current.getFullYear()/getMonth() locally).
+  const currentMonthKey = SOFIA_DATE_FMT.format(current).slice(0, 7)
+  const firstOfMonth = new Date(`${currentMonthKey}-01T12:00:00Z`)
+  const gridStart = startOfWeek(firstOfMonth)
   const cells = Array.from({ length: 42 }, (_, i) => addDays(gridStart, i))
   const cellDateKeys = useMemo(() => cells.map(d => SOFIA_DATE_FMT.format(d)), [cells])
-  const currentMonthKey = SOFIA_DATE_FMT.format(current).slice(0, 7)
 
   // Events covering a given Sofia date key — used for aria-labels and the
   // overflow count, independent of the week-level bar packing.

--- a/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
@@ -17,13 +17,20 @@ import type { EventDetail } from './types'
 const RANGE_DAY_MONTH_FMT = new Intl.DateTimeFormat('bg-BG', { day: '2-digit', month: '2-digit', timeZone: TZ })
 const RANGE_FULL_FMT = new Intl.DateTimeFormat('bg-BG', { day: '2-digit', month: '2-digit', year: 'numeric', timeZone: TZ })
 
-/** '23.10 – 25.10.2026' for a multi-day all-day event; a single full date otherwise. */
+/**
+ * '23.10 – 25.10.2026' for a multi-day all-day event within one year,
+ * '30.12.2026 – 02.01.2027' when the span crosses a year boundary (the
+ * short day/month start format would otherwise leave the start year
+ * ambiguous), or a single full date for a same-day event.
+ */
 function formatAllDayRange(startIso: string, endIso: string): string {
   const keys = sofiaDateKeysBetween(startIso, endIso)
   if (keys.length === 1) return formatLongDate(startIso)
   const start = new Date(`${keys[0]}T12:00:00Z`)
   const end = new Date(`${keys[keys.length - 1]}T12:00:00Z`)
-  return `${RANGE_DAY_MONTH_FMT.format(start)} – ${RANGE_FULL_FMT.format(end)}`
+  const sameYear = keys[0].slice(0, 4) === keys[keys.length - 1].slice(0, 4)
+  const startFmt = sameYear ? RANGE_DAY_MONTH_FMT : RANGE_FULL_FMT
+  return `${startFmt.format(start)} – ${RANGE_FULL_FMT.format(end)}`
 }
 
 const EVENT_TYPE_STYLES: Record<string, { bg: string; color: string; label: string }> = {

--- a/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { ReactNode } from 'react'
-import { formatTime, formatLongDate } from '@/lib/format'
+import { formatTime, formatLongDate, TZ } from '@/lib/format'
+import { sofiaDateKeysBetween } from '@/lib/calendar-dates'
 import { X, QrCode, Download } from 'lucide-react'
 import {
   Dialog,
@@ -12,6 +13,18 @@ import {
 } from '@/components/ui/dialog'
 import type { TranslationKey } from '@/lib/i18n'
 import type { EventDetail } from './types'
+
+const RANGE_DAY_MONTH_FMT = new Intl.DateTimeFormat('bg-BG', { day: '2-digit', month: '2-digit', timeZone: TZ })
+const RANGE_FULL_FMT = new Intl.DateTimeFormat('bg-BG', { day: '2-digit', month: '2-digit', year: 'numeric', timeZone: TZ })
+
+/** '23.10 – 25.10.2026' for a multi-day all-day event; a single full date otherwise. */
+function formatAllDayRange(startIso: string, endIso: string): string {
+  const keys = sofiaDateKeysBetween(startIso, endIso)
+  if (keys.length === 1) return formatLongDate(startIso)
+  const start = new Date(`${keys[0]}T12:00:00Z`)
+  const end = new Date(`${keys[keys.length - 1]}T12:00:00Z`)
+  return `${RANGE_DAY_MONTH_FMT.format(start)} – ${RANGE_FULL_FMT.format(end)}`
+}
 
 const EVENT_TYPE_STYLES: Record<string, { bg: string; color: string; label: string }> = {
   'in-person': { bg: 'rgba(129,178,154,0.18)', color: '#2d6a4f',  label: 'In-Person' },
@@ -99,16 +112,20 @@ export default function EventPopupShell({
                   <line x1="8" x2="8" y1="2" y2="6"/>
                   <line x1="3" x2="21" y1="10" y2="10"/>
                 </svg>
-                <span className="font-medium">{formatLongDate(event.start_time)}</span>
+                <span className="font-medium">
+                  {event.is_all_day ? formatAllDayRange(event.start_time, event.end_time) : formatLongDate(event.start_time)}
+                </span>
               </div>
-              <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
-                  stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="12" cy="12" r="10"/>
-                  <polyline points="12 6 12 12 16 14"/>
-                </svg>
-                <span>{formatTime(event.start_time)} – {formatTime(event.end_time)}</span>
-              </div>
+              {!event.is_all_day && (
+                <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+                    stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="10"/>
+                    <polyline points="12 6 12 12 16 14"/>
+                  </svg>
+                  <span>{formatTime(event.start_time)} – {formatTime(event.end_time)}</span>
+                </div>
+              )}
               {!isGuest && event.meeting_url && (
                 <div className="flex items-center gap-2 text-xs mt-1">
                   <svg width="13" height="13" viewBox="0 0 24 24" fill="none"

--- a/app/(dashboard)/calendar/components/popup/types.ts
+++ b/app/(dashboard)/calendar/components/popup/types.ts
@@ -37,6 +37,7 @@ export type EventDetail = {
   available_roles: string[]
   start_time: string
   end_time: string
+  is_all_day: boolean
   category: 'N21' | 'Personal'
   event_type: 'in-person' | 'online' | 'hybrid' | null
   week_number: number

--- a/app/(dashboard)/calendar/components/useCalendar.ts
+++ b/app/(dashboard)/calendar/components/useCalendar.ts
@@ -5,15 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 import { apiClient } from '@/lib/apiClient'
 import { type CalendarEvent, type View } from '@/app/(dashboard)/calendar/types'
 import { toMonthParam } from '@/app/(dashboard)/calendar/utils'
-import { SOFIA_DATE_FMT, nextMonthKey, prevMonthKey } from '@/lib/calendar-dates'
-
-/** Noon UTC on the 1st of a 'YYYY-MM' month key — keeps the same calendar
- *  day for Sofia and for any runtime timezone within the realistic range of
- *  users/servers this app runs in, so local getters (getFullYear/getMonth)
- *  agree with the Sofia month without needing a Sofia-aware read everywhere. */
-function monthKeyToDate(monthKey: string): Date {
-  return new Date(`${monthKey}-01T12:00:00Z`)
-}
+import { SOFIA_DATE_FMT, nextMonthKey, prevMonthKey, monthKeyToDate } from '@/lib/calendar-dates'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 

--- a/app/(dashboard)/calendar/components/useCalendar.ts
+++ b/app/(dashboard)/calendar/components/useCalendar.ts
@@ -5,6 +5,15 @@ import { useQuery } from '@tanstack/react-query'
 import { apiClient } from '@/lib/apiClient'
 import { type CalendarEvent, type View } from '@/app/(dashboard)/calendar/types'
 import { toMonthParam } from '@/app/(dashboard)/calendar/utils'
+import { SOFIA_DATE_FMT, nextMonthKey, prevMonthKey } from '@/lib/calendar-dates'
+
+/** Noon UTC on the 1st of a 'YYYY-MM' month key — keeps the same calendar
+ *  day for Sofia and for any runtime timezone within the realistic range of
+ *  users/servers this app runs in, so local getters (getFullYear/getMonth)
+ *  agree with the Sofia month without needing a Sofia-aware read everywhere. */
+function monthKeyToDate(monthKey: string): Date {
+  return new Date(`${monthKey}-01T12:00:00Z`)
+}
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -26,10 +35,7 @@ export function useCalendar({
   isAuthenticated,
 }: UseCalendarOptions) {
   const [view, setView]             = useState<View>(initialEventId ? 'agenda' : 'month')
-  const [current, setCurrent]       = useState<Date>(() => {
-    const [y, m] = initialMonth.split('-').map(Number)
-    return new Date(y, m - 1, 1)
-  })
+  const [current, setCurrent]       = useState<Date>(() => monthKeyToDate(initialMonth))
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null)
   const [showN21, setShowN21]                 = useState(true)
   const [showPersonal, setShowPersonal]       = useState(true)
@@ -69,13 +75,12 @@ export function useCalendar({
 
   const navigate = useCallback((dir: 1 | -1) => {
     setCurrent(prev => {
-      const d = new Date(prev)
-      d.setMonth(d.getMonth() + dir)
-      return d
+      const monthKey = SOFIA_DATE_FMT.format(prev).slice(0, 7)
+      return monthKeyToDate(dir === 1 ? nextMonthKey(monthKey) : prevMonthKey(monthKey))
     })
   }, [])
 
-  const goToday = useCallback(() => setCurrent(new Date()), [])
+  const goToday = useCallback(() => setCurrent(monthKeyToDate(SOFIA_DATE_FMT.format(new Date()).slice(0, 7))), [])
 
   const handleEventClick = useCallback((id: string) => {
     setSelectedEventId(id)

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #652 | dev/2607-DEV-652 | lib/calendar-dates.ts (new), lib/server/calendar.ts, app/api/calendar/feed.ics/route.ts, app/api/calendar/route.ts, app/(dashboard)/calendar/{page.tsx,utils.ts}, supabase/functions/sync-google-calendar; migration: no | 2026-07-23 |
+| #653 | dev/2607-DEV-653 | app/(dashboard)/calendar/components/{MonthView.tsx,EventPill.tsx,AgendaView.tsx,useCalendar.ts,popup/EventPopupShell.tsx,popup/types.ts}, lib/i18n/domains/calendar.ts, new segment/lane packer test file; migration: no | 2026-07-24 |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,45 +1,44 @@
 ## Goal
-Issue #602 (2607-DEV-602, branch `dev/2607-DEV-602`): Calendar refactor 6/8 — test coverage (Sofia-TZ date utils + `lib/format.ts` DST boundaries, ICS description snapshot, unauthenticated calendar e2e smoke).
+Issue #653 (2607-DEV-653, branch `dev/2607-DEV-653`): Calendar multi-day rendering — Month view spanning bars, Agenda per-day rows, popup date range for all-day events. Depends on #652 (merged, PR #654).
 
 ## Now
-PR [#651](https://github.com/teamenjoyvd/tevd-portal/pull/651) open (ready for review, not draft). CI green (Build/Lint/Test/TypeCheck/SecurityAudit/migrations-replay/`390px smoke vs preview`/Vercel) as of the GCR fix commit `a2ba772`. CodeRabbit's re-review after that commit came back "rate limited" (not re-run) rather than clean — not yet a second genuine CodeRabbit pass.
+BUILD complete locally: `tsc --noEmit` clean, `npm run lint` 0 errors (no new warnings), `npx vitest run` 207/207 passed (incl. 8 new `lib/calendar-layout.test.ts` lane-packer tests). Committed on `dev/2607-DEV-653` (not pushed — no push requested yet). Browser/390px/preview verification from the issue's Verification section has NOT been run (no dev server / preview check performed this session).
 
 ## Next
-- Get a real CodeRabbit re-review on commit `a2ba772` (current one was rate-limited) or confirm no new findings another way before merging
-- Merge PR #651 (squash, matches repo convention)
-- Post-merge tail: `migrate-prod` should auto-skip (no migrations in this PR); smoke-check `https://www.teamenjoyvd.com`; issue #602 auto-closes via the PR's `Closes #602`. `#602`'s `docs/CLAIMS.md` row was removed ahead of merge per explicit user instruction (CI green, PR waiting on the cleanup merge) — not the normal post-merge-only rule
-- Separately outstanding: issue #601's post-merge tail was never finished last session (prod smoke-check / `migrate-prod` confirmation not verified) — worth a quick check next time prod state comes up, though its `docs/CLAIMS.md` row has now been pruned (issue closed, PR #649 merged 2026-07-23T11:27:39Z)
+- Run `/code-review low` on the diff and fix findings locally before any push
+- Manually verify against the issue's DoD checklist: Month view continuous bar across a real multi-day event (Oct 2026 `WES` event, or June 2026), week-boundary split segments, `+N` overflow correctness, arrow-key traversal + click-empty-space-still-fires-onDayClick, 390px no horizontal overflow, Agenda `Day N/M` markers (en + bg), popup date range (no `01:00–01:00`)
+- Push branch, open PR as DRAFT, wait CI green + preview READY, then Ready → CodeRabbit pass → Merge → GCR (remove #653's `docs/CLAIMS.md` row, close issue)
 
 ## Constraints
 - Never push directly to `main`; `dev/[YYMM]-DEV-[GH#]` branches only
 - Never mark Done on static analysis alone — Vercel PR preview must be READY and CI green
 - No `git push` without the user explicitly asking for a push in-conversation (quote required)
 - No failing check gets weakened/skipped to pass
-- Never spin a solo cleanup-only PR just to prune a `docs/CLAIMS.md` row — fold it into the merging feature PR (repeat past mistake, see `feedback_no_standalone_claims_cleanup_pr` memory)
-- A `blocked` GitHub label is not authoritative — verify the actual named blocking issues before treating a ticket as blocked (2607-DEV-602's label was stale; #587-592 had all closed 2026-07-23)
+- Never spin a solo cleanup-only PR just to prune a `docs/CLAIMS.md` row — fold it into the merging feature PR
 
 ## Decisions
-DECISION: #602's ICS-description logic (`feed.ics/route.ts`) extracted verbatim into `lib/server/calendar.ts`'s `buildEventDescription()` — additive, behavior-preserving — so the Phase 1c format is snapshot-testable without mocking Clerk/Supabase auth.
-DECISION: CodeRabbit's "seed deterministic event data" suggestion for the e2e popup-coverage gap was not implemented (heavy lift, no existing calendar-seed script, out of proportion for a test-coverage ticket); instead the silent `if (count > 0)` skip was converted to a hard `expect(...).toBeVisible()` so an empty month fails loudly instead of silently passing.
-DECISION: CodeRabbit's "use the `Personal` locator" finding was rejected as a false positive — `cal.inPerson`/"In-person" and `cal.personal`/"Personal" are two distinct real buttons; the PR's own live-Preview CI run had already passed using the original `'In-person'` locator. Replied on the thread, left unresolved (not applied).
+DECISION: Segment/lane packing for Month-view spanning bars extracted into a pure, DOM-free `lib/calendar-layout.ts` (`packWeek`) rather than inlined in `MonthView.tsx`, so the packing algorithm (ordering, lane assignment, overflow) is directly unit-testable without React/DOM — matches the issue's explicit ask ("pure function, unit-tested directly — not through the DOM").
+DECISION: Day-cell/bar layout uses one shared CSS Grid per week row (day cells `gridRow: '1 / -1'`, bars as later DOM siblings with explicit `gridColumn`/`gridRow`) rather than absolute positioning — bars naturally paint above day cells and clicks on empty cell area fall through to the cell's own `onClick`, satisfying the "click interception" DoD item with no `pointer-events` hack.
+DECISION: `useCalendar`'s `current` month state and `MonthView`'s day-number/`isCurrentMonth` test now derive from Sofia date keys (`SOFIA_DATE_FMT`) instead of runtime-local `Date` getters, per issue item 2.4 — `current` is anchored to noon UTC on the 1st of the month so local getters agree with the Sofia month across realistic runtime timezones.
+DECISION: All-day popup date range formatted via a small local `formatAllDayRange` helper (bg-BG locale, matching `formatLongDate`'s existing locale) rather than adding new translated strings — the range is numeric dates only, no fixed English/Bulgarian words to translate beyond the em dash.
 
 ## Facts
 - Hosted DEV Supabase project: `iymwxdewcpvpjgzewtzk`, prod: `ynykjpnetfwqzdnsgkkg`
-- CI's `Authenticated E2E (Clerk)` job is a ~5s gated skip (missing secrets) — does not run specs; not real coverage. `mobile-390`'s `390px smoke vs preview` job is real, runs against the live Vercel Preview, and did execute `e2e/calendar.spec.ts` (confirmed via job log: "1 [mobile-390] › e2e/calendar.spec.ts:21:7 ... (3.4s)").
-- This repo's local sandbox has a reproducible pre-existing Node-fetch flake reaching Supabase from the Next dev server under browser-driven (Playwright) load — confirmed present on a clean `main` checkout too (same failure line, same error), so it's environment-specific, not caused by any #602 change. Plain `curl` against the same route never reproduces it. Do not re-litigate this as a real bug without new evidence; the actual gate is CI/Preview, which passed.
-- PR #651: `dev/2607-DEV-602` → `main`, title `[2607-DEV-602] Calendar refactor 6: test coverage (date utils, ICS snapshot, calendar e2e)`, body has `Closes #602`.
-- No new routes, no schema/migration changes this ticket.
+- #652 merged as PR #654 (`a6aad9b`) before this session started; #653's `blocked` label removed, confirmed no other blockers.
+- New file `lib/calendar-layout.ts` (+ `lib/calendar-layout.test.ts`, 8 tests): `packWeek()` pure segment/lane packer, `MAX_LANES = 3`.
+- `lib/calendar-dates.ts` gained `prevMonthKey` (symmetric to existing `nextMonthKey`), needed for Sofia-month-key-based navigation in `useCalendar.ts`.
+- Files touched this session: `MonthView.tsx`, `EventPill.tsx`, `AgendaView.tsx`, `useCalendar.ts`, `popup/EventPopupShell.tsx`, `popup/types.ts`, `lib/i18n/domains/calendar.ts`, `lib/calendar-dates.ts`, `lib/calendar-layout.ts` (new), `lib/calendar-layout.test.ts` (new). No schema/migration changes.
+- Accessibility trade (flagged in the issue as worth a second opinion): bars are `aria-hidden`/`tabIndex={-1}`; each `role="gridcell"` gets an `aria-label` enumerating covering events with `Day N/M` context instead.
 
 ## Done
-#602 PLAN — RESULT: verdict READY; found the `blocked` label stale (dependencies #587-592 all closed).
-#602 CLAIM — RESULT: re-entry on existing issue #602 (label removed, Design Checklist completed in the issue body); branch `dev/2607-DEV-602` cut from `main`; `docs/CLAIMS.md` row added (no overlap with #601's then-in-flight row).
-#602 BUILD — RESULT: `app/(dashboard)/calendar/utils.test.ts` (new, 15 tests), `lib/format.test.ts` extended (`calMonth`/`calDay`/`formatDateMediumEn`/`formatDateLongEn`), `buildEventDescription()` extracted into `lib/server/calendar.ts` with `lib/server/calendar.test.ts` snapshot coverage, `e2e/calendar.spec.ts` (new, unauthenticated smoke). 51 unit tests / `tsc --noEmit` clean. PR #651 opened ready-for-review; CI green including the real `390px smoke vs preview` job.
-#602 GCR — RESULT: CodeRabbit posted 4 findings on commit `0639913`. 3 applied (DST test instants corrected; e2e popup-skip converted to a hard assertion; empty-string `category` handling made consistent with location/meeting_url, +1 new test) in commit `a2ba772`, threads resolved via GraphQL. 1 rejected as a false positive (filter-locator label mix-up), replied on-thread with reasoning, left unresolved.
+#653 PLAN — RESULT: issue #653 already carried a complete Design Checklist (DoD, affected files, gotchas) from its author; verified premises against current code (`MonthView.tsx:39`, `AgendaView.tsx:32` start-date-only bucketing; `EventPopupShell.tsx:110` unconditional start–end render; `lib/calendar-dates.ts`/`is_all_day` plumbing already present from #652) before proceeding — no redesign needed.
+#653 CLAIM — RESULT: branch `dev/2607-DEV-653` cut from `main` (`a6aad9b`); `docs/CLAIMS.md` #652 row (merged) replaced with a #653 row; issue body updated with `## Branch`; `blocked` label removed.
+#653 BUILD — RESULT: `lib/calendar-layout.ts` (new, `packWeek` segment/lane packer) + 8 unit tests; `MonthView.tsx` rewritten to a shared week-grid layout with spanning bars, Sofia-keyed day numbers/`isCurrentMonth`, per-cell `aria-label`; `EventPill.tsx` gained `continuesLeft`/`continuesRight`; `AgendaView.tsx` fans multi-day events across covered days with a `Day N/M` marker (new `cal.dayOf` i18n key, en+bg); `EventPopupShell.tsx`/`popup/types.ts` show a date range for all-day events instead of `01:00–01:00`; `useCalendar.ts` + `lib/calendar-dates.ts` (`prevMonthKey`, new) made month navigation Sofia-month-key based. `tsc --noEmit` clean, `npm run lint` 0 errors, `npx vitest run` 207/207 passed. Committed locally, not pushed. Browser/preview/390px verification not yet done.
 
 ## Open items
-- Get a genuine CodeRabbit re-review on `a2ba772` (last one was rate-limited) before merging PR #651
-- #601's post-merge tail (prod smoke-check, `migrate-prod` confirmation) was left unverified in a prior session — flag if prod state comes up again
-- Issue #603+ (calendar refactor phases 7-8, if any) — not investigated this session
+- Full DoD verification (browser, 390px, arrow-key/click-through, real multi-day events) — see `## Next`
+- `/code-review low` on the diff before pushing
+- Issue #601's post-merge tail (prod smoke-check, `migrate-prod` confirmation) — carried over from a prior session, unrelated to #653, flag if prod state comes up again
 
 ## Failed attempts
 (none this session)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,12 +2,12 @@
 Issue #653 (2607-DEV-653, branch `dev/2607-DEV-653`): Calendar multi-day rendering — Month view spanning bars, Agenda per-day rows, popup date range for all-day events. Depends on #652 (merged, PR #654).
 
 ## Now
-BUILD complete locally: `tsc --noEmit` clean, `npm run lint` 0 errors (no new warnings), `npx vitest run` 207/207 passed (incl. 8 new `lib/calendar-layout.test.ts` lane-packer tests). Committed on `dev/2607-DEV-653` (not pushed — no push requested yet). Browser/390px/preview verification from the issue's Verification section has NOT been run (no dev server / preview check performed this session).
+PR [#655](https://github.com/teamenjoyvd/tevd-portal/pull/655) open as DRAFT (`dev/2607-DEV-653` → `main`), body has `Closes #653`. `/code-review low` ran, found one real bug (Month view `gridStart` derived from `current` instead of the Sofia month key — `current` isn't always day-1 since `handleDayClick` sets it to whatever day was clicked) — fixed and re-verified. Waiting on CI + Vercel Preview.
 
 ## Next
-- Run `/code-review low` on the diff and fix findings locally before any push
-- Manually verify against the issue's DoD checklist: Month view continuous bar across a real multi-day event (Oct 2026 `WES` event, or June 2026), week-boundary split segments, `+N` overflow correctness, arrow-key traversal + click-empty-space-still-fires-onDayClick, 390px no horizontal overflow, Agenda `Day N/M` markers (en + bg), popup date range (no `01:00–01:00`)
-- Push branch, open PR as DRAFT, wait CI green + preview READY, then Ready → CodeRabbit pass → Merge → GCR (remove #653's `docs/CLAIMS.md` row, close issue)
+- Wait for CI green + Vercel Preview READY on PR #655
+- Manually verify against the issue's DoD checklist against the preview: Month view continuous bar across a real multi-day event (Oct 2026 `WES` event, or June 2026), week-boundary split segments, `+N` overflow correctness, arrow-key traversal + click-empty-space-still-fires-onDayClick, 390px no horizontal overflow, Agenda `Day N/M` markers (en + bg), popup date range (no `01:00–01:00`)
+- Mark PR ready → one CodeRabbit pass → fix findings in one batched push → Merge → GCR (remove #653's `docs/CLAIMS.md` row, close issue)
 
 ## Constraints
 - Never push directly to `main`; `dev/[YYMM]-DEV-[GH#]` branches only

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,12 +2,11 @@
 Issue #653 (2607-DEV-653, branch `dev/2607-DEV-653`): Calendar multi-day rendering — Month view spanning bars, Agenda per-day rows, popup date range for all-day events. Depends on #652 (merged, PR #654).
 
 ## Now
-PR [#655](https://github.com/teamenjoyvd/tevd-portal/pull/655) open, marked ready for review by the user (no longer draft) at 2026-07-23T22:23:17Z. `/code-review low` found one real bug (Month view `gridStart` derived from `current` instead of the Sofia month key) — fixed. `390px smoke vs preview` initially failed twice post-push: first on a stale e2e selector (`[role="gridcell"] button` — fixed, spanning bars are now row-level siblings of gridcells, not children), then intermittently on `e2e/library-guide.spec.ts` timing out against `/library?type=guides` — confirmed as a pre-existing preview-infra flake unrelated to this PR (this branch touches zero files under `app/library`/`lib/server`/`scripts`; same commit passed on one re-run and failed on another). All CI checks green as of the latest re-run except CodeRabbit, which just started its real (non-draft) pass.
+PR [#655](https://github.com/teamenjoyvd/tevd-portal/pull/655) ready for review, CI green (390px smoke flake investigated and confirmed pre-existing/unrelated — see Decisions). CodeRabbit's real pass found 2 actionable comments + 1 nitpick, all applied in commit fixing PR655 review comments, both threads resolved via GraphQL.
 
 ## Next
-- Wait for CodeRabbit's pass on PR #655, fix all findings in one batched push (GCR step)
-- Manually verify against the issue's DoD checklist against the preview: Month view continuous bar across a real multi-day event (Oct 2026 `WES` event, or June 2026), week-boundary split segments, `+N` overflow correctness, arrow-key traversal + click-empty-space-still-fires-onDayClick, 390px no horizontal overflow, Agenda `Day N/M` markers (en + bg), popup date range (no `01:00–01:00`)
-- Merge → GCR (remove #653's `docs/CLAIMS.md` row, close issue)
+- Manually verify against the issue's DoD checklist against the preview: Month view continuous bar across a real multi-day event (Oct 2026 `WES` event, or June 2026), week-boundary split segments, `+N` overflow correctness, arrow-key traversal + click-empty-space-still-fires-onDayClick, 390px no horizontal overflow, Agenda `Day N/M` markers (en + bg), popup date range (no `01:00–01:00`), and the new cross-year range formatting
+- Wait for CI to go green on the GCR-fix commit, then Merge → GCR post-merge tail (remove #653's `docs/CLAIMS.md` row, close issue, no migrations to gate)
 
 ## Constraints
 - Never push directly to `main`; `dev/[YYMM]-DEV-[GH#]` branches only
@@ -21,6 +20,8 @@ DECISION: Segment/lane packing for Month-view spanning bars extracted into a pur
 DECISION: Day-cell/bar layout uses one shared CSS Grid per week row (day cells `gridRow: '1 / -1'`, bars as later DOM siblings with explicit `gridColumn`/`gridRow`) rather than absolute positioning — bars naturally paint above day cells and clicks on empty cell area fall through to the cell's own `onClick`, satisfying the "click interception" DoD item with no `pointer-events` hack.
 DECISION: `useCalendar`'s `current` month state and `MonthView`'s day-number/`isCurrentMonth` test now derive from Sofia date keys (`SOFIA_DATE_FMT`) instead of runtime-local `Date` getters, per issue item 2.4 — `current` is anchored to noon UTC on the 1st of the month so local getters agree with the Sofia month across realistic runtime timezones.
 DECISION: All-day popup date range formatted via a small local `formatAllDayRange` helper (bg-BG locale, matching `formatLongDate`'s existing locale) rather than adding new translated strings — the range is numeric dates only, no fixed English/Bulgarian words to translate beyond the em dash.
+
+DECISION: `390px smoke vs preview` failures on this PR were investigated at the user's request rather than assumed away. Root cause split in two: (1) a stale e2e selector — fixed, not a flake; (2) `e2e/library-guide.spec.ts` timing out against `/library?type=guides` on the Vercel preview, confirmed pre-existing/environmental because the identical commit passed on one CI run and failed on the immediate re-run, and this branch touches zero files under `app/library`/`lib/server`/`scripts` (verified via `git diff main --stat`). Matches the existing `project_preview_smoke_guest_flow` memory's history of this spec being fragile against preview. Re-ran the job; it passed clean.
 
 ## Facts
 - Hosted DEV Supabase project: `iymwxdewcpvpjgzewtzk`, prod: `ynykjpnetfwqzdnsgkkg`

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,12 +2,12 @@
 Issue #653 (2607-DEV-653, branch `dev/2607-DEV-653`): Calendar multi-day rendering — Month view spanning bars, Agenda per-day rows, popup date range for all-day events. Depends on #652 (merged, PR #654).
 
 ## Now
-PR [#655](https://github.com/teamenjoyvd/tevd-portal/pull/655) open as DRAFT (`dev/2607-DEV-653` → `main`), body has `Closes #653`. `/code-review low` ran, found one real bug (Month view `gridStart` derived from `current` instead of the Sofia month key — `current` isn't always day-1 since `handleDayClick` sets it to whatever day was clicked) — fixed and re-verified. Waiting on CI + Vercel Preview.
+PR [#655](https://github.com/teamenjoyvd/tevd-portal/pull/655) open, marked ready for review by the user (no longer draft) at 2026-07-23T22:23:17Z. `/code-review low` found one real bug (Month view `gridStart` derived from `current` instead of the Sofia month key) — fixed. `390px smoke vs preview` initially failed twice post-push: first on a stale e2e selector (`[role="gridcell"] button` — fixed, spanning bars are now row-level siblings of gridcells, not children), then intermittently on `e2e/library-guide.spec.ts` timing out against `/library?type=guides` — confirmed as a pre-existing preview-infra flake unrelated to this PR (this branch touches zero files under `app/library`/`lib/server`/`scripts`; same commit passed on one re-run and failed on another). All CI checks green as of the latest re-run except CodeRabbit, which just started its real (non-draft) pass.
 
 ## Next
-- Wait for CI green + Vercel Preview READY on PR #655
+- Wait for CodeRabbit's pass on PR #655, fix all findings in one batched push (GCR step)
 - Manually verify against the issue's DoD checklist against the preview: Month view continuous bar across a real multi-day event (Oct 2026 `WES` event, or June 2026), week-boundary split segments, `+N` overflow correctness, arrow-key traversal + click-empty-space-still-fires-onDayClick, 390px no horizontal overflow, Agenda `Day N/M` markers (en + bg), popup date range (no `01:00–01:00`)
-- Mark PR ready → one CodeRabbit pass → fix findings in one batched push → Merge → GCR (remove #653's `docs/CLAIMS.md` row, close issue)
+- Merge → GCR (remove #653's `docs/CLAIMS.md` row, close issue)
 
 ## Constraints
 - Never push directly to `main`; `dev/[YYMM]-DEV-[GH#]` branches only

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -38,7 +38,12 @@ test.describe('calendar', () => {
     // Fails loudly rather than silently skipping popup coverage — this repo's
     // public calendar always has upcoming club events in the current month,
     // so 0 here is itself a bug, not an empty fixture to route around.
-    const firstEvent = visible(page, page.locator('[role="gridcell"] button')).first()
+    // Event pill/bar buttons are row-level siblings of the gridcells, not
+    // their DOM children — spanning bars must share the week's CSS Grid to
+    // lay out across multiple day columns (2607-DEV-653) — so the selector
+    // is scoped to the row rather than the cell. Gridcells themselves are
+    // plain divs (never <button>), so this still matches only event pills.
+    const firstEvent = visible(page, page.locator('[role="row"] button')).first()
     await expect(firstEvent, 'no calendar events found in the current month view').toBeVisible()
     await firstEvent.click()
     const dialog = page.getByRole('dialog')

--- a/lib/calendar-dates.ts
+++ b/lib/calendar-dates.ts
@@ -86,6 +86,16 @@ export function prevMonthKey(monthKey: string): string {
 }
 
 /**
+ * Noon UTC on the 1st of a 'YYYY-MM' month key — keeps the same calendar day
+ * for Sofia and for any runtime timezone within the realistic range of
+ * users/servers this app runs in, so local getters (getFullYear/getMonth)
+ * agree with the Sofia month without needing a Sofia-aware read everywhere.
+ */
+export function monthKeyToDate(monthKey: string): Date {
+  return new Date(`${monthKey}-01T12:00:00Z`)
+}
+
+/**
  * ICS all-day VEVENT date range: start = a Date whose UTC Y/M/D equal the
  * Sofia start day; end = a Date whose UTC Y/M/D equal the Sofia end day + 1
  * (VALUE=DATE DTEND is exclusive per RFC 5545 §3.8.2.2, while the DB stores

--- a/lib/calendar-dates.ts
+++ b/lib/calendar-dates.ts
@@ -77,6 +77,14 @@ export function nextMonthKey(monthKey: string): string {
   return `${nextYear}-${String(nextMonth).padStart(2, '0')}`
 }
 
+/** 'YYYY-MM' of the month preceding a 'YYYY-MM' month key, rolling the year back at January. */
+export function prevMonthKey(monthKey: string): string {
+  const [year, month] = monthKey.split('-').map(Number)
+  const prevMonth = month === 1 ? 12 : month - 1
+  const prevYear = month === 1 ? year - 1 : year
+  return `${prevYear}-${String(prevMonth).padStart(2, '0')}`
+}
+
 /**
  * ICS all-day VEVENT date range: start = a Date whose UTC Y/M/D equal the
  * Sofia start day; end = a Date whose UTC Y/M/D equal the Sofia end day + 1

--- a/lib/calendar-layout.test.ts
+++ b/lib/calendar-layout.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { packWeek, MAX_LANES, type LayoutEvent } from '@/lib/calendar-layout'
+
+const WEEK = ['2026-10-19', '2026-10-20', '2026-10-21', '2026-10-22', '2026-10-23', '2026-10-24', '2026-10-25']
+
+function ev(id: string, start: string, end: string): LayoutEvent {
+  return { id, start_time: `${start}T09:00:00Z`, end_time: `${end}T09:00:00Z` }
+}
+
+describe('packWeek', () => {
+  it('places a single-day event at its own column, span 1', () => {
+    const { segments } = packWeek(WEEK, [ev('a', '2026-10-21', '2026-10-21')])
+    expect(segments).toEqual([
+      expect.objectContaining({ startCol: 2, span: 1, lane: 0, continuesLeft: false, continuesRight: false }),
+    ])
+  })
+
+  it('spans a full week', () => {
+    const { segments } = packWeek(WEEK, [ev('a', '2026-10-19', '2026-10-25')])
+    expect(segments[0]).toMatchObject({ startCol: 0, span: 7, continuesLeft: false, continuesRight: false })
+  })
+
+  it('splits a week-boundary crossing span into continuesRight / continuesLeft halves', () => {
+    // Event runs Fri 23 -> Mon 26 (26th falls in the next week).
+    const nextWeek = ['2026-10-26', '2026-10-27', '2026-10-28', '2026-10-29', '2026-10-30', '2026-10-31', '2026-11-01']
+    const spanning = ev('a', '2026-10-23', '2026-10-26')
+
+    const week1 = packWeek(WEEK, [spanning])
+    expect(week1.segments[0]).toMatchObject({ startCol: 4, span: 3, continuesLeft: false, continuesRight: true })
+
+    const week2 = packWeek(nextWeek, [spanning])
+    expect(week2.segments[0]).toMatchObject({ startCol: 0, span: 1, continuesLeft: true, continuesRight: false })
+  })
+
+  it('packs two overlapping spans into lanes 0 and 1', () => {
+    const a = ev('a', '2026-10-20', '2026-10-22')
+    const b = ev('b', '2026-10-21', '2026-10-23')
+    const { segments } = packWeek(WEEK, [a, b])
+    const byId = Object.fromEntries(segments.map(s => [s.event.id, s.lane]))
+    expect(byId.a).toBe(0)
+    expect(byId.b).toBe(1)
+  })
+
+  it('reuses a freed lane once the earlier segment ends before the next starts', () => {
+    const a = ev('a', '2026-10-19', '2026-10-20')
+    const b = ev('b', '2026-10-21', '2026-10-22')
+    const { segments } = packWeek(WEEK, [a, b])
+    const byId = Object.fromEntries(segments.map(s => [s.event.id, s.lane]))
+    expect(byId.a).toBe(0)
+    expect(byId.b).toBe(0)
+  })
+
+  it('drops segments past MAX_LANES and reports a per-column overflow count', () => {
+    const events = Array.from({ length: MAX_LANES + 1 }, (_, i) => ev(`e${i}`, '2026-10-21', '2026-10-21'))
+    const { segments, overflowByCol } = packWeek(WEEK, events)
+    expect(segments).toHaveLength(MAX_LANES)
+    expect(overflowByCol[2]).toBe(1)
+    expect(overflowByCol.filter(n => n === 0)).toHaveLength(6)
+  })
+
+  it('orders deterministically by startCol asc, span desc, start_time, id — independent of input order', () => {
+    const wide = ev('wide', '2026-10-20', '2026-10-22')
+    const narrow = ev('narrow', '2026-10-20', '2026-10-20')
+    const forward = packWeek(WEEK, [narrow, wide]).segments.map(s => s.event.id)
+    const backward = packWeek(WEEK, [wide, narrow]).segments.map(s => s.event.id)
+    expect(forward).toEqual(['wide', 'narrow'])
+    expect(backward).toEqual(['wide', 'narrow'])
+  })
+
+  it('ignores events entirely outside the week', () => {
+    const { segments } = packWeek(WEEK, [ev('a', '2026-09-01', '2026-09-02')])
+    expect(segments).toHaveLength(0)
+  })
+})

--- a/lib/calendar-layout.ts
+++ b/lib/calendar-layout.ts
@@ -1,0 +1,87 @@
+// ── lib/calendar-layout.ts ───────────────────────────────────────────────
+// Pure segment/lane layout for Month-view spanning event bars. No DOM, no
+// React — kept separate so the packing algorithm is unit-testable directly.
+import { sofiaDateKeysBetween } from '@/lib/calendar-dates'
+
+export const MAX_LANES = 3
+
+export type LayoutEvent = {
+  id: string
+  start_time: string
+  end_time: string
+}
+
+export type Segment<T extends LayoutEvent> = {
+  event: T
+  startCol: number // 0-6, index into the week's 7 day keys
+  span: number // 1-7
+  lane: number
+  continuesLeft: boolean
+  continuesRight: boolean
+}
+
+/**
+ * Packs events into segments + lanes for a single week (7 Sofia date keys,
+ * Monday-first). Events outside the week are ignored; events overlapping the
+ * week are clipped to it, with continuesLeft/Right marking the clip.
+ *
+ * Deterministic ordering (startCol asc, span desc, start_time asc, id asc) so
+ * server and client render identical markup — no Date.now(), no locale
+ * comparison. Lanes beyond MAX_LANES are dropped; per-day overflow counts are
+ * derived by the caller from the dropped segments.
+ */
+export function packWeek<T extends LayoutEvent>(
+  weekDateKeys: string[],
+  events: T[]
+): { segments: Segment<T>[]; overflowByCol: number[] } {
+  const weekStart = weekDateKeys[0]
+  const weekEnd = weekDateKeys[weekDateKeys.length - 1]
+
+  const candidates = events
+    .map(event => {
+      const keys = sofiaDateKeysBetween(event.start_time, event.end_time)
+      const eventStart = keys[0]
+      const eventEnd = keys[keys.length - 1]
+      if (eventEnd < weekStart || eventStart > weekEnd) return null
+
+      // Date keys are 'YYYY-MM-DD' strings, lexically sortable — clip via
+      // plain string min/max, then look up the clipped keys' positions in
+      // this week's 7 consecutive day keys.
+      const clippedStart = eventStart < weekStart ? weekStart : eventStart
+      const clippedEnd = eventEnd > weekEnd ? weekEnd : eventEnd
+      const startCol = weekDateKeys.indexOf(clippedStart)
+      const endCol = weekDateKeys.indexOf(clippedEnd)
+
+      return {
+        event,
+        startCol,
+        span: endCol - startCol + 1,
+        continuesLeft: eventStart < weekStart,
+        continuesRight: eventEnd > weekEnd,
+      }
+    })
+    .filter((s): s is NonNullable<typeof s> => s !== null)
+    .sort((a, b) =>
+      a.startCol - b.startCol ||
+      b.span - a.span ||
+      a.event.start_time.localeCompare(b.event.start_time) ||
+      a.event.id.localeCompare(b.event.id)
+    )
+
+  const laneEnds: number[] = [] // laneEnds[lane] = last occupied column
+  const segments: Segment<T>[] = []
+  const overflowByCol = Array.from({ length: 7 }, () => 0)
+
+  for (const c of candidates) {
+    let lane = laneEnds.findIndex(end => end < c.startCol)
+    if (lane === -1) lane = laneEnds.length
+    if (lane >= MAX_LANES) {
+      for (let col = c.startCol; col < c.startCol + c.span; col++) overflowByCol[col]++
+      continue
+    }
+    laneEnds[lane] = c.startCol + c.span - 1
+    segments.push({ ...c, lane })
+  }
+
+  return { segments, overflowByCol }
+}

--- a/lib/i18n/domains/calendar.ts
+++ b/lib/i18n/domains/calendar.ts
@@ -25,4 +25,5 @@ export const calendar = {
   'cal.qrDownload':         { en: 'Download PNG',             bg: 'Изтегли PNG'                   },
   'cal.roleRequestsClosed': { en: 'Role requests closed.',    bg: 'Заявките за роли са затворени.' },
   'cal.allDay':             { en: 'All day',                  bg: 'Целодневно'                    },
+  'cal.dayOf':              { en: 'Day {n}/{m}',              bg: 'Ден {n}/{m}'                   },
 } as const


### PR DESCRIPTION
## Summary
- Month view packs events into a shared week grid (`lib/calendar-layout.ts` pure `packWeek` segment/lane packer) so multi-day events render as one continuous bar with week-boundary segments and lane-based `+N` overflow, instead of being bucketed into a single start-day cell.
- Agenda fans a multi-day event out into one row per covered Sofia day with a `Day N/M` marker (new `cal.dayOf` i18n key, en + bg).
- Event popup shows a date range for all-day events instead of a meaningless `01:00 – 01:00`.
- Grid cell day numbers / `isCurrentMonth` derive from the Sofia date key; `useCalendar`'s month navigation is now Sofia-month-key based (`lib/calendar-dates.ts` gained `prevMonthKey`).

Closes #653

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors, no new warnings
- [x] `npx vitest run` — 207/207 passed (incl. 8 new `lib/calendar-layout.test.ts` lane-packer tests)
- [x] `/code-review low` run locally, one real bug found and fixed (Month view `gridStart` incorrectly derived from `current` after a day click) — verified with a fresh `tsc`/`vitest` pass
- [ ] Manual browser verification per the issue's Verification section (Month view continuous bar on a real multi-day event, week-boundary split, Agenda `Day N/M`, popup range, arrow-key + click-through, 390px no overflow) — pending Vercel Preview
- [ ] CI green + Vercel Preview READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar events spanning multiple days now appear on each applicable day.
  * Multi-day events display their position in the range, such as “Day 2/3.”
  * Month views show connected event bars with improved overlap handling and “+N more” indicators.
  * All-day events now display complete date ranges in event details.

* **Bug Fixes**
  * Improved calendar date handling across time zones and month navigation.

* **Tests**
  * Added coverage for event layout, overlaps, week boundaries, and overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->