### PR TITLE
[2607-DEV-642] Fix cancelled guests mislabeled as Pending in admin registrations tab

### DIFF
--- a/app/(dashboard)/calendar/components/popup/CoreAdminActions.tsx
+++ b/app/(dashboard)/calendar/components/popup/CoreAdminActions.tsx
@@ -6,7 +6,7 @@ import { apiClient } from '@/lib/apiClient'
 import type { TranslationKey } from '@/lib/i18n'
 import { PendingPopover } from './PendingPopover'
 import MemberActions from './MemberActions'
-import { SLOT_STATUS_STYLES } from './styles'
+import { SLOT_STATUS_STYLES, REGISTRATION_STATUS_STYLES } from './styles'
 import type { EventDetail, GuestRegistration, RoleSlot } from './types'
 
 function AdminRegistrationsTab({ eventId }: { eventId: string }) {
@@ -38,10 +38,8 @@ function AdminRegistrationsTab({ eventId }: { eventId: string }) {
   return (
     <div className="px-4 py-3 space-y-2">
       {registrations.map(g => {
-        const isAttended = !!g.attended_at
-        const statusColor = isAttended ? '#2d6a4f' : g.status === 'confirmed' ? '#3d405b' : '#7a5c00'
-        const statusBg    = isAttended ? 'rgba(129,178,154,0.2)' : g.status === 'confirmed' ? 'rgba(61,64,91,0.08)' : 'rgba(242,204,143,0.3)'
-        const statusLabel = isAttended ? 'Attended' : g.status === 'confirmed' ? 'Confirmed' : 'Pending'
+        const registrationStyle = REGISTRATION_STATUS_STYLES[g.status as keyof typeof REGISTRATION_STATUS_STYLES] ?? REGISTRATION_STATUS_STYLES.pending
+        const statusLabel = g.status === 'attended' ? 'Attended' : g.status === 'cancelled' ? 'Cancelled' : g.status === 'confirmed' ? 'Confirmed' : 'Pending'
 
         return (
           <div
@@ -63,7 +61,7 @@ function AdminRegistrationsTab({ eventId }: { eventId: string }) {
               </div>
               <span
                 className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
-                style={{ backgroundColor: statusBg, color: statusColor }}
+                style={{ backgroundColor: registrationStyle.bg, color: registrationStyle.color }}
               >
                 {statusLabel}
               </span>

--- a/app/(dashboard)/calendar/components/popup/styles.ts
+++ b/app/(dashboard)/calendar/components/popup/styles.ts
@@ -9,3 +9,10 @@ export const REQUEST_STATUS_STYLES = {
   approved: { bg: '#81b29a33', color: '#2d6a4f'  },
   denied:   { bg: '#bc474920', color: '#bc4749'  },
 }
+
+export const REGISTRATION_STATUS_STYLES = {
+  attended:  { bg: 'rgba(129,178,154,0.2)',  color: '#2d6a4f' },
+  cancelled: { bg: '#bc474920',              color: '#bc4749' },
+  confirmed: { bg: 'rgba(61,64,91,0.08)',    color: '#3d405b' },
+  pending:   { bg: 'rgba(242,204,143,0.3)',  color: '#7a5c00' },
+}

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #613 | `dev/2607-DEV-613` | `app/globals.css`, `app/(dashboard)/calendar/components/CalendarClient.tsx`, `app/admin/calendar/components/AdminCalendarClient.tsx`, `styles/brand-tokens.css`, `components/admin/StatusPill.tsx`, Mapbox tile components (`LocationTile`/`AboutMapTile`), `docs/design/DESIGN-SYSTEM.md`; migration: no | 2026-07-25T19:00:00Z |
+| #642 | `dev/2607-DEV-642` | `app/(dashboard)/calendar/components/popup/CoreAdminActions.tsx`, `app/(dashboard)/calendar/components/popup/styles.ts`; migration: no | 2026-07-26T00:00:00Z |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,44 +1,29 @@
 ## Goal
-Issue #613 (2607-DEV-613, branch `dev/2607-DEV-613`): purge dead legacy CSS palette tokens, add semantic `--status-*` tokens for `StatusPill`, fix Mapbox dark styling, update DESIGN-SYSTEM.md.
+Issue #642 (2607-DEV-642, branch `dev/2607-DEV-642`): admin registrations tab mislabels cancelled guests as "Pending" — fix the status ternary to distinguish cancelled from pending.
 
 ## Now
-PR [#664](https://github.com/teamenjoyvd/tevd-portal/pull/664) open as **draft** against `main` (`Closes #613`), branch `dev/2607-DEV-613` pushed (commits `561fb4d` code+docs). CI and Vercel Preview not yet checked this turn — draft was just opened.
+PR [#668](https://github.com/teamenjoyvd/tevd-portal/pull/668) open as **draft** against `main` (`Closes #642`), branch `dev/2607-DEV-642` pushed (commit `af611fe`). CI/Preview not yet checked this turn — draft was just opened.
 
 ## Next
-- Check CI status and Vercel Preview READY on PR #664.
-- No authenticated Clerk DEV credentials available locally — needs a human visual check of `StatusPill` light/dark on the live Preview (admin > reminders) before marking ready for review.
+- Check CI status and Vercel Preview READY on PR #668.
+- Manual visual check on preview: admin > calendar > event > Registrations tab shows "Cancelled" (red) for a cancelled guest; 390px check.
 - When ready: mark PR ready for review to trigger the single CodeRabbit pass (per docs/ai/BUILD.md FINALIZE), address findings in one batched push.
-- After merge: run the post-merge tail (prod Vercel deploy check, confirm issue #613 auto-closed, remove `docs/CLAIMS.md` `#613` row).
-4. `docs/design/DESIGN-SYSTEM.md`: Component states + Usage rules sections, reflecting actual scope (note Mapbox/calendar chips already correct).
-5. `npm run build` + `npm run lint`, then `/code-review low` before pushing draft PR.
+- After merge: run the post-merge tail (prod Vercel deploy check, confirm issue #642 auto-closed, remove `docs/CLAIMS.md` `#642` row).
 
 ## Constraints
 - Never push directly to `main`; `dev/[YYMM]-DEV-[GH#]` branches only
-- No `git push` without the user explicitly asking for a push in-conversation (quote required) — not asked yet this session
 - Never mark Done on static analysis alone — Vercel PR preview must be READY and CI green
 - No failing check gets weakened/skipped to pass
-- Change only lines the task requires — do not touch `--forest`/`--crimson`/`--sienna`/`--stone` (still live, used by calendar files) or the 3 other files also using non-firing `dark:` classes (`ReminderTable.tsx`, `RemindersTab.tsx`, `LinksGuidesTile.tsx` — out of scope, noted only)
-
-## Decisions
-DECISION: skip the Mapbox dark-style item entirely — `LocationTile.tsx` and `AboutMapTile.tsx` already implement the exact prescribed pattern (`setStyle()` + `styledata` + `MutationObserver`/`useTheme` watching `data-theme`). Verified by reading both files in full; issue's "confirmed live" claim does not match current code.
-DECISION: skip the "calendar chip restyle" — repo-wide grep for `--eggshell|--deep|--sage|--sandy` returns zero hits outside `globals.css`'s own definitions. The calendar files (`FilterControls.tsx`, `MonthView.tsx`, `AgendaView.tsx`, `AdminCalendarClient.tsx`) use `--forest`/`--crimson`/`--sienna`, which `styles/brand-tokens.css:16-17` documents as intentional legacy aliases for brand tokens — not part of this purge, not touching them.
-DECISION: only delete the 4 named-dead tokens from `globals.css`'s legacy `:root` block; keep `--forest`/`--crimson`/`--sienna`/`--stone` since they're actively referenced elsewhere and out of the issue's literal scope.
-DECISION: `StatusPill` status->token mapping: `sent`->success, `claimed`->info, `failed`+`permanently_failed`->alert (both, distinguished only by label text — only 4 semantic tokens exist for 5 states), `pending`/default->pending.
+- Change only lines the task requires
 
 ## Facts
-- Theming mechanism: `data-theme="dark"|"light"` attribute on `<html>`, set by `lib/hooks/useTheme.ts` and read via `document.documentElement.getAttribute('data-theme')` — NOT Tailwind's default `dark:` variant (media or `.dark` class), which is why `StatusPill.tsx`'s `dark:bg-*` classes never fire. No `@custom-variant dark` defined anywhere in the repo (confirmed by grep).
-- `styles/brand-tokens.css` pattern for dark overrides: single `[data-theme="dark"] { --token: value; }` block redefining light-mode custom properties — new `--status-*` tokens should follow this same shape.
-- Other files with the same non-firing `dark:` bug (NOT in scope for #613): `app/admin/calendar/[id]/components/ReminderTable.tsx`, `app/admin/settings/components/RemindersTab.tsx`, `app/(dashboard)/components/tiles/LinksGuidesTile.tsx`.
-- `StatusPill` consumers: `ReminderTable.tsx`, `RemindersTab.tsx` — both just render `<StatusPill status={...} />`, no external color coupling.
+- `guest_registrations.status` enum (`20260410000001_guest_event_registrations.sql:3`) only ever stores `'pending'`/`'confirmed'` at the DB layer; `app/api/admin/events/[id]/registrations/route.ts:51` synthesizes `'attended'`/`'cancelled'` from `attended_at`/`cancelled_at` before returning. So `g.status` on the client can only be one of exactly 4 values — the new `REGISTRATION_STATUS_STYLES` map's keys cover all of them, `?? .pending` fallback is defensive/unreachable.
+- `app/(dashboard)/calendar/components/popup/styles.ts` pattern: one exported `*_STYLES` const per status-pill shape used in this popup dir (`SLOT_STATUS_STYLES` for role slots, `REQUEST_STATUS_STYLES` for role requests, now `REGISTRATION_STATUS_STYLES` for guest registrations) — each a plain `{ key: { bg, color } }` map of hardcoded hex/rgba, not CSS tokens.
 
 ## Done
-#613 CLAIM — RESULT: `blocked` label removed (deps #611/#612 both merged), branch `dev/2607-DEV-613` cut from up-to-date `main`, issue `## Branch` section added, `docs/CLAIMS.md` row registered (pruned stale `#612` row, its PR #663 already merged).
-#613 BUILD (code) — RESULT: trimmed scope executed — `app/globals.css` (4 dead tokens removed, `body` bg fixed to `var(--bg-global)`), `styles/brand-tokens.css` (8 new `--status-*` tokens, light+dark), `components/admin/StatusPill.tsx` (rebuilt on tokens via inline style), `docs/design/DESIGN-SYSTEM.md` (Component States + Usage Rules sections). `npm run build` exit 0 (full route manifest generated, TypeScript clean), `npm run lint` 0 errors/485 warnings (none in changed files, pre-existing baseline). Manual diff review done (no `/code-review` skill invokable this session). `npm install` was also run mid-session — 29 packages (`@radix-ui/react-toggle`, `-toggle-group`, `-switch` etc.) were declared in `package.json` but missing from `node_modules`, unrelated pre-existing gap from the merged #610 PR; `package-lock.json` unchanged, so this was a local sync only, not a dependency change.
+#642 CLAIM — RESULT: issue retitled `[2607-DEV-642] ...`, `## Design Checklist` (4/4 checked) + `## Branch` appended to issue body, branch `dev/2607-DEV-642` cut from `main` and pushed, `docs/CLAIMS.md` row registered (pruned stale `#613` row, its PR #664 already merged).
+#642 BUILD (code) — RESULT: `CoreAdminActions.tsx` (status ternary replaced with `REGISTRATION_STATUS_STYLES` lookup + explicit `status === 'cancelled'` branch, dropped `!!attended_at` truthiness check), `styles.ts` (new `REGISTRATION_STATUS_STYLES` map, cancelled color reuses `REQUEST_STATUS_STYLES.denied`'s `#bc4749`/`#bc474920`). `npm run build` exit 0 (full route manifest, TypeScript clean) after `npm install` synced 57 missing packages into `node_modules` (`package-lock.json`/`package.json` unchanged — local sync only, pre-existing gap unrelated to this ticket). `npm run lint` 0 errors/480 warnings (none in changed files). Manual diff review done (`/code-review` skill is user-invocation-only, not callable this session) — traced `guest_registrations` status enum to confirm no other status value reaches the branch. Draft PR #668 opened.
 
 ## Open items
-- No local authenticated visual check of `StatusPill` in light/dark was possible (no stored admin Clerk DEV credentials, same gap as #608/#607) — needs a human check on the Vercel Preview before marking ready for review.
-- PR body should note the trimmed scope (Mapbox/calendar-chip items already satisfied, not touched) so reviewers aren't surprised by the smaller diff.
-- Not yet committed/pushed — no push requested in-conversation yet.
-
-## Failed attempts
-- ATTEMPT: ran `npm run build` concurrently with `npm install` (mid-flight dependency sync) — the build process appeared to hang at "Creating an optimized production build..." for several minutes with no forward log output. FIXED by not killing it: confirmed via `Get-CimInstance Win32_Process` that it was still spawning live Turbopack worker processes, so it was slow (3.4min compile), not stuck — waited it out instead of killing. Avoid running `npm install` concurrently with a build in future sessions; it's likely what caused the slowdown/confusion.
+- No local authenticated visual check on the Vercel Preview yet this turn (PR just opened) — needs confirmation once Preview is READY.
+- PR marked ready for review only after CI green + Preview READY + manual check, per BUILD.md VERIFY stage.


### PR DESCRIPTION
## Summary
- `CoreAdminActions.tsx`'s `AdminRegistrationsTab` only branched on attended/confirmed status, so cancelled guest registrations displayed as "Pending" — misleading admins reviewing capacity/attendance.
- Adds a `REGISTRATION_STATUS_STYLES` map (colocated with the file's existing `SLOT_STATUS_STYLES`/`REQUEST_STATUS_STYLES` pattern, reusing the existing denied/red token `#bc4749`) and switches label/color logic to branch on `status` directly instead of truthiness-checking `attended_at`.
- No API/schema change needed — `app/api/admin/events/[id]/registrations/route.ts` already emits `status: 'attended' | 'cancelled' | 'confirmed' | 'pending'`; this was a pure client-rendering gap.

Closes #642

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] `CoreAdminActions.tsx` + `styles.ts` fix
- [x] `npm run build` (exit 0), `npm run lint` (0 errors)
- [x] Manual code review (traced `guest_registrations` status enum to confirm no other status values reach this branch)
**Next:** wait for CI green + Vercel Preview READY, then verify 390px + visual check on preview, mark ready for review

## Test plan
- [ ] Vercel Preview READY
- [ ] CI green (confirm Authenticated E2E actually ran its steps, not skipped)
- [ ] Manual check on preview: admin > calendar > event > Registrations tab shows "Cancelled" (red) for a cancelled guest, other statuses unchanged
- [ ] 390px mobile check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved registration status badges with consistent colors for attended, cancelled, confirmed, and pending statuses.
  * Simplified status labels and ensured each registration displays the appropriate visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->