### PR TITLE
[2607-DEV-666] Profile bento standardization 2: status tokens, back links, colour sweep

### DIFF
--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -49,14 +49,14 @@ function SpouseLinkBanner({
     <Link
       href="/profile/spouse-link"
       className="flex items-center gap-2 rounded-xl px-4 py-3"
-      style={{ backgroundColor: '#f2cc8f33', textDecoration: 'none', marginTop: mt * 4 }}
+      style={{ backgroundColor: 'var(--status-pending-bg)', textDecoration: 'none', marginTop: mt * 4 }}
     >
-      <span className="text-sm font-medium" style={{ color: '#7a5c00' }}>
+      <span className="text-sm font-medium" style={{ color: 'var(--status-pending-fg)' }}>
         {count === 1
           ? t('profile.spouseLinkBanner.single')
           : t('profile.spouseLinkBanner.multiple').replace('{{count}}', String(count))}
       </span>
-      <span className="ml-auto text-xs font-semibold" style={{ color: '#7a5c00' }}>{t('profile.spouseLinkBanner.review')}</span>
+      <span className="ml-auto text-xs font-semibold" style={{ color: 'var(--status-pending-fg)' }}>{t('profile.spouseLinkBanner.review')}</span>
     </Link>
   )
 }
@@ -196,7 +196,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <p className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>{t('profile.aboHash')}</p>
             <p className="text-sm font-medium font-mono" style={{ color: 'var(--text-primary)' }}>
-              {aboNumber} <Check size={14} className="inline-block align-text-bottom" style={{ color: '#2d6a4f' }} />
+              {aboNumber} <Check size={14} className="inline-block align-text-bottom" style={{ color: 'var(--status-success-fg)' }} />
             </p>
           </div>
           <div style={{ borderTop: '1px solid var(--border-default)', paddingTop: 10 }}>
@@ -261,12 +261,12 @@ export const AboInfoContent = memo(function AboInfoContent() {
       {aboMode === 'pending' && (
         <div className="space-y-3">
           {verRequest?.status === 'denied' && (
-            <div className="rounded-xl px-4 py-3 mb-2" style={{ backgroundColor: '#bc474915' }}>
-              <p className="text-sm font-medium" style={{ color: 'var(--brand-crimson)' }}>
+            <div className="rounded-xl px-4 py-3 mb-2" style={{ backgroundColor: 'var(--status-alert-bg)' }}>
+              <p className="text-sm font-medium" style={{ color: 'var(--status-alert-fg)' }}>
                 {t('profile.prevDenied')}
               </p>
               {verRequest.admin_note && (
-                <p className="text-xs mt-0.5" style={{ color: 'var(--brand-crimson)' }}>
+                <p className="text-xs mt-0.5" style={{ color: 'var(--status-alert-fg)' }}>
                   {verRequest.admin_note}
                 </p>
               )}
@@ -281,11 +281,11 @@ export const AboInfoContent = memo(function AboInfoContent() {
             </div>
           )}
           {verRequest?.status === 'pending' && (
-            <div className="rounded-xl px-4 py-3" style={{ backgroundColor: '#f2cc8f33' }}>
-              <p className="text-sm font-medium" style={{ color: '#7a5c00' }}>
+            <div className="rounded-xl px-4 py-3" style={{ backgroundColor: 'var(--status-pending-bg)' }}>
+              <p className="text-sm font-medium" style={{ color: 'var(--status-pending-fg)' }}>
                 {verRequest.request_type === 'manual' ? t('profile.manualVerifPending') : t('profile.verifPending')}
               </p>
-              <p className="text-xs mt-0.5" style={{ color: '#7a5c00' }}>
+              <p className="text-xs mt-0.5" style={{ color: 'var(--status-pending-fg)' }}>
                 {verRequest.request_type === 'manual'
                   ? `Upline ${verRequest.claimed_upline_abo}`
                   : `ABO ${verRequest.claimed_abo} · Upline ${verRequest.claimed_upline_abo}`}
@@ -438,8 +438,8 @@ function VerificationForm({
             value={aboInput}
             onChange={e => onAboChange(e.target.value)}
             placeholder="e.g. 7023040472"
-            className="w-full border border-black/10 rounded-xl px-3 py-2.5 text-sm font-mono"
-            style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-global)' }}
+            className="w-full border rounded-xl px-3 py-2.5 text-sm font-mono"
+            style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-global)', borderColor: 'var(--border-default)' }}
           />
         </div>
       )}
@@ -451,8 +451,8 @@ function VerificationForm({
           value={uplineInput}
           onChange={e => onUplineChange(e.target.value)}
           placeholder="e.g. 7010970187"
-          className="w-full border border-black/10 rounded-xl px-3 py-2.5 text-sm font-mono"
-          style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-global)' }}
+          className="w-full border rounded-xl px-3 py-2.5 text-sm font-mono"
+          style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-global)', borderColor: 'var(--border-default)' }}
         />
       </div>
       {submitError && (
@@ -470,8 +470,8 @@ function VerificationForm({
       <button
         onClick={onSubmit}
         disabled={submitPending || (verificationMode === 'standard' ? (!aboInput || !uplineInput) : !uplineInput)}
-        className="w-full py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
-        style={{ backgroundColor: 'var(--text-primary)' }}
+        className="w-full py-2.5 rounded-xl text-sm font-semibold disabled:opacity-40 hover:opacity-90 transition-opacity"
+        style={{ backgroundColor: 'var(--text-primary)', color: 'var(--brand-parchment)' }}
       >
         {submitPending ? t('profile.submitting') : t('profile.submitVerif')}
       </button>
@@ -502,8 +502,8 @@ function SpouseLinkSection({
 }) {
   if (spouseLinkRequest?.status === 'pending') {
     return (
-      <div className="mt-4 rounded-xl px-4 py-3" style={{ backgroundColor: '#f2cc8f33' }}>
-        <p className="text-sm font-medium" style={{ color: '#7a5c00' }}>
+      <div className="mt-4 rounded-xl px-4 py-3" style={{ backgroundColor: 'var(--status-pending-bg)' }}>
+        <p className="text-sm font-medium" style={{ color: 'var(--status-pending-fg)' }}>
           {t('profile.spouseLinkPending')}
         </p>
         <button
@@ -521,12 +521,12 @@ function SpouseLinkSection({
   return (
     <div className="mt-4 space-y-3" style={{ borderTop: '1px solid var(--border-default)', paddingTop: 16 }}>
       {spouseLinkRequest?.status === 'denied' && (
-        <div className="rounded-xl px-4 py-3" style={{ backgroundColor: '#bc474915' }}>
-          <p className="text-sm font-medium" style={{ color: 'var(--brand-crimson)' }}>
+        <div className="rounded-xl px-4 py-3" style={{ backgroundColor: 'var(--status-alert-bg)' }}>
+          <p className="text-sm font-medium" style={{ color: 'var(--status-alert-fg)' }}>
             {t('profile.spouseLinkDenied')}
           </p>
           {spouseLinkRequest.admin_note && (
-            <p className="text-xs mt-0.5" style={{ color: 'var(--brand-crimson)' }}>
+            <p className="text-xs mt-0.5" style={{ color: 'var(--status-alert-fg)' }}>
               {spouseLinkRequest.admin_note}
             </p>
           )}
@@ -543,8 +543,8 @@ function SpouseLinkSection({
           value={spouseAboInput}
           onChange={e => onAboChange(e.target.value)}
           placeholder="e.g. 7023040472"
-          className="w-full border border-black/10 rounded-xl px-3 py-2.5 text-sm font-mono"
-          style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-global)' }}
+          className="w-full border rounded-xl px-3 py-2.5 text-sm font-mono"
+          style={{ color: 'var(--text-primary)', backgroundColor: 'var(--bg-global)', borderColor: 'var(--border-default)' }}
         />
       </div>
       {submitError && (
@@ -553,8 +553,8 @@ function SpouseLinkSection({
       <button
         onClick={onSubmit}
         disabled={submitPending || !spouseAboInput}
-        className="w-full py-2.5 rounded-xl text-sm font-semibold text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
-        style={{ backgroundColor: 'var(--text-primary)' }}
+        className="w-full py-2.5 rounded-xl text-sm font-semibold disabled:opacity-40 hover:opacity-90 transition-opacity"
+        style={{ backgroundColor: 'var(--text-primary)', color: 'var(--brand-parchment)' }}
       >
         {submitPending ? t('profile.submitting') : (spouseLinkRequest?.status === 'denied' ? t('profile.spouseLinkResubmit') : t('profile.spouseLinkSubmit'))}
       </button>

--- a/app/(dashboard)/profile/components/AdminSection.tsx
+++ b/app/(dashboard)/profile/components/AdminSection.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { Shield } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { BentoHeader } from './BentoHeader'
@@ -9,14 +10,12 @@ export function AdminSection() {
   return (
     <div>
       <BentoHeader icon={Shield} title={t('profile.adminTools')} tone="teal" />
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(8, minmax(0, 1fr))', gap: '12px' }}>
-        <a href="/admin"
-          style={{ gridColumn: 'span 2', backgroundColor: 'var(--brand-forest)', color: 'var(--brand-parchment)' }}
-          className="rounded-xl px-4 py-3 flex flex-col gap-1 hover:opacity-80 transition-opacity">
-          <span className="text-xs font-bold tracking-widest uppercase" style={{ color: 'var(--brand-parchment)' }}>{t('profile.adminTools.admin')}</span>
-          <span className="text-[10px] opacity-60" style={{ color: 'var(--brand-parchment)' }}>{t('profile.adminTools.portalManagement')}</span>
-        </a>
-      </div>
+      <Link href="/admin"
+        style={{ backgroundColor: 'var(--brand-forest)', color: 'var(--brand-parchment)' }}
+        className="rounded-xl px-4 py-3 flex flex-col gap-1 hover:opacity-80 transition-opacity w-fit">
+        <span className="text-xs font-bold tracking-widest uppercase" style={{ color: 'var(--brand-parchment)' }}>{t('profile.adminTools.admin')}</span>
+        <span className="text-[10px] opacity-60" style={{ color: 'var(--brand-parchment)' }}>{t('profile.adminTools.portalManagement')}</span>
+      </Link>
     </div>
   )
 }

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -116,7 +116,7 @@ export function CalendarSection({ profileId }: { profileId: string }) {
           disabled={regenerateCal.isPending}
           aria-label={t('profile.calSubRegenerate')}
           aria-busy={regenerateCal.isPending}
-          className="p-2 rounded-xl border transition-colors hover:opacity-80 disabled:opacity-40 flex-shrink-0"
+          className="p-2 rounded-xl border transition-opacity hover:opacity-80 disabled:opacity-40 flex-shrink-0"
           style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
         >
           <RefreshCw size={14} className={regenerateCal.isPending ? 'motion-safe:animate-spin' : ''} />

--- a/app/(dashboard)/profile/components/CalendarSection.tsx
+++ b/app/(dashboard)/profile/components/CalendarSection.tsx
@@ -116,7 +116,7 @@ export function CalendarSection({ profileId }: { profileId: string }) {
           disabled={regenerateCal.isPending}
           aria-label={t('profile.calSubRegenerate')}
           aria-busy={regenerateCal.isPending}
-          className="p-2 rounded-xl border transition-colors hover:bg-black/5 disabled:opacity-40 flex-shrink-0"
+          className="p-2 rounded-xl border transition-colors hover:opacity-80 disabled:opacity-40 flex-shrink-0"
           style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}
         >
           <RefreshCw size={14} className={regenerateCal.isPending ? 'motion-safe:animate-spin' : ''} />

--- a/app/(dashboard)/profile/components/InvitesBento.tsx
+++ b/app/(dashboard)/profile/components/InvitesBento.tsx
@@ -58,7 +58,7 @@ export function InvitesBento() {
             <div
               key={i}
               className="h-14 rounded-xl animate-pulse"
-              style={{ backgroundColor: 'rgba(0,0,0,0.06)' }}
+              style={{ backgroundColor: 'var(--skeleton-base)' }}
             />
           ))}
         </div>
@@ -68,7 +68,7 @@ export function InvitesBento() {
             <div
               key={label}
               className="rounded-xl px-3 py-2 flex flex-col gap-0.5"
-              style={{ backgroundColor: 'rgba(0,0,0,0.04)' }}
+              style={{ backgroundColor: 'var(--bg-card-raised)' }}
             >
               <span className="text-xl font-bold tabular-nums" style={{ color: 'var(--text-primary)' }}>
                 {value}
@@ -85,7 +85,7 @@ export function InvitesBento() {
       <Link
         href="/profile/invites"
         className="mt-auto text-xs font-semibold px-3 py-2 rounded-xl transition-opacity hover:opacity-70 text-left block"
-        style={{ backgroundColor: 'rgba(0,0,0,0.05)', color: 'var(--text-primary)' }}
+        style={{ backgroundColor: 'var(--border-default)', color: 'var(--text-primary)' }}
       >
         {t('profile.invites.viewAll')} →
       </Link>

--- a/app/(dashboard)/profile/components/InvitesSection.tsx
+++ b/app/(dashboard)/profile/components/InvitesSection.tsx
@@ -20,7 +20,7 @@ import { useLanguage } from '@/lib/hooks/useLanguage'
 import { apiClient } from '@/lib/apiClient'
 import { formatDate } from '@/lib/format'
 import { guestStatus, computeFunnel, type GuestRow as InviteGuestRow } from '@/lib/invites'
-import { REG_STATUS_STYLES } from '../types'
+import { StatusBadge } from './StatusBadge'
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -148,7 +148,7 @@ export function InvitesSection() {
     return (
       <div className="p-4 space-y-3">
         {[...Array(2)].map((_, i) => (
-          <div key={i} className="h-20 rounded-xl animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
+          <div key={i} className="h-20 rounded-xl animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
         ))}
       </div>
     )
@@ -282,9 +282,9 @@ export function InvitesSection() {
                     <p className="text-sm font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
                       {link.event.title}
                       {revoked && (
-                        <span className="ml-2 px-2 py-0.5 rounded-full text-[10px] font-semibold align-middle" style={REG_STATUS_STYLES.cancelled}>
+                        <StatusBadge status="cancelled" className="ml-2 px-2 py-0.5 rounded-full text-[10px] font-semibold align-middle">
                           {t('profile.invites.revoked')}
-                        </span>
+                        </StatusBadge>
                       )}
                     </p>
                     <p className="text-[10px] mt-0.5" style={{ color: 'var(--text-secondary)' }}>
@@ -307,9 +307,9 @@ export function InvitesSection() {
                     <span>→</span>
                     <span>{guests.length} {t('profile.invites.registrations')}</span>
                     <span>→</span>
-                    <span style={{ color: confirmed > 0 ? '#3d405b' : undefined }}>{confirmed} {t('profile.invites.confirmed')}</span>
+                    <span style={{ color: confirmed > 0 ? 'var(--status-success-fg)' : undefined }}>{confirmed} {t('profile.invites.confirmed')}</span>
                     <span>→</span>
-                    <span style={{ color: attended > 0 ? '#2d6a4f' : undefined }}>{attended} {t('profile.invites.attended')}</span>
+                    <span style={{ color: attended > 0 ? 'var(--status-success-fg)' : undefined }}>{attended} {t('profile.invites.attended')}</span>
                     <span style={{ fontSize: 10 }}>{isOpen ? '▲' : '▼'}</span>
                   </button>
 
@@ -318,7 +318,7 @@ export function InvitesSection() {
                       <AlertDialogTrigger asChild>
                         <button
                           className="text-[10px] font-semibold px-2.5 py-1 rounded-lg border transition-colors hover:opacity-70 disabled:opacity-40"
-                          style={{ borderColor: 'var(--border-default)', color: '#bc4749' }}
+                          style={{ borderColor: 'var(--border-default)', color: 'var(--brand-crimson)' }}
                           disabled={revokingId === link.id}
                         >
                           {t('profile.invites.revoke')}
@@ -346,7 +346,7 @@ export function InvitesSection() {
                     <div className="hidden sm:block overflow-x-auto">
                       <table className="w-full text-xs" style={{ minWidth: 480 }}>
                         <thead>
-                          <tr style={{ backgroundColor: 'rgba(0,0,0,0.03)', borderTop: '1px solid var(--border-default)' }}>
+                          <tr style={{ backgroundColor: 'var(--bg-card-raised)', borderTop: '1px solid var(--border-default)' }}>
                             {[
                               t('profile.invites.col.name'),
                               t('profile.invites.col.email'),
@@ -367,8 +367,7 @@ export function InvitesSection() {
                                 <td className="px-4 py-2 font-medium" style={{ color: 'var(--text-primary)' }}>{g.name}</td>
                                 <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{g.email}</td>
                                 <td className="px-4 py-2">
-                                  <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold"
-                                    style={REG_STATUS_STYLES[s]}>{s}</span>
+                                  <StatusBadge status={s} className="px-2 py-0.5 rounded-full text-[10px] font-semibold">{s}</StatusBadge>
                                 </td>
                                 <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{fmt(g.created_at)}</td>
                                 <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{fmt(g.attended_at)}</td>
@@ -387,8 +386,7 @@ export function InvitesSection() {
                           <div key={g.id} className="px-4 py-3 space-y-1" style={{ borderTop: '1px solid var(--border-default)' }}>
                             <div className="flex items-center justify-between gap-2">
                               <p className="text-xs font-medium truncate" style={{ color: 'var(--text-primary)' }}>{g.name}</p>
-                              <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold shrink-0"
-                                style={REG_STATUS_STYLES[s]}>{s}</span>
+                              <StatusBadge status={s} className="px-2 py-0.5 rounded-full text-[10px] font-semibold shrink-0">{s}</StatusBadge>
                             </div>
                             <p className="text-[11px] truncate" style={{ color: 'var(--text-secondary)' }}>{g.email}</p>
                             <p className="text-[10px]" style={{ color: 'var(--text-secondary)' }}>

--- a/app/(dashboard)/profile/components/ParticipationSection.tsx
+++ b/app/(dashboard)/profile/components/ParticipationSection.tsx
@@ -9,8 +9,9 @@ import { formatDate } from '@/lib/format'
 import { BentoHeader } from './BentoHeader'
 import { BentoSkeleton } from './BentoSkeleton'
 import { BentoEmpty } from './BentoEmpty'
-import { type EventRoleRequest, VARIABLE_CAP, REG_STATUS_STYLES } from '../types'
+import { type EventRoleRequest, VARIABLE_CAP } from '../types'
 import { ShowMoreButton } from './shared'
+import { StatusBadge } from './StatusBadge'
 import { apiClient } from '@/lib/apiClient'
 
 export function ParticipationSection({ profileId, role }: { profileId: string; role: string }) {
@@ -38,7 +39,6 @@ export function ParticipationSection({ profileId, role }: { profileId: string; r
   const overflow = roles.length - VARIABLE_CAP
 
   const RoleRow = ({ er }: { er: EventRoleRequest }) => {
-    const rs = REG_STATUS_STYLES[er.status.toLowerCase()] ?? REG_STATUS_STYLES.pending
     return (
       <div className="flex items-start justify-between gap-3 text-xs py-1.5">
         <div className="min-w-0">
@@ -51,8 +51,7 @@ export function ParticipationSection({ profileId, role }: { profileId: string; r
           </p>
           {er.note && <p className="mt-0.5 italic" style={{ color: 'var(--text-secondary)' }}>{er.note}</p>}
         </div>
-        <span className="font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
-          style={{ backgroundColor: rs.bg, color: rs.color }}>{er.status}</span>
+        <StatusBadge status={er.status} className="font-semibold px-2 py-0.5 rounded-full flex-shrink-0">{er.status}</StatusBadge>
       </div>
     )
   }

--- a/app/(dashboard)/profile/components/PaymentsSection.tsx
+++ b/app/(dashboard)/profile/components/PaymentsSection.tsx
@@ -109,8 +109,8 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
           title={t('payment.title')}
           action={
             <button onClick={handleOpenSubmit}
-              className="px-3 py-1.5 rounded-xl text-xs font-semibold text-white hover:opacity-90 transition-opacity flex-shrink-0"
-              style={{ backgroundColor: 'var(--brand-forest)' }}>{t('payment.submitShort')}</button>
+              className="px-3 py-1.5 rounded-xl text-xs font-semibold hover:opacity-90 transition-opacity flex-shrink-0"
+              style={{ backgroundColor: 'var(--brand-forest)', color: 'var(--brand-parchment)' }}>{t('payment.submitShort')}</button>
           }
         />
         {Object.keys(visibleByItem).length === 0 ? (
@@ -137,8 +137,8 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
         <div className="border-t pt-4" style={{ borderColor: 'var(--border-default)' }}>
           <button
             onClick={() => { setListDrawerOpen(false); setSubmitDrawerOpen(true) }}
-            className="w-full py-2.5 rounded-xl text-sm font-semibold text-white hover:opacity-90 transition-opacity"
-            style={{ backgroundColor: 'var(--brand-forest)' }}
+            className="w-full py-2.5 rounded-xl text-sm font-semibold hover:opacity-90 transition-opacity"
+            style={{ backgroundColor: 'var(--brand-forest)', color: 'var(--brand-parchment)' }}
           >
             {t('payment.submitShort')}
           </button>

--- a/app/(dashboard)/profile/components/ProfileBackLink.tsx
+++ b/app/(dashboard)/profile/components/ProfileBackLink.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { useLanguage } from '@/lib/hooks/useLanguage'
+
+export function ProfileBackLink() {
+  const { t } = useLanguage()
+  return (
+    <Link
+      href="/profile"
+      className="inline-flex items-center gap-1 text-xs font-semibold mb-3 md:mb-5 hover:opacity-70 transition-opacity"
+      style={{ color: 'var(--text-secondary)' }}
+    >
+      <ArrowLeft size={14} />
+      {t('profile.backToProfile')}
+    </Link>
+  )
+}

--- a/app/(dashboard)/profile/components/StatusBadge.tsx
+++ b/app/(dashboard)/profile/components/StatusBadge.tsx
@@ -21,6 +21,7 @@ const STATUS_TOKEN_MAP: Record<string, StatusToken> = {
   expiring:  'info',
   cancelled: 'neutral',
   revoked:   'neutral',
+  inactive:  'neutral',
   // Identity entries — lets callers (e.g. EXPIRY_TOKEN in ../types.ts) pass an
   // already-resolved token name straight through instead of a raw status.
   success:   'success',

--- a/app/(dashboard)/profile/components/StatusBadge.tsx
+++ b/app/(dashboard)/profile/components/StatusBadge.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import * as React from 'react'
+
+type StatusToken = 'success' | 'info' | 'alert' | 'pending' | 'neutral'
+
+// Mirrors components/admin/StatusPill.tsx's token lookup, but the caller
+// supplies the label — some callers render the raw status string verbatim
+// and a badge-owned label would silently change that copy.
+const STATUS_TOKEN_MAP: Record<string, StatusToken> = {
+  approved:  'success',
+  completed: 'success',
+  confirmed: 'success',
+  attended:  'success',
+  valid:     'success',
+  pending:   'pending',
+  denied:    'alert',
+  failed:    'alert',
+  expired:   'alert',
+  claimed:   'info',
+  expiring:  'info',
+  cancelled: 'neutral',
+  revoked:   'neutral',
+  // Identity entries — lets callers (e.g. EXPIRY_TOKEN in ../types.ts) pass an
+  // already-resolved token name straight through instead of a raw status.
+  success:   'success',
+  info:      'info',
+  alert:     'alert',
+  neutral:   'neutral',
+}
+
+const DEFAULT_CLASSNAME = 'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold'
+
+export function StatusBadge({
+  status,
+  children,
+  className,
+  style,
+}: {
+  status: string
+  children: React.ReactNode
+  className?: string
+  style?: React.CSSProperties
+}) {
+  const token = STATUS_TOKEN_MAP[status.toLowerCase()] ?? 'pending'
+  return (
+    <span
+      className={className ?? DEFAULT_CLASSNAME}
+      style={{
+        backgroundColor: `var(--status-${token}-bg)`,
+        color: `var(--status-${token}-fg)`,
+        ...style,
+      }}
+    >
+      {children}
+    </span>
+  )
+}

--- a/app/(dashboard)/profile/components/TravelDocContent.tsx
+++ b/app/(dashboard)/profile/components/TravelDocContent.tsx
@@ -8,7 +8,8 @@ import { Drawer } from '@/components/ui/drawer'
 import { TravelDocDrawerForm } from './TravelDocDrawerForm'
 import { BentoHeader } from './BentoHeader'
 import { BentoSkeleton } from './BentoSkeleton'
-import { type Profile } from '../types'
+import { StatusBadge } from './StatusBadge'
+import { type Profile, EXPIRY_TOKEN } from '../types'
 import { apiClient } from '@/lib/apiClient'
 import { useProfile } from '../useProfile'
 
@@ -49,12 +50,6 @@ function getExpiryText(profile: Profile): string {
     year: 'numeric',
     timeZone: 'UTC',
   })
-}
-
-const EXPIRY_STYLES = {
-  ok:       'bg-[#81b29a]/10 border-[#81b29a]/30 text-[#2d6a4f]',
-  warning:  'bg-[#f2cc8f]/20 border-[#f2cc8f] text-[#7a5c00]',
-  critical: 'bg-[#bc4749]/10 border-[#bc4749]/40 text-[var(--brand-crimson)]',
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -212,9 +207,13 @@ export const TravelDocContent = memo(function TravelDocContent() {
           </div>
 
           {expiryState && (
-            <div className={`mt-2 rounded-xl border px-3 py-2.5 text-xs font-medium ${EXPIRY_STYLES[expiryState]}`}>
+            <StatusBadge
+              status={EXPIRY_TOKEN[expiryState]}
+              className="mt-2 block w-full rounded-xl border px-3 py-2.5 text-xs font-medium"
+              style={{ borderColor: `color-mix(in srgb, var(--status-${EXPIRY_TOKEN[expiryState]}-fg) 35%, transparent)` }}
+            >
               {expiryState === 'ok' ? t('profile.expiry.ok') : expiryState === 'warning' ? t('profile.expiry.warning') : t('profile.expiry.critical')}
-            </div>
+            </StatusBadge>
           )}
         </div>
       </div>

--- a/app/(dashboard)/profile/components/TravelDocDrawerForm.tsx
+++ b/app/(dashboard)/profile/components/TravelDocDrawerForm.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { StatusBadge } from './StatusBadge'
+import { EXPIRY_TOKEN } from '../types'
 
 function getExpiryState(validThrough: string | null): 'ok' | 'warning' | 'critical' | null {
   if (!validThrough) return null
@@ -9,12 +11,6 @@ function getExpiryState(validThrough: string | null): 'ok' | 'warning' | 'critic
   if (diffDays < 90)  return 'critical'
   if (diffDays < 180) return 'warning'
   return 'ok'
-}
-
-const EXPIRY_STYLES = {
-  ok:       'bg-[#81b29a]/10 border-[#81b29a]/30 text-[#2d6a4f]',
-  warning:  'bg-[#f2cc8f]/20 border-[#f2cc8f] text-[#7a5c00]',
-  critical: 'bg-[#bc4749]/10 border-[#bc4749]/40 text-[var(--brand-crimson)]',
 }
 
 export function TravelDocDrawerForm({
@@ -115,7 +111,11 @@ export function TravelDocDrawerForm({
       </div>
 
       {expiryState && (
-        <div className={`rounded-xl border px-4 py-3 text-sm font-medium ${EXPIRY_STYLES[expiryState]}`}>
+        <StatusBadge
+          status={EXPIRY_TOKEN[expiryState]}
+          className="block w-full rounded-xl border px-4 py-3 text-sm font-medium"
+          style={{ borderColor: `color-mix(in srgb, var(--status-${EXPIRY_TOKEN[expiryState]}-fg) 35%, transparent)` }}
+        >
           {EXPIRY_LABELS[expiryState]}
           {form.valid_through && (
             <span className="font-normal ml-1 opacity-70">
@@ -124,7 +124,7 @@ export function TravelDocDrawerForm({
               })}
             </span>
           )}
-        </div>
+        </StatusBadge>
       )}
 
       {isError && (

--- a/app/(dashboard)/profile/components/VitalsSection.tsx
+++ b/app/(dashboard)/profile/components/VitalsSection.tsx
@@ -23,15 +23,15 @@ function VitalCard({ vs }: { vs: ProfileVitalSign }) {
     <div
       className="rounded-xl p-3 flex flex-col gap-1"
       style={{
-        backgroundColor: recorded ? 'rgba(188,71,73,0.08)' : 'var(--bg-global)',
-        border: `1px solid ${recorded ? 'rgba(188,71,73,0.2)' : 'var(--border-default)'}`,
+        backgroundColor: recorded ? 'color-mix(in srgb, var(--brand-crimson) 8%, transparent)' : 'var(--bg-global)',
+        border: `1px solid ${recorded ? 'color-mix(in srgb, var(--brand-crimson) 20%, transparent)' : 'var(--border-default)'}`,
       }}
     >
       <span
         className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full self-start"
         style={{
-          backgroundColor: recorded ? 'rgba(188,71,73,0.12)' : 'var(--border-default)',
-          color: recorded ? 'var(--brand-crimson)' : 'var(--text-secondary)',
+          backgroundColor: recorded ? 'var(--status-alert-bg)' : 'var(--border-default)',
+          color: recorded ? 'var(--status-alert-fg)' : 'var(--text-secondary)',
         }}
       >
         {recorded ? t('profile.vitalRecorded') : t('profile.vitalNotRecorded')}

--- a/app/(dashboard)/profile/components/shared.tsx
+++ b/app/(dashboard)/profile/components/shared.tsx
@@ -3,9 +3,21 @@
 // ── Shared JSX sub-components used across profile section files ──────────────
 // Kept separate from types.ts because .ts files cannot contain JSX.
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatDate, formatCurrency } from '@/lib/format'
-import { type TripEntry, type GenericPayment, PAYMENT_STATUS_STYLES, REG_STATUS_STYLES } from '../types'
+import { type TripEntry, type GenericPayment } from '../types'
+import { StatusBadge } from './StatusBadge'
 
 export function ShowMoreButton({ count, onClick }: { count: number; onClick: () => void }) {
   const { t } = useLanguage()
@@ -32,9 +44,7 @@ export function TripRow({
   const { t } = useLanguage()
   if (!entry.trip) return null
   const isCancelled = !!entry.cancelled_at
-  const regStyle = isCancelled
-    ? REG_STATUS_STYLES.cancelled
-    : (REG_STATUS_STYLES[entry.registration_status] ?? REG_STATUS_STYLES.pending)
+  const regStatus = isCancelled ? 'cancelled' : entry.registration_status
   return (
     <div
       className="rounded-xl p-3"
@@ -48,22 +58,34 @@ export function TripRow({
             {formatDate(entry.trip.start_date)} – {formatDate(entry.trip.end_date)}
           </p>
         </div>
-        <span
-          className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
-          style={{ backgroundColor: regStyle.bg, color: regStyle.color }}
-        >
+        <StatusBadge status={regStatus} className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0">
           {isCancelled ? t('home.shared.cancelled') : entry.registration_status}
-        </span>
+        </StatusBadge>
       </div>
       {!isCancelled && (
-        <button
-          onClick={() => { if (confirm(t('home.shared.cancelConfirm'))) onCancel(entry.trip!.id) }}
-          disabled={cancelPending}
-          className="mt-2 text-[11px] font-medium hover:opacity-70 transition-opacity disabled:opacity-40"
-          style={{ color: 'var(--brand-crimson)' }}
-        >
-          {t('home.shared.cancelPart')}
-        </button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <button
+              disabled={cancelPending}
+              className="mt-2 text-[11px] font-medium hover:opacity-70 transition-opacity disabled:opacity-40"
+              style={{ color: 'var(--brand-crimson)' }}
+            >
+              {t('home.shared.cancelPart')}
+            </button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{t('home.shared.cancelPart')}</AlertDialogTitle>
+              <AlertDialogDescription>{t('home.shared.cancelConfirm')}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{t('profile.cancel')}</AlertDialogCancel>
+              <AlertDialogAction onClick={() => onCancel(entry.trip!.id)}>
+                {t('home.shared.cancelPart')}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       )}
     </div>
   )
@@ -77,7 +99,6 @@ export function PaymentRow({
   cancelledTripIds: Set<string>
 }) {
   const { t } = useLanguage()
-  const ps = PAYMENT_STATUS_STYLES[pay.status] ?? PAYMENT_STATUS_STYLES.pending
   const linkedTripCancelled = pay.payable_items?.item_type === 'trip' && cancelledTripIds.size > 0
   return (
     <div
@@ -89,15 +110,12 @@ export function PaymentRow({
       </span>
       <span style={{ color: 'var(--text-secondary)' }}>{formatDate(pay.transaction_date)}</span>
       {pay.payment_method && <span style={{ color: 'var(--text-secondary)' }}>{pay.payment_method}</span>}
-      <span
-        className="ml-auto font-semibold px-2 py-0.5 rounded-full flex-shrink-0 flex items-center gap-1"
-        style={{ backgroundColor: ps.bg, color: ps.color }}
-      >
+      <StatusBadge status={pay.status} className="ml-auto font-semibold px-2 py-0.5 rounded-full flex-shrink-0 flex items-center gap-1">
         {pay.status}
         {(pay.admin_note || linkedTripCancelled) && (
           <span title={linkedTripCancelled ? t('home.shared.tripCancelled') : (pay.admin_note ?? '')} style={{ cursor: 'help', fontSize: 10, lineHeight: 1 }}>ⓘ</span>
         )}
-      </span>
+      </StatusBadge>
       {pay.proof_url && (
         <a href={pay.proof_url} target="_blank" rel="noopener noreferrer"
           className="flex-shrink-0 hover:underline" style={{ color: 'var(--brand-teal)' }}>{t('home.shared.proofLink')}</a>

--- a/app/(dashboard)/profile/invites/page.tsx
+++ b/app/(dashboard)/profile/invites/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from '@clerk/nextjs/server'
 import { redirect } from 'next/navigation'
-import Link from 'next/link'
 import { InvitesSection } from '../components/InvitesSection'
+import { ProfileBackLink } from '../components/ProfileBackLink'
 
 export default async function ProfileInvitesPage() {
   const { userId } = await auth()
@@ -9,14 +9,7 @@ export default async function ProfileInvitesPage() {
 
   return (
     <div className="py-8 pb-16 px-4 md:px-6 xl:px-8 md:max-w-[1280px] md:mx-auto">
-      {/* Back link */}
-      <Link
-        href="/profile"
-        className="inline-flex items-center gap-1 text-xs font-semibold mb-3 md:mb-5 hover:opacity-70 transition-opacity"
-        style={{ color: 'var(--text-secondary)' }}
-      >
-        ← Back to Profile
-      </Link>
+      <ProfileBackLink />
 
       {/* Full invites section */}
       <div

--- a/app/(dashboard)/profile/los-upload/LosUploadClient.tsx
+++ b/app/(dashboard)/profile/los-upload/LosUploadClient.tsx
@@ -9,6 +9,7 @@ import { DropZone } from '@/components/los-import/DropZone'
 import { AssemblySummary } from '@/components/los-import/AssemblySummary'
 import { SubtreePreview, type ChangeStatus, type NodeMeta } from '@/components/los-import/SubtreePreview'
 import { useLanguage } from '@/lib/hooks/useLanguage'
+import { ProfileBackLink } from '../components/ProfileBackLink'
 
 type Submission = {
   id: string
@@ -149,6 +150,7 @@ export function LosUploadClient({ aboNumber }: { aboNumber: string | null }) {
   if (!aboNumber) {
     return (
       <div className="py-8 max-w-[900px] mx-auto px-4 sm:px-6">
+        <ProfileBackLink />
         <h1 className="font-display text-2xl font-semibold mb-2" style={{ color: 'var(--text-primary)' }}>Upload your LOS</h1>
         <div className="rounded-xl border px-5 py-8 text-center" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
           <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
@@ -161,6 +163,7 @@ export function LosUploadClient({ aboNumber }: { aboNumber: string | null }) {
 
   return (
     <div className="py-8 pb-16 max-w-[900px] mx-auto px-4 sm:px-6 space-y-6">
+      <ProfileBackLink />
       <div>
         <h1 className="font-display text-2xl font-semibold mb-1" style={{ color: 'var(--text-primary)' }}>Upload your LOS</h1>
         <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>

--- a/app/(dashboard)/profile/spouse-link/SpouseLinkClient.tsx
+++ b/app/(dashboard)/profile/spouse-link/SpouseLinkClient.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { toast } from '@/lib/toast'
+import { ProfileBackLink } from '../components/ProfileBackLink'
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -267,6 +268,7 @@ export default function SpouseLinkClient({
 
   const content = (
     <>
+      <ProfileBackLink />
       <div
         style={{
           borderRadius: 'var(--bento-radius)',

--- a/app/(dashboard)/profile/types.ts
+++ b/app/(dashboard)/profile/types.ts
@@ -170,21 +170,12 @@ export type LosSummaryData = {
 // Raised to 6 to support the 2×3 vitals card grid.
 export const VARIABLE_CAP = 6
 
-export const PAYMENT_STATUS_STYLES: Record<string, { bg: string; color: string }> = {
-  pending:   { bg: '#f2cc8f33', color: '#7a5c00' },
-  completed: { bg: 'rgba(129,178,154,0.15)', color: '#2d6a4f' },
-  approved:  { bg: 'rgba(129,178,154,0.15)', color: '#2d6a4f' },
-  failed:    { bg: 'rgba(188,71,73,0.10)', color: '#bc4749' },
-  denied:    { bg: 'rgba(188,71,73,0.10)', color: '#bc4749' },
-}
+// Travel-document expiry banner tokens — maps to the same semantic status
+// tokens StatusBadge resolves (see StatusBadge.tsx's identity entries).
+export type ExpiryState = 'ok' | 'warning' | 'critical'
 
-export const REG_STATUS_STYLES: Record<string, { bg: string; color: string }> = {
-  pending:   { bg: '#f2cc8f33', color: '#7a5c00' },
-  approved:  { bg: 'rgba(129,178,154,0.15)', color: '#2d6a4f' },
-  denied:    { bg: 'rgba(188,71,73,0.10)', color: '#bc4749' },
-  cancelled: { bg: 'rgba(138,133,119,0.15)', color: '#5c5950' },
-  // Guest-invite specific states (InvitesSection/InvitesBento) — reuse the
-  // shared `cancelled` entry above for revoked/self-cancelled guests.
-  confirmed: { bg: 'rgba(61,64,91,0.08)',   color: '#3d405b' },
-  attended:  { bg: 'rgba(129,178,154,0.2)', color: '#2d6a4f' },
+export const EXPIRY_TOKEN: Record<ExpiryState, string> = {
+  ok:       'success',
+  warning:  'pending',
+  critical: 'alert',
 }

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #665 | `dev/2607-DEV-665` | `components/bento/BentoCard.tsx`, `styles/brand-tokens.css`, `docs/design/DESIGN-SYSTEM.md`, `docs/architecture/DECISIONS.md`, all of `app/(dashboard)/profile/components/` (13 content components + shared shell), `e2e/profile-bento-auth.spec.ts`; migration: no | 2026-07-26T00:00:00Z |
+| #666 | `dev/2607-DEV-666` | `styles/brand-tokens.css`, `app/(dashboard)/profile/types.ts`, `app/(dashboard)/profile/components/` (`StatusBadge.tsx` new, `ProfileBackLink.tsx` new, `shared.tsx`, `ParticipationSection.tsx`, `InvitesSection.tsx`, `AboInfoContent.tsx`, `VitalsSection.tsx`, `InvitesBento.tsx`, `PaymentsSection.tsx`, `CalendarSection.tsx`, `AdminSection.tsx`, `TravelDocContent.tsx`, `TravelDocDrawerForm.tsx`), `app/(dashboard)/profile/invites/page.tsx`, `app/(dashboard)/profile/los-upload/LosUploadClient.tsx`, `app/(dashboard)/profile/spouse-link/SpouseLinkClient.tsx`, `lib/i18n/translations.ts`, `docs/features/profile-refactor.md`; migration: no | 2026-07-26T00:00:00Z |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,13 +2,14 @@
 BUILD issue #666 (2607-DEV-666, branch `dev/2607-DEV-666`): Profile bento standardization 2 — semantic status token consolidation (`StatusBadge`, delete `PAYMENT_STATUS_STYLES`/`REG_STATUS_STYLES`/`EXPIRY_STYLES`), unified `ProfileBackLink` on the 3 drill pages, remaining raw-colour-literal sweep, shadcn `AlertDialog` for trip cancel, `next/link` for AdminSection.
 
 ## Now
-Starting EXECUTE stage. Local branch `claude/build-666-5662de` fast-forwarded to include `origin/dev/2607-DEV-666`'s CLAIM-registration commit (063b990) — CLAIMS.md now has the #666 row, stale #665 row already pruned by that commit.
+PR #670 opened as draft (`Closes #666`), commit 9af5d57 pushed to `dev/2607-DEV-666`. Waiting on CI + Vercel Preview.
 
 ## Next
-1. Step 5: brand-tokens.css neutral tokens + DESIGN-SYSTEM.md doc, StatusBadge.tsx, EXPIRY_TOKEN in types.ts, route shared.tsx/ParticipationSection/InvitesSection through it, TravelDocContent/TravelDocDrawerForm dedupe, remaining literal sweep, profile-refactor.md doc update.
-2. Step 6: ProfileBackLink.tsx + 3 drill pages + i18n key, AlertDialog for shared.tsx TripRow cancel, AdminSection next/link.
-3. Verification per issue's Verification section (build/lint, e2e, both-theme badge check, AlertDialog check, back-link check, admin nav check).
-4. `/code-review low` before first push; push draft PR with `Closes #666`.
+1. Check CI status and Vercel Preview READY on PR #670.
+2. On the Preview: both-theme status-badge check, AlertDialog replaces confirm on trip cancel, back link present/working on all 3 drill pages at 1280/390, `/admin` nav from AdminSection is client-side (not reload).
+3. Run `npm run test:e2e:auth` for real against a real Clerk/Supabase target (not possible in this worktree — no `.env.local`/local Supabase/seeded Clerk users) — paste output.
+4. Mark PR ready for review → one CodeRabbit pass → batched fix push → merge → GCR (remove CLAIMS.md row, close issue).
+5. After merge: no migrations in this PR, so no prod gate to approve — just confirm prod Vercel deploy READY and smoke-check `/profile`.
 
 ## Constraints
 - 390px mobile-first.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,51 +1,46 @@
 ## Goal
-BUILD issue #665 (2607-DEV-665, branch `dev/2607-DEV-665`): migrate all 13 `/profile` bentos onto the shared `BentoCard`/`.card` design system — shell, header, skeleton, empty state, elevation tokens.
+BUILD issue #666 (2607-DEV-666, branch `dev/2607-DEV-666`): Profile bento standardization 2 — semantic status token consolidation (`StatusBadge`, delete `PAYMENT_STATUS_STYLES`/`REG_STATUS_STYLES`/`EXPIRY_STYLES`), unified `ProfileBackLink` on the 3 drill pages, remaining raw-colour-literal sweep, shadcn `AlertDialog` for trip cancel, `next/link` for AdminSection.
 
 ## Now
-PR #667 opened as draft (`Closes #665`), branch pushed. Waiting on CI + Vercel Preview.
+Starting EXECUTE stage. Local branch `claude/build-666-5662de` fast-forwarded to include `origin/dev/2607-DEV-666`'s CLAIM-registration commit (063b990) — CLAIMS.md now has the #666 row, stale #665 row already pruned by that commit.
 
 ## Next
-1. Check CI status and Vercel Preview READY on PR #667.
-2. On the Preview: confirm 1280px chrome doesn't overlap Calendar/EmailPrefs/InvitesBento headers, 390px no horizontal overflow, dark theme on all 13 bentos + `/` + `/about` + one modal (Step 1 touched shared `--shadow-*` tokens), loading throttle shows header+shimmer with no vanish/pop and correct switch positions on EmailPrefsSection.
-3. Run `npm run test:e2e:auth` + `npm run test:mobile` for real against a real Clerk/Supabase target (not possible in this worktree, no `.env.local`/local Supabase/seeded Clerk users) — paste output, since CI's authenticated E2E job is a known skip.
-4. Mark PR ready for review → one CodeRabbit pass → batched fix push → merge → GCR (remove CLAIMS.md row, close issue).
-5. After merge: no migrations in this PR, so no prod gate to approve — just confirm prod Vercel deploy READY and smoke-check `/profile`.
+1. Step 5: brand-tokens.css neutral tokens + DESIGN-SYSTEM.md doc, StatusBadge.tsx, EXPIRY_TOKEN in types.ts, route shared.tsx/ParticipationSection/InvitesSection through it, TravelDocContent/TravelDocDrawerForm dedupe, remaining literal sweep, profile-refactor.md doc update.
+2. Step 6: ProfileBackLink.tsx + 3 drill pages + i18n key, AlertDialog for shared.tsx TripRow cancel, AdminSection next/link.
+3. Verification per issue's Verification section (build/lint, e2e, both-theme badge check, AlertDialog check, back-link check, admin nav check).
+4. `/code-review low` before first push; push draft PR with `Closes #666`.
 
 ## Constraints
-- 390px mobile-first — every bento must render correctly at 390px, including the mobile static-stack path.
-- shadcn/ui for any interactive primitive added.
-- Component co-location — profile-only components stay under `app/(dashboard)/profile/components/`.
-- No Tailwind `dark:` variants in the profile folder — use `[data-theme="dark"]` selectors.
-- Preserve dnd-kit drag/reorder, collapse/expand, and `profile.ui_prefs` persistence exactly.
-- Cards stay non-interactive — no `interactive-lift`, no whole-card `onClick`.
-- No `.bento-tile` entrance animation.
-- Do not adopt `.bento-grid` class (`grid-auto-rows`/`grid-auto-flow: dense` conflict) — keep profile's explicit inline grid, only source `gap` from `var(--bento-gap)`.
-- Headers stay in content components, not hoisted into `SortableBento` (stateful action buttons live there).
-- `PersonalDetailsContent`'s crimson border: plain `style={{ borderColor: 'var(--brand-crimson)' }}` override, NOT `variant="edge-alert"`.
+- 390px mobile-first.
+- shadcn/ui for all interactive primitives (AlertDialog for trip-cancel confirm).
+- Component co-location — StatusBadge/ProfileBackLink stay under `app/(dashboard)/profile/components/`.
+- No Tailwind `dark:` variants — use `[data-theme="dark"]` selectors.
+- `--status-neutral-*` is shared CSS — verify no unintended change to `/admin` (consumes same token block via StatusPill).
+- Each page's existing max-width (1280/900/860 drift) is NOT fixed here — logged as NOTED only.
 - No `git push` without the user explicitly asking for a push in-conversation (quote required) — not asked yet this session.
-- Part 2 (status-token consolidation, back links, colour sweep) is a separate, later issue — do not do that work here even though it touches the same files.
-- NOTED items in the issue (RoleRow remount, resetLayout pre-hydration bug, raw status strings, etc.) are deliberately NOT fixed here.
 
 ## Decisions
-DECISION: follow the issue's own Step 0-4 ordering verbatim rather than re-deriving a plan — it already verified its own file:line claims (confirmed `BentoCard.tsx:69` spread order during PLAN).
-DECISION: write the new `e2e/profile-bento-auth.spec.ts` before Step 2's shell refactor (per issue), so it's the checkpoint for the atomic 13-file change, not an afterthought.
+(none yet — following issue's Step 5/6 ordering verbatim)
 
 ## Facts
-- Route: `app/(dashboard)/profile/` — `page.tsx` (server) → `ProfileClient.tsx` (builds `bentoMap`, order/collapse state, `profile.ui_prefs` persistence) → `BentoGrid.tsx` (desktop, dnd-kit, dynamic import) or static stack (mobile) → `SortableBento.tsx` (shared shell).
-- 13 bento ids: `bento-registry.ts` `BENTO_IDS`/`DEFAULT_ORDER`.
-- `BentoCard`/`Eyebrow` live in `components/bento/BentoCard.tsx`; `style` spreads after `spanStyle` at line 69 (verified).
-- `components/ui/skeleton.tsx` exports `Skeleton({ className, style })` using `.skeleton-shimmer` + `--skeleton-base`.
-- Test commands: `npm run build`, `npm run lint`, `npm run test:e2e:auth`, `npm run test:mobile` (authenticated E2E CI job is a known skip — must run locally against DEV, per memory).
-- `BENTO_HEIGHT = { S: 160, M: 280 }` currently lives in `ProfileClient.tsx:40` — moving to `bento-registry.ts` per issue.
+- `styles/brand-tokens.css` already has 4 status pairs (success/info/alert/pending) light (L54-61) + dark (L93-100) — neutral is a 5th pair to add in both blocks.
+- `components/admin/StatusPill.tsx` is the pattern to mirror for `StatusBadge` — switch-based token+label, `{status}->{token,label}`, inline `style` backgroundColor/color from `var(--status-{token}-bg/fg)`. `StatusBadge` takes `{status, children}` instead (caller supplies label).
+- `PAYMENT_STATUS_STYLES`/`REG_STATUS_STYLES` (app/(dashboard)/profile/types.ts:173-190) consumed by: `components/shared.tsx` (TripRow L35-37/51-56, PaymentRow L80/92-96), `ParticipationSection.tsx` (RoleRow L41/54-55), `InvitesSection.tsx` (L285 revoked badge, L370-371 desktop table badge, L390-391 mobile card badge) — L285/370/390 spread `style={REG_STATUS_STYLES[...]}` directly (bg/color valid CSS props here, NOT the `{bg,color}` object form the issue calls a bug — re-verify against issue text before assuming no bug).
+- `EXPIRY_STYLES` duplicated verbatim in `TravelDocContent.tsx:54-58` and `TravelDocDrawerForm.tsx:14-18` (Tailwind arbitrary-value classes, not inline style objects).
+- Drill pages: `profile/invites/page.tsx` (Server Component, hardcoded `← Back to Profile` Link L13-19), `profile/los-upload/LosUploadClient.tsx` (Client, no-abo return ~L149-160, main return ~L162-270, no back link), `profile/spouse-link/SpouseLinkClient.tsx` (Client, single top-level return ~L304, no back link).
+- i18n: flat-key format in `lib/i18n/domains/profile.ts` (`'profile.key': { en, bg }`), re-exported via `lib/i18n/translations.ts` shim. No `profile.backToProfile` key exists yet.
+- `components/ui/alert-dialog.tsx` shadcn wrapper already used elsewhere in profile (InvitesSection revoke, CalendarSection regenerate) — same import pattern to follow for shared.tsx TripRow cancel.
+- AdminSection.tsx: single `<a href="/admin">` in an 8-col inline grid built for exactly one tile.
 
 ## Done
-PLAN + CLAIM for #665 — RESULT: issue CLAIM-complete (`## Design Checklist` all checked, `## Branch` = `dev/2607-DEV-665`), branch cut from `main` and pushed, `docs/CLAIMS.md` row registered (pruned stale merged #613 row).
-Step 1 — RESULT: `BentoCard` forwardRef, dark `--shadow-*` tokens, `BentoHeader`/`BentoSkeleton`/`BentoEmpty` created, `bento-registry.ts` `BENTO_META`/`BENTO_ICON_MAP`/`BENTO_HEIGHT`, `profile.calendar.generating` i18n string, DESIGN-SYSTEM.md:74 fixed. `npm run build`/`lint` clean vs baseline. Committed 7bd6fb4.
-Step 4 — RESULT: `e2e/profile-bento-auth.spec.ts` (5 tests) written, wired into `playwright.config.ts` (`authenticated` testMatch + `desktop` testIgnore gained `profile-bento-auth`; `mobile-390` picks it up unchanged). `playwright test --list` confirms correct project routing. Committed b9147e6.
-Step 2 — RESULT: atomic shell refactor across `SortableBento.tsx` (now renders `BentoCard` directly, both collapsed/expanded branches, `bento-mobile-full` deleted), `BentoGrid.tsx` (gap token), `ProfileClient.tsx` (reads `BENTO_META`/`BENTO_HEIGHT`, computes `personalDetailsIncomplete` and passes it as `cardStyle` through `SortableBento`→`BentoCard`), and all 13 content components (wrapper `rounded-2xl p-6 h-full` + inline bg/border stripped, 7 `*_MIN_HEIGHT` exports deleted + the already-dead `INVITES_MIN_HEIGHT` in `InvitesSection.tsx` = 8 total). `npm run build`/`lint` clean, 480 warnings matches baseline exactly. New e2e spec NOT run for real (env gap, see Open items) — not yet committed.
+Step 5 + Step 6 — RESULT: `--status-neutral-bg/fg` tokens (light+dark) added to `brand-tokens.css` + documented in `DESIGN-SYSTEM.md`; `StatusBadge.tsx` created (mirrors `StatusPill`, caller supplies label, identity token entries let `EXPIRY_TOKEN` pass through); `PAYMENT_STATUS_STYLES`/`REG_STATUS_STYLES` deleted from `types.ts`, replaced by `ExpiryState`/`EXPIRY_TOKEN`; `shared.tsx` (TripRow bug fixed — `style={REG_STATUS_STYLES[s]}` never set `backgroundColor` since `bg` isn't a CSS prop; PaymentRow), `ParticipationSection.tsx`, `InvitesSection.tsx` (3 sites) all routed through `StatusBadge`; `TravelDocContent.tsx`/`TravelDocDrawerForm.tsx` `EXPIRY_STYLES` duplication replaced by `EXPIRY_TOKEN` via `StatusBadge` (border via `color-mix()`); literal sweep done (AboInfoContent 11 sites, VitalsSection, InvitesBento incl. new light-mode `--bg-card-raised` token, InvitesSection, PaymentsSection/AboInfoContent `text-white`→`var(--brand-parchment)`, CalendarSection `hover:bg-black/5`→`hover:opacity-80`); `profile-refactor.md` updated; `ProfileBackLink.tsx` created + wired into all 3 drill pages + `profile.backToProfile` i18n key added; `shared.tsx` TripRow cancel now uses shadcn `AlertDialog` instead of `confirm()`; `AdminSection` bare `<a>` → `next/link`, 8-col grid collapsed to a single `w-fit` link.
+`npm install` run (worktree had no `node_modules`). `npm run build` clean. `npm run lint`: 476 warnings vs 477 baseline (confirmed via `git stash`/`stash pop` diff) — no new warnings introduced. `rg 'REG_STATUS_STYLES|PAYMENT_STATUS_STYLES|EXPIRY_STYLES'` returns zero hits outside the removal note in `profile-refactor.md`.
 
 ## Open items
-- New `e2e/profile-bento-auth.spec.ts` (5 tests) has NOT been executed against a real Clerk/Supabase session — this worktree has no `.env.local`, no local Supabase, no seeded Clerk test users (same gap noted on #613/#608/#607). `playwright test --list` confirms the file is wired correctly into both the `authenticated` and `mobile-390` projects and excluded from `desktop`; actual pass/fail is still unverified. Must run for real (`npm run test:e2e:auth` + `npm run test:mobile`) before claiming Step 2/Verification done, per docs/ai/BUILD.md VERIFY.
+- No live browser verification possible: this worktree has no `.env.local` — dev server 500s on `supabaseUrl is required` for any DB-backed route and redirects to `/sign-in` (Clerk keyless mode) — same known gap as #665's session (no local Supabase, no seeded Clerk test user). Both-theme status-badge check, AlertDialog check, back-link check, and AdminSection nav check are all UNVERIFIED against a real running app.
+- `npm run test:e2e:auth` not run for real (same env gap) — `playwright test --list` confirms `profile-bento-auth.spec.ts` (from #665) still resolves with no syntax breakage, but that spec doesn't cover this issue's new surfaces anyway.
+- Not yet run: `/code-review low` on the diff (BUILD.md EXECUTE step, required before first push).
+- Not yet committed or pushed — awaiting explicit user go-ahead per hard constraints.
 
 ## Failed attempts
 (none yet)

--- a/docs/design/DESIGN-SYSTEM.md
+++ b/docs/design/DESIGN-SYSTEM.md
@@ -79,8 +79,8 @@ Dark mode redefines the same token names with the same blur/offset geometry, tin
 
 Semantic status tokens in `styles/brand-tokens.css`, each a `bg`/`fg` pair with
 real `[data-theme="dark"]` overrides — consumed via inline `style` in
-`components/admin/StatusPill.tsx`, not Tailwind `dark:` classes (see Usage
-rules below for why):
+`components/admin/StatusPill.tsx` and `app/(dashboard)/profile/components/StatusBadge.tsx`,
+not Tailwind `dark:` classes (see Usage rules below for why):
 
 | Token | Light `bg` / `fg` | Dark `bg` / `fg` | Used for |
 |---|---|---|---|
@@ -88,9 +88,11 @@ rules below for why):
 | `--status-info` | `rgba(62,119,133,.12)` / `#2c5964` | `rgba(94,168,184,.18)` / `#8fd0dd` | `claimed` |
 | `--status-alert` | `rgba(188,71,73,.12)` / `#96393b` | `rgba(224,110,112,.18)` / `#f19a9b` | `failed`, `permanently_failed` |
 | `--status-pending` | `rgba(224,122,95,.14)` / `#a3502e` | `rgba(232,150,120,.20)` / `#f0b08d` | `pending` (default) |
+| `--status-neutral` | `rgba(138,133,119,.15)` / `#5c5950` | `rgba(181,176,168,.20)` / `#B5B0A8` | `cancelled`, `revoked` |
 
-Only 4 semantic tokens cover 5 status values — `failed` and
-`permanently_failed` share `--status-alert`, distinguished by label text only.
+5 semantic tokens cover 7 status values — `failed` and
+`permanently_failed` share `--status-alert`, `cancelled` and `revoked` share
+`--status-neutral`, distinguished by label text only.
 
 ## Animation
 

--- a/docs/features/profile-refactor.md
+++ b/docs/features/profile-refactor.md
@@ -49,12 +49,16 @@ export type LosSummaryData = { ... }
 ```
 
 Also exports shared constants and utilities used by multiple sections:
-- `PAYMENT_STATUS_STYLES`
-- `REG_STATUS_STYLES`
+- `EXPIRY_TOKEN` — travel-doc expiry state → semantic status token, consumed by `StatusBadge`
 - `VARIABLE_CAP`
 - `ShowMoreButton`
 - `TripRow`
 - `PaymentRow`
+
+Status badges (`PAYMENT_STATUS_STYLES`/`REG_STATUS_STYLES` — removed) are now rendered by
+`app/(dashboard)/profile/components/StatusBadge.tsx`, which resolves a raw status string to
+one of the semantic `--status-*` tokens in `styles/brand-tokens.css` (mirrors
+`components/admin/StatusPill.tsx`, but the caller supplies the label).
 
 ### `app/(dashboard)/profile/components/SortableBento.tsx` (new)
 

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -28,6 +28,7 @@ export const profile = {
   'profile.saving':             { en: 'Saving…',                 bg: 'Запазване…'               },
   'profile.saved':              { en: 'Saved ✓',                 bg: 'Запазено ✓'               },
   'profile.edit':               { en: 'Edit',                    bg: 'Редактирай'               },
+  'profile.backToProfile':      { en: 'Back to Profile',         bg: 'Обратно към профила'      },
   'profile.calSub':             { en: 'Calendar Subscription',   bg: 'Абонамент за календар'    },
   'profile.calSubDesc':         { en: 'Subscribe to your personalised calendar feed on your phone or any calendar app.', bg: 'Абонирайте се за персонализирания си календар на телефона или в приложение за календар.' },
   'profile.calSubInstructions': { en: 'Open your phone calendar app → Add calendar → From URL → Paste the link below. Your calendar will update automatically.', bg: 'Отворете приложението за календар → Добавяне на календар → По URL → Поставете линка по-долу. Календарът ви ще се обновява автоматично.' },

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -28,6 +28,7 @@
   --text-tertiary:     #8A8577;
   --text-nav:          var(--text-secondary); /* nav chrome — bumped in dark mode */
   --border-default:    rgba(45, 51, 42, 0.08);
+  --bg-card-raised:    rgba(45, 51, 42, 0.04);
   --border-hover:      rgba(188, 71, 73, 0.30);
   --nav-border:        rgba(45, 51, 42, 0.08); /* nav pill border — more visible in dark mode */
   --accent-left-info:  var(--brand-teal);
@@ -59,6 +60,8 @@
   --status-alert-fg:    #96393b;
   --status-pending-bg:  rgba(224, 122, 95, 0.14);
   --status-pending-fg:  #a3502e;
+  --status-neutral-bg:  rgba(138, 133, 119, 0.15);
+  --status-neutral-fg:  #5c5950;
 
   /* ── Font scale ── */
   --font-scale: 1;
@@ -98,6 +101,8 @@ html { font-size: calc(var(--font-scale) * 16px); }
   --status-alert-fg:    #f19a9b;
   --status-pending-bg:  rgba(232, 150, 120, 0.20);
   --status-pending-fg:  #f0b08d;
+  --status-neutral-bg:  rgba(181, 176, 168, 0.20);
+  --status-neutral-fg:  #B5B0A8;
 }
 
 /* ── Utility classes ── */


### PR DESCRIPTION
## Summary
- Consolidates the profile section's parallel status-colour system into the shared `--status-*` semantic tokens: new `StatusBadge` component (mirrors `StatusPill`, caller supplies label) + new `--status-neutral-*` token pair for `cancelled`/`revoked`; deletes `PAYMENT_STATUS_STYLES`/`REG_STATUS_STYLES`/`EXPIRY_STYLES`.
- Fixes a real bug en route: `InvitesSection` badges spread `style={REG_STATUS_STYLES[s]}` directly, and `bg` isn't a valid CSS property, so those three badges never rendered a background.
- Adds a unified `ProfileBackLink` to all 3 drill pages (`/profile/invites`, `/profile/los-upload`, `/profile/spouse-link`) with a new i18n key, replacing a hardcoded English-only link on one page and adding links to the other two which had none.
- Replaces the native `confirm()` for trip cancellation with a shadcn `AlertDialog`, and `AdminSection`'s bare `<a href="/admin">` with `next/link` (collapsing the 8-column grid built for one tile).
- Sweeps remaining raw colour literals to tokens across `AboInfoContent`, `VitalsSection`, `InvitesBento` (new light-mode `--bg-card-raised` token), `InvitesSection`, `PaymentsSection`, `CalendarSection`.

Closes #666

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` — 476 warnings vs 477 baseline (no new warnings; confirmed via `git stash`/`stash pop` diff)
- [x] `rg 'REG_STATUS_STYLES|PAYMENT_STATUS_STYLES|EXPIRY_STYLES'` returns zero hits outside the removal note in docs
- [ ] Both-theme status-badge check (this worktree has no `.env.local`/local Supabase/seeded Clerk user — same gap as #665's session; needs a real DEV target)
- [ ] AlertDialog replaces native confirm on trip cancel
- [ ] Back link present and working on all three drill pages, at 1280 and 390
- [ ] `/admin` navigation from `AdminSection` is a client-side transition, not a reload
- [ ] `npm run test:e2e:auth` against real DEV target
- [ ] Vercel preview READY + CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent status badges across invitations, participation, payments, and travel-document expiry indicators.
  * Added translated “Back to Profile” navigation to profile-related pages.
  * Added a confirmation dialog before cancelling trips.
* **Style**
  * Improved theme-aware colors, borders, alerts, buttons, cards, loading states, and status indicators across the profile dashboard.
  * Refined admin, calendar, invitations, payments, and vital-record displays for more consistent visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->