### PR TITLE
[2607-DEV-639] getBaseUrl() fails closed instead of trusting Host header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ ICAL_TOKEN_SECRET=
 
 # --- optional --- (`npm run check:env` warns instead of failing)
 
-# App base URL for absolute links (iCal subscription URLs, notification emails).
-# Every consumer falls back to a sensible default when unset.
+# App base URL for absolute links (iCal subscription URLs, notification emails,
+# guest magic links). Required to exercise those flows locally — getBaseUrl()
+# throws rather than falling back to the request's Host header (spoofable).
 NEXT_PUBLIC_APP_URL=

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #613 | `dev/2607-DEV-613` | `app/globals.css`, `app/(dashboard)/calendar/components/CalendarClient.tsx`, `app/admin/calendar/components/AdminCalendarClient.tsx`, `styles/brand-tokens.css`, `components/admin/StatusPill.tsx`, Mapbox tile components (`LocationTile`/`AboutMapTile`), `docs/design/DESIGN-SYSTEM.md`; migration: no | 2026-07-25T19:00:00Z |
+| #639 | `dev/2607-DEV-639` | `lib/utils/base-url.ts`, `lib/utils/base-url.test.ts` (new), `.env.example`; migration: no | 2026-07-26T00:00:00Z |

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,3 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
+| #639 | `dev/2607-DEV-639` | `lib/utils/base-url.ts`, `lib/utils/base-url.test.ts` (new), `.env.example`; migration: no | 2026-07-26T00:00:00Z |

--- a/lib/utils/base-url.test.ts
+++ b/lib/utils/base-url.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getBaseUrl } from '@/lib/utils/base-url'
+
+const ORIGINAL = process.env.NEXT_PUBLIC_APP_URL
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.NEXT_PUBLIC_APP_URL
+  else process.env.NEXT_PUBLIC_APP_URL = ORIGINAL
+})
+
+describe('getBaseUrl', () => {
+  it('returns the configured URL with a trailing slash stripped', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://portal.example/'
+    await expect(getBaseUrl()).resolves.toBe('https://portal.example')
+  })
+
+  it('throws when NEXT_PUBLIC_APP_URL is unset', async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    await expect(getBaseUrl()).rejects.toThrow('NEXT_PUBLIC_APP_URL is not set')
+  })
+
+  it('throws when NEXT_PUBLIC_APP_URL is empty', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = '   '
+    await expect(getBaseUrl()).rejects.toThrow('NEXT_PUBLIC_APP_URL is not set')
+  })
+})

--- a/lib/utils/base-url.test.ts
+++ b/lib/utils/base-url.test.ts
@@ -23,4 +23,9 @@ describe('getBaseUrl', () => {
     process.env.NEXT_PUBLIC_APP_URL = '   '
     await expect(getBaseUrl()).rejects.toThrow('NEXT_PUBLIC_APP_URL is not set')
   })
+
+  it('throws when NEXT_PUBLIC_APP_URL is slash-only', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = '////'
+    await expect(getBaseUrl()).rejects.toThrow('NEXT_PUBLIC_APP_URL is not set')
+  })
 })

--- a/lib/utils/base-url.ts
+++ b/lib/utils/base-url.ts
@@ -7,11 +7,11 @@
  * (email `actionUrl`, ICS feed subscription URL, magic links).
  */
 export async function getBaseUrl(): Promise<string> {
-  const configured = process.env.NEXT_PUBLIC_APP_URL?.trim()
-  if (configured === undefined || configured === '') {
+  const normalized = process.env.NEXT_PUBLIC_APP_URL?.trim().replace(/\/+$/, '')
+  if (normalized === undefined || normalized === '') {
     throw new Error(
       'NEXT_PUBLIC_APP_URL is not set. Set it in .env.local to build absolute links locally.'
     )
   }
-  return configured.replace(/\/+$/, '')
+  return normalized
 }

--- a/lib/utils/base-url.ts
+++ b/lib/utils/base-url.ts
@@ -1,19 +1,17 @@
-import { headers } from 'next/headers'
-
 /**
  * Resolve the app's public base URL, without a trailing slash.
  *
- * Prefers `NEXT_PUBLIC_APP_URL` (set in every deployed environment); falls back
- * to the incoming request's `Host` header for local/dev where that env var is
- * unset. `http` is used only for localhost — everything else is `https`.
- *
- * Server-only (reads `next/headers`). Callers must `await` it.
+ * Requires `NEXT_PUBLIC_APP_URL` (set in every deployed environment). Throws
+ * rather than falling back to the incoming request's `Host` header, which is
+ * attacker-controlled and must never be trusted for externally-visible links
+ * (email `actionUrl`, ICS feed subscription URL, magic links).
  */
 export async function getBaseUrl(): Promise<string> {
   const configured = process.env.NEXT_PUBLIC_APP_URL?.trim()
-  if (configured !== undefined && configured !== '') return configured.replace(/\/+$/, '')
-
-  const host = (await headers()).get('host') ?? 'tevd-portal.vercel.app'
-  const isLocal = host.startsWith('localhost') || host.startsWith('127.0.0.1')
-  return `${isLocal ? 'http' : 'https'}://${host}`
+  if (configured === undefined || configured === '') {
+    throw new Error(
+      'NEXT_PUBLIC_APP_URL is not set. Set it in .env.local to build absolute links locally.'
+    )
+  }
+  return configured.replace(/\/+$/, '')
 }


### PR DESCRIPTION
## Summary
- `getBaseUrl()` no longer falls back to the request's `Host` header when `NEXT_PUBLIC_APP_URL` is unset — it now throws. That fallback fed an attacker-controllable value into emailed action links, ICS feed subscription URLs, and guest magic links. `NEXT_PUBLIC_APP_URL` is set in every deployed environment (prod/preview/DEV), so this only changes local-dev-without-the-var behavior: from a silent security hole to a clear error.
- Added `lib/utils/base-url.test.ts` covering configured/unset/whitespace-only cases.
- Updated `.env.example` comment to reflect the new required-for-these-flows behavior.

Closes #639

## Test plan
- [x] `npx vitest run` — 210/210 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [ ] CI green
- [ ] Vercel preview READY

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] Fail-closed fix in `lib/utils/base-url.ts`
- [x] Unit tests added
- [x] `.env.example` comment updated
- [x] Local verification: vitest full suite, tsc, eslint all clean
**Next:** Run `/code-review low` on this diff, wait for CI + Vercel preview, then mark ready for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generation of absolute links by consistently using the configured public application URL.
  * Removed unreliable fallback behavior when the public URL is unavailable; the application now reports a clear configuration error instead.

* **Documentation**
  * Clarified that the public application URL is required for iCal subscriptions, notification emails, guest magic links, and other absolute-link features.
  * Added coverage to verify URL normalization and missing-configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->