### PR TITLE
Remove Profile link from main/footer nav; fix footer hover dead-zone

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -51,7 +51,7 @@ export default function Footer() {
           </nav>
 
           {/* Col 3 — Socials + contact: Tickets → Mail → Instagram → Facebook */}
-          <div className="flex items-center gap-3 md:justify-end">
+          <div className="flex items-center gap-3 md:justify-end md:justify-self-end">
 
             {/* Tickets */}
             <a href="https://epaygo.bg/3640737494" target="_blank" rel="noopener noreferrer"

--- a/lib/nav.ts
+++ b/lib/nav.ts
@@ -2,8 +2,8 @@
 // Adding, removing, or renaming a route = one edit here, propagates everywhere.
 //
 // Consumer guide:
-//   Header    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + profile, no /los, no /roles)
-//   Footer    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + profile + roles, no /los)
+//   Header    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library, no /los, no /roles)
+//   Footer    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + roles, no /los)
 //   AdminNav  — ADMIN_NAV
 
 export type NavItem = {
@@ -42,10 +42,9 @@ export const MEMBER_NAV: NavItem[] = [
   { href: '/library', labels: { en: 'Library',    bg: 'Библиотека'  }, minRole: 'member' },
   { href: '/los',     labels: { en: 'My Network', bg: 'Моята мрежа' }, minRole: 'member' },
   { href: '/roles',   labels: { en: 'Roles',      bg: 'Роли'        }, minRole: 'core'   },
-  { href: '/profile', labels: { en: 'Profile',    bg: 'Профил'      }, minRole: 'guest'  },
 ]
 
-// Footer and Header both show library + profile + roles but not /los
+// Footer and Header both show library + roles but not /los
 export const FOOTER_MEMBER_NAV: NavItem[] = MEMBER_NAV.filter(
   item => item.href !== '/los'
 )

--- a/lib/nav.ts
+++ b/lib/nav.ts
@@ -2,7 +2,7 @@
 // Adding, removing, or renaming a route = one edit here, propagates everywhere.
 //
 // Consumer guide:
-//   Header    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library, no /los, no /roles)
+//   Header    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + roles, no /los)
 //   Footer    — PUBLIC_NAV + FOOTER_MEMBER_NAV (library + roles, no /los)
 //   AdminNav  — ADMIN_NAV
 


### PR DESCRIPTION
## Summary
- Removed the `/profile` entry from `MEMBER_NAV` in `lib/nav.ts` — the single source of truth feeding both the header (top nav, desktop + mobile drawer) and footer nav. `UserDropdown`'s account-menu "Profile" link and the `/profile` page are untouched.
- Fixed a footer layout bug found during investigation: the socials column (Col 3) stretched to fill its full grid-column width by default even though its icons were right-aligned, leaving an invisible hit-box that intercepted hover/click on the footer nav's rightmost pill (previously "Profile", now "Roles"). Constrained that column to its content width (`md:justify-self-end`) so the dead-zone doesn't just relocate to whichever item ends up last.

## Test plan
- [x] `git diff` reviewed — only intended lines changed in both files
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new errors (pre-existing warnings only)
- [ ] Manual check in Vercel preview: header (desktop + mobile) and footer no longer show "Profile"; hover the last footer nav pill ("Roles") across its full width with no dead zone; social icons still right-aligned and clickable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the footer’s desktop layout so the social and contact links align more consistently within the grid.

* **Documentation**
  * Updated navigation configuration comments to accurately describe the header and footer entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->