### PR TITLE
Fix month-view multi-day bar regression merged in #656

### DIFF
--- a/app/(dashboard)/calendar/components/MonthView.tsx
+++ b/app/(dashboard)/calendar/components/MonthView.tsx
@@ -149,7 +149,11 @@ export function MonthView({
                     onKeyDown={e => handleGridKeyDown(e, index, date)}
                     onFocus={() => setFocusIndex(index)}
                     className="border-l border-black/5 p-1 cursor-pointer hover:bg-black/[0.02] transition-colors overflow-hidden focus:outline-none focus:ring-2 focus:ring-inset"
-                    style={{ gridRow: '1 / -1', minWidth: 0, ['--tw-ring-color' as string]: 'var(--brand-teal)' }}
+                    style={{
+                      gridRow: '1 / -1',
+                      gridColumn: `calc(var(--col-offset) + ${di + 1}) / span 1`,
+                      ['--tw-ring-color' as string]: 'var(--brand-teal)',
+                    }}
                   >
                     <div className="flex justify-center">
                       <span


### PR DESCRIPTION
## Summary
#656 was merged into \`main\` containing only its first, incorrect commit (\`min-width: 0\` on day cells) — the follow-up revert and real fix pushed to that branch afterward landed too late to be included, since GitHub doesn't retroactively update an already-merged PR. \`main\` currently ships the broken version, which visibly worsens the original bug (event bars fully overlapping day numbers instead of just misaligning columns).

**Root cause** (confirmed via an isolated CSS Grid repro matching this file's exact structure): day cells had no explicit \`grid-column\`, relying on auto-placement. Event bars use explicit row+column positioning. Per the CSS Grid spec, explicitly-positioned items are placed before auto-placed ones, so a bar at (row 2, col N) makes auto-placement treat col N as unavailable for the day cell that legitimately needs the same column (it spans all rows). That cell gets pushed to the next column, cascading every later cell one column right, until the last day of the week overflows into a new implicit column that collapses to near-zero width.

**Fix:** give each day cell an explicit \`gridColumn\` (mirroring the bar's own \`calc(var(--col-offset) + ...)\` pattern) so cell and bar can share a column across different rows without triggering auto-placement avoidance.

## Test plan
- [x] \`npx tsc --noEmit\` passes
- [x] Isolated grid repro (same CSS/structure) confirms 8 uniform column tracks with 1-day and 4-day spanning bars
- [ ] Verify on Vercel PR preview: month view with a multi-day event no longer compresses/misaligns day columns