### PR TITLE
[2607-DEV-610] Profile refactor 5: invites logic consolidation + shadcn filters

### DIFF
--- a/app/(dashboard)/profile/components/InvitesBento.tsx
+++ b/app/(dashboard)/profile/components/InvitesBento.tsx
@@ -4,18 +4,14 @@ import { useQuery } from '@tanstack/react-query'
 import Link from 'next/link'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { apiClient } from '@/lib/apiClient'
+import { computeFunnel, type GuestRow } from '@/lib/invites'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type GuestRow = {
-  id:          string
-  attended_at: string | null
-  status:      string
-}
-
 type ShareLink = {
-  id:     string
-  guests: GuestRow[]
+  id:         string
+  revoked_at: string | null
+  guests:     GuestRow[]
 }
 
 type ApiResponse = { links: ShareLink[]; total: number }
@@ -33,12 +29,10 @@ export function InvitesBento() {
   const totalLinks = data?.links?.length ?? 0
   const { totalGuests, confirmed, attended } = (data?.links ?? []).reduce(
     (acc, link) => {
-      acc.totalGuests += link.guests.length
-      link.guests.forEach((g) => {
-        const isAttended = !!g.attended_at
-        if (isAttended) acc.attended++
-        if (isAttended || g.status === 'confirmed') acc.confirmed++
-      })
+      const funnel = computeFunnel(link.guests, !!link.revoked_at)
+      acc.totalGuests += funnel.registrations
+      acc.confirmed   += funnel.confirmed
+      acc.attended    += funnel.attended
       return acc
     },
     { totalGuests: 0, confirmed: 0, attended: 0 },

--- a/app/(dashboard)/profile/components/InvitesBento.tsx
+++ b/app/(dashboard)/profile/components/InvitesBento.tsx
@@ -29,7 +29,7 @@ export function InvitesBento() {
   const totalLinks = data?.links?.length ?? 0
   const { totalGuests, confirmed, attended } = (data?.links ?? []).reduce(
     (acc, link) => {
-      const funnel = computeFunnel(link.guests, !!link.revoked_at)
+      const funnel = computeFunnel(link.guests, link.revoked_at !== null)
       acc.totalGuests += funnel.registrations
       acc.confirmed   += funnel.confirmed
       acc.attended    += funnel.attended

--- a/app/(dashboard)/profile/components/InvitesSection.tsx
+++ b/app/(dashboard)/profile/components/InvitesSection.tsx
@@ -14,19 +14,21 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { apiClient } from '@/lib/apiClient'
+import { formatDate } from '@/lib/format'
+import { guestStatus, computeFunnel, type GuestRow as InviteGuestRow } from '@/lib/invites'
+import { REG_STATUS_STYLES } from '../types'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-type GuestRow = {
-  id:          string
-  name:        string
-  email:       string
-  status:       string
-  attended_at:  string | null
-  cancelled_at: string | null
-  created_at:   string
+type GuestRow = InviteGuestRow & {
+  id:         string
+  name:       string
+  email:      string
+  created_at: string
 }
 
 type ShareLink = {
@@ -45,26 +47,7 @@ type ApiResponse = { links: ShareLink[]; total: number }
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function fmt(d: string | null): string {
-  if (!d) return '—'
-  return new Date(d).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
-}
-
-// Precedence: an already-attended or confirmed guest keeps that status even
-// if the link is later revoked — revocation only blocks guests who never
-// used it (they show as 'cancelled').
-function guestStatus(g: GuestRow, linkRevoked: boolean): 'pending' | 'confirmed' | 'attended' | 'cancelled' {
-  if (g.attended_at !== null) return 'attended'
-  if (g.cancelled_at !== null) return 'cancelled'
-  if (g.status === 'confirmed') return 'confirmed'
-  if (linkRevoked) return 'cancelled'
-  return 'pending'
-}
-
-const STATUS_STYLE: Record<string, { bg: string; color: string }> = {
-  pending:   { bg: 'rgba(242,204,143,0.3)', color: '#7a5c00' },
-  confirmed: { bg: 'rgba(61,64,91,0.08)',   color: '#3d405b' },
-  attended:  { bg: 'rgba(129,178,154,0.2)', color: '#2d6a4f' },
-  cancelled: { bg: 'rgba(188,71,73,0.12)',  color: '#bc4749' },
+  return d ? formatDate(d) : '—'
 }
 
 export const INVITES_MIN_HEIGHT = 240
@@ -205,47 +188,49 @@ export function InvitesSection() {
       {/* Filter bar */}
       <div className="flex flex-wrap gap-2">
         {/* Event filter */}
-        <select
-          value={filterEvent}
-          onChange={e => setFilterEvent(e.target.value)}
-          className="text-xs rounded-lg border px-2 py-1 outline-none"
-          style={{ borderColor: 'var(--border-default)', color: 'var(--text-primary)', backgroundColor: 'var(--bg-card)' }}
-        >
-          <option value="all">{t('profile.invites.filterByEvent')}</option>
-          {eventOptions.map(([id, title]) => (
-            <option key={id} value={id}>{title}</option>
-          ))}
-        </select>
+        <Select value={filterEvent} onValueChange={setFilterEvent}>
+          <SelectTrigger className="w-auto h-7 py-1 text-xs">
+            <SelectValue placeholder={t('profile.invites.filterByEvent')} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t('profile.invites.filterByEvent')}</SelectItem>
+            {eventOptions.map(([id, title]) => (
+              <SelectItem key={id} value={id}>{title}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
         {/* Status pills */}
-        {(['all', 'pending', 'confirmed', 'attended', 'cancelled'] as const).map(s => (
-          <button
-            key={s}
-            onClick={() => setFilterStatus(s)}
-            className="text-[11px] font-semibold px-2.5 py-1 rounded-full transition-all"
-            style={{
-              backgroundColor: filterStatus === s ? 'var(--brand-teal)' : 'rgba(0,0,0,0.05)',
-              color: filterStatus === s ? 'white' : 'var(--text-secondary)',
-            }}
-          >
-            {s === 'all' ? t('profile.invites.filterByStatus') : s}
-          </button>
-        ))}
+        <ToggleGroup
+          type="single"
+          size="sm"
+          value={filterStatus}
+          onValueChange={v => v && setFilterStatus(v)}
+        >
+          {(['all', 'pending', 'confirmed', 'attended', 'cancelled'] as const).map(s => (
+            <ToggleGroupItem key={s} value={s}>
+              {s === 'all' ? t('profile.invites.filterByStatus') : s}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
 
         {/* Method pills */}
-        {(['all', 'native', 'clipboard'] as const).map(m => (
-          <button
-            key={m}
-            onClick={() => setFilterMethod(m)}
-            className="text-[11px] font-semibold px-2.5 py-1 rounded-full transition-all"
-            style={{
-              backgroundColor: filterMethod === m ? 'var(--brand-forest)' : 'rgba(0,0,0,0.05)',
-              color: filterMethod === m ? 'white' : 'var(--text-secondary)',
-            }}
-          >
-            {m === 'all' ? t('profile.invites.filterByMethod') : t(`profile.invites.shareMethod.${m}` as any)}
-          </button>
-        ))}
+        <ToggleGroup
+          type="single"
+          size="sm"
+          value={filterMethod}
+          onValueChange={v => v && setFilterMethod(v)}
+        >
+          {(['all', 'native', 'clipboard'] as const).map(m => (
+            <ToggleGroupItem
+              key={m}
+              value={m}
+              className="data-[state=on]:bg-[var(--brand-forest)]"
+            >
+              {m === 'all' ? t('profile.invites.filterByMethod') : t(`profile.invites.shareMethod.${m}`)}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
 
         {/* Date range */}
         <input
@@ -284,8 +269,7 @@ export function InvitesSection() {
           {filtered.map(link => {
             const guests    = link.guests
             const revoked   = !!link.revoked_at
-            const confirmed = guests.filter(g => ['confirmed', 'attended'].includes(guestStatus(g, revoked))).length
-            const attended  = guests.filter(g => g.attended_at !== null).length
+            const { confirmed, attended } = computeFunnel(guests, revoked)
             const isOpen    = !!expanded[link.id]
 
             return (
@@ -300,7 +284,7 @@ export function InvitesSection() {
                     <p className="text-sm font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
                       {link.event.title}
                       {revoked && (
-                        <span className="ml-2 px-2 py-0.5 rounded-full text-[10px] font-semibold align-middle" style={STATUS_STYLE.cancelled}>
+                        <span className="ml-2 px-2 py-0.5 rounded-full text-[10px] font-semibold align-middle" style={REG_STATUS_STYLES.cancelled}>
                           {t('profile.invites.revoked')}
                         </span>
                       )}
@@ -386,7 +370,7 @@ export function InvitesSection() {
                                 <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{g.email}</td>
                                 <td className="px-4 py-2">
                                   <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold"
-                                    style={STATUS_STYLE[s]}>{s}</span>
+                                    style={REG_STATUS_STYLES[s]}>{s}</span>
                                 </td>
                                 <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{fmt(g.created_at)}</td>
                                 <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{fmt(g.attended_at)}</td>
@@ -406,7 +390,7 @@ export function InvitesSection() {
                             <div className="flex items-center justify-between gap-2">
                               <p className="text-xs font-medium truncate" style={{ color: 'var(--text-primary)' }}>{g.name}</p>
                               <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold shrink-0"
-                                style={STATUS_STYLE[s]}>{s}</span>
+                                style={REG_STATUS_STYLES[s]}>{s}</span>
                             </div>
                             <p className="text-[11px] truncate" style={{ color: 'var(--text-secondary)' }}>{g.email}</p>
                             <p className="text-[10px]" style={{ color: 'var(--text-secondary)' }}>

--- a/app/(dashboard)/profile/components/InvitesSection.tsx
+++ b/app/(dashboard)/profile/components/InvitesSection.tsx
@@ -47,7 +47,7 @@ type ApiResponse = { links: ShareLink[]; total: number }
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function fmt(d: string | null): string {
-  return d ? formatDate(d) : '—'
+  return d !== null ? formatDate(d) : '—'
 }
 
 export const INVITES_MIN_HEIGHT = 240
@@ -205,7 +205,7 @@ export function InvitesSection() {
           type="single"
           size="sm"
           value={filterStatus}
-          onValueChange={v => v && setFilterStatus(v)}
+          onValueChange={v => { if (v !== '') setFilterStatus(v) }}
         >
           {(['all', 'pending', 'confirmed', 'attended', 'cancelled'] as const).map(s => (
             <ToggleGroupItem key={s} value={s}>
@@ -219,7 +219,7 @@ export function InvitesSection() {
           type="single"
           size="sm"
           value={filterMethod}
-          onValueChange={v => v && setFilterMethod(v)}
+          onValueChange={v => { if (v !== '') setFilterMethod(v) }}
         >
           {(['all', 'native', 'clipboard'] as const).map(m => (
             <ToggleGroupItem

--- a/app/(dashboard)/profile/types.ts
+++ b/app/(dashboard)/profile/types.ts
@@ -183,4 +183,8 @@ export const REG_STATUS_STYLES: Record<string, { bg: string; color: string }> = 
   approved:  { bg: 'rgba(129,178,154,0.15)', color: '#2d6a4f' },
   denied:    { bg: 'rgba(188,71,73,0.10)', color: '#bc4749' },
   cancelled: { bg: 'rgba(138,133,119,0.15)', color: '#5c5950' },
+  // Guest-invite specific states (InvitesSection/InvitesBento) — reuse the
+  // shared `cancelled` entry above for revoked/self-cancelled guests.
+  confirmed: { bg: 'rgba(61,64,91,0.08)',   color: '#3d405b' },
+  attended:  { bg: 'rgba(129,178,154,0.2)', color: '#2d6a4f' },
 }

--- a/components/ui/toggle-group.tsx
+++ b/components/ui/toggle-group.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
+import { type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: "default",
+  variant: "default",
+})
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, children, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn("flex items-center justify-center gap-1", className)}
+    {...props}
+  >
+    <ToggleGroupContext.Provider value={{ variant, size }}>
+      {children}
+    </ToggleGroupContext.Provider>
+  </ToggleGroupPrimitive.Root>
+))
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleVariants>
+>(({ className, children, variant, size, ...props }, ref) => {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+})
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
+
+export { ToggleGroup, ToggleGroupItem }

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import * as TogglePrimitive from "@radix-ui/react-toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center rounded-full font-semibold transition-all hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2 text-[var(--text-secondary)] bg-[rgba(0,0,0,0.05)] data-[state=on]:text-white data-[state=on]:bg-[var(--brand-teal)]",
+  {
+    variants: {
+      variant: {
+        default: "",
+        outline:
+          "border border-[var(--border-default)] bg-transparent",
+      },
+      size: {
+        default: "h-8 px-3 text-xs",
+        sm: "h-6 px-2.5 text-[11px]",
+        lg: "h-10 px-4 text-sm",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+))
+
+Toggle.displayName = TogglePrimitive.Root.displayName
+
+export { Toggle, toggleVariants }

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #609 | `dev/2607-DEV-609` | `components/ui/switch.tsx` (new), `lib/roles.ts` (new), `lib/i18n/domains/profile.ts`, `app/(dashboard)/profile/components/EmailPrefsSection.tsx`, `AboInfoContent.tsx`, `PersonalDetailsContent.tsx`, `TravelDocContent.tsx`, `TravelDocDrawerForm.tsx`, `PersonalDrawerForm.tsx`, `AdminSection.tsx`, `CalendarSection.tsx`; migration: no | 2026-07-25T14:00:00Z |
+| #610 | `dev/2607-DEV-610` | `lib/invites.ts` (new), `components/ui/toggle-group.tsx` (new), `app/(dashboard)/profile/components/InvitesSection.tsx`, `InvitesBento.tsx`, `app/(dashboard)/profile/types.ts`; migration: no | 2026-07-25T00:00:00Z |

--- a/lib/invites.ts
+++ b/lib/invites.ts
@@ -1,0 +1,37 @@
+// ── lib/invites.ts — guest-invite status derivation ──────────────────────────
+// Single source of truth for guest status + funnel counts, shared by
+// InvitesSection.tsx (member-facing table) and InvitesBento.tsx (dashboard stat tile).
+
+export type GuestRow = {
+  status:       string
+  attended_at:  string | null
+  cancelled_at: string | null
+}
+
+export type GuestStatus = 'pending' | 'confirmed' | 'attended' | 'cancelled'
+
+// Precedence: an already-attended or confirmed guest keeps that status even
+// if the link is later revoked, or the guest self-cancels after confirming —
+// only a guest with no terminal state yet is affected by link revocation.
+export function guestStatus(g: GuestRow, linkRevoked: boolean): GuestStatus {
+  if (g.attended_at !== null) return 'attended'
+  if (g.cancelled_at !== null) return 'cancelled'
+  if (g.status === 'confirmed') return 'confirmed'
+  if (linkRevoked) return 'cancelled'
+  return 'pending'
+}
+
+export type Funnel = { registrations: number; confirmed: number; attended: number }
+
+export function computeFunnel(guests: GuestRow[], linkRevoked: boolean): Funnel {
+  return guests.reduce<Funnel>(
+    (acc, g) => {
+      acc.registrations++
+      const s = guestStatus(g, linkRevoked)
+      if (s === 'confirmed' || s === 'attended') acc.confirmed++
+      if (s === 'attended') acc.attended++
+      return acc
+    },
+    { registrations: 0, confirmed: 0, attended: 0 },
+  )
+}

--- a/lib/invites.ts
+++ b/lib/invites.ts
@@ -10,9 +10,10 @@ export type GuestRow = {
 
 export type GuestStatus = 'pending' | 'confirmed' | 'attended' | 'cancelled'
 
-// Precedence: an already-attended or confirmed guest keeps that status even
-// if the link is later revoked, or the guest self-cancels after confirming —
-// only a guest with no terminal state yet is affected by link revocation.
+// Precedence: attended is terminal and unaffected by cancellation or link
+// revocation. Below that, self-cancellation (cancelled_at) always overrides
+// a confirmed status. Link revocation only affects guests with no terminal
+// state yet (never confirmed, cancelled, or attended).
 export function guestStatus(g: GuestRow, linkRevoked: boolean): GuestStatus {
   if (g.attended_at !== null) return 'attended'
   if (g.cancelled_at !== null) return 'cancelled'

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@radix-ui/react-slot": "^1.3.3",
         "@radix-ui/react-switch": "^1.3.7",
         "@radix-ui/react-tabs": "^1.1.3",
+        "@radix-ui/react-toggle": "^1.1.18",
+        "@radix-ui/react-toggle-group": "^1.1.19",
         "@radix-ui/react-tooltip": "^1.2.14",
         "@react-email/components": "^1.0.12",
         "@react-email/render": "^2.0.6",
@@ -1973,6 +1975,361 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+      "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+      "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-toggle": "1.1.18",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tooltip": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.14.tgz",
@@ -2426,6 +2783,21 @@
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "@radix-ui/react-slot": "^1.3.3",
     "@radix-ui/react-switch": "^1.3.7",
     "@radix-ui/react-tabs": "^1.1.3",
+    "@radix-ui/react-toggle": "^1.1.18",
+    "@radix-ui/react-toggle-group": "^1.1.19",
     "@radix-ui/react-tooltip": "^1.2.14",
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.6",


### PR DESCRIPTION
## Summary
- `lib/invites.ts` (new): `guestStatus` + `computeFunnel`, single source of truth for guest status precedence — replaces three near-duplicate copies split across `InvitesSection.tsx` and `InvitesBento.tsx`.
- **Behavior fix, not just refactor**: `InvitesBento`'s funnel count previously ignored `cancelled_at` (T4 self-cancel) and `revoked_at` (T2 revoke) entirely, overcounting confirmed guests. It now shares the exact precedence `InvitesSection` already used correctly, so the Bento confirmed-count may *decrease* for profiles with self-cancelled or link-revoked confirmed guests — this is the intended fix, please confirm during review.
- `InvitesSection`: local `fmt()`/`guestStatus()`/`STATUS_STYLE` removed in favor of `lib/format.formatDate` (bg-BG/Europe/Sofia — avoids the browser-locale hydration-mismatch class of bug `lib/format.ts`'s own header warns about) and `REG_STATUS_STYLES`.
- Native `<select>` event filter → shadcn `Select`; hand-rolled filter pill buttons → shadcn `ToggleGroup` (new component, installed via `npx shadcn add`). `Tabs` was ruled out per `docs/ai/GOTCHAS.md`'s no-`defaultValue`/URL-sync requirement, which would be disproportionate for filter pills with no deep-link need.

## Reviewer callout
`REG_STATUS_STYLES.cancelled` (gray, `#5c5950`) is now shared by both trip-registration-cancelled (`shared.tsx`) and guest-invite-cancelled/revoked. Invites previously used a distinct red (`#bc4749`) for this state, matching the "revoked" pill styling elsewhere in the same component. Folding into the shared style is the ticket's explicit ask ("fold `STATUS_STYLE` into `REG_STATUS_STYLES`"), but it is a visible color change for revoked/self-cancelled guest rows — flagging for a sanity check rather than resolving silently.

Native date `<input>` fields (from/to filters) were kept as-is per the ticket's own text ("acceptable on mobile — flag for reviewer at impl time").

## Test plan
- [x] `npm run check-types` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 207/207 passing
- [x] `npm run build` — succeeds, `/profile/invites` route compiles
- [ ] Vercel preview: confirm `/profile/invites` renders correctly at 390×812 (Select, ToggleGroup filters, expand/collapse, revoke dialog)
- [ ] Vercel preview: confirm funnel numbers on `/profile` bento tile vs `/profile/invites` table match (post-fix, should now agree)
- [ ] `/code-review low` pass (not yet run — the skill can't be invoked from an agent session; please trigger manually before marking ready)

Closes #610

## Session State
**Status:** DONE
**Completed:**
- [x] lib/invites.ts created (guestStatus, computeFunnel)
- [x] InvitesSection.tsx and InvitesBento.tsx consolidated onto shared lib
- [x] REG_STATUS_STYLES extended (confirmed/attended)
- [x] Native select -> shadcn Select; filter pills -> shadcn ToggleGroup
- [x] Local lint/types/tests/build all green
- [x] CodeRabbit review (4 comments) applied in one batched commit (885f95e), all 4 threads resolved
**Next:** Vercel preview check at 390x812 (Select/ToggleGroup filters, expand/collapse, revoke dialog); confirm bento funnel numbers now match the invites-table numbers post-fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added streamlined single-select controls for filtering invites by event, status, and method.
  - Added consistent invite status displays, including confirmed, attended, cancelled, and revoked states.

- **Improvements**
  - Invite funnel totals now consistently show registrations, confirmations, and attendance.
  - Standardized date formatting and empty-value displays across invite views.
  - Updated guest tables, cards, and invite summaries for clearer status presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
