### PR TITLE
[2607-DEV-679] Strip shell quotes from supabase status env export in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,22 @@ jobs:
         run: |
           supabase start
           supabase db reset
-      - name: Export local Supabase keys
-        if: steps.check.outputs.ready == 'true'
-        run: supabase status -o env >> "$GITHUB_ENV"
-      - name: Map local Supabase keys to app env names
+      # `supabase status -o env` emits SHELL-QUOTED assignments
+      # (API_URL="http://127.0.0.1:54321"). $GITHUB_ENV is parsed literally, not
+      # sourced, so appending that output directly makes the quotes part of the
+      # value — every consumer then sees `"http://127.0.0.1:54321"`, which fails
+      # the anchored allowlist regex in scripts/seed-clerk-test-users.js:60 and
+      # would hand quoted JWTs to createClient. Source the output first so the
+      # shell strips the quotes, then write the bare values. Kept as ONE step:
+      # shell variables do not survive between steps, only $GITHUB_ENV does.
+      - name: Export local Supabase keys as app env names
         if: steps.check.outputs.ready == 'true'
         run: |
+          supabase status -o env > supabase-status.env
+          set -a
+          . ./supabase-status.env
+          set +a
+          rm -f supabase-status.env
           {
             echo "NEXT_PUBLIC_SUPABASE_URL=$API_URL"
             echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY"

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -8,3 +8,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 |---|---|---|---|
 | #671 | `dev/2607-DEV-671` | `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx`; migration: no | 2026-07-27T00:00:00Z |
 | #673 | `dev/2607-DEV-673` | `app/(dashboard)/components/tiles/AnnouncementTile.tsx`, `app/(dashboard)/components/tiles/LocationTile.tsx`; migration: no | 2026-07-27T00:00:00Z |
+| #679 | `dev/2607-DEV-679` | `.github/workflows/ci.yml` (e2e-authenticated job env export); migration: no | 2026-07-31T00:00:00Z |

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -4,8 +4,7 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 **Race window (known limitation):** this is a plain markdown file, not a lock — reading it, checking for overlap, and adding a row are three separate, non-atomic steps. Two agents can both read "no overlap" before either has committed their row. Mitigation, not a guarantee: `git pull` and re-read this file immediately before committing the new row (last step, right before the commit), so the window is only as wide as that final pull-and-check. If this repo's actual concurrent-agent volume ever makes that race a real recurring problem (not just theoretical), switch to a stronger primitive — e.g. GitHub issue assignment, which GitHub applies atomically server-side — instead of hardening this file further.
 
+_No claims in flight._
+
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #671 | `dev/2607-DEV-671` | `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx`; migration: no | 2026-07-27T00:00:00Z |
-| #673 | `dev/2607-DEV-673` | `app/(dashboard)/components/tiles/AnnouncementTile.tsx`, `app/(dashboard)/components/tiles/LocationTile.tsx`; migration: no | 2026-07-27T00:00:00Z |
-| #679 | `dev/2607-DEV-679` | `.github/workflows/ci.yml` (e2e-authenticated job env export); migration: no | 2026-07-31T00:00:00Z |

--- a/scripts/seed-clerk-test-users.js
+++ b/scripts/seed-clerk-test-users.js
@@ -52,10 +52,17 @@ const ADMIN_EMAIL = process.env.E2E_CLERK_ADMIN_EMAIL || 'e2e-admin-tevd-portal@
 // abo_number: trg_guard_abo_number_null (20260716000100_normalize_prod_schema_drift.sql)
 // rejects a NULL abo_number on a primary profile with role member or core. Admin is
 // exempt by design there ("ops role, no LOS identity"), so it stays NULL. The value is
-// text and UNIQUE (baseline.sql:31,47) with no format check — this reserved-looking
-// string cannot collide with a real ABO number on the hosted DEV project.
+// text and UNIQUE (baseline.sql:31,47) with no format check. The reserved-looking
+// string will not collide with a real ABO number, but uniqueness is NOT guaranteed
+// on the hosted DEV project this script also targets: a stale fixture row (same
+// email re-created in Clerk after a wipe, hence a new clerk_id) would still hold
+// this value, and `onConflict: 'clerk_id'` does not resolve a violation of the
+// separate profiles_abo_number_key constraint. assertAboNumberFree() below turns
+// that into an actionable error instead of a raw constraint failure.
+const MEMBER_ABO = process.env.E2E_CLERK_MEMBER_ABO || 'E2E-MEMBER-0001'
+
 const TEST_USERS = [
-  { email: MEMBER_EMAIL, role: 'member', firstName: 'E2E', lastName: 'Member', aboNumber: 'E2E-MEMBER-0001' },
+  { email: MEMBER_EMAIL, role: 'member', firstName: 'E2E', lastName: 'Member', aboNumber: MEMBER_ABO },
   { email: ADMIN_EMAIL, role: 'admin', firstName: 'E2E', lastName: 'Admin', aboNumber: null },
 ]
 
@@ -79,7 +86,34 @@ async function ensureClerkUser(clerk, { email, role, firstName, lastName }) {
   })
 }
 
+// profiles.abo_number is UNIQUE, but the upsert below conflict-resolves on clerk_id
+// only — a row holding this abo_number under a DIFFERENT clerk_id raises a raw
+// constraint error naming neither the fixture nor the remedy. Check first and fail
+// with something actionable. Read-only: never mutate a row this script does not own
+// (and nulling the holder's abo_number would itself trip trg_guard_abo_number_null).
+async function assertAboNumberFree(supabase, clerkId, aboNumber, email) {
+  if (aboNumber == null) return
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('clerk_id')
+    .eq('abo_number', aboNumber)
+    .maybeSingle()
+
+  if (error) throw new Error(`abo_number precheck failed for ${email}: ${error.message}`)
+  if (data == null || data.clerk_id === clerkId) return
+
+  throw new Error(
+    `abo_number "${aboNumber}" (fixture for ${email}) is already held by profile ` +
+      `clerk_id=${data.clerk_id}. This is a stale fixture from an earlier Clerk test ` +
+      `instance. Clear or reassign that profile's abo_number, or set ` +
+      `E2E_CLERK_MEMBER_ABO to a different reserved value.`,
+  )
+}
+
 async function upsertProfile(supabase, clerkId, { role, firstName, lastName, email, aboNumber }) {
+  await assertAboNumberFree(supabase, clerkId, aboNumber, email)
+
   const { error } = await supabase.from('profiles').upsert(
     {
       clerk_id: clerkId,

--- a/scripts/seed-clerk-test-users.js
+++ b/scripts/seed-clerk-test-users.js
@@ -49,9 +49,14 @@ loadEnvFile(path.join(root, '.env.local'))
 const MEMBER_EMAIL = process.env.E2E_CLERK_MEMBER_EMAIL || 'e2e-member-tevd-portal@example.com'
 const ADMIN_EMAIL = process.env.E2E_CLERK_ADMIN_EMAIL || 'e2e-admin-tevd-portal@example.com'
 
+// abo_number: trg_guard_abo_number_null (20260716000100_normalize_prod_schema_drift.sql)
+// rejects a NULL abo_number on a primary profile with role member or core. Admin is
+// exempt by design there ("ops role, no LOS identity"), so it stays NULL. The value is
+// text and UNIQUE (baseline.sql:31,47) with no format check — this reserved-looking
+// string cannot collide with a real ABO number on the hosted DEV project.
 const TEST_USERS = [
-  { email: MEMBER_EMAIL, role: 'member', firstName: 'E2E', lastName: 'Member' },
-  { email: ADMIN_EMAIL, role: 'admin', firstName: 'E2E', lastName: 'Admin' },
+  { email: MEMBER_EMAIL, role: 'member', firstName: 'E2E', lastName: 'Member', aboNumber: 'E2E-MEMBER-0001' },
+  { email: ADMIN_EMAIL, role: 'admin', firstName: 'E2E', lastName: 'Admin', aboNumber: null },
 ]
 
 const DEV_PROJECT_REF = 'iymwxdewcpvpjgzewtzk'
@@ -74,13 +79,14 @@ async function ensureClerkUser(clerk, { email, role, firstName, lastName }) {
   })
 }
 
-async function upsertProfile(supabase, clerkId, { role, firstName, lastName, email }) {
+async function upsertProfile(supabase, clerkId, { role, firstName, lastName, email, aboNumber }) {
   const { error } = await supabase.from('profiles').upsert(
     {
       clerk_id: clerkId,
       first_name: firstName,
       last_name: lastName,
       role,
+      abo_number: aboNumber ?? null,
       contact_email: email,
       display_names: { en: `${firstName} ${lastName}` },
     },


### PR DESCRIPTION
Fixes #679.

## Problem

The `Authenticated E2E (Clerk)` job had been reporting green in ~6s without running any specs, because `ci.yml` gates every step on two Clerk secrets that were not configured. Those secrets are now in place — and the job immediately failed at the seed step for a **separate, latent reason** that could never surface while it was skipping:

```
seed-clerk-test-users: refusing to run — NEXT_PUBLIC_SUPABASE_URL (""http://127.0.0.1:54321"")
is not a local instance or the hosted DEV project.
```

## Cause

`supabase status -o env` emits **shell-quoted** assignments (`API_URL="http://127.0.0.1:54321"`). `$GITHUB_ENV` is parsed literally, not sourced, so appending that output verbatim kept the quotes as part of every value. From run [30256453185](https://github.com/teamenjoyvd/tevd-portal/actions/runs/30256453185):

```
##[debug]API_URL='"http://127.0.0.1:54321"'
##[debug]ANON_KEY='"***"'
##[debug]SERVICE_ROLE_KEY='"***"'
##[debug]NEXT_PUBLIC_SUPABASE_URL='"http://127.0.0.1:54321"'
```

The outer `'…'` is GitHub's debug formatting; the inner `"…"` are literal characters in the value.

`scripts/seed-clerk-test-users.js:60` uses an anchored allowlist regex — `/^https?:\/\/(127\.0\.0\.1|localhost)(:|\/|$)/` — which a leading `"` defeats. The guard is correct and `127.0.0.1` is explicitly on its allowlist; only the value was corrupted.

**All three propagated values were affected, not just the URL.** Relaxing the guard alone would have moved the failure downstream: the quoted anon/service JWTs would have reached `createClient` and failed auth a step later.

Note this is not a DEV-environment issue. `ci.yml` boots a disposable local Supabase in Docker (`supabase start; supabase db reset`) and discards it; it never targets DEV or preview.

## Fix

Merge the two export steps into one and source the output so the shell strips the quotes before bare values are written to `$GITHUB_ENV`. They must be a single step — shell variables do not survive between steps, only `$GITHUB_ENV` does.

## Verification

Reproduced the exact output shape from the run log locally:

| | value seen by the script | `isSafe` |
|---|---|---|
| before | `"\"http://127.0.0.1:54321\""` | `false` |
| after | `"http://127.0.0.1:54321"` | `true` |

All three values emerge unquoted after the change. `ci.yml` re-parsed with `js-yaml`; the job's 11 steps are intact and in order.

**The real confirmation is this PR's own CI run.** The job should now take several minutes and reach `Run authenticated Playwright project`, rather than finishing in seconds. That turns four previously-dormant suites into genuine coverage: `admin-auth`, `los-submission-auth`, `profile-bento-auth`, and (once merged) the new admin 390px spec from #678.

## Notes

- Latent since #560 — unreachable until the secrets landed.
- `docs/CLAIMS.md` gains the row for this issue.
- Not folded into #678: that is a large admin layout sweep, and this needs to land first so #678's regression spec has a working gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for profiles with and without ABO numbers.
  * Improved seeded test data to better represent member and administrator scenarios.
* **Chores**
  * Improved authenticated testing setup and environment configuration handling for more reliable automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->