### PR TITLE
[2607-DEV-673] Bulgarian announcement title wrap inflates home bento row 3 and breaks the map tile

### DIFF
--- a/app/(dashboard)/components/tiles/AnnouncementTile.tsx
+++ b/app/(dashboard)/components/tiles/AnnouncementTile.tsx
@@ -30,7 +30,7 @@ export default function AnnouncementTile({ titles, contents, slug }: Props) {
         {slug ? (
           <Link href={`/news/${slug}`}>
             <h2
-              className="font-display text-xl font-semibold leading-snug mb-2 hover:opacity-80 transition-opacity"
+              className="font-display text-xl font-semibold leading-snug mb-2 md:line-clamp-2 md:min-h-[2.75em] hover:opacity-80 transition-opacity"
               style={{ color: 'var(--text-primary)' }}
             >
               {title}
@@ -38,7 +38,7 @@ export default function AnnouncementTile({ titles, contents, slug }: Props) {
           </Link>
         ) : (
           <h2
-            className="font-display text-xl font-semibold leading-snug mb-2"
+            className="font-display text-xl font-semibold leading-snug mb-2 md:line-clamp-2 md:min-h-[2.75em]"
             style={{ color: 'var(--text-primary)' }}
           >
             {title}
@@ -46,14 +46,8 @@ export default function AnnouncementTile({ titles, contents, slug }: Props) {
         )}
         {content && (
           <p
-            className="font-body text-sm leading-relaxed"
-            style={{
-              color: 'var(--text-secondary)',
-              display: '-webkit-box',
-              WebkitLineClamp: 4,
-              WebkitBoxOrient: 'vertical',
-              overflow: 'hidden',
-            } as React.CSSProperties}
+            className="font-body text-sm leading-relaxed line-clamp-4 md:line-clamp-3"
+            style={{ color: 'var(--text-secondary)' }}
           >
             {content}
           </p>

--- a/app/(dashboard)/components/tiles/LocationTile.tsx
+++ b/app/(dashboard)/components/tiles/LocationTile.tsx
@@ -64,7 +64,7 @@ export default function LocationTile({
   const { theme, mounted } = useTheme()
   const isDark = mounted ? theme === 'dark' : false
   const mapContainer = useRef<HTMLDivElement>(null)
-  const mapRef = useRef<{ remove: () => void; setStyle: (s: string) => void; once: (e: string, cb: () => void) => void } | null>(null)
+  const mapRef = useRef<{ remove: () => void; setStyle: (s: string) => void; once: (e: string, cb: () => void) => void; resize: () => void } | null>(null)
   const [ready, setReady] = useState(false)
 
   // Initialization
@@ -123,6 +123,17 @@ export default function LocationTile({
       mapRef.current.once('styledata', () => setReady(true))
     }
   }, [theme, mounted])
+
+  // Re-measure the canvas when the card grows or shrinks (e.g. a taller sibling
+  // bento tile drags this row with it) — mapbox-gl v2 only observes window resize.
+  useEffect(() => {
+    if (!mapContainer.current) return
+    const observer = new ResizeObserver(() => {
+      mapRef.current?.resize()
+    })
+    observer.observe(mapContainer.current)
+    return () => observer.disconnect()
+  }, [])
 
   if (!TOKEN) return <LocationFallback colSpan={colSpan} mobileColSpan={mobileColSpan} rowSpan={rowSpan} style={style} />
 

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -7,3 +7,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
 | #671 | `dev/2607-DEV-671` | `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx`; migration: no | 2026-07-27T00:00:00Z |
+| #673 | `dev/2607-DEV-673` | `app/(dashboard)/components/tiles/AnnouncementTile.tsx`, `app/(dashboard)/components/tiles/LocationTile.tsx`; migration: no | 2026-07-27T00:00:00Z |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,36 +1,37 @@
 ## Goal
-BUILD issue #671 (2607-DEV-671, branch `dev/2607-DEV-671`): fix QR share dialog styling in the calendar event popup — missing portal/overlay, padding, border, close button.
+BUILD issue #673 (2607-DEV-673, branch `dev/2607-DEV-673`): fix Bulgarian announcement title wrap inflating home bento row 3 + Mapbox canvas not re-measuring under it.
 
 ## Now
-Starting EXECUTE stage — about to edit `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx` lines 195-225.
+Starting EXECUTE stage — about to edit `app/(dashboard)/components/tiles/AnnouncementTile.tsx` (title/body clamp) then `app/(dashboard)/components/tiles/LocationTile.tsx` (ResizeObserver + map.resize()).
 
 ## Next
-1. Rewrite the QR `Dialog` block per the PLAN DoD (portal+overlay, padding/border, header spacing+color, close button, img border, download button restyle).
-2. `npm run lint` and `npx tsc --noEmit`.
-3. `/code-review low` on the diff, fix findings locally.
-4. Push branch, open PR as draft (`Closes #671`), wait CI green + Preview READY.
-5. Manual verification per issue's Verification section (desktop + 390px + dark mode, focus/Esc/outside-click, download filename) — needs a running preview since this worktree has no `.env.local`.
-6. Mark PR ready → one CodeRabbit pass → batched fix push → merge → GCR (remove CLAIMS.md row, close issue).
-7. No migrations in this PR — no prod gate to approve, just confirm prod deploy READY.
+1. Edit `AnnouncementTile.tsx`: `h2` gets `md:line-clamp-2 md:min-h-[2.75em]`; body clamp switches from inline `WebkitLineClamp: 4` to Tailwind `line-clamp-4 md:line-clamp-3` classes so it can be responsive.
+2. Edit `LocationTile.tsx`: add `ResizeObserver` effect on `mapContainer.current` calling `mapRef.current.resize()`, disconnect on cleanup; widen `mapRef` structural type to include `resize: () => void`.
+3. `npm run lint` and `npx tsc --noEmit`.
+4. `/code-review low` on the diff, fix findings locally.
+5. Push branch, open PR as draft (`Closes #673`), wait CI green + Preview READY.
+6. Manual verification: EN/BG toggle at 1440px (row 3 height unchanged, no forest band under map) and at 390px (BG title unclamped, cards stack).
+7. Mark PR ready → one CodeRabbit pass → batched fix push → merge → GCR (remove CLAIMS.md row, close issue).
+8. No migrations in this PR — no prod gate to approve, just confirm prod deploy READY.
 
 ## Constraints
 - 390px mobile-first.
 - No `git push` of commits without the user explicitly asking for a push in-conversation (quote required) — not asked yet this session. (Branch-ref push for CLAIM scaffolding already done per docs/ai/CLAIM.md, that's a separate, already-approved-by-workflow action.)
-- Single file only: `EventPopupShell.tsx` — issue explicitly says nothing else in the file or in `EventPopup.tsx` changes.
+- Two files only: `AnnouncementTile.tsx`, `LocationTile.tsx` — per issue's Affected Files list; EST ~20 changed lines.
+- Resize observer must be a separate effect from the theme-swap effect and must not touch `setReady` (per issue's Gotchas Flagged).
 
 ## Decisions
 (none yet — following issue's prescribed change list verbatim, PLAN already validated it against source)
 
 ## Facts
-- Target block: `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx:195-225` (the QR `Dialog`).
-- `components/ui/dialog.tsx` already exports `DialogPortal`/`DialogOverlay` (re-exported from Radix primitives) — no new component work needed, just import + use.
-- Reference pattern for portal/overlay usage: `app/(dashboard)/calendar/components/CalendarClient.tsx:163-185`.
-- Reference pattern for padding/border/header/button shape: `components/ui/alert-dialog.tsx` (`AlertDialogContent` L36-44, `AlertDialogHeader` L52, `AlertDialogAction` L93-97).
-- No existing i18n close-label key in `lib/i18n/domains/calendar.ts` or `events.ts` — use a hardcoded `aria-label`, matching the header close button which also has none today.
-- No E2E covers the QR dialog (`e2e/calendar.spec.ts` has zero `qr` matches) — verification is manual/visual only.
+- `AnnouncementTile.tsx` title `h2` currently unclamped (`app/(dashboard)/components/tiles/AnnouncementTile.tsx:32-46`); body clamp is inline-style `WebkitLineClamp: 4` (line 53).
+- `LocationTile.tsx` has `mapRef` typed `{ remove; setStyle; once }` (line 67), no `resize`; init effect at lines 71-116; theme-swap effect at 119-125; render at 129-153, map container div at 133.
+- Desktop-only grid: `app/(dashboard)/page.tsx:81` wraps the whole desktop bento in `hidden md:block`; row 3 track `minmax(220px, auto)` at line 84 (repeat(4, ...)).
+- `LocationTileLazy.tsx` wraps `LocationTile` in `next/dynamic` with `ssr:false` — no changes needed there.
+- No E2E covers home bento (confirmed: no home-bento spec in `e2e/`).
 
 ## Done
-PLAN + CLAIM completed this session: issue #671 Design Checklist + Branch sections added, `dev/2607-DEV-671` branch cut and pushed, `docs/CLAIMS.md` updated (added #671, pruned merged #666 row), committed as 55de0d3.
+PLAN + CLAIM completed this session: issue #673 already had a complete Design Checklist authored at creation (verified DoD against current codebase, matched exactly); added `## Branch` section, cut `dev/2607-DEV-673` from `main`, `docs/CLAIMS.md` row added and committed (8545f19).
 
 ## Open items
 (none yet)


### PR DESCRIPTION
## Summary
- `AnnouncementTile.tsx`: title `h2` reserves a fixed two-line height on `md+` (`md:line-clamp-2 md:min-h-[2.75em]`) so a longer Bulgarian title no longer inflates the shared bento grid row 3; body clamp is now responsive (`line-clamp-4 md:line-clamp-3`). Mobile (`<md`) stays unclamped.
- `LocationTile.tsx`: adds a `ResizeObserver` on the map container that calls `map.resize()` whenever the card grows or shrinks — mapbox-gl v2's `trackResize` only observes window resize, not container size, so the canvas previously stayed stale under the announcement-driven row growth.

Closes #673

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] AnnouncementTile.tsx title/body clamp
- [x] LocationTile.tsx ResizeObserver + map.resize()
- [x] `npm run lint` and `npx tsc --noEmit` clean
- [x] `/code-review low` (manual, no findings)
**Next:** wait CI green + Preview READY, then manual verification (EN/BG toggle at 1440px and 390px per issue's Verification checklist)

## Test plan
- [ ] Vercel preview: toggle EN then BG on `/` at 1440px — row 3 height unchanged, no forest band under the map
- [ ] At 390px BG the announcement card still renders its full title without overflow
- [ ] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved announcement tile text layout with responsive truncation and consistent minimum heights.
  * Refined announcement tile hover behavior for linked content.
  * Improved map rendering so location tiles resize correctly when their container changes size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->