### PR TITLE
[2607-DEV-665] Profile bento standardization 1: card shell, header, skeletons, elevation

### DIFF
--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -3,7 +3,7 @@
 import { memo, useState } from 'react'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { IdCard } from 'lucide-react'
+import { IdCard, Check } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { getRoleColors } from '@/lib/role-colors'
 import { BentoHeader } from './BentoHeader'
@@ -196,7 +196,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <p className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>{t('profile.aboHash')}</p>
             <p className="text-sm font-medium font-mono" style={{ color: 'var(--text-primary)' }}>
-              {aboNumber} <span style={{ color: '#2d6a4f' }}>✓</span>
+              {aboNumber} <Check size={14} className="inline-block align-text-bottom" style={{ color: '#2d6a4f' }} />
             </p>
           </div>
           <div style={{ borderTop: '1px solid var(--border-default)', paddingTop: 10 }}>

--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -142,7 +142,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
 
   if (role === 'guest' && profileIsPending) {
     return (
-      <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+      <div>
         <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-5 pr-24" style={{ color: 'var(--brand-crimson)' }}>
           {t('profile.tile.aboInfo')}
         </p>
@@ -181,7 +181,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
     /stale|old|outdated|re.import/i.test(verRequest.admin_note)
 
   return (
-    <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+    <div>
       <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-5 pr-24" style={{ color: 'var(--brand-crimson)' }}>
         {t('profile.tile.aboInfo')}
       </p>

--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -7,6 +7,7 @@ import { IdCard } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { getRoleColors } from '@/lib/role-colors'
 import { BentoHeader } from './BentoHeader'
+import { BentoSkeleton } from './BentoSkeleton'
 import { type SpouseLinkRequest } from '../types'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
@@ -146,10 +147,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
     return (
       <div>
         <BentoHeader icon={IdCard} title={t('profile.tile.aboInfo')} />
-        <div className="space-y-3 animate-pulse">
-          <div className="h-4 rounded-lg w-3/4" style={{ backgroundColor: 'var(--border-default)' }} />
-          <div className="h-4 rounded-lg w-1/2" style={{ backgroundColor: 'var(--border-default)' }} />
-        </div>
+        <BentoSkeleton rows={2} />
       </div>
     )
   }

--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -3,8 +3,10 @@
 import { memo, useState } from 'react'
 import Link from 'next/link'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { IdCard } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { getRoleColors } from '@/lib/role-colors'
+import { BentoHeader } from './BentoHeader'
 import { type SpouseLinkRequest } from '../types'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
@@ -143,9 +145,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
   if (role === 'guest' && profileIsPending) {
     return (
       <div>
-        <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-5 pr-24" style={{ color: 'var(--brand-crimson)' }}>
-          {t('profile.tile.aboInfo')}
-        </p>
+        <BentoHeader icon={IdCard} title={t('profile.tile.aboInfo')} />
         <div className="space-y-3 animate-pulse">
           <div className="h-4 rounded-lg w-3/4" style={{ backgroundColor: 'var(--border-default)' }} />
           <div className="h-4 rounded-lg w-1/2" style={{ backgroundColor: 'var(--border-default)' }} />
@@ -182,9 +182,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
 
   return (
     <div>
-      <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-5 pr-24" style={{ color: 'var(--brand-crimson)' }}>
-        {t('profile.tile.aboInfo')}
-      </p>
+      <BentoHeader icon={IdCard} title={t('profile.tile.aboInfo')} />
 
       {aboMode === 'confirmed' && (
         <div className="space-y-3">

--- a/app/(dashboard)/profile/components/AdminSection.tsx
+++ b/app/(dashboard)/profile/components/AdminSection.tsx
@@ -5,7 +5,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 export function AdminSection() {
   const { t } = useLanguage()
   return (
-    <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+    <div>
       <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-4 pr-24" style={{ color: 'var(--brand-teal)' }}>{t('profile.adminTools')}</p>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(8, minmax(0, 1fr))', gap: '12px' }}>
         <a href="/admin"

--- a/app/(dashboard)/profile/components/AdminSection.tsx
+++ b/app/(dashboard)/profile/components/AdminSection.tsx
@@ -1,12 +1,14 @@
 'use client'
 
+import { Shield } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { BentoHeader } from './BentoHeader'
 
 export function AdminSection() {
   const { t } = useLanguage()
   return (
     <div>
-      <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-4 pr-24" style={{ color: 'var(--brand-teal)' }}>{t('profile.adminTools')}</p>
+      <BentoHeader icon={Shield} title={t('profile.adminTools')} tone="teal" />
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(8, minmax(0, 1fr))', gap: '12px' }}>
         <a href="/admin"
           style={{ gridColumn: 'span 2', backgroundColor: 'var(--brand-forest)', color: 'var(--brand-parchment)' }}

--- a/app/(dashboard)/profile/components/BentoEmpty.tsx
+++ b/app/(dashboard)/profile/components/BentoEmpty.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export function BentoEmpty({ message, hint }: { message: string; hint?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center text-center py-6">
+      <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{message}</p>
+      {hint && (
+        <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>{hint}</p>
+      )}
+    </div>
+  )
+}

--- a/app/(dashboard)/profile/components/BentoGrid.tsx
+++ b/app/(dashboard)/profile/components/BentoGrid.tsx
@@ -23,7 +23,7 @@ import { SortableBento, DragHandle } from './SortableBento'
 // loaded by ProfileClient.tsx (next/dynamic, ssr:false) so mobile never
 // pulls this chunk in.
 
-type BentoEntry = { colSpan: number; minHeight: number; node: React.ReactNode }
+type BentoEntry = { colSpan: number; minHeight: number; node: React.ReactNode; cardStyle?: React.CSSProperties }
 
 function SortableBentoItem({
   id,
@@ -60,6 +60,7 @@ function SortableBentoItem({
         opacity: isDragging ? 0.5 : 1,
       }}
       dragHandle={<DragHandle ref={setActivatorNodeRef} {...attributes} {...listeners} />}
+      cardStyle={entry.cardStyle}
     >
       {entry.node}
     </SortableBento>
@@ -95,7 +96,7 @@ export default function BentoGrid({
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <SortableContext items={orderedBentos.map(b => b.id)} strategy={rectSortingStrategy}>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, minmax(0, 1fr))', gap: '12px' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(12, minmax(0, 1fr))', gap: 'var(--bento-gap)' }}>
           {orderedBentos.map(({ id, entry }) => (
             <SortableBentoItem
               key={id}

--- a/app/(dashboard)/profile/components/BentoHeader.tsx
+++ b/app/(dashboard)/profile/components/BentoHeader.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import { Eyebrow } from '@/components/bento/BentoCard'
+
+type BentoHeaderProps = {
+  icon: LucideIcon
+  title: string
+  subtitle?: string
+  action?: ReactNode
+  tone?: 'crimson' | 'teal'
+}
+
+// Shared eyebrow header for all profile bentos. The responsive right gutter
+// (pr-10 mobile, pr-20 desktop) clears the collapse/drag chrome anchored to
+// the card's top-right corner — mobile hides the drag handle, so only the
+// ~40px chevron needs clearing there.
+export function BentoHeader({ icon: Icon, title, subtitle, action, tone = 'crimson' }: BentoHeaderProps) {
+  const color = tone === 'teal' ? 'var(--brand-teal)' : 'var(--brand-crimson)'
+  return (
+    <div className="flex items-start justify-between mb-4 pr-10 md:pr-20">
+      <div className="flex items-start gap-2 min-w-0">
+        <Icon size={14} className="flex-shrink-0 mt-0.5" style={{ color }} />
+        <div className="min-w-0">
+          <Eyebrow style={{ color }}>{title}</Eyebrow>
+          {subtitle && (
+            <p className="text-xs mt-0.5 truncate" style={{ color: 'var(--text-secondary)' }}>
+              {subtitle}
+            </p>
+          )}
+        </div>
+      </div>
+      {action && <div className="flex-shrink-0">{action}</div>}
+    </div>
+  )
+}

--- a/app/(dashboard)/profile/components/BentoSkeleton.tsx
+++ b/app/(dashboard)/profile/components/BentoSkeleton.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { Skeleton } from '@/components/ui/skeleton'
+
+// Body-only loading state — the card shell and BentoHeader stay mounted
+// above this, so a loading bento never disappears then pops back.
+export function BentoSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      {Array.from({ length: rows }, (_, i) => (
+        <Skeleton key={i} className="h-4" style={{ width: i === rows - 1 ? '60%' : '100%' }} />
+      ))}
+    </div>
+  )
+}

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -17,8 +17,6 @@ import {
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
 
-export const CALENDAR_MIN_HEIGHT = 160
-
 const DEFAULT_CALENDAR_NAME = 'teamenjoyVD'
 
 export function CalendarSection({ profileId }: { profileId: string }) {
@@ -85,7 +83,7 @@ export function CalendarSection({ profileId }: { profileId: string }) {
   }, [displayName, saveDisplayName])
 
   return (
-    <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+    <div>
       <p className="text-xs font-semibold tracking-widest uppercase mb-1" style={{ color: 'var(--text-secondary)' }}>{t('profile.calSub')}</p>
       <p className="text-xs mb-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{t('profile.calSubDesc')}</p>
       <p className="text-xs mb-3 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{t('profile.calSubInstructions')}</p>

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -82,7 +82,7 @@ export function CalendarSection({ profileId }: { profileId: string }) {
     saveDisplayName.mutate(displayName)
   }, [displayName, saveDisplayName])
 
-  if (calLoading) {
+  if (calLoading === true) {
     return (
       <div>
         <BentoHeader icon={CalendarIcon} title={t('profile.calSub')} />
@@ -99,7 +99,7 @@ export function CalendarSection({ profileId }: { profileId: string }) {
 
       {/* Feed URL row */}
       <div className="flex items-center gap-2">
-        <input readOnly value={calData?.url ?? ''} placeholder={t('profile.calendar.generating')}
+        <input readOnly value={calData?.url ?? ''} placeholder={t('profile.calGenerating')}
           className="flex-1 min-w-0 border rounded-xl px-3 py-2 text-xs font-mono truncate"
           style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)', backgroundColor: 'var(--bg-global)' }} />
         <button

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -19,8 +19,6 @@ import {
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
 
-const DEFAULT_CALENDAR_NAME = 'teamenjoyVD'
-
 export function CalendarSection({ profileId }: { profileId: string }) {
   const { t } = useLanguage()
   const queryClient = useQueryClient()

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Copy, Check, RefreshCw, Save, Calendar as CalendarIcon } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { BentoHeader } from './BentoHeader'
+import { BentoSkeleton } from './BentoSkeleton'
 import {
   AlertDialog,
   AlertDialogContent,
@@ -40,7 +41,7 @@ export function CalendarSection({ profileId }: { profileId: string }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fullProfile?.id, savedDisplayName])
 
-  const { data: calData, refetch: refetchCal } = useQuery<{ url: string }>({
+  const { data: calData, isLoading: calLoading, refetch: refetchCal } = useQuery<{ url: string }>({
     queryKey: ['cal-feed-token'],
     queryFn: () => apiClient('/api/calendar/feed-token'),
     enabled: !!profileId,
@@ -82,6 +83,15 @@ export function CalendarSection({ profileId }: { profileId: string }) {
   const handleSaveName = useCallback(() => {
     saveDisplayName.mutate(displayName)
   }, [displayName, saveDisplayName])
+
+  if (calLoading) {
+    return (
+      <div>
+        <BentoHeader icon={CalendarIcon} title={t('profile.calSub')} />
+        <BentoSkeleton rows={2} />
+      </div>
+    )
+  }
 
   return (
     <div>

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -92,7 +92,7 @@ export function CalendarSection({ profileId }: { profileId: string }) {
 
       {/* Feed URL row */}
       <div className="flex items-center gap-2">
-        <input readOnly value={calData?.url ?? ''} placeholder="Generating…"
+        <input readOnly value={calData?.url ?? ''} placeholder={t('profile.calendar.generating')}
           className="flex-1 min-w-0 border rounded-xl px-3 py-2 text-xs font-mono truncate"
           style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)', backgroundColor: 'var(--bg-global)' }} />
         <button

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useCallback, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Copy, Check, RefreshCw, Save } from 'lucide-react'
+import { Copy, Check, RefreshCw, Save, Calendar as CalendarIcon } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { BentoHeader } from './BentoHeader'
 import {
   AlertDialog,
   AlertDialogContent,
@@ -84,7 +85,7 @@ export function CalendarSection({ profileId }: { profileId: string }) {
 
   return (
     <div>
-      <p className="text-xs font-semibold tracking-widest uppercase mb-1" style={{ color: 'var(--text-secondary)' }}>{t('profile.calSub')}</p>
+      <BentoHeader icon={CalendarIcon} title={t('profile.calSub')} />
       <p className="text-xs mb-1 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{t('profile.calSubDesc')}</p>
       <p className="text-xs mb-3 leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{t('profile.calSubInstructions')}</p>
 

--- a/app/(dashboard)/profile/components/EmailPrefsSection.tsx
+++ b/app/(dashboard)/profile/components/EmailPrefsSection.tsx
@@ -8,8 +8,6 @@ import { type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '../types'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
 
-export const EMAIL_PREFS_MIN_HEIGHT = 280
-
 type PrefKey = keyof NotificationPrefs
 
 interface PrefRow {
@@ -63,7 +61,7 @@ export function EmailPrefsSection() {
   }, [save.mutate])
 
   return (
-    <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+    <div>
       {/* Eyebrow */}
       <div className="flex items-center justify-between mb-4">
         <p className="text-xs font-semibold tracking-[0.25em] uppercase" style={{ color: 'var(--brand-crimson)' }}>

--- a/app/(dashboard)/profile/components/EmailPrefsSection.tsx
+++ b/app/(dashboard)/profile/components/EmailPrefsSection.tsx
@@ -2,8 +2,10 @@
 
 import { useState, useCallback, useEffect } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Mail } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Switch } from '@/components/ui/switch'
+import { BentoHeader } from './BentoHeader'
 import { type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '../types'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
@@ -62,24 +64,24 @@ export function EmailPrefsSection() {
 
   return (
     <div>
-      {/* Eyebrow */}
-      <div className="flex items-center justify-between mb-4">
-        <p className="text-xs font-semibold tracking-[0.25em] uppercase" style={{ color: 'var(--brand-crimson)' }}>
-          {t('profile.emailNotifications')}
-        </p>
-        <div className="flex items-center gap-2">
-          {saved && (
-            <span className="text-xs font-medium" style={{ color: 'var(--brand-forest)' }}>
-              {t('profile.saved')}
-            </span>
-          )}
-          {save.isError && (
-            <span className="text-xs font-medium" style={{ color: 'var(--brand-crimson)' }}>
-              {t('profile.error')}
-            </span>
-          )}
-        </div>
-      </div>
+      <BentoHeader
+        icon={Mail}
+        title={t('profile.emailNotifications')}
+        action={
+          <div className="flex items-center gap-2">
+            {saved && (
+              <span className="text-xs font-medium" style={{ color: 'var(--brand-forest)' }}>
+                {t('profile.saved')}
+              </span>
+            )}
+            {save.isError && (
+              <span className="text-xs font-medium" style={{ color: 'var(--brand-crimson)' }}>
+                {t('profile.error')}
+              </span>
+            )}
+          </div>
+        }
+      />
 
       {/* Rows */}
       <div className="space-y-3">

--- a/app/(dashboard)/profile/components/EmailPrefsSection.tsx
+++ b/app/(dashboard)/profile/components/EmailPrefsSection.tsx
@@ -6,6 +6,7 @@ import { Mail } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Switch } from '@/components/ui/switch'
 import { BentoHeader } from './BentoHeader'
+import { BentoSkeleton } from './BentoSkeleton'
 import { type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '../types'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
@@ -29,7 +30,7 @@ export function EmailPrefsSection() {
   const { t } = useLanguage()
   const qc = useQueryClient()
 
-  const { data: profile } = useProfile()
+  const { data: profile, isLoading } = useProfile()
   const prefs = profile?.notification_prefs ?? DEFAULT_NOTIFICATION_PREFS
 
   const [local, setLocal] = useState<NotificationPrefs>(prefs)
@@ -61,6 +62,15 @@ export function EmailPrefsSection() {
       return next
     })
   }, [save.mutate])
+
+  if (isLoading) {
+    return (
+      <div>
+        <BentoHeader icon={Mail} title={t('profile.emailNotifications')} />
+        <BentoSkeleton rows={5} />
+      </div>
+    )
+  }
 
   return (
     <div>

--- a/app/(dashboard)/profile/components/InvitesBento.tsx
+++ b/app/(dashboard)/profile/components/InvitesBento.tsx
@@ -48,49 +48,47 @@ export function InvitesBento() {
   ]
 
   return (
-    <div>
-      <div className="flex flex-col gap-4 h-full">
-        <BentoHeader icon={UserPlus} title={t('profile.bento.invites')} />
+    <div className="flex flex-col gap-4 h-full">
+      <BentoHeader icon={UserPlus} title={t('profile.bento.invites')} />
 
-        {/* Stat chips */}
-        {isLoading ? (
-          <div className="grid grid-cols-2 gap-2">
-            {[...Array(4)].map((_, i) => (
-              <div
-                key={i}
-                className="h-14 rounded-xl animate-pulse"
-                style={{ backgroundColor: 'rgba(0,0,0,0.06)' }}
-              />
-            ))}
-          </div>
-        ) : (
-          <div className="grid grid-cols-2 gap-2">
-            {stats.map(({ label, value }) => (
-              <div
-                key={label}
-                className="rounded-xl px-3 py-2 flex flex-col gap-0.5"
-                style={{ backgroundColor: 'rgba(0,0,0,0.04)' }}
-              >
-                <span className="text-xl font-bold tabular-nums" style={{ color: 'var(--text-primary)' }}>
-                  {value}
-                </span>
-                <span className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>
-                  {label}
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
+      {/* Stat chips */}
+      {isLoading ? (
+        <div className="grid grid-cols-2 gap-2">
+          {[...Array(4)].map((_, i) => (
+            <div
+              key={i}
+              className="h-14 rounded-xl animate-pulse"
+              style={{ backgroundColor: 'rgba(0,0,0,0.06)' }}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-2">
+          {stats.map(({ label, value }) => (
+            <div
+              key={label}
+              className="rounded-xl px-3 py-2 flex flex-col gap-0.5"
+              style={{ backgroundColor: 'rgba(0,0,0,0.04)' }}
+            >
+              <span className="text-xl font-bold tabular-nums" style={{ color: 'var(--text-primary)' }}>
+                {value}
+              </span>
+              <span className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>
+                {label}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
 
-        {/* CTA */}
-        <Link
-          href="/profile/invites"
-          className="mt-auto text-xs font-semibold px-3 py-2 rounded-xl transition-opacity hover:opacity-70 text-left block"
-          style={{ backgroundColor: 'rgba(0,0,0,0.05)', color: 'var(--text-primary)' }}
-        >
-          {t('profile.invites.viewAll')} →
-        </Link>
-      </div>
+      {/* CTA */}
+      <Link
+        href="/profile/invites"
+        className="mt-auto text-xs font-semibold px-3 py-2 rounded-xl transition-opacity hover:opacity-70 text-left block"
+        style={{ backgroundColor: 'rgba(0,0,0,0.05)', color: 'var(--text-primary)' }}
+      >
+        {t('profile.invites.viewAll')} →
+      </Link>
     </div>
   )
 }

--- a/app/(dashboard)/profile/components/InvitesBento.tsx
+++ b/app/(dashboard)/profile/components/InvitesBento.tsx
@@ -2,9 +2,11 @@
 
 import { useQuery } from '@tanstack/react-query'
 import Link from 'next/link'
+import { UserPlus } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { apiClient } from '@/lib/apiClient'
 import { computeFunnel, type GuestRow } from '@/lib/invites'
+import { BentoHeader } from './BentoHeader'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -48,10 +50,7 @@ export function InvitesBento() {
   return (
     <div>
       <div className="flex flex-col gap-4 h-full">
-        {/* Header */}
-        <p className="text-[10px] font-semibold tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>
-          {t('profile.bento.invites')}
-        </p>
+        <BentoHeader icon={UserPlus} title={t('profile.bento.invites')} />
 
         {/* Stat chips */}
         {isLoading ? (

--- a/app/(dashboard)/profile/components/InvitesBento.tsx
+++ b/app/(dashboard)/profile/components/InvitesBento.tsx
@@ -46,7 +46,7 @@ export function InvitesBento() {
   ]
 
   return (
-    <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+    <div>
       <div className="flex flex-col gap-4 h-full">
         {/* Header */}
         <p className="text-[10px] font-semibold tracking-widest uppercase" style={{ color: 'var(--text-secondary)' }}>

--- a/app/(dashboard)/profile/components/InvitesSection.tsx
+++ b/app/(dashboard)/profile/components/InvitesSection.tsx
@@ -50,8 +50,6 @@ function fmt(d: string | null): string {
   return d !== null ? formatDate(d) : '—'
 }
 
-export const INVITES_MIN_HEIGHT = 240
-
 // ── Component ────────────────────────────────────────────────────────────────
 
 export function InvitesSection() {

--- a/app/(dashboard)/profile/components/ParticipationSection.tsx
+++ b/app/(dashboard)/profile/components/ParticipationSection.tsx
@@ -9,8 +9,6 @@ import { type EventRoleRequest, VARIABLE_CAP, REG_STATUS_STYLES } from '../types
 import { ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
 
-export const PARTICIPATION_MIN_HEIGHT = 280
-
 export function ParticipationSection({ profileId, role }: { profileId: string; role: string }) {
   const { t } = useLanguage()
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -23,7 +21,7 @@ export function ParticipationSection({ profileId, role }: { profileId: string; r
   })
 
   if (isLoading) {
-    return <div className="rounded-2xl animate-pulse h-full" style={{ backgroundColor: 'var(--border-default)' }} />
+    return <div className="animate-pulse h-full rounded-lg" style={{ backgroundColor: 'var(--border-default)' }} />
   }
 
   const roles = eventRolesData ?? []
@@ -52,7 +50,7 @@ export function ParticipationSection({ profileId, role }: { profileId: string; r
 
   return (
     <>
-      <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+      <div>
         <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-6 pr-24" style={{ color: 'var(--brand-crimson)' }}>{t('profile.participation')}</p>
         {roles.length === 0 ? (
           <div className="space-y-1">

--- a/app/(dashboard)/profile/components/ParticipationSection.tsx
+++ b/app/(dashboard)/profile/components/ParticipationSection.tsx
@@ -8,6 +8,7 @@ import { Drawer } from '@/components/ui/drawer'
 import { formatDate } from '@/lib/format'
 import { BentoHeader } from './BentoHeader'
 import { BentoSkeleton } from './BentoSkeleton'
+import { BentoEmpty } from './BentoEmpty'
 import { type EventRoleRequest, VARIABLE_CAP, REG_STATUS_STYLES } from '../types'
 import { ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -61,10 +62,7 @@ export function ParticipationSection({ profileId, role }: { profileId: string; r
       <div>
         <BentoHeader icon={Users} title={t('profile.participation')} />
         {roles.length === 0 ? (
-          <div className="space-y-1">
-            <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('profile.participation.empty')}</p>
-            <p className="text-xs" style={{ color: 'var(--text-secondary)', opacity: 0.7 }}>{t('profile.participation.emptyHint')}</p>
-          </div>
+          <BentoEmpty message={t('profile.participation.empty')} hint={t('profile.participation.emptyHint')} />
         ) : (
           <div className="space-y-2">
             {visible.map(er => <RoleRow key={er.id} er={er} />)}

--- a/app/(dashboard)/profile/components/ParticipationSection.tsx
+++ b/app/(dashboard)/profile/components/ParticipationSection.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { formatDate } from '@/lib/format'
 import { BentoHeader } from './BentoHeader'
+import { BentoSkeleton } from './BentoSkeleton'
 import { type EventRoleRequest, VARIABLE_CAP, REG_STATUS_STYLES } from '../types'
 import { ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -23,7 +24,12 @@ export function ParticipationSection({ profileId, role }: { profileId: string; r
   })
 
   if (isLoading) {
-    return <div className="animate-pulse h-full rounded-lg" style={{ backgroundColor: 'var(--border-default)' }} />
+    return (
+      <div>
+        <BentoHeader icon={Users} title={t('profile.participation')} />
+        <BentoSkeleton rows={2} />
+      </div>
+    )
   }
 
   const roles = eventRolesData ?? []

--- a/app/(dashboard)/profile/components/ParticipationSection.tsx
+++ b/app/(dashboard)/profile/components/ParticipationSection.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { Users } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { formatDate } from '@/lib/format'
+import { BentoHeader } from './BentoHeader'
 import { type EventRoleRequest, VARIABLE_CAP, REG_STATUS_STYLES } from '../types'
 import { ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -51,7 +53,7 @@ export function ParticipationSection({ profileId, role }: { profileId: string; r
   return (
     <>
       <div>
-        <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-6 pr-24" style={{ color: 'var(--brand-crimson)' }}>{t('profile.participation')}</p>
+        <BentoHeader icon={Users} title={t('profile.participation')} />
         {roles.length === 0 ? (
           <div className="space-y-1">
             <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('profile.participation.empty')}</p>

--- a/app/(dashboard)/profile/components/PaymentsSection.tsx
+++ b/app/(dashboard)/profile/components/PaymentsSection.tsx
@@ -8,6 +8,7 @@ import { Drawer } from '@/components/ui/drawer'
 import { PaymentForm } from '@/components/payment/PaymentForm'
 import { formatCurrency } from '@/lib/format'
 import { BentoHeader } from './BentoHeader'
+import { BentoSkeleton } from './BentoSkeleton'
 import { type TripEntry, type GenericPayment, type PayableItem, VARIABLE_CAP } from '../types'
 import { PaymentRow, ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -85,7 +86,12 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
   const handleOpenSubmit = useCallback(() => setSubmitDrawerOpen(true), [])
 
   if (isLoading) {
-    return <div className="animate-pulse h-full rounded-lg" style={{ backgroundColor: 'var(--border-default)' }} />
+    return (
+      <div>
+        <BentoHeader icon={CreditCard} title={t('payment.title')} />
+        <BentoSkeleton rows={3} />
+      </div>
+    )
   }
 
   const allPayments = paymentsData ?? []

--- a/app/(dashboard)/profile/components/PaymentsSection.tsx
+++ b/app/(dashboard)/profile/components/PaymentsSection.tsx
@@ -2,10 +2,12 @@
 
 import { useState, useCallback } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { CreditCard } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { PaymentForm } from '@/components/payment/PaymentForm'
 import { formatCurrency } from '@/lib/format'
+import { BentoHeader } from './BentoHeader'
 import { type TripEntry, type GenericPayment, type PayableItem, VARIABLE_CAP } from '../types'
 import { PaymentRow, ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -96,12 +98,15 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
   return (
     <>
       <div>
-        <div className="flex items-center justify-between mb-4 pr-24">
-          <p className="text-xs font-semibold tracking-[0.25em] uppercase" style={{ color: 'var(--brand-crimson)' }}>{t('payment.title')}</p>
-          <button onClick={handleOpenSubmit}
-            className="px-3 py-1.5 rounded-xl text-xs font-semibold text-white hover:opacity-90 transition-opacity flex-shrink-0"
-            style={{ backgroundColor: 'var(--brand-forest)' }}>{t('payment.submitShort')}</button>
-        </div>
+        <BentoHeader
+          icon={CreditCard}
+          title={t('payment.title')}
+          action={
+            <button onClick={handleOpenSubmit}
+              className="px-3 py-1.5 rounded-xl text-xs font-semibold text-white hover:opacity-90 transition-opacity flex-shrink-0"
+              style={{ backgroundColor: 'var(--brand-forest)' }}>{t('payment.submitShort')}</button>
+          }
+        />
         {Object.keys(visibleByItem).length === 0 ? (
           <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('payment.none')}</p>
         ) : (

--- a/app/(dashboard)/profile/components/PaymentsSection.tsx
+++ b/app/(dashboard)/profile/components/PaymentsSection.tsx
@@ -10,8 +10,6 @@ import { type TripEntry, type GenericPayment, type PayableItem, VARIABLE_CAP } f
 import { PaymentRow, ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
 
-export const PAYMENTS_MIN_HEIGHT = 280
-
 function groupByItem(payments: GenericPayment[]): Record<string, GenericPayment[]> {
   const map: Record<string, GenericPayment[]> = {}
   for (const pay of payments) {
@@ -85,7 +83,7 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
   const handleOpenSubmit = useCallback(() => setSubmitDrawerOpen(true), [])
 
   if (isLoading) {
-    return <div className="rounded-2xl animate-pulse h-full" style={{ backgroundColor: 'var(--border-default)' }} />
+    return <div className="animate-pulse h-full rounded-lg" style={{ backgroundColor: 'var(--border-default)' }} />
   }
 
   const allPayments = paymentsData ?? []
@@ -97,7 +95,7 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
 
   return (
     <>
-      <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+      <div>
         <div className="flex items-center justify-between mb-4 pr-24">
           <p className="text-xs font-semibold tracking-[0.25em] uppercase" style={{ color: 'var(--brand-crimson)' }}>{t('payment.title')}</p>
           <button onClick={handleOpenSubmit}

--- a/app/(dashboard)/profile/components/PaymentsSection.tsx
+++ b/app/(dashboard)/profile/components/PaymentsSection.tsx
@@ -6,9 +6,9 @@ import { CreditCard } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { PaymentForm } from '@/components/payment/PaymentForm'
-import { formatCurrency } from '@/lib/format'
 import { BentoHeader } from './BentoHeader'
 import { BentoSkeleton } from './BentoSkeleton'
+import { BentoEmpty } from './BentoEmpty'
 import { type TripEntry, type GenericPayment, type PayableItem, VARIABLE_CAP } from '../types'
 import { PaymentRow, ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -114,7 +114,7 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
           }
         />
         {Object.keys(visibleByItem).length === 0 ? (
-          <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('payment.none')}</p>
+          <BentoEmpty message={t('payment.none')} />
         ) : (
           <PaymentGroups groups={visibleByItem} cancelledTripIds={cancelledTripIds} />
         )}

--- a/app/(dashboard)/profile/components/PersonalDetailsContent.tsx
+++ b/app/(dashboard)/profile/components/PersonalDetailsContent.tsx
@@ -2,9 +2,11 @@
 
 import { memo, useState, useEffect } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { User } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { PersonalDrawerForm } from './PersonalDrawerForm'
+import { BentoHeader } from './BentoHeader'
 import { type Profile } from '../types'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
@@ -161,18 +163,19 @@ export const PersonalDetailsContent = memo(function PersonalDetailsContent() {
   return (
     <>
       <div>
-        <div className="flex items-center justify-between mb-5 pr-24">
-          <p className="text-xs font-semibold tracking-[0.25em] uppercase" style={{ color: 'var(--brand-crimson)' }}>
-            {t('profile.tile.personalDetails')}
-          </p>
-          <button
-            onClick={() => setDrawerOpen(true)}
-            className="text-xs font-semibold hover:opacity-70 transition-opacity px-3 py-1.5 rounded-xl border"
-            style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
-          >
-            {t('profile.edit')}
-          </button>
-        </div>
+        <BentoHeader
+          icon={User}
+          title={t('profile.tile.personalDetails')}
+          action={
+            <button
+              onClick={() => setDrawerOpen(true)}
+              className="text-xs font-semibold hover:opacity-70 transition-opacity px-3 py-1.5 rounded-xl border"
+              style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
+            >
+              {t('profile.edit')}
+            </button>
+          }
+        />
 
         <div className="space-y-3">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/app/(dashboard)/profile/components/PersonalDetailsContent.tsx
+++ b/app/(dashboard)/profile/components/PersonalDetailsContent.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { PersonalDrawerForm } from './PersonalDrawerForm'
 import { BentoHeader } from './BentoHeader'
+import { BentoSkeleton } from './BentoSkeleton'
 import { type Profile } from '../types'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
@@ -147,12 +148,9 @@ export const PersonalDetailsContent = memo(function PersonalDetailsContent() {
 
   if (isLoading || !profile) {
     return (
-      <div className="animate-pulse">
-        <div className="h-3 rounded w-1/2 mb-5" style={{ backgroundColor: 'var(--border-default)' }} />
-        <div className="space-y-3">
-          <div className="h-3 rounded w-3/4" style={{ backgroundColor: 'var(--border-default)' }} />
-          <div className="h-3 rounded w-1/2" style={{ backgroundColor: 'var(--border-default)' }} />
-        </div>
+      <div>
+        <BentoHeader icon={User} title={t('profile.tile.personalDetails')} />
+        <BentoSkeleton rows={3} />
       </div>
     )
   }

--- a/app/(dashboard)/profile/components/PersonalDetailsContent.tsx
+++ b/app/(dashboard)/profile/components/PersonalDetailsContent.tsx
@@ -145,7 +145,7 @@ export const PersonalDetailsContent = memo(function PersonalDetailsContent() {
 
   if (isLoading || !profile) {
     return (
-      <div className="rounded-2xl p-6 h-full animate-pulse" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+      <div className="animate-pulse">
         <div className="h-3 rounded w-1/2 mb-5" style={{ backgroundColor: 'var(--border-default)' }} />
         <div className="space-y-3">
           <div className="h-3 rounded w-3/4" style={{ backgroundColor: 'var(--border-default)' }} />
@@ -160,15 +160,7 @@ export const PersonalDetailsContent = memo(function PersonalDetailsContent() {
 
   return (
     <>
-      <div
-        className="rounded-2xl p-6 h-full"
-        style={{
-          backgroundColor: 'var(--bg-card)',
-          border: incomplete
-            ? '1px solid var(--brand-crimson)'
-            : '1px solid var(--border-default)',
-        }}
-      >
+      <div>
         <div className="flex items-center justify-between mb-5 pr-24">
           <p className="text-xs font-semibold tracking-[0.25em] uppercase" style={{ color: 'var(--brand-crimson)' }}>
             {t('profile.tile.personalDetails')}

--- a/app/(dashboard)/profile/components/ProfileClient.tsx
+++ b/app/(dashboard)/profile/components/ProfileClient.tsx
@@ -8,16 +8,16 @@ import { AboInfoContent } from './AboInfoContent'
 import { TravelDocContent } from './TravelDocContent'
 import { UserSettingsContent } from './UserSettingsContent'
 import { SortableBento } from './SortableBento'
-import { TripsSection, TRIPS_MIN_HEIGHT } from './TripsSection'
-import { PaymentsSection, PAYMENTS_MIN_HEIGHT } from './PaymentsSection'
-import { VitalsSection, VITALS_MIN_HEIGHT } from './VitalsSection'
-import { ParticipationSection, PARTICIPATION_MIN_HEIGHT } from './ParticipationSection'
-import { CalendarSection, CALENDAR_MIN_HEIGHT } from './CalendarSection'
-import { StatsSection, STATS_MIN_HEIGHT } from './StatsSection'
+import { TripsSection } from './TripsSection'
+import { PaymentsSection } from './PaymentsSection'
+import { VitalsSection } from './VitalsSection'
+import { ParticipationSection } from './ParticipationSection'
+import { CalendarSection } from './CalendarSection'
+import { StatsSection } from './StatsSection'
 import { AdminSection } from './AdminSection'
-import { EmailPrefsSection, EMAIL_PREFS_MIN_HEIGHT } from './EmailPrefsSection'
+import { EmailPrefsSection } from './EmailPrefsSection'
 import { InvitesBento } from './InvitesBento'
-import { BENTO_IDS, DEFAULT_ORDER } from './bento-registry'
+import { BENTO_IDS, DEFAULT_ORDER, BENTO_META, BENTO_HEIGHT } from './bento-registry'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
 
@@ -37,8 +37,12 @@ type Props = {
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const BENTO_HEIGHT = { S: 160, M: 280 } as const
 const DESKTOP_QUERY = '(min-width: 768px)' // matches Tailwind `md` breakpoint used below
+
+function metaFor(id: string) {
+  const meta = BENTO_META[id]
+  return { colSpan: meta.colSpan, minHeight: BENTO_HEIGHT[meta.height] }
+}
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
@@ -138,59 +142,67 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
     persistPrefs(DEFAULT_ORDER, {})
   }, [persistPrefs])
 
-  type BentoEntry = { colSpan: number; minHeight: number; node: React.ReactNode }
+  type BentoEntry = { colSpan: number; minHeight: number; node: React.ReactNode; cardStyle?: React.CSSProperties }
+
+  // Incomplete-profile crimson border on PersonalDetailsContent's card: derived
+  // here (not inside the content component, which no longer renders its own
+  // card shell) via the same ['profile'] query the content component uses —
+  // TanStack Query dedupes the request (docs/architecture/DECISIONS.md
+  // Cross-Section Data Dependency Rule).
+  const personalDetailsIncomplete = !!fullProfile && !fullProfile.first_name
 
   const bentoMap: Record<string, BentoEntry | null> = {
     [BENTO_IDS.PERSONAL_DETAILS]: {
-      colSpan: 6, minHeight: BENTO_HEIGHT.M,
+      ...metaFor(BENTO_IDS.PERSONAL_DETAILS),
       node: <PersonalDetailsContent />,
+      cardStyle: personalDetailsIncomplete ? { borderColor: 'var(--brand-crimson)' } : undefined,
     },
     [BENTO_IDS.ABO_INFO]: {
-      colSpan: 6, minHeight: BENTO_HEIGHT.M,
+      ...metaFor(BENTO_IDS.ABO_INFO),
       node: <AboInfoContent />,
     },
     [BENTO_IDS.TRAVEL_DOC]: !isGuest ? {
-      colSpan: 6, minHeight: BENTO_HEIGHT.S,
+      ...metaFor(BENTO_IDS.TRAVEL_DOC),
       node: <TravelDocContent />,
     } : null,
     [BENTO_IDS.SETTINGS]: {
-      colSpan: 6, minHeight: BENTO_HEIGHT.M,
+      ...metaFor(BENTO_IDS.SETTINGS),
       node: <UserSettingsContent />,
     },
     [BENTO_IDS.TRIPS]: !isGuest ? {
-      colSpan: 6, minHeight: TRIPS_MIN_HEIGHT,
+      ...metaFor(BENTO_IDS.TRIPS),
       node: <TripsSection profileId={profileId} role={role} />,
     } : null,
     [BENTO_IDS.PAYMENTS]: !isGuest ? {
-      colSpan: 6, minHeight: PAYMENTS_MIN_HEIGHT,
+      ...metaFor(BENTO_IDS.PAYMENTS),
       node: <PaymentsSection profileId={profileId} role={role} />,
     } : null,
     [BENTO_IDS.EMAIL_PREFS]: !isGuest ? {
-      colSpan: 6, minHeight: EMAIL_PREFS_MIN_HEIGHT,
+      ...metaFor(BENTO_IDS.EMAIL_PREFS),
       node: <EmailPrefsSection />,
     } : null,
     [BENTO_IDS.VITALS]: !isGuest ? {
-      colSpan: 6, minHeight: VITALS_MIN_HEIGHT,
+      ...metaFor(BENTO_IDS.VITALS),
       node: <VitalsSection profileId={profileId} role={role} />,
     } : null,
     [BENTO_IDS.PARTICIPATION]: !isGuest ? {
-      colSpan: 6, minHeight: PARTICIPATION_MIN_HEIGHT,
+      ...metaFor(BENTO_IDS.PARTICIPATION),
       node: <ParticipationSection profileId={profileId} role={role} />,
     } : null,
     [BENTO_IDS.CALENDAR]: {
-      colSpan: 6, minHeight: CALENDAR_MIN_HEIGHT,
+      ...metaFor(BENTO_IDS.CALENDAR),
       node: <CalendarSection profileId={profileId} />,
     },
     [BENTO_IDS.STATS]: (aboNumber !== null || isCore) ? {
-      colSpan: 6, minHeight: STATS_MIN_HEIGHT,
+      ...metaFor(BENTO_IDS.STATS),
       node: <StatsSection role={role} aboNumber={aboNumber} />,
     } : null,
     [BENTO_IDS.INVITES]: hasInvites ? {
-      colSpan: 6, minHeight: BENTO_HEIGHT.M,
+      ...metaFor(BENTO_IDS.INVITES),
       node: <InvitesBento />,
     } : null,
     [BENTO_IDS.ADMIN]: isAdmin ? {
-      colSpan: 6, minHeight: BENTO_HEIGHT.S,
+      ...metaFor(BENTO_IDS.ADMIN),
       node: <AdminSection />,
     } : null,
   }
@@ -249,6 +261,7 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
                 onToggleCollapse={() => toggleCollapse(id)}
                 colSpan={entry.colSpan}
                 minHeight={entry.minHeight}
+                cardStyle={entry.cardStyle}
                 disableDrag
               >
                 {entry.node}

--- a/app/(dashboard)/profile/components/ProfileClient.tsx
+++ b/app/(dashboard)/profile/components/ProfileClient.tsx
@@ -17,7 +17,7 @@ import { StatsSection } from './StatsSection'
 import { AdminSection } from './AdminSection'
 import { EmailPrefsSection } from './EmailPrefsSection'
 import { InvitesBento } from './InvitesBento'
-import { BENTO_IDS, DEFAULT_ORDER, BENTO_META, BENTO_HEIGHT } from './bento-registry'
+import { BENTO_IDS, DEFAULT_ORDER, BENTO_META, BENTO_HEIGHT, type BentoId } from './bento-registry'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
 
@@ -39,7 +39,7 @@ type Props = {
 
 const DESKTOP_QUERY = '(min-width: 768px)' // matches Tailwind `md` breakpoint used below
 
-function metaFor(id: string) {
+function metaFor(id: BentoId) {
   const meta = BENTO_META[id]
   return { colSpan: meta.colSpan, minHeight: BENTO_HEIGHT[meta.height] }
 }

--- a/app/(dashboard)/profile/components/SortableBento.tsx
+++ b/app/(dashboard)/profile/components/SortableBento.tsx
@@ -4,7 +4,7 @@ import { forwardRef, type ReactNode } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Button } from '@/components/ui/button'
 import BentoCard from '@/components/bento/BentoCard'
-import { BENTO_KEY_MAP, BENTO_ICON_MAP } from './bento-registry'
+import { BENTO_KEY_MAP, BENTO_ICON_MAP, type BentoId } from './bento-registry'
 
 // ── Drag handle ───────────────────────────────────────────────────────────────
 // No @dnd-kit import here — this file is also the mobile-path render, and the
@@ -85,7 +85,7 @@ export function SortableBento({
 
   const bentoKey = BENTO_KEY_MAP[id]
   const label = bentoKey ? t(bentoKey) : id
-  const Icon = BENTO_ICON_MAP[id]
+  const Icon = BENTO_ICON_MAP[id as BentoId] as typeof BENTO_ICON_MAP[BentoId] | undefined
 
   if (collapsed) {
     return (

--- a/app/(dashboard)/profile/components/SortableBento.tsx
+++ b/app/(dashboard)/profile/components/SortableBento.tsx
@@ -3,12 +3,13 @@
 import { forwardRef, type ReactNode } from 'react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Button } from '@/components/ui/button'
-import { BENTO_KEY_MAP } from './bento-registry'
+import BentoCard from '@/components/bento/BentoCard'
+import { BENTO_KEY_MAP, BENTO_ICON_MAP } from './bento-registry'
 
 // ── Drag handle ───────────────────────────────────────────────────────────────
-// No @dnd-kit import here — this file is the mobile-path render, and the drag
-// wiring (ref/attributes/listeners) is supplied by BentoGrid.tsx's dnd-kit
-// wrapper so @dnd-kit/* stays out of this module's chunk.
+// No @dnd-kit import here — this file is also the mobile-path render, and the
+// drag wiring (ref/attributes/listeners) is supplied by BentoGrid.tsx's
+// dnd-kit wrapper so @dnd-kit/* stays out of this module's chunk.
 
 function GripIcon() {
   return (
@@ -46,6 +47,10 @@ export const DragHandle = forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLS
 )
 
 // ── SortableBento ─────────────────────────────────────────────────────────────
+// The bento is a grid cell, a drag target and a card all in one element now
+// that BentoCard forwards refs — no separate outer div contributing only a
+// class name. Headers/skeletons/empty-states inside `children` migrate to
+// the shared BentoHeader/BentoSkeleton/BentoEmpty components separately.
 
 export function SortableBento({
   id,
@@ -58,6 +63,7 @@ export function SortableBento({
   cardRef,
   dragStyle,
   dragHandle,
+  cardStyle,
 }: {
   id: string
   collapsed: boolean
@@ -70,73 +76,74 @@ export function SortableBento({
   cardRef?: (node: HTMLDivElement | null) => void
   dragStyle?: React.CSSProperties
   dragHandle?: ReactNode
+  // Per-bento style override (e.g. PersonalDetailsContent's incomplete-profile
+  // crimson border) — sourced from ProfileClient's bentoMap, not from inside
+  // the content component, since content no longer renders its own card shell.
+  cardStyle?: React.CSSProperties
 }) {
   const { t } = useLanguage()
 
-  const style: React.CSSProperties = {
-    ...(disableDrag ? {} : { gridColumn: `span ${colSpan}` }),
-    position: 'relative',
-    // Mobile stack (disableDrag): no minHeight — cards size to their content
-    minHeight: disableDrag || collapsed ? undefined : minHeight,
-    ...dragStyle,
-  }
-
   const bentoKey = BENTO_KEY_MAP[id]
   const label = bentoKey ? t(bentoKey) : id
+  const Icon = BENTO_ICON_MAP[id]
+
+  if (collapsed) {
+    return (
+      <BentoCard
+        ref={cardRef}
+        colSpan={colSpan}
+        className="flex items-center justify-between"
+        style={{ paddingTop: 12, paddingBottom: 12, ...dragStyle, ...cardStyle }}
+      >
+        <div className="flex items-center gap-3">
+          {!disableDrag && dragHandle}
+          {Icon && <Icon size={14} style={{ color: 'var(--text-secondary)', opacity: 0.6, flexShrink: 0 }} />}
+          <span className="text-xs font-semibold tracking-[0.2em] uppercase" style={{ color: 'var(--text-secondary)' }}>
+            {label}
+          </span>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onToggleCollapse}
+          title={t('profile.bento.expand')}
+          aria-label={t('profile.bento.expand')}
+          style={{ fontSize: 12, lineHeight: 1, opacity: 0.5, flexShrink: 0 }}
+        >
+          ▸
+        </Button>
+      </BentoCard>
+    )
+  }
 
   return (
-    <div
+    <BentoCard
       ref={cardRef}
-      className={!disableDrag && colSpan === 6 ? 'bento-mobile-full' : ''}
-      style={style}
+      colSpan={colSpan}
+      className="flex flex-col relative overflow-hidden"
+      style={{
+        // Mobile stack (disableDrag): no minHeight — cards size to their content
+        minHeight: disableDrag ? undefined : minHeight,
+        ...dragStyle,
+        ...cardStyle,
+      }}
     >
-      {collapsed ? (
-        <div
-          className="rounded-2xl px-6 py-4 flex items-center justify-between"
-          style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+      <div style={{ position: 'absolute', top: 12, right: 12, display: 'flex', alignItems: 'center', gap: 6, zIndex: 10 }}>
+        {!disableDrag && dragHandle}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onToggleCollapse}
+          title={t('profile.bento.collapse')}
+          aria-label={t('profile.bento.collapse')}
+          style={{ fontSize: 12, lineHeight: 1, opacity: 0.5, flexShrink: 0 }}
         >
-          <div className="flex items-center gap-3">
-            {!disableDrag && dragHandle}
-            <span className="text-xs font-semibold tracking-[0.2em] uppercase" style={{ color: 'var(--text-secondary)' }}>
-              {label}
-            </span>
-          </div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={onToggleCollapse}
-            title={t('profile.bento.expand')}
-            aria-label={t('profile.bento.expand')}
-            style={{ fontSize: 12, lineHeight: 1, opacity: 0.5, flexShrink: 0 }}
-          >
-            ▸
-          </Button>
-        </div>
-      ) : (
-        <>
-          <div style={{ position: 'absolute', top: 18, right: 16, display: 'flex', alignItems: 'center', gap: 6, zIndex: 10 }}>
-            {!disableDrag && dragHandle}
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={onToggleCollapse}
-              title={t('profile.bento.collapse')}
-              aria-label={t('profile.bento.collapse')}
-              style={{ fontSize: 12, lineHeight: 1, opacity: 0.5, flexShrink: 0 }}
-            >
-              ▾
-            </Button>
-          </div>
-          {/*
-            Desktop: height 100% fills the grid cell (minHeight set on parent).
-            Mobile (disableDrag): height auto — parent has no fixed height, so
-            h-full children resolve to auto and the card sizes to its content.
-          */}
-          <div style={{ overflow: 'hidden', height: disableDrag ? 'auto' : '100%' }}>{children}</div>
-        </>
-      )}
-    </div>
+          ▾
+        </Button>
+      </div>
+      <div className="flex-1 min-h-0 overflow-hidden">{children}</div>
+    </BentoCard>
   )
 }

--- a/app/(dashboard)/profile/components/StatsSection.tsx
+++ b/app/(dashboard)/profile/components/StatsSection.tsx
@@ -6,8 +6,6 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import { type LosSummaryData } from '../types'
 import { apiClient } from '@/lib/apiClient'
 
-export const STATS_MIN_HEIGHT = 160
-
 export function StatsSection({ role, aboNumber }: { role: string; aboNumber: string | null }) {
   const { t } = useLanguage()
   const isCore = role === 'core'
@@ -20,14 +18,14 @@ export function StatsSection({ role, aboNumber }: { role: string; aboNumber: str
   })
 
   if (isLoading) {
-    return <div className="rounded-2xl animate-pulse h-full" style={{ backgroundColor: 'var(--border-default)' }} />
+    return <div className="animate-pulse h-full rounded-lg" style={{ backgroundColor: 'var(--border-default)' }} />
   }
 
   // Merged LOS bento: show when there are stats to display OR the user (core) can upload.
   if (!losSummary && !isCore) return null
 
   return (
-    <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+    <div>
       <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-4 pr-24" style={{ color: 'var(--brand-crimson)' }}>{t('profile.stats')}</p>
       {losSummary && (
         <div className="flex flex-wrap items-center gap-4">

--- a/app/(dashboard)/profile/components/StatsSection.tsx
+++ b/app/(dashboard)/profile/components/StatsSection.tsx
@@ -2,7 +2,9 @@
 
 import { useQuery } from '@tanstack/react-query'
 import Link from 'next/link'
+import { BarChart3 } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { BentoHeader } from './BentoHeader'
 import { type LosSummaryData } from '../types'
 import { apiClient } from '@/lib/apiClient'
 
@@ -26,7 +28,7 @@ export function StatsSection({ role, aboNumber }: { role: string; aboNumber: str
 
   return (
     <div>
-      <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-4 pr-24" style={{ color: 'var(--brand-crimson)' }}>{t('profile.stats')}</p>
+      <BentoHeader icon={BarChart3} title={t('profile.stats')} />
       {losSummary && (
         <div className="flex flex-wrap items-center gap-4">
           <div>

--- a/app/(dashboard)/profile/components/StatsSection.tsx
+++ b/app/(dashboard)/profile/components/StatsSection.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { BarChart3 } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { BentoHeader } from './BentoHeader'
+import { BentoSkeleton } from './BentoSkeleton'
 import { type LosSummaryData } from '../types'
 import { apiClient } from '@/lib/apiClient'
 
@@ -20,7 +21,12 @@ export function StatsSection({ role, aboNumber }: { role: string; aboNumber: str
   })
 
   if (isLoading) {
-    return <div className="animate-pulse h-full rounded-lg" style={{ backgroundColor: 'var(--border-default)' }} />
+    return (
+      <div>
+        <BentoHeader icon={BarChart3} title={t('profile.stats')} />
+        <BentoSkeleton rows={2} />
+      </div>
+    )
   }
 
   // Merged LOS bento: show when there are stats to display OR the user (core) can upload.

--- a/app/(dashboard)/profile/components/TravelDocContent.tsx
+++ b/app/(dashboard)/profile/components/TravelDocContent.tsx
@@ -2,9 +2,11 @@
 
 import { memo, useState, useEffect } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Plane } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { TravelDocDrawerForm } from './TravelDocDrawerForm'
+import { BentoHeader } from './BentoHeader'
 import { type Profile } from '../types'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
@@ -165,18 +167,19 @@ export const TravelDocContent = memo(function TravelDocContent() {
   return (
     <>
       <div>
-        <div className="flex items-center justify-between mb-5 pr-24">
-          <p className="text-xs font-semibold tracking-[0.25em] uppercase" style={{ color: 'var(--brand-crimson)' }}>
-            {t('profile.tile.travelDoc')}
-          </p>
-          <button
-            onClick={() => setDrawerOpen(true)}
-            className="text-xs font-semibold hover:opacity-70 transition-opacity px-3 py-1.5 rounded-xl border"
-            style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
-          >
-            {t('profile.edit')}
-          </button>
-        </div>
+        <BentoHeader
+          icon={Plane}
+          title={t('profile.tile.travelDoc')}
+          action={
+            <button
+              onClick={() => setDrawerOpen(true)}
+              className="text-xs font-semibold hover:opacity-70 transition-opacity px-3 py-1.5 rounded-xl border"
+              style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
+            >
+              {t('profile.edit')}
+            </button>
+          }
+        />
 
         <div className="space-y-3">
           <div>

--- a/app/(dashboard)/profile/components/TravelDocContent.tsx
+++ b/app/(dashboard)/profile/components/TravelDocContent.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { TravelDocDrawerForm } from './TravelDocDrawerForm'
 import { BentoHeader } from './BentoHeader'
+import { BentoSkeleton } from './BentoSkeleton'
 import { type Profile } from '../types'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
@@ -149,12 +150,9 @@ export const TravelDocContent = memo(function TravelDocContent() {
 
   if (isLoading || !profile) {
     return (
-      <div className="animate-pulse">
-        <div className="h-3 rounded w-1/2 mb-5" style={{ backgroundColor: 'var(--border-default)' }} />
-        <div className="space-y-3">
-          <div className="h-3 rounded w-3/4" style={{ backgroundColor: 'var(--border-default)' }} />
-          <div className="h-3 rounded w-1/2" style={{ backgroundColor: 'var(--border-default)' }} />
-        </div>
+      <div>
+        <BentoHeader icon={Plane} title={t('profile.tile.travelDoc')} />
+        <BentoSkeleton rows={3} />
       </div>
     )
   }

--- a/app/(dashboard)/profile/components/TravelDocContent.tsx
+++ b/app/(dashboard)/profile/components/TravelDocContent.tsx
@@ -147,7 +147,7 @@ export const TravelDocContent = memo(function TravelDocContent() {
 
   if (isLoading || !profile) {
     return (
-      <div className="rounded-2xl p-6 h-full animate-pulse" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+      <div className="animate-pulse">
         <div className="h-3 rounded w-1/2 mb-5" style={{ backgroundColor: 'var(--border-default)' }} />
         <div className="space-y-3">
           <div className="h-3 rounded w-3/4" style={{ backgroundColor: 'var(--border-default)' }} />
@@ -164,7 +164,7 @@ export const TravelDocContent = memo(function TravelDocContent() {
 
   return (
     <>
-      <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+      <div>
         <div className="flex items-center justify-between mb-5 pr-24">
           <p className="text-xs font-semibold tracking-[0.25em] uppercase" style={{ color: 'var(--brand-crimson)' }}>
             {t('profile.tile.travelDoc')}

--- a/app/(dashboard)/profile/components/TripsSection.tsx
+++ b/app/(dashboard)/profile/components/TripsSection.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { BentoHeader } from './BentoHeader'
 import { BentoSkeleton } from './BentoSkeleton'
+import { BentoEmpty } from './BentoEmpty'
 import { type TripEntry, VARIABLE_CAP } from '../types'
 import { TripRow, ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -49,10 +50,7 @@ export function TripsSection({ profileId, role }: { profileId: string; role: str
       <div>
         <BentoHeader icon={Luggage} title={t('profile.trips')} />
         {trips.length === 0 ? (
-          <div className="space-y-1">
-            <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('profile.trips.empty')}</p>
-            <p className="text-xs" style={{ color: 'var(--text-secondary)', opacity: 0.7 }}>{t('profile.trips.emptyHint')}</p>
-          </div>
+          <BentoEmpty message={t('profile.trips.empty')} hint={t('profile.trips.emptyHint')} />
         ) : (
           <div className="space-y-2">
             {visible.map(entry => (

--- a/app/(dashboard)/profile/components/TripsSection.tsx
+++ b/app/(dashboard)/profile/components/TripsSection.tsx
@@ -6,6 +6,7 @@ import { Luggage } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { BentoHeader } from './BentoHeader'
+import { BentoSkeleton } from './BentoSkeleton'
 import { type TripEntry, VARIABLE_CAP } from '../types'
 import { TripRow, ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -31,7 +32,12 @@ export function TripsSection({ profileId, role }: { profileId: string; role: str
   const handleCancel = useCallback((tripId: string) => { cancelTrip.mutate(tripId) }, [cancelTrip])
 
   if (isLoading) {
-    return <div className="animate-pulse h-full rounded-lg" style={{ backgroundColor: 'var(--border-default)' }} />
+    return (
+      <div>
+        <BentoHeader icon={Luggage} title={t('profile.trips')} />
+        <BentoSkeleton rows={2} />
+      </div>
+    )
   }
 
   const trips = tripsData ?? []

--- a/app/(dashboard)/profile/components/TripsSection.tsx
+++ b/app/(dashboard)/profile/components/TripsSection.tsx
@@ -2,8 +2,10 @@
 
 import { useState, useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Luggage } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
+import { BentoHeader } from './BentoHeader'
 import { type TripEntry, VARIABLE_CAP } from '../types'
 import { TripRow, ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -39,7 +41,7 @@ export function TripsSection({ profileId, role }: { profileId: string; role: str
   return (
     <>
       <div>
-        <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-4 pr-24" style={{ color: 'var(--brand-crimson)' }}>{t('profile.trips')}</p>
+        <BentoHeader icon={Luggage} title={t('profile.trips')} />
         {trips.length === 0 ? (
           <div className="space-y-1">
             <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>{t('profile.trips.empty')}</p>

--- a/app/(dashboard)/profile/components/TripsSection.tsx
+++ b/app/(dashboard)/profile/components/TripsSection.tsx
@@ -8,8 +8,6 @@ import { type TripEntry, VARIABLE_CAP } from '../types'
 import { TripRow, ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
 
-export const TRIPS_MIN_HEIGHT = 280
-
 export function TripsSection({ profileId, role }: { profileId: string; role: string }) {
   const { t } = useLanguage()
   const qc = useQueryClient()
@@ -31,7 +29,7 @@ export function TripsSection({ profileId, role }: { profileId: string; role: str
   const handleCancel = useCallback((tripId: string) => { cancelTrip.mutate(tripId) }, [cancelTrip])
 
   if (isLoading) {
-    return <div className="rounded-2xl animate-pulse h-full" style={{ backgroundColor: 'var(--border-default)' }} />
+    return <div className="animate-pulse h-full rounded-lg" style={{ backgroundColor: 'var(--border-default)' }} />
   }
 
   const trips = tripsData ?? []
@@ -40,7 +38,7 @@ export function TripsSection({ profileId, role }: { profileId: string; role: str
 
   return (
     <>
-      <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+      <div>
         <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-4 pr-24" style={{ color: 'var(--brand-crimson)' }}>{t('profile.trips')}</p>
         {trips.length === 0 ? (
           <div className="space-y-1">

--- a/app/(dashboard)/profile/components/UserSettingsContent.tsx
+++ b/app/(dashboard)/profile/components/UserSettingsContent.tsx
@@ -17,7 +17,7 @@ export const UserSettingsContent = memo(function UserSettingsContent() {
   const { lang, toggle: toggleLang, t } = useLanguage()
 
   return (
-    <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+    <div>
       <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-5 pr-24" style={{ color: 'var(--brand-crimson)' }}>
         {t('profile.settings')}
       </p>

--- a/app/(dashboard)/profile/components/UserSettingsContent.tsx
+++ b/app/(dashboard)/profile/components/UserSettingsContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { memo } from 'react'
-import { Settings } from 'lucide-react'
+import { Settings, Sun, Moon } from 'lucide-react'
 import { useTheme } from '@/lib/hooks/useTheme'
 import { useFontSize, type FontSize } from '@/lib/hooks/useFontSize'
 import { useLanguage } from '@/lib/hooks/useLanguage'
@@ -40,18 +40,7 @@ export const UserSettingsContent = memo(function UserSettingsContent() {
                     border: '1px solid var(--border-default)',
                   }}
                 >
-                  {th === 'light' ? (
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
-                      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <circle cx="12" cy="12" r="4"/>
-                      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
-                    </svg>
-                  ) : (
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
-                      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
-                    </svg>
-                  )}
+                  {th === 'light' ? <Sun size={12} /> : <Moon size={12} />}
                   {th === 'light' ? t('profile.theme.light') : t('profile.theme.dark')}
                 </button>
               )

--- a/app/(dashboard)/profile/components/UserSettingsContent.tsx
+++ b/app/(dashboard)/profile/components/UserSettingsContent.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { memo } from 'react'
+import { Settings } from 'lucide-react'
 import { useTheme } from '@/lib/hooks/useTheme'
 import { useFontSize, type FontSize } from '@/lib/hooks/useFontSize'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { BentoHeader } from './BentoHeader'
 
 const FONT_STEPS: { value: FontSize; label: string; size: number }[] = [
   { value: 'md', label: 'A',  size: 16 },
@@ -18,9 +20,7 @@ export const UserSettingsContent = memo(function UserSettingsContent() {
 
   return (
     <div>
-      <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-5 pr-24" style={{ color: 'var(--brand-crimson)' }}>
-        {t('profile.settings')}
-      </p>
+      <BentoHeader icon={Settings} title={t('profile.settings')} />
 
       <div className="space-y-5">
         {/* Theme */}

--- a/app/(dashboard)/profile/components/VitalsSection.tsx
+++ b/app/(dashboard)/profile/components/VitalsSection.tsx
@@ -87,7 +87,7 @@ export function VitalsSection({ profileId, role }: { profileId: string; role: st
       <div>
         <BentoHeader icon={HeartPulse} title={t('profile.vitalSigns')} subtitle={t('profile.vitalSigns.adminNote')} />
         {visible.length === 0 ? (
-          <BentoEmpty message={t('profile.vitalSigns.empty')} hint={t('profile.vitalSigns.emptyHint')} />
+          <BentoEmpty message={t('profile.vitalSigns.empty')} />
         ) : (
           <div className="grid grid-cols-2 gap-2">
             {visible.map(vs => <VitalCard key={vs.definition_id} vs={vs} />)}

--- a/app/(dashboard)/profile/components/VitalsSection.tsx
+++ b/app/(dashboard)/profile/components/VitalsSection.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { isVitalRecorded } from '@/lib/vitals'
 import { BentoHeader } from './BentoHeader'
+import { BentoSkeleton } from './BentoSkeleton'
 import { type ProfileVitalSign, VARIABLE_CAP } from '../types'
 import { ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -69,7 +70,12 @@ export function VitalsSection({ profileId, role }: { profileId: string; role: st
   )
 
   if (isLoading) {
-    return <div className="animate-pulse h-full rounded-lg" style={{ backgroundColor: 'var(--border-default)' }} />
+    return (
+      <div>
+        <BentoHeader icon={HeartPulse} title={t('profile.vitalSigns')} subtitle={t('profile.vitalSigns.adminNote')} />
+        <BentoSkeleton rows={2} />
+      </div>
+    )
   }
 
   const visible = vitals.slice(0, VARIABLE_CAP)

--- a/app/(dashboard)/profile/components/VitalsSection.tsx
+++ b/app/(dashboard)/profile/components/VitalsSection.tsx
@@ -2,9 +2,11 @@
 
 import { useState, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { HeartPulse } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { Drawer } from '@/components/ui/drawer'
 import { isVitalRecorded } from '@/lib/vitals'
+import { BentoHeader } from './BentoHeader'
 import { type ProfileVitalSign, VARIABLE_CAP } from '../types'
 import { ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -76,12 +78,7 @@ export function VitalsSection({ profileId, role }: { profileId: string; role: st
   return (
     <>
       <div>
-        <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-1 pr-24" style={{ color: 'var(--brand-crimson)' }}>
-          {t('profile.vitalSigns')}
-        </p>
-        <p className="text-xs mb-4" style={{ color: 'var(--text-secondary)' }}>
-          {t('profile.vitalSigns.adminNote')}
-        </p>
+        <BentoHeader icon={HeartPulse} title={t('profile.vitalSigns')} subtitle={t('profile.vitalSigns.adminNote')} />
         <div className="grid grid-cols-2 gap-2">
           {visible.map(vs => <VitalCard key={vs.definition_id} vs={vs} />)}
         </div>

--- a/app/(dashboard)/profile/components/VitalsSection.tsx
+++ b/app/(dashboard)/profile/components/VitalsSection.tsx
@@ -9,8 +9,6 @@ import { type ProfileVitalSign, VARIABLE_CAP } from '../types'
 import { ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
 
-export const VITALS_MIN_HEIGHT = 280
-
 function VitalCard({ vs }: { vs: ProfileVitalSign }) {
   const { t } = useLanguage()
   const label    = vs.vital_sign_definitions!.label
@@ -69,7 +67,7 @@ export function VitalsSection({ profileId, role }: { profileId: string; role: st
   )
 
   if (isLoading) {
-    return <div className="rounded-2xl animate-pulse h-full" style={{ backgroundColor: 'var(--border-default)' }} />
+    return <div className="animate-pulse h-full rounded-lg" style={{ backgroundColor: 'var(--border-default)' }} />
   }
 
   const visible = vitals.slice(0, VARIABLE_CAP)
@@ -77,7 +75,7 @@ export function VitalsSection({ profileId, role }: { profileId: string; role: st
 
   return (
     <>
-      <div className="rounded-2xl p-6 h-full" style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}>
+      <div>
         <p className="text-xs font-semibold tracking-[0.25em] uppercase mb-1 pr-24" style={{ color: 'var(--brand-crimson)' }}>
           {t('profile.vitalSigns')}
         </p>

--- a/app/(dashboard)/profile/components/VitalsSection.tsx
+++ b/app/(dashboard)/profile/components/VitalsSection.tsx
@@ -8,6 +8,7 @@ import { Drawer } from '@/components/ui/drawer'
 import { isVitalRecorded } from '@/lib/vitals'
 import { BentoHeader } from './BentoHeader'
 import { BentoSkeleton } from './BentoSkeleton'
+import { BentoEmpty } from './BentoEmpty'
 import { type ProfileVitalSign, VARIABLE_CAP } from '../types'
 import { ShowMoreButton } from './shared'
 import { apiClient } from '@/lib/apiClient'
@@ -85,14 +86,14 @@ export function VitalsSection({ profileId, role }: { profileId: string; role: st
     <>
       <div>
         <BentoHeader icon={HeartPulse} title={t('profile.vitalSigns')} subtitle={t('profile.vitalSigns.adminNote')} />
-        <div className="grid grid-cols-2 gap-2">
-          {visible.map(vs => <VitalCard key={vs.definition_id} vs={vs} />)}
-        </div>
-        {overflow > 0 && (
-          <div>
-            <ShowMoreButton count={overflow} onClick={() => setDrawerOpen(true)} />
+        {visible.length === 0 ? (
+          <BentoEmpty message={t('profile.vitalSigns.empty')} hint={t('profile.vitalSigns.emptyHint')} />
+        ) : (
+          <div className="grid grid-cols-2 gap-2">
+            {visible.map(vs => <VitalCard key={vs.definition_id} vs={vs} />)}
           </div>
         )}
+        {overflow > 0 && <ShowMoreButton count={overflow} onClick={() => setDrawerOpen(true)} />}
       </div>
 
       <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title={t('profile.allVitalSigns')}>

--- a/app/(dashboard)/profile/components/bento-registry.ts
+++ b/app/(dashboard)/profile/components/bento-registry.ts
@@ -1,3 +1,19 @@
+import {
+  User,
+  IdCard,
+  Plane,
+  Settings,
+  Luggage,
+  CreditCard,
+  Mail,
+  HeartPulse,
+  Users,
+  Calendar,
+  BarChart3,
+  Shield,
+  UserPlus,
+  type LucideIcon,
+} from 'lucide-react'
 import { type TranslationKey } from '@/lib/i18n/translations'
 
 // ── Bento ids ─────────────────────────────────────────────────────────────────
@@ -50,4 +66,44 @@ export const BENTO_KEY_MAP: Record<string, TranslationKey> = {
   [BENTO_IDS.STATS]:            'profile.bento.stats',
   [BENTO_IDS.ADMIN]:            'profile.bento.admin',
   [BENTO_IDS.INVITES]:          'profile.bento.invites',
+}
+
+// ── Layout metadata ───────────────────────────────────────────────────────────
+
+export const BENTO_HEIGHT = { S: 160, M: 280 } as const
+
+type BentoHeightTier = keyof typeof BENTO_HEIGHT
+
+export const BENTO_META: Record<string, { colSpan: number; height: BentoHeightTier }> = {
+  [BENTO_IDS.PERSONAL_DETAILS]: { colSpan: 6, height: 'M' },
+  [BENTO_IDS.ABO_INFO]:         { colSpan: 6, height: 'M' },
+  [BENTO_IDS.TRAVEL_DOC]:       { colSpan: 6, height: 'S' },
+  [BENTO_IDS.SETTINGS]:         { colSpan: 6, height: 'M' },
+  [BENTO_IDS.TRIPS]:            { colSpan: 6, height: 'M' },
+  [BENTO_IDS.PAYMENTS]:         { colSpan: 6, height: 'M' },
+  [BENTO_IDS.EMAIL_PREFS]:      { colSpan: 6, height: 'M' },
+  [BENTO_IDS.VITALS]:           { colSpan: 6, height: 'M' },
+  [BENTO_IDS.PARTICIPATION]:    { colSpan: 6, height: 'M' },
+  [BENTO_IDS.CALENDAR]:         { colSpan: 6, height: 'S' },
+  [BENTO_IDS.STATS]:            { colSpan: 6, height: 'S' },
+  [BENTO_IDS.ADMIN]:            { colSpan: 6, height: 'S' },
+  [BENTO_IDS.INVITES]:          { colSpan: 6, height: 'M' },
+}
+
+// ── Bento id → icon map — also used by the collapsed bar ─────────────────────
+
+export const BENTO_ICON_MAP: Record<string, LucideIcon> = {
+  [BENTO_IDS.PERSONAL_DETAILS]: User,
+  [BENTO_IDS.ABO_INFO]:         IdCard,
+  [BENTO_IDS.TRAVEL_DOC]:       Plane,
+  [BENTO_IDS.SETTINGS]:         Settings,
+  [BENTO_IDS.TRIPS]:            Luggage,
+  [BENTO_IDS.PAYMENTS]:         CreditCard,
+  [BENTO_IDS.EMAIL_PREFS]:      Mail,
+  [BENTO_IDS.VITALS]:           HeartPulse,
+  [BENTO_IDS.PARTICIPATION]:    Users,
+  [BENTO_IDS.CALENDAR]:         Calendar,
+  [BENTO_IDS.STATS]:            BarChart3,
+  [BENTO_IDS.ADMIN]:            Shield,
+  [BENTO_IDS.INVITES]:          UserPlus,
 }

--- a/app/(dashboard)/profile/components/bento-registry.ts
+++ b/app/(dashboard)/profile/components/bento-registry.ts
@@ -73,8 +73,9 @@ export const BENTO_KEY_MAP: Record<string, TranslationKey> = {
 export const BENTO_HEIGHT = { S: 160, M: 280 } as const
 
 type BentoHeightTier = keyof typeof BENTO_HEIGHT
+export type BentoId = (typeof BENTO_IDS)[keyof typeof BENTO_IDS]
 
-export const BENTO_META: Record<string, { colSpan: number; height: BentoHeightTier }> = {
+export const BENTO_META: Record<BentoId, { colSpan: number; height: BentoHeightTier }> = {
   [BENTO_IDS.PERSONAL_DETAILS]: { colSpan: 6, height: 'M' },
   [BENTO_IDS.ABO_INFO]:         { colSpan: 6, height: 'M' },
   [BENTO_IDS.TRAVEL_DOC]:       { colSpan: 6, height: 'S' },
@@ -92,7 +93,7 @@ export const BENTO_META: Record<string, { colSpan: number; height: BentoHeightTi
 
 // ── Bento id → icon map — also used by the collapsed bar ─────────────────────
 
-export const BENTO_ICON_MAP: Record<string, LucideIcon> = {
+export const BENTO_ICON_MAP: Record<BentoId, LucideIcon> = {
   [BENTO_IDS.PERSONAL_DETAILS]: User,
   [BENTO_IDS.ABO_INFO]:         IdCard,
   [BENTO_IDS.TRAVEL_DOC]:       Plane,

--- a/components/bento/BentoCard.tsx
+++ b/components/bento/BentoCard.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
 type CardVariant = 'default' | 'forest' | 'crimson' | 'teal' | 'edge-info' | 'edge-alert'
 
-type BentoCardProps = {
+export type BentoCardProps = {
   children?: React.ReactNode
   variant?: CardVariant
   colSpan?: number
@@ -34,7 +34,7 @@ export function Eyebrow({ children, style }: { children: React.ReactNode; style?
 
 // ── BentoCard ──────────────────────────────────────────────────────────────────
 
-export default function BentoCard({
+const BentoCard = forwardRef<HTMLDivElement, BentoCardProps>(function BentoCard({
   children,
   variant = 'default',
   colSpan,
@@ -43,7 +43,7 @@ export default function BentoCard({
   className = '',
   style,
   onClick,
-}: BentoCardProps) {
+}, ref) {
   const variantClass =
     variant === 'default'     ? 'card' :
     variant === 'forest'      ? 'card card--forest' :
@@ -65,6 +65,7 @@ export default function BentoCard({
 
   return (
     <div
+      ref={ref}
       className={`${variantClass} ${liftClass} ${className}`.trim()}
       style={{ ...spanStyle, ...style }}
       onClick={onClick}
@@ -72,4 +73,6 @@ export default function BentoCard({
       {children}
     </div>
   )
-}
+})
+
+export default BentoCard

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #613 | `dev/2607-DEV-613` | `app/globals.css`, `app/(dashboard)/calendar/components/CalendarClient.tsx`, `app/admin/calendar/components/AdminCalendarClient.tsx`, `styles/brand-tokens.css`, `components/admin/StatusPill.tsx`, Mapbox tile components (`LocationTile`/`AboutMapTile`), `docs/design/DESIGN-SYSTEM.md`; migration: no | 2026-07-25T19:00:00Z |
+| #665 | `dev/2607-DEV-665` | `components/bento/BentoCard.tsx`, `styles/brand-tokens.css`, `docs/design/DESIGN-SYSTEM.md`, `docs/architecture/DECISIONS.md`, all of `app/(dashboard)/profile/components/` (13 content components + shared shell), `e2e/profile-bento-auth.spec.ts`; migration: no | 2026-07-26T00:00:00Z |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,44 +1,51 @@
 ## Goal
-Issue #613 (2607-DEV-613, branch `dev/2607-DEV-613`): purge dead legacy CSS palette tokens, add semantic `--status-*` tokens for `StatusPill`, fix Mapbox dark styling, update DESIGN-SYSTEM.md.
+BUILD issue #665 (2607-DEV-665, branch `dev/2607-DEV-665`): migrate all 13 `/profile` bentos onto the shared `BentoCard`/`.card` design system — shell, header, skeleton, empty state, elevation tokens.
 
 ## Now
-PR [#664](https://github.com/teamenjoyvd/tevd-portal/pull/664) open as **draft** against `main` (`Closes #613`), branch `dev/2607-DEV-613` pushed (commits `561fb4d` code+docs). CI and Vercel Preview not yet checked this turn — draft was just opened.
+Step 1: shared primitive (`BentoCard` forwardRef), elevation tokens, new co-located components (`BentoHeader`/`BentoSkeleton`/`BentoEmpty`), `bento-registry.ts` (`BENTO_META`/`BENTO_ICON_MAP`), i18n string.
 
 ## Next
-- Check CI status and Vercel Preview READY on PR #664.
-- No authenticated Clerk DEV credentials available locally — needs a human visual check of `StatusPill` light/dark on the live Preview (admin > reminders) before marking ready for review.
-- When ready: mark PR ready for review to trigger the single CodeRabbit pass (per docs/ai/BUILD.md FINALIZE), address findings in one batched push.
-- After merge: run the post-merge tail (prod Vercel deploy check, confirm issue #613 auto-closed, remove `docs/CLAIMS.md` `#613` row).
-4. `docs/design/DESIGN-SYSTEM.md`: Component states + Usage rules sections, reflecting actual scope (note Mapbox/calendar chips already correct).
-5. `npm run build` + `npm run lint`, then `/code-review low` before pushing draft PR.
+1. Step 1 (this step) — build check.
+2. Step 4 (write first per issue) — new `e2e/profile-bento-auth.spec.ts` regression spec.
+3. Step 2 — atomic shell refactor: `SortableBento.tsx`, `BentoGrid.tsx`, `ProfileClient.tsx`, all 13 content components lose their `rounded-2xl p-6 h-full` wrapper. Run new e2e spec as the checkpoint.
+4. Step 3a — headers: all 13 components → `<BentoHeader>`.
+5. Step 3b — skeletons: all 13 → `<BentoSkeleton>`, add missing states to `CalendarSection`/`EmailPrefsSection`.
+6. Step 3c — empty states/icons: `<BentoEmpty>`, lucide icon swaps, dead-code removal per issue.
+7. Verification pass per issue's `## Verification` section (build, lint, e2e local, 1280/390 screenshots, dark theme incl. `/` and `/about`).
+8. `/code-review low` before push; open draft PR `Closes #665`.
 
 ## Constraints
-- Never push directly to `main`; `dev/[YYMM]-DEV-[GH#]` branches only
-- No `git push` without the user explicitly asking for a push in-conversation (quote required) — not asked yet this session
-- Never mark Done on static analysis alone — Vercel PR preview must be READY and CI green
-- No failing check gets weakened/skipped to pass
-- Change only lines the task requires — do not touch `--forest`/`--crimson`/`--sienna`/`--stone` (still live, used by calendar files) or the 3 other files also using non-firing `dark:` classes (`ReminderTable.tsx`, `RemindersTab.tsx`, `LinksGuidesTile.tsx` — out of scope, noted only)
+- 390px mobile-first — every bento must render correctly at 390px, including the mobile static-stack path.
+- shadcn/ui for any interactive primitive added.
+- Component co-location — profile-only components stay under `app/(dashboard)/profile/components/`.
+- No Tailwind `dark:` variants in the profile folder — use `[data-theme="dark"]` selectors.
+- Preserve dnd-kit drag/reorder, collapse/expand, and `profile.ui_prefs` persistence exactly.
+- Cards stay non-interactive — no `interactive-lift`, no whole-card `onClick`.
+- No `.bento-tile` entrance animation.
+- Do not adopt `.bento-grid` class (`grid-auto-rows`/`grid-auto-flow: dense` conflict) — keep profile's explicit inline grid, only source `gap` from `var(--bento-gap)`.
+- Headers stay in content components, not hoisted into `SortableBento` (stateful action buttons live there).
+- `PersonalDetailsContent`'s crimson border: plain `style={{ borderColor: 'var(--brand-crimson)' }}` override, NOT `variant="edge-alert"`.
+- No `git push` without the user explicitly asking for a push in-conversation (quote required) — not asked yet this session.
+- Part 2 (status-token consolidation, back links, colour sweep) is a separate, later issue — do not do that work here even though it touches the same files.
+- NOTED items in the issue (RoleRow remount, resetLayout pre-hydration bug, raw status strings, etc.) are deliberately NOT fixed here.
 
 ## Decisions
-DECISION: skip the Mapbox dark-style item entirely — `LocationTile.tsx` and `AboutMapTile.tsx` already implement the exact prescribed pattern (`setStyle()` + `styledata` + `MutationObserver`/`useTheme` watching `data-theme`). Verified by reading both files in full; issue's "confirmed live" claim does not match current code.
-DECISION: skip the "calendar chip restyle" — repo-wide grep for `--eggshell|--deep|--sage|--sandy` returns zero hits outside `globals.css`'s own definitions. The calendar files (`FilterControls.tsx`, `MonthView.tsx`, `AgendaView.tsx`, `AdminCalendarClient.tsx`) use `--forest`/`--crimson`/`--sienna`, which `styles/brand-tokens.css:16-17` documents as intentional legacy aliases for brand tokens — not part of this purge, not touching them.
-DECISION: only delete the 4 named-dead tokens from `globals.css`'s legacy `:root` block; keep `--forest`/`--crimson`/`--sienna`/`--stone` since they're actively referenced elsewhere and out of the issue's literal scope.
-DECISION: `StatusPill` status->token mapping: `sent`->success, `claimed`->info, `failed`+`permanently_failed`->alert (both, distinguished only by label text — only 4 semantic tokens exist for 5 states), `pending`/default->pending.
+DECISION: follow the issue's own Step 0-4 ordering verbatim rather than re-deriving a plan — it already verified its own file:line claims (confirmed `BentoCard.tsx:69` spread order during PLAN).
+DECISION: write the new `e2e/profile-bento-auth.spec.ts` before Step 2's shell refactor (per issue), so it's the checkpoint for the atomic 13-file change, not an afterthought.
 
 ## Facts
-- Theming mechanism: `data-theme="dark"|"light"` attribute on `<html>`, set by `lib/hooks/useTheme.ts` and read via `document.documentElement.getAttribute('data-theme')` — NOT Tailwind's default `dark:` variant (media or `.dark` class), which is why `StatusPill.tsx`'s `dark:bg-*` classes never fire. No `@custom-variant dark` defined anywhere in the repo (confirmed by grep).
-- `styles/brand-tokens.css` pattern for dark overrides: single `[data-theme="dark"] { --token: value; }` block redefining light-mode custom properties — new `--status-*` tokens should follow this same shape.
-- Other files with the same non-firing `dark:` bug (NOT in scope for #613): `app/admin/calendar/[id]/components/ReminderTable.tsx`, `app/admin/settings/components/RemindersTab.tsx`, `app/(dashboard)/components/tiles/LinksGuidesTile.tsx`.
-- `StatusPill` consumers: `ReminderTable.tsx`, `RemindersTab.tsx` — both just render `<StatusPill status={...} />`, no external color coupling.
+- Route: `app/(dashboard)/profile/` — `page.tsx` (server) → `ProfileClient.tsx` (builds `bentoMap`, order/collapse state, `profile.ui_prefs` persistence) → `BentoGrid.tsx` (desktop, dnd-kit, dynamic import) or static stack (mobile) → `SortableBento.tsx` (shared shell).
+- 13 bento ids: `bento-registry.ts` `BENTO_IDS`/`DEFAULT_ORDER`.
+- `BentoCard`/`Eyebrow` live in `components/bento/BentoCard.tsx`; `style` spreads after `spanStyle` at line 69 (verified).
+- `components/ui/skeleton.tsx` exports `Skeleton({ className, style })` using `.skeleton-shimmer` + `--skeleton-base`.
+- Test commands: `npm run build`, `npm run lint`, `npm run test:e2e:auth`, `npm run test:mobile` (authenticated E2E CI job is a known skip — must run locally against DEV, per memory).
+- `BENTO_HEIGHT = { S: 160, M: 280 }` currently lives in `ProfileClient.tsx:40` — moving to `bento-registry.ts` per issue.
 
 ## Done
-#613 CLAIM — RESULT: `blocked` label removed (deps #611/#612 both merged), branch `dev/2607-DEV-613` cut from up-to-date `main`, issue `## Branch` section added, `docs/CLAIMS.md` row registered (pruned stale `#612` row, its PR #663 already merged).
-#613 BUILD (code) — RESULT: trimmed scope executed — `app/globals.css` (4 dead tokens removed, `body` bg fixed to `var(--bg-global)`), `styles/brand-tokens.css` (8 new `--status-*` tokens, light+dark), `components/admin/StatusPill.tsx` (rebuilt on tokens via inline style), `docs/design/DESIGN-SYSTEM.md` (Component States + Usage Rules sections). `npm run build` exit 0 (full route manifest generated, TypeScript clean), `npm run lint` 0 errors/485 warnings (none in changed files, pre-existing baseline). Manual diff review done (no `/code-review` skill invokable this session). `npm install` was also run mid-session — 29 packages (`@radix-ui/react-toggle`, `-toggle-group`, `-switch` etc.) were declared in `package.json` but missing from `node_modules`, unrelated pre-existing gap from the merged #610 PR; `package-lock.json` unchanged, so this was a local sync only, not a dependency change.
+PLAN + CLAIM for #665 — RESULT: issue CLAIM-complete (`## Design Checklist` all checked, `## Branch` = `dev/2607-DEV-665`), branch cut from `main` and pushed, `docs/CLAIMS.md` row registered (pruned stale merged #613 row).
 
 ## Open items
-- No local authenticated visual check of `StatusPill` in light/dark was possible (no stored admin Clerk DEV credentials, same gap as #608/#607) — needs a human check on the Vercel Preview before marking ready for review.
-- PR body should note the trimmed scope (Mapbox/calendar-chip items already satisfied, not touched) so reviewers aren't surprised by the smaller diff.
-- Not yet committed/pushed — no push requested in-conversation yet.
+(none yet — populate as Step 1 proceeds)
 
 ## Failed attempts
-- ATTEMPT: ran `npm run build` concurrently with `npm install` (mid-flight dependency sync) — the build process appeared to hang at "Creating an optimized production build..." for several minutes with no forward log output. FIXED by not killing it: confirmed via `Get-CimInstance Win32_Process` that it was still spawning live Turbopack worker processes, so it was slow (3.4min compile), not stuck — waited it out instead of killing. Avoid running `npm install` concurrently with a build in future sessions; it's likely what caused the slowdown/confusion.
+(none yet)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,17 +2,15 @@
 BUILD issue #665 (2607-DEV-665, branch `dev/2607-DEV-665`): migrate all 13 `/profile` bentos onto the shared `BentoCard`/`.card` design system — shell, header, skeleton, empty state, elevation tokens.
 
 ## Now
-Step 1: shared primitive (`BentoCard` forwardRef), elevation tokens, new co-located components (`BentoHeader`/`BentoSkeleton`/`BentoEmpty`), `bento-registry.ts` (`BENTO_META`/`BENTO_ICON_MAP`), i18n string.
+Step 2 next: atomic shell refactor across `SortableBento.tsx`, `BentoGrid.tsx`, `ProfileClient.tsx`, and all 13 content components.
 
 ## Next
-1. Step 1 (this step) — build check.
-2. Step 4 (write first per issue) — new `e2e/profile-bento-auth.spec.ts` regression spec.
-3. Step 2 — atomic shell refactor: `SortableBento.tsx`, `BentoGrid.tsx`, `ProfileClient.tsx`, all 13 content components lose their `rounded-2xl p-6 h-full` wrapper. Run new e2e spec as the checkpoint.
-4. Step 3a — headers: all 13 components → `<BentoHeader>`.
-5. Step 3b — skeletons: all 13 → `<BentoSkeleton>`, add missing states to `CalendarSection`/`EmailPrefsSection`.
-6. Step 3c — empty states/icons: `<BentoEmpty>`, lucide icon swaps, dead-code removal per issue.
-7. Verification pass per issue's `## Verification` section (build, lint, e2e local, 1280/390 screenshots, dark theme incl. `/` and `/about`).
-8. `/code-review low` before push; open draft PR `Closes #665`.
+1. Step 2 — atomic shell refactor: `SortableBento.tsx` renders `BentoCard` directly (both branches), delete `bento-mobile-full`; `BentoGrid.tsx` gap token; `ProfileClient.tsx` reads `BENTO_META`; all 13 content components lose `rounded-2xl p-6 h-full` wrapper + inline bg/border + `*_MIN_HEIGHT` exports. Run new e2e spec as the checkpoint (best-effort locally — see Open items on env gap).
+2. Step 3a — headers: all 13 components → `<BentoHeader>`.
+3. Step 3b — skeletons: all 13 → `<BentoSkeleton>`, add missing states to `CalendarSection`/`EmailPrefsSection`.
+4. Step 3c — empty states/icons: `<BentoEmpty>`, lucide icon swaps, dead-code removal per issue.
+5. Verification pass per issue's `## Verification` section (build, lint, e2e local, 1280/390 screenshots, dark theme incl. `/` and `/about`).
+6. `/code-review low` before push; open draft PR `Closes #665`.
 
 ## Constraints
 - 390px mobile-first — every bento must render correctly at 390px, including the mobile static-stack path.
@@ -45,7 +43,7 @@ DECISION: write the new `e2e/profile-bento-auth.spec.ts` before Step 2's shell r
 PLAN + CLAIM for #665 — RESULT: issue CLAIM-complete (`## Design Checklist` all checked, `## Branch` = `dev/2607-DEV-665`), branch cut from `main` and pushed, `docs/CLAIMS.md` row registered (pruned stale merged #613 row).
 
 ## Open items
-(none yet — populate as Step 1 proceeds)
+- New `e2e/profile-bento-auth.spec.ts` (5 tests) has NOT been executed against a real Clerk/Supabase session — this worktree has no `.env.local`, no local Supabase, no seeded Clerk test users (same gap noted on #613/#608/#607). `playwright test --list` confirms the file is wired correctly into both the `authenticated` and `mobile-390` projects and excluded from `desktop`; actual pass/fail is still unverified. Must run for real (`npm run test:e2e:auth` + `npm run test:mobile`) before claiming Step 2/Verification done, per docs/ai/BUILD.md VERIFY.
 
 ## Failed attempts
 (none yet)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,14 +2,15 @@
 BUILD issue #665 (2607-DEV-665, branch `dev/2607-DEV-665`): migrate all 13 `/profile` bentos onto the shared `BentoCard`/`.card` design system — shell, header, skeleton, empty state, elevation tokens.
 
 ## Now
-Step 3a next: headers — all 13 content components → `<BentoHeader>`.
+All of Step 1/2/3/4 (issue's own numbered plan) implemented and committed. Running `/code-review low` next, then push + draft PR.
 
 ## Next
-1. Step 3a — headers: all 13 components → `<BentoHeader>`; fix missing `pr-24`/gutter clearance (Calendar, EmailPrefs, InvitesBento); Vitals subtitle prop; Admin `tone="teal"`.
-2. Step 3b — skeletons: all 13 → `<BentoSkeleton>`, add missing states to `CalendarSection`/`EmailPrefsSection`.
-3. Step 3c — empty states/icons: `<BentoEmpty>`, lucide icon swaps, dead-code removal per issue (`DEFAULT_CALENDAR_NAME`, unused `formatCurrency` import in PaymentsSection, redundant `ShowMoreButton` wrapper div in VitalsSection).
-4. Verification pass per issue's `## Verification` section (build, lint, e2e local, 1280/390 screenshots, dark theme incl. `/` and `/about`).
-5. `/code-review low` before push; open draft PR `Closes #665`.
+1. `/code-review low` on the branch diff; fix findings locally.
+2. Push `dev/2607-DEV-665`, open draft PR `Closes #665`.
+3. Wait for CI green + Vercel Preview READY — this is the actual verification gate; local browser check is blocked in this worktree (no Supabase env vars, confirmed by starting the dev server: `Error: supabaseUrl is required` at `lib/supabase/service.ts:8`, same gap as #613/#608/#607).
+4. On the Preview: confirm 1280px chrome doesn't overlap Calendar/EmailPrefs/InvitesBento headers, 390px no horizontal overflow, dark theme on all 13 bentos + `/` + `/about` + one modal (Step 1 touched shared `--shadow-*` tokens), loading throttle shows header+shimmer with no vanish/pop and correct switch positions on EmailPrefsSection.
+5. Run `npm run test:e2e:auth` + `npm run test:mobile` for real against a real Clerk/Supabase target (not possible in this worktree) — paste output, since CI's authenticated E2E job is a known skip.
+6. Mark PR ready for review → one CodeRabbit pass → batched fix push → merge → GCR (remove CLAIMS.md row, close issue).
 
 ## Constraints
 - 390px mobile-first — every bento must render correctly at 390px, including the mobile static-stack path.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,15 +2,14 @@
 BUILD issue #665 (2607-DEV-665, branch `dev/2607-DEV-665`): migrate all 13 `/profile` bentos onto the shared `BentoCard`/`.card` design system — shell, header, skeleton, empty state, elevation tokens.
 
 ## Now
-All of Step 1/2/3/4 (issue's own numbered plan) implemented and committed. Running `/code-review low` next, then push + draft PR.
+PR #667 opened as draft (`Closes #665`), branch pushed. Waiting on CI + Vercel Preview.
 
 ## Next
-1. `/code-review low` on the branch diff; fix findings locally.
-2. Push `dev/2607-DEV-665`, open draft PR `Closes #665`.
-3. Wait for CI green + Vercel Preview READY — this is the actual verification gate; local browser check is blocked in this worktree (no Supabase env vars, confirmed by starting the dev server: `Error: supabaseUrl is required` at `lib/supabase/service.ts:8`, same gap as #613/#608/#607).
-4. On the Preview: confirm 1280px chrome doesn't overlap Calendar/EmailPrefs/InvitesBento headers, 390px no horizontal overflow, dark theme on all 13 bentos + `/` + `/about` + one modal (Step 1 touched shared `--shadow-*` tokens), loading throttle shows header+shimmer with no vanish/pop and correct switch positions on EmailPrefsSection.
-5. Run `npm run test:e2e:auth` + `npm run test:mobile` for real against a real Clerk/Supabase target (not possible in this worktree) — paste output, since CI's authenticated E2E job is a known skip.
-6. Mark PR ready for review → one CodeRabbit pass → batched fix push → merge → GCR (remove CLAIMS.md row, close issue).
+1. Check CI status and Vercel Preview READY on PR #667.
+2. On the Preview: confirm 1280px chrome doesn't overlap Calendar/EmailPrefs/InvitesBento headers, 390px no horizontal overflow, dark theme on all 13 bentos + `/` + `/about` + one modal (Step 1 touched shared `--shadow-*` tokens), loading throttle shows header+shimmer with no vanish/pop and correct switch positions on EmailPrefsSection.
+3. Run `npm run test:e2e:auth` + `npm run test:mobile` for real against a real Clerk/Supabase target (not possible in this worktree, no `.env.local`/local Supabase/seeded Clerk users) — paste output, since CI's authenticated E2E job is a known skip.
+4. Mark PR ready for review → one CodeRabbit pass → batched fix push → merge → GCR (remove CLAIMS.md row, close issue).
+5. After merge: no migrations in this PR, so no prod gate to approve — just confirm prod Vercel deploy READY and smoke-check `/profile`.
 
 ## Constraints
 - 390px mobile-first — every bento must render correctly at 390px, including the mobile static-stack path.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,15 +2,14 @@
 BUILD issue #665 (2607-DEV-665, branch `dev/2607-DEV-665`): migrate all 13 `/profile` bentos onto the shared `BentoCard`/`.card` design system — shell, header, skeleton, empty state, elevation tokens.
 
 ## Now
-Step 2 next: atomic shell refactor across `SortableBento.tsx`, `BentoGrid.tsx`, `ProfileClient.tsx`, and all 13 content components.
+Step 3a next: headers — all 13 content components → `<BentoHeader>`.
 
 ## Next
-1. Step 2 — atomic shell refactor: `SortableBento.tsx` renders `BentoCard` directly (both branches), delete `bento-mobile-full`; `BentoGrid.tsx` gap token; `ProfileClient.tsx` reads `BENTO_META`; all 13 content components lose `rounded-2xl p-6 h-full` wrapper + inline bg/border + `*_MIN_HEIGHT` exports. Run new e2e spec as the checkpoint (best-effort locally — see Open items on env gap).
-2. Step 3a — headers: all 13 components → `<BentoHeader>`.
-3. Step 3b — skeletons: all 13 → `<BentoSkeleton>`, add missing states to `CalendarSection`/`EmailPrefsSection`.
-4. Step 3c — empty states/icons: `<BentoEmpty>`, lucide icon swaps, dead-code removal per issue.
-5. Verification pass per issue's `## Verification` section (build, lint, e2e local, 1280/390 screenshots, dark theme incl. `/` and `/about`).
-6. `/code-review low` before push; open draft PR `Closes #665`.
+1. Step 3a — headers: all 13 components → `<BentoHeader>`; fix missing `pr-24`/gutter clearance (Calendar, EmailPrefs, InvitesBento); Vitals subtitle prop; Admin `tone="teal"`.
+2. Step 3b — skeletons: all 13 → `<BentoSkeleton>`, add missing states to `CalendarSection`/`EmailPrefsSection`.
+3. Step 3c — empty states/icons: `<BentoEmpty>`, lucide icon swaps, dead-code removal per issue (`DEFAULT_CALENDAR_NAME`, unused `formatCurrency` import in PaymentsSection, redundant `ShowMoreButton` wrapper div in VitalsSection).
+4. Verification pass per issue's `## Verification` section (build, lint, e2e local, 1280/390 screenshots, dark theme incl. `/` and `/about`).
+5. `/code-review low` before push; open draft PR `Closes #665`.
 
 ## Constraints
 - 390px mobile-first — every bento must render correctly at 390px, including the mobile static-stack path.
@@ -41,6 +40,9 @@ DECISION: write the new `e2e/profile-bento-auth.spec.ts` before Step 2's shell r
 
 ## Done
 PLAN + CLAIM for #665 — RESULT: issue CLAIM-complete (`## Design Checklist` all checked, `## Branch` = `dev/2607-DEV-665`), branch cut from `main` and pushed, `docs/CLAIMS.md` row registered (pruned stale merged #613 row).
+Step 1 — RESULT: `BentoCard` forwardRef, dark `--shadow-*` tokens, `BentoHeader`/`BentoSkeleton`/`BentoEmpty` created, `bento-registry.ts` `BENTO_META`/`BENTO_ICON_MAP`/`BENTO_HEIGHT`, `profile.calendar.generating` i18n string, DESIGN-SYSTEM.md:74 fixed. `npm run build`/`lint` clean vs baseline. Committed 7bd6fb4.
+Step 4 — RESULT: `e2e/profile-bento-auth.spec.ts` (5 tests) written, wired into `playwright.config.ts` (`authenticated` testMatch + `desktop` testIgnore gained `profile-bento-auth`; `mobile-390` picks it up unchanged). `playwright test --list` confirms correct project routing. Committed b9147e6.
+Step 2 — RESULT: atomic shell refactor across `SortableBento.tsx` (now renders `BentoCard` directly, both collapsed/expanded branches, `bento-mobile-full` deleted), `BentoGrid.tsx` (gap token), `ProfileClient.tsx` (reads `BENTO_META`/`BENTO_HEIGHT`, computes `personalDetailsIncomplete` and passes it as `cardStyle` through `SortableBento`→`BentoCard`), and all 13 content components (wrapper `rounded-2xl p-6 h-full` + inline bg/border stripped, 7 `*_MIN_HEIGHT` exports deleted + the already-dead `INVITES_MIN_HEIGHT` in `InvitesSection.tsx` = 8 total). `npm run build`/`lint` clean, 480 warnings matches baseline exactly. New e2e spec NOT run for real (env gap, see Open items) — not yet committed.
 
 ## Open items
 - New `e2e/profile-bento-auth.spec.ts` (5 tests) has NOT been executed against a real Clerk/Supabase session — this worktree has no `.env.local`, no local Supabase, no seeded Clerk test users (same gap noted on #613/#608/#607). `playwright test --list` confirms the file is wired correctly into both the `authenticated` and `mobile-390` projects and excluded from `desktop`; actual pass/fail is still unverified. Must run for real (`npm run test:e2e:auth` + `npm run test:mobile`) before claiming Step 2/Verification done, per docs/ai/BUILD.md VERIFY.

--- a/docs/design/DESIGN-SYSTEM.md
+++ b/docs/design/DESIGN-SYSTEM.md
@@ -71,7 +71,7 @@ Hierarchical shadow system for layering UI surfaces. All shadows are defined in
 | `--shadow-hover` | Hover state of interactive cards (`.interactive-lift` class) | `0 2px 4px rgba(45, 51, 42, 0.05), 0 12px 24px -8px rgba(45, 51, 42, 0.10)` |
 | `--shadow-modal` | Overlay surfaces (dialog, sheet, popover, dropdown) | `0 4px 12px rgba(26, 31, 24, 0.08), 0 24px 48px -12px rgba(26, 31, 24, 0.18)` |
 
-Dark mode uses the same token names with parchment-tinted values for consistency.
+Dark mode redefines the same token names with the same blur/offset geometry, tint swapped from the light forest base to the dark `--brand-void` base at roughly 3x the alpha — a shadow needs more opacity to read against a dark surface.
 
 ## Component States
 

--- a/e2e/profile-bento-auth.spec.ts
+++ b/e2e/profile-bento-auth.spec.ts
@@ -9,12 +9,13 @@ import { BENTO_IDS } from '../app/(dashboard)/profile/components/bento-registry'
  * shell — this spec is the checkpoint for that atomic change (issue
  * "Step 2"), written first so it fails loudly on a half-migrated tree.
  *
- * Two projects exercise it (see playwright.config.ts): 'authenticated'
- * (1280px, dnd-kit desktop grid path — drag/collapse/persistence) and
- * 'mobile-390' (the static-stack path — no drag handle, no horizontal
- * overflow). Each test guards its own project via testInfo.project.name
- * so running the whole file under either project is a no-op for the
- * tests that don't apply there, rather than a hard skip at the file level.
+ * Runs entirely under the 'authenticated' project (see playwright.config.ts)
+ * at 1280px for the dnd-kit drag/collapse/persistence path; the static-stack
+ * describe block overrides the viewport to 390px via test.use() instead of
+ * relying on the 'mobile-390' project, because that project runs in
+ * preview-smoke.yml against a live Vercel Preview with no Clerk secrets
+ * configured — clerk.signIn() would fail outright there, the same reason
+ * admin-auth.spec.ts/los-submission-auth.spec.ts are excluded from it too.
  *
  * Requires local Supabase + a seeded Clerk test-instance member (see
  * scripts/seed-clerk-test-users.js). Never target a preview/prod-DB
@@ -137,8 +138,13 @@ test.describe('desktop bento grid — drag, collapse, layout persistence', () =>
 })
 
 test.describe('mobile static stack (390px)', () => {
+  // Runs inside the 'authenticated' project (Clerk sign-in required) with an
+  // explicit viewport override, rather than under the 'mobile-390' project —
+  // see the file-level comment above for why.
+  test.use({ viewport: { width: 390, height: 844 } })
+
   test.beforeEach(async ({}, testInfo) => {
-    test.skip(testInfo.project.name !== 'mobile-390', 'static-stack path only asserted in the mobile-390 project')
+    test.skip(testInfo.project.name !== 'authenticated', 'runs under authenticated with a 390px viewport override')
   })
 
   test('renders the static stack with no drag handle and no horizontal overflow', async ({ page }) => {

--- a/e2e/profile-bento-auth.spec.ts
+++ b/e2e/profile-bento-auth.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect, type Page } from '@playwright/test'
+import { clerk } from '@clerk/testing/playwright'
+import { BENTO_IDS } from '../app/(dashboard)/profile/components/bento-registry'
+
+/**
+ * Regression coverage for the #665 profile-bento shell refactor. dnd-kit
+ * drag/reorder, collapse/expand, and `profile.ui_prefs` persistence must
+ * survive SortableBento/BentoGrid being rebuilt on the shared BentoCard
+ * shell — this spec is the checkpoint for that atomic change (issue
+ * "Step 2"), written first so it fails loudly on a half-migrated tree.
+ *
+ * Two projects exercise it (see playwright.config.ts): 'authenticated'
+ * (1280px, dnd-kit desktop grid path — drag/collapse/persistence) and
+ * 'mobile-390' (the static-stack path — no drag handle, no horizontal
+ * overflow). Each test guards its own project via testInfo.project.name
+ * so running the whole file under either project is a no-op for the
+ * tests that don't apply there, rather than a hard skip at the file level.
+ *
+ * Requires local Supabase + a seeded Clerk test-instance member (see
+ * scripts/seed-clerk-test-users.js). Never target a preview/prod-DB
+ * deployment — same rule as admin-auth.spec.ts.
+ */
+
+const MEMBER_EMAIL = process.env.E2E_CLERK_MEMBER_EMAIL ?? 'e2e-member-tevd-portal@example.com'
+
+// ProfileClient debounces ui_prefs PATCH by 500ms after every reorder/
+// collapse/reset call — give it margin before reload or the write races
+// the navigation.
+const PERSIST_DEBOUNCE_MARGIN_MS = 800
+
+async function signInAndOpenProfile(page: Page) {
+  await page.goto('/')
+  await clerk.signIn({ page, emailAddress: MEMBER_EMAIL })
+  await page.goto('/profile')
+  await expect(page.locator('body')).toBeVisible()
+}
+
+async function getPersistedUiPrefs(page: Page) {
+  const response = await page.request.get('/api/profile')
+  expect(response.status(), 'GET /api/profile').toBe(200)
+  const body = await response.json()
+  return (body.ui_prefs ?? {}) as { bento_order?: string[]; bento_collapsed?: Record<string, boolean> }
+}
+
+test.describe('desktop bento grid — drag, collapse, layout persistence', () => {
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'authenticated', 'desktop dnd-kit grid path only runs in the authenticated (1280px) project')
+  })
+
+  test('reset layout restores the default order and clears collapse state', async ({ page }) => {
+    await signInAndOpenProfile(page)
+
+    await page.getByRole('button', { name: 'Reset layout' }).click()
+    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+
+    const prefs = await getPersistedUiPrefs(page)
+    expect(prefs.bento_collapsed ?? {}).toEqual({})
+    // PERSONAL_DETAILS and ABO_INFO are unconditional (rendered for every
+    // role) and lead DEFAULT_ORDER — stable anchors regardless of which
+    // conditional bentos (Trips, Payments, Admin, ...) this test user sees.
+    const order = prefs.bento_order ?? []
+    expect(order.indexOf(BENTO_IDS.PERSONAL_DETAILS)).toBeLessThan(order.indexOf(BENTO_IDS.ABO_INFO))
+  })
+
+  test('dragging a bento past another persists the new order after reload', async ({ page }) => {
+    await signInAndOpenProfile(page)
+
+    await page.getByRole('button', { name: 'Reset layout' }).click()
+    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+    // Collapse all first: fixed-size bars make the drag geometry
+    // deterministic and keep the assertion independent of each bento's
+    // (soon to change, per Step 3) internal content layout.
+    await page.getByRole('button', { name: 'Collapse all' }).click()
+    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+
+    const handles = page.locator('[title="Drag to reorder"]')
+    await expect(handles.first()).toBeVisible()
+    const firstBox = await handles.nth(0).boundingBox()
+    const secondBox = await handles.nth(1).boundingBox()
+    expect(firstBox, 'first drag handle bounding box').not.toBeNull()
+    expect(secondBox, 'second drag handle bounding box').not.toBeNull()
+
+    const beforeOrder = (await getPersistedUiPrefs(page)).bento_order ?? []
+    const [firstId, secondId] = beforeOrder
+
+    // Manual pointer sequence (not page.dragTo) — dnd-kit's PointerSensor
+    // needs an initial move past its 8px activation distance before the
+    // drag registers, then intermediate moves so closestCenter has real
+    // in-flight rects to compare against.
+    await page.mouse.move(firstBox!.x + firstBox!.width / 2, firstBox!.y + firstBox!.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(firstBox!.x + firstBox!.width / 2, firstBox!.y + firstBox!.height / 2 + 12)
+    await page.mouse.move(secondBox!.x + secondBox!.width / 2, secondBox!.y + secondBox!.height / 2 + 4, { steps: 10 })
+    await page.mouse.move(secondBox!.x + secondBox!.width / 2, secondBox!.y + secondBox!.height / 2 + 8, { steps: 5 })
+    await page.mouse.up()
+    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+
+    await page.reload()
+    const afterOrder = (await getPersistedUiPrefs(page)).bento_order ?? []
+    expect(afterOrder.indexOf(secondId), `${secondId} should now precede ${firstId}`).toBeLessThan(afterOrder.indexOf(firstId))
+  })
+
+  test('collapsing a bento persists after reload', async ({ page }) => {
+    await signInAndOpenProfile(page)
+    await page.getByRole('button', { name: 'Reset layout' }).click()
+    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+
+    await page.getByRole('button', { name: 'Collapse', exact: true }).first().click()
+    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+
+    const beforeReload = await getPersistedUiPrefs(page)
+    const collapsedIds = Object.entries(beforeReload.bento_collapsed ?? {}).filter(([, v]) => v).map(([k]) => k)
+    expect(collapsedIds.length, 'exactly one bento collapsed').toBe(1)
+
+    await page.reload()
+    const afterReload = await getPersistedUiPrefs(page)
+    expect(afterReload.bento_collapsed?.[collapsedIds[0]]).toBe(true)
+    // The collapsed bar's expand control replaces the per-item collapse
+    // button — confirms the UI, not just the persisted flag, reflects state.
+    await expect(page.getByRole('button', { name: 'Expand', exact: true }).first()).toBeVisible()
+  })
+
+  test('expand-all toggles every bento back open', async ({ page }) => {
+    await signInAndOpenProfile(page)
+    await page.getByRole('button', { name: 'Collapse all' }).click()
+    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+    await expect(page.getByRole('button', { name: 'Expand all' })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Expand all' }).click()
+    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+
+    const prefs = await getPersistedUiPrefs(page)
+    const anyCollapsed = Object.values(prefs.bento_collapsed ?? {}).some(Boolean)
+    expect(anyCollapsed, 'no bento should remain collapsed').toBe(false)
+    await expect(page.getByRole('button', { name: 'Collapse all' })).toBeVisible()
+  })
+})
+
+test.describe('mobile static stack (390px)', () => {
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile-390', 'static-stack path only asserted in the mobile-390 project')
+  })
+
+  test('renders the static stack with no drag handle and no horizontal overflow', async ({ page }) => {
+    await signInAndOpenProfile(page)
+
+    // disableDrag path (ProfileClient's isDesktop gate false below the
+    // md breakpoint) never renders DragHandle — SortableBento only wires
+    // it when !disableDrag.
+    await expect(page.locator('[title="Drag to reorder"]')).toHaveCount(0)
+
+    // Collapse/expand still work without drag — proves the shared shell
+    // isn't drag-coupled.
+    const collapseButtons = page.getByRole('button', { name: 'Collapse', exact: true })
+    await expect(collapseButtons.first()).toBeVisible()
+    await collapseButtons.first().click()
+    await expect(page.getByRole('button', { name: 'Expand', exact: true }).first()).toBeVisible()
+
+    const scrollWidth = await page.evaluate(() => document.scrollingElement?.scrollWidth ?? 0)
+    expect(scrollWidth, 'no horizontal overflow at 390px').toBeLessThanOrEqual(390)
+  })
+})

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -120,6 +120,8 @@ export const profile = {
   'profile.vitalRecorded':            { en: '✓ Recorded',                                       bg: '✓ Записано'                                      },
   'profile.vitalNotRecorded':         { en: '○ Not recorded',                                   bg: '○ Не е записано'                                 },
   'profile.vitalSigns.adminNote':     { en: 'Your coach logs these after events.',               bg: 'Вашият треньор записва тези след събития.'        },
+  'profile.vitalSigns.empty':         { en: 'No vital signs recorded yet.',                      bg: 'Все още няма записани жизнени показатели.'        },
+  'profile.vitalSigns.emptyHint':     { en: 'Your coach logs these after events.',               bg: 'Вашият треньор записва тези след събития.'        },
   // StatsSection
   'profile.stats':                    { en: 'STATS',                                            bg: 'СТАТИСТИКА'                                      },
   'profile.statsDepth':               { en: 'Depth',                                            bg: 'Дълбочина'                                       },

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -34,7 +34,7 @@ export const profile = {
   'profile.calSubCopy':         { en: 'Copy link',               bg: 'Копирай линк'             },
   'profile.calSubCopied':       { en: 'Copied!',                 bg: 'Копирано!'                },
   'profile.calSubRegenerate':   { en: 'Regenerate',              bg: 'Регенерирай'              },
-  'profile.calendar.generating': { en: 'Generating…',           bg: 'Генериране…'              },
+  'profile.calGenerating':      { en: 'Generating…',            bg: 'Генериране…'              },
   'profile.calSubRegenerateConfirmTitle': { en: 'Regenerate your calendar link?', bg: 'Регенериране на линка за календара?' },
   'profile.calSubRegenerateConfirmDesc':  { en: 'Your old link will stop working.', bg: 'Старият линк ще спре да работи.' },
   'profile.calDisplayName':     { en: 'Calendar display name',   bg: 'Показвано име на календара' },
@@ -121,7 +121,6 @@ export const profile = {
   'profile.vitalNotRecorded':         { en: '○ Not recorded',                                   bg: '○ Не е записано'                                 },
   'profile.vitalSigns.adminNote':     { en: 'Your coach logs these after events.',               bg: 'Вашият треньор записва тези след събития.'        },
   'profile.vitalSigns.empty':         { en: 'No vital signs recorded yet.',                      bg: 'Все още няма записани жизнени показатели.'        },
-  'profile.vitalSigns.emptyHint':     { en: 'Your coach logs these after events.',               bg: 'Вашият треньор записва тези след събития.'        },
   // StatsSection
   'profile.stats':                    { en: 'STATS',                                            bg: 'СТАТИСТИКА'                                      },
   'profile.statsDepth':               { en: 'Depth',                                            bg: 'Дълбочина'                                       },

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -34,6 +34,7 @@ export const profile = {
   'profile.calSubCopy':         { en: 'Copy link',               bg: 'Копирай линк'             },
   'profile.calSubCopied':       { en: 'Copied!',                 bg: 'Копирано!'                },
   'profile.calSubRegenerate':   { en: 'Regenerate',              bg: 'Регенерирай'              },
+  'profile.calendar.generating': { en: 'Generating…',           bg: 'Генериране…'              },
   'profile.calSubRegenerateConfirmTitle': { en: 'Regenerate your calendar link?', bg: 'Регенериране на линка за календара?' },
   'profile.calSubRegenerateConfirmDesc':  { en: 'Your old link will stop working.', bg: 'Старият линк ще спре да работи.' },
   'profile.calDisplayName':     { en: 'Calendar display name',   bg: 'Показвано име на календара' },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,9 +52,12 @@ export default defineConfig({
       // browserName pinned: devices['iPhone 12'] defaults to webkit, but CI
       // (preview-smoke.yml) installs chromium only — keep local & CI identical.
       name: 'mobile-390',
-      // profile-bento-auth.spec.ts is intentionally NOT ignored here — its
-      // mobile-390-only describe block asserts the static-stack path.
-      testIgnore: /(admin-auth|los-submission-auth)\.spec\.ts/,
+      // profile-bento-auth.spec.ts excluded here too, same reason as
+      // admin-auth/los-submission-auth: preview-smoke.yml runs this project
+      // against a live Vercel Preview with no Clerk secrets configured, so
+      // clerk.signIn() fails outright. Its 390px static-stack coverage runs
+      // under 'authenticated' instead, with an explicit viewport override.
+      testIgnore: /(admin-auth|los-submission-auth|profile-bento-auth)\.spec\.ts/,
       use: {
         ...devices['iPhone 12'],
         browserName: 'chromium',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,6 +52,8 @@ export default defineConfig({
       // browserName pinned: devices['iPhone 12'] defaults to webkit, but CI
       // (preview-smoke.yml) installs chromium only — keep local & CI identical.
       name: 'mobile-390',
+      // profile-bento-auth.spec.ts is intentionally NOT ignored here — its
+      // mobile-390-only describe block asserts the static-stack path.
       testIgnore: /(admin-auth|los-submission-auth)\.spec\.ts/,
       use: {
         ...devices['iPhone 12'],
@@ -61,14 +63,17 @@ export default defineConfig({
     },
     {
       name: 'desktop',
-      testIgnore: /(admin-auth|los-submission-auth)\.spec\.ts/,
+      // profile-bento-auth.spec.ts excluded here too — it's Clerk-authenticated
+      // and already covered at 1280px by the 'authenticated' project below;
+      // running it a second time on 'desktop' would just duplicate the sign-in.
+      testIgnore: /(admin-auth|los-submission-auth|profile-bento-auth)\.spec\.ts/,
       use: { viewport: { width: 1280, height: 800 } },
     },
     {
       // Authenticated coverage (issue #560) — requires local Supabase +
       // npm run e2e:seed-clerk. Never target a preview/prod-DB deployment.
       name: 'authenticated',
-      testMatch: /(admin-auth|los-submission-auth)\.spec\.ts/,
+      testMatch: /(admin-auth|los-submission-auth|profile-bento-auth)\.spec\.ts/,
       use: { viewport: { width: 1280, height: 800 } },
     },
   ],

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -83,6 +83,13 @@ html { font-size: calc(var(--font-scale) * 16px); }
   --logo-text:          var(--brand-parchment); /* wordmark visible on dark backdrop */
   --skeleton-base:      rgba(250, 248, 243, 0.06);
 
+  /* Elevation shadows — same blur/offset geometry as light, tint swapped to
+     the dark base (--brand-void) at ~3x alpha: a shadow needs more opacity
+     to read against a dark surface. */
+  --shadow-rest:  0 1px 2px rgba(26, 31, 24, 0.12), 0 2px 8px rgba(26, 31, 24, 0.12);
+  --shadow-hover: 0 2px 4px rgba(26, 31, 24, 0.15), 0 12px 24px -8px rgba(26, 31, 24, 0.30);
+  --shadow-modal: 0 4px 12px rgba(26, 31, 24, 0.24), 0 24px 48px -12px rgba(26, 31, 24, 0.54);
+
   --status-success-bg:  rgba(127, 184, 143, 0.18);
   --status-success-fg:  #9fd6ae;
   --status-info-bg:     rgba(94, 168, 184, 0.18);


### PR DESCRIPTION
Closes #665

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] Step 1 — `BentoCard` forwardRef, dark `--shadow-*` tokens, `BentoHeader`/`BentoSkeleton`/`BentoEmpty`, `bento-registry.ts` `BENTO_META`/`BENTO_ICON_MAP`/`BENTO_HEIGHT`, `profile.calendar.generating` i18n string, DESIGN-SYSTEM.md:74 fix
- [x] Step 4 — `e2e/profile-bento-auth.spec.ts` (drag reorder, collapse persistence, expand/collapse-all, 390px static-stack), wired into `playwright.config.ts`'s `authenticated`/`mobile-390`/`desktop` projects
- [x] Step 2 — atomic shell refactor: `SortableBento.tsx`/`BentoGrid.tsx`/`ProfileClient.tsx` + all 13 content components onto the shared `BentoCard`
- [x] Step 3a/b/c — `BentoHeader`/`BentoSkeleton`/`BentoEmpty` across all 13 bentos, lucide icon swaps, dead-code cleanup (`DEFAULT_CALENDAR_NAME`, unused `formatCurrency` import, redundant `ShowMoreButton` wrapper, dead `INVITES_MIN_HEIGHT`)

**Next:**
- Local browser verification is blocked in this worktree (no Supabase env vars — `Error: supabaseUrl is required` on `npm run dev`). Needs a human check on this PR's Vercel Preview: 1280px chrome-overlap (Calendar/EmailPrefs/InvitesBento), 390px no horizontal overflow, dark theme on all 13 bentos + `/` + `/about` + one modal (shared `--shadow-*` tokens changed), loading-state throttle check.
- Run `npm run test:e2e:auth` + `npm run test:mobile` for real against a Clerk/Supabase target — the new spec's wiring is confirmed via `playwright test --list` but it has not executed for real yet (CI's authenticated E2E job is a known skip).
- `/code-review low` was not run locally (blocked: `disable-model-invocation` in this session) — relying on CI + the CodeRabbit pass once this is marked ready for review.

## Summary
Migrates all 13 `/profile` bentos from a hand-rolled card shell onto the shared 2026 Bento Design System (`BentoCard`/`.card`) — one consistent header, skeleton, and empty-state pattern, dark-mode elevation shadows, drag-reorder/collapse/`ui_prefs` persistence preserved and covered by a new Playwright spec.

Part 1 of 2 — status-token consolidation, back links, and the colour sweep are a separate follow-up issue that branches off this one.

## Test plan
- [x] `npm run build` clean at every step (recorded baseline, each step re-verified)
- [x] `npm run lint`: 0 errors, warning count at or below the 480-warning baseline throughout
- [x] `npx tsc --noEmit` clean at every step
- [ ] Vercel Preview READY + CI green
- [ ] `npm run test:e2e:auth` + `npm run test:mobile` run for real against DEV
- [ ] Manual 1280px/390px/dark-theme check on the Preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent profile dashboard headers with icons, subtitles, actions, loading skeletons, and empty states.
  * Improved profile Bento layout management, including responsive sizing, styling, collapse/expand controls, and drag-and-drop behavior.
  * Added clearer empty-state messaging for trips, payments, participation, and vital signs.
  * Added theme-aware dark-mode shadows and improved settings theme icons.
* **Bug Fixes**
  * Improved loading feedback for profile, calendar, email preferences, and other dashboard sections.
* **Tests**
  * Added end-to-end coverage for Bento ordering, collapsing, resetting, and mobile behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->