### PR TITLE
[2607-DEV-671] Fix QR share dialog styling in calendar event popup

### DIFF
--- a/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
@@ -9,6 +9,8 @@ import {
   DialogContent,
   DialogDescription,
   DialogHeader,
+  DialogOverlay,
+  DialogPortal,
   DialogTitle,
 } from '@/components/ui/dialog'
 import type { TranslationKey } from '@/lib/i18n'
@@ -193,35 +195,53 @@ export default function EventPopupShell({
       </div>
 
       <Dialog open={qrDataUrl !== null} onOpenChange={(open) => { if (!open) onQrDismiss() }}>
-        <DialogContent
-          className="left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
-          style={{ width: 320, maxWidth: '90vw' }}
-        >
-          <DialogHeader>
-            <DialogTitle>{t('cal.qrTitle')}</DialogTitle>
-            <DialogDescription>{t('cal.qrDescription')}</DialogDescription>
-          </DialogHeader>
-          {qrDataUrl && (
-            <div className="flex flex-col items-center gap-4">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={qrDataUrl}
-                alt={t('cal.qrTitle')}
-                width={256}
-                height={256}
-                className="h-auto w-full max-w-[256px] rounded-lg border border-black/5"
-              />
-              <button
-                onClick={downloadQr}
-                className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium text-white transition-opacity hover:opacity-80"
-                style={{ background: 'var(--brand-teal)' }}
-              >
-                <Download size={14} />
-                {t('cal.qrDownload')}
-              </button>
-            </div>
-          )}
-        </DialogContent>
+        <DialogPortal>
+          <DialogOverlay className="z-[60]" style={{ backgroundColor: 'rgba(0,0,0,0.32)' }} />
+          <DialogContent
+            className="left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 p-5 z-[60]"
+            style={{ width: 320, maxWidth: '90vw', border: '1px solid var(--border-default)' }}
+          >
+            <DialogHeader className="mb-5">
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex-1 min-w-0">
+                  <DialogTitle className="font-display" style={{ color: 'var(--text-primary)' }}>
+                    {t('cal.qrTitle')}
+                  </DialogTitle>
+                  <DialogDescription>{t('cal.qrDescription')}</DialogDescription>
+                </div>
+                <button
+                  onClick={onQrDismiss}
+                  aria-label="Close"
+                  className="w-6 h-6 flex items-center justify-center rounded-full hover:bg-black/5 transition-colors flex-shrink-0 mt-0.5"
+                  style={{ color: 'var(--text-secondary)' }}
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            </DialogHeader>
+            {qrDataUrl && (
+              <div className="flex flex-col items-center gap-4">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={qrDataUrl}
+                  alt={t('cal.qrTitle')}
+                  width={256}
+                  height={256}
+                  className="h-auto w-full max-w-[256px] rounded-lg border"
+                  style={{ borderColor: 'var(--border-default)' }}
+                />
+                <button
+                  onClick={downloadQr}
+                  className="flex items-center gap-1.5 rounded-xl px-5 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+                  style={{ backgroundColor: 'var(--brand-teal)' }}
+                >
+                  <Download size={14} />
+                  {t('cal.qrDownload')}
+                </button>
+              </div>
+            )}
+          </DialogContent>
+        </DialogPortal>
       </Dialog>
     </>
   )

--- a/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
@@ -219,7 +219,7 @@ export default function EventPopupShell({
                 </button>
               </div>
             </DialogHeader>
-            {qrDataUrl && (
+            {qrDataUrl !== null && (
               <div className="flex flex-col items-center gap-4">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #666 | `dev/2607-DEV-666` | `styles/brand-tokens.css`, `app/(dashboard)/profile/types.ts`, `app/(dashboard)/profile/components/` (`StatusBadge.tsx` new, `ProfileBackLink.tsx` new, `shared.tsx`, `ParticipationSection.tsx`, `InvitesSection.tsx`, `AboInfoContent.tsx`, `VitalsSection.tsx`, `InvitesBento.tsx`, `PaymentsSection.tsx`, `CalendarSection.tsx`, `AdminSection.tsx`, `TravelDocContent.tsx`, `TravelDocDrawerForm.tsx`), `app/(dashboard)/profile/invites/page.tsx`, `app/(dashboard)/profile/los-upload/LosUploadClient.tsx`, `app/(dashboard)/profile/spouse-link/SpouseLinkClient.tsx`, `lib/i18n/translations.ts`, `docs/features/profile-refactor.md`; migration: no | 2026-07-26T00:00:00Z |
+| #671 | `dev/2607-DEV-671` | `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx`; migration: no | 2026-07-27T00:00:00Z |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,47 +1,39 @@
 ## Goal
-BUILD issue #666 (2607-DEV-666, branch `dev/2607-DEV-666`): Profile bento standardization 2 — semantic status token consolidation (`StatusBadge`, delete `PAYMENT_STATUS_STYLES`/`REG_STATUS_STYLES`/`EXPIRY_STYLES`), unified `ProfileBackLink` on the 3 drill pages, remaining raw-colour-literal sweep, shadcn `AlertDialog` for trip cancel, `next/link` for AdminSection.
+BUILD issue #671 (2607-DEV-671, branch `dev/2607-DEV-671`): fix QR share dialog styling in the calendar event popup — missing portal/overlay, padding, border, close button.
 
 ## Now
-PR #670 opened as draft (`Closes #666`), commit 9af5d57 pushed to `dev/2607-DEV-666`. Waiting on CI + Vercel Preview.
+Starting EXECUTE stage — about to edit `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx` lines 195-225.
 
 ## Next
-1. Check CI status and Vercel Preview READY on PR #670.
-2. On the Preview: both-theme status-badge check, AlertDialog replaces confirm on trip cancel, back link present/working on all 3 drill pages at 1280/390, `/admin` nav from AdminSection is client-side (not reload).
-3. Run `npm run test:e2e:auth` for real against a real Clerk/Supabase target (not possible in this worktree — no `.env.local`/local Supabase/seeded Clerk users) — paste output.
-4. Mark PR ready for review → one CodeRabbit pass → batched fix push → merge → GCR (remove CLAIMS.md row, close issue).
-5. After merge: no migrations in this PR, so no prod gate to approve — just confirm prod Vercel deploy READY and smoke-check `/profile`.
+1. Rewrite the QR `Dialog` block per the PLAN DoD (portal+overlay, padding/border, header spacing+color, close button, img border, download button restyle).
+2. `npm run lint` and `npx tsc --noEmit`.
+3. `/code-review low` on the diff, fix findings locally.
+4. Push branch, open PR as draft (`Closes #671`), wait CI green + Preview READY.
+5. Manual verification per issue's Verification section (desktop + 390px + dark mode, focus/Esc/outside-click, download filename) — needs a running preview since this worktree has no `.env.local`.
+6. Mark PR ready → one CodeRabbit pass → batched fix push → merge → GCR (remove CLAIMS.md row, close issue).
+7. No migrations in this PR — no prod gate to approve, just confirm prod deploy READY.
 
 ## Constraints
 - 390px mobile-first.
-- shadcn/ui for all interactive primitives (AlertDialog for trip-cancel confirm).
-- Component co-location — StatusBadge/ProfileBackLink stay under `app/(dashboard)/profile/components/`.
-- No Tailwind `dark:` variants — use `[data-theme="dark"]` selectors.
-- `--status-neutral-*` is shared CSS — verify no unintended change to `/admin` (consumes same token block via StatusPill).
-- Each page's existing max-width (1280/900/860 drift) is NOT fixed here — logged as NOTED only.
-- No `git push` without the user explicitly asking for a push in-conversation (quote required) — not asked yet this session.
+- No `git push` of commits without the user explicitly asking for a push in-conversation (quote required) — not asked yet this session. (Branch-ref push for CLAIM scaffolding already done per docs/ai/CLAIM.md, that's a separate, already-approved-by-workflow action.)
+- Single file only: `EventPopupShell.tsx` — issue explicitly says nothing else in the file or in `EventPopup.tsx` changes.
 
 ## Decisions
-(none yet — following issue's Step 5/6 ordering verbatim)
+(none yet — following issue's prescribed change list verbatim, PLAN already validated it against source)
 
 ## Facts
-- `styles/brand-tokens.css` already has 4 status pairs (success/info/alert/pending) light (L54-61) + dark (L93-100) — neutral is a 5th pair to add in both blocks.
-- `components/admin/StatusPill.tsx` is the pattern to mirror for `StatusBadge` — switch-based token+label, `{status}->{token,label}`, inline `style` backgroundColor/color from `var(--status-{token}-bg/fg)`. `StatusBadge` takes `{status, children}` instead (caller supplies label).
-- `PAYMENT_STATUS_STYLES`/`REG_STATUS_STYLES` (app/(dashboard)/profile/types.ts:173-190) consumed by: `components/shared.tsx` (TripRow L35-37/51-56, PaymentRow L80/92-96), `ParticipationSection.tsx` (RoleRow L41/54-55), `InvitesSection.tsx` (L285 revoked badge, L370-371 desktop table badge, L390-391 mobile card badge) — L285/370/390 spread `style={REG_STATUS_STYLES[...]}` directly (bg/color valid CSS props here, NOT the `{bg,color}` object form the issue calls a bug — re-verify against issue text before assuming no bug).
-- `EXPIRY_STYLES` duplicated verbatim in `TravelDocContent.tsx:54-58` and `TravelDocDrawerForm.tsx:14-18` (Tailwind arbitrary-value classes, not inline style objects).
-- Drill pages: `profile/invites/page.tsx` (Server Component, hardcoded `← Back to Profile` Link L13-19), `profile/los-upload/LosUploadClient.tsx` (Client, no-abo return ~L149-160, main return ~L162-270, no back link), `profile/spouse-link/SpouseLinkClient.tsx` (Client, single top-level return ~L304, no back link).
-- i18n: flat-key format in `lib/i18n/domains/profile.ts` (`'profile.key': { en, bg }`), re-exported via `lib/i18n/translations.ts` shim. No `profile.backToProfile` key exists yet.
-- `components/ui/alert-dialog.tsx` shadcn wrapper already used elsewhere in profile (InvitesSection revoke, CalendarSection regenerate) — same import pattern to follow for shared.tsx TripRow cancel.
-- AdminSection.tsx: single `<a href="/admin">` in an 8-col inline grid built for exactly one tile.
+- Target block: `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx:195-225` (the QR `Dialog`).
+- `components/ui/dialog.tsx` already exports `DialogPortal`/`DialogOverlay` (re-exported from Radix primitives) — no new component work needed, just import + use.
+- Reference pattern for portal/overlay usage: `app/(dashboard)/calendar/components/CalendarClient.tsx:163-185`.
+- Reference pattern for padding/border/header/button shape: `components/ui/alert-dialog.tsx` (`AlertDialogContent` L36-44, `AlertDialogHeader` L52, `AlertDialogAction` L93-97).
+- No existing i18n close-label key in `lib/i18n/domains/calendar.ts` or `events.ts` — use a hardcoded `aria-label`, matching the header close button which also has none today.
+- No E2E covers the QR dialog (`e2e/calendar.spec.ts` has zero `qr` matches) — verification is manual/visual only.
 
 ## Done
-Step 5 + Step 6 — RESULT: `--status-neutral-bg/fg` tokens (light+dark) added to `brand-tokens.css` + documented in `DESIGN-SYSTEM.md`; `StatusBadge.tsx` created (mirrors `StatusPill`, caller supplies label, identity token entries let `EXPIRY_TOKEN` pass through); `PAYMENT_STATUS_STYLES`/`REG_STATUS_STYLES` deleted from `types.ts`, replaced by `ExpiryState`/`EXPIRY_TOKEN`; `shared.tsx` (TripRow bug fixed — `style={REG_STATUS_STYLES[s]}` never set `backgroundColor` since `bg` isn't a CSS prop; PaymentRow), `ParticipationSection.tsx`, `InvitesSection.tsx` (3 sites) all routed through `StatusBadge`; `TravelDocContent.tsx`/`TravelDocDrawerForm.tsx` `EXPIRY_STYLES` duplication replaced by `EXPIRY_TOKEN` via `StatusBadge` (border via `color-mix()`); literal sweep done (AboInfoContent 11 sites, VitalsSection, InvitesBento incl. new light-mode `--bg-card-raised` token, InvitesSection, PaymentsSection/AboInfoContent `text-white`→`var(--brand-parchment)`, CalendarSection `hover:bg-black/5`→`hover:opacity-80`); `profile-refactor.md` updated; `ProfileBackLink.tsx` created + wired into all 3 drill pages + `profile.backToProfile` i18n key added; `shared.tsx` TripRow cancel now uses shadcn `AlertDialog` instead of `confirm()`; `AdminSection` bare `<a>` → `next/link`, 8-col grid collapsed to a single `w-fit` link.
-`npm install` run (worktree had no `node_modules`). `npm run build` clean. `npm run lint`: 476 warnings vs 477 baseline (confirmed via `git stash`/`stash pop` diff) — no new warnings introduced. `rg 'REG_STATUS_STYLES|PAYMENT_STATUS_STYLES|EXPIRY_STYLES'` returns zero hits outside the removal note in `profile-refactor.md`.
+PLAN + CLAIM completed this session: issue #671 Design Checklist + Branch sections added, `dev/2607-DEV-671` branch cut and pushed, `docs/CLAIMS.md` updated (added #671, pruned merged #666 row), committed as 55de0d3.
 
 ## Open items
-- No live browser verification possible: this worktree has no `.env.local` — dev server 500s on `supabaseUrl is required` for any DB-backed route and redirects to `/sign-in` (Clerk keyless mode) — same known gap as #665's session (no local Supabase, no seeded Clerk test user). Both-theme status-badge check, AlertDialog check, back-link check, and AdminSection nav check are all UNVERIFIED against a real running app.
-- `npm run test:e2e:auth` not run for real (same env gap) — `playwright test --list` confirms `profile-bento-auth.spec.ts` (from #665) still resolves with no syntax breakage, but that spec doesn't cover this issue's new surfaces anyway.
-- Not yet run: `/code-review low` on the diff (BUILD.md EXECUTE step, required before first push).
-- Not yet committed or pushed — awaiting explicit user go-ahead per hard constraints.
+(none yet)
 
 ## Failed attempts
 (none yet)


### PR DESCRIPTION
Closes #671

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] `EventPopupShell.tsx`: QR dialog wrapped in explicit `DialogPortal`/`DialogOverlay`
- [x] Padding (`p-5`), border, header spacing/color, close button, image border, download button restyled per `AlertDialogContent` reference
- [x] `npm run lint` (476 warnings, unchanged from baseline) and `npx tsc --noEmit` both clean
- [x] Manual diff self-review (low effort) — no findings
**Next:** wait for CI + Vercel Preview READY, then manual verification per issue's Verification section (desktop + 390px + dark mode screenshots, focus/Esc/outside-click behavior, download filename) — this worktree has no `.env.local` so verification needs the Preview deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the QR-sharing dialog experience with a proper overlay and portal-based presentation.
  * Added a dedicated close button for easier dismissal.
  * Updated dialog positioning, layering, borders, QR image, and download button styling for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->