### PR TITLE
[2607-DEV-683] Fix bento layout persistence and its flaky spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,22 @@ jobs:
         run: |
           supabase start
           supabase db reset
-      - name: Export local Supabase keys
-        if: steps.check.outputs.ready == 'true'
-        run: supabase status -o env >> "$GITHUB_ENV"
-      - name: Map local Supabase keys to app env names
+      # `supabase status -o env` emits SHELL-QUOTED assignments
+      # (API_URL="http://127.0.0.1:54321"). $GITHUB_ENV is parsed literally, not
+      # sourced, so appending that output directly makes the quotes part of the
+      # value — every consumer then sees `"http://127.0.0.1:54321"`, which fails
+      # the anchored allowlist regex in scripts/seed-clerk-test-users.js:60 and
+      # would hand quoted JWTs to createClient. Source the output first so the
+      # shell strips the quotes, then write the bare values. Kept as ONE step:
+      # shell variables do not survive between steps, only $GITHUB_ENV does.
+      - name: Export local Supabase keys as app env names
         if: steps.check.outputs.ready == 'true'
         run: |
+          supabase status -o env > supabase-status.env
+          set -a
+          . ./supabase-status.env
+          set +a
+          rm -f supabase-status.env
           {
             echo "NEXT_PUBLIC_SUPABASE_URL=$API_URL"
             echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY"

--- a/app/(dashboard)/profile/components/BentoGrid.tsx
+++ b/app/(dashboard)/profile/components/BentoGrid.tsx
@@ -30,11 +30,13 @@ function SortableBentoItem({
   entry,
   collapsed,
   onToggleCollapse,
+  controlsDisabled,
 }: {
   id: string
   entry: BentoEntry
   collapsed: boolean
   onToggleCollapse: () => void
+  controlsDisabled?: boolean
 }) {
   const {
     attributes,
@@ -44,13 +46,17 @@ function SortableBentoItem({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id })
+    // dnd-kit's own gate: stops the sensor activating at all before the saved
+    // layout is restored. Hiding the handle alone would still leave the item
+    // draggable by other means.
+  } = useSortable({ id, disabled: controlsDisabled })
 
   return (
     <SortableBento
       id={id}
       collapsed={collapsed}
       onToggleCollapse={onToggleCollapse}
+      controlsDisabled={controlsDisabled}
       colSpan={entry.colSpan}
       minHeight={entry.minHeight}
       cardRef={setNodeRef}
@@ -73,12 +79,14 @@ export default function BentoGrid({
   bentoCollapsed,
   onToggleCollapse,
   onReorder,
+  controlsDisabled,
 }: {
   orderedBentos: { id: string; entry: BentoEntry }[]
   bentoOrder: string[]
   bentoCollapsed: Record<string, boolean>
   onToggleCollapse: (id: string) => void
   onReorder: (next: string[]) => void
+  controlsDisabled?: boolean
 }) {
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -104,6 +112,7 @@ export default function BentoGrid({
               entry={entry}
               collapsed={!!bentoCollapsed[id]}
               onToggleCollapse={() => onToggleCollapse(id)}
+              controlsDisabled={controlsDisabled}
             />
           ))}
         </div>

--- a/app/(dashboard)/profile/components/ProfileClient.tsx
+++ b/app/(dashboard)/profile/components/ProfileClient.tsx
@@ -135,10 +135,19 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
     }, PERSIST_DEBOUNCE_MS)
   }, [flushPrefs, t])
 
+  // Mirrored into refs so the handlers below can read the latest values without
+  // reaching for them inside a state updater. React updaters must be pure — it
+  // may replay them — so persistPrefs (which mutates a ref and arms a timer)
+  // must not run in there, even though it happens to be idempotent today.
   const bentoCollapsedRef = useRef(bentoCollapsed)
   useEffect(() => {
     bentoCollapsedRef.current = bentoCollapsed
   }, [bentoCollapsed])
+
+  const bentoOrderRef = useRef(bentoOrder)
+  useEffect(() => {
+    bentoOrderRef.current = bentoOrder
+  }, [bentoOrder])
 
   const handleReorder = useCallback((next: string[]) => {
     if (!layoutRestored) return
@@ -148,11 +157,9 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
 
   const toggleCollapse = useCallback((id: string) => {
     if (!layoutRestored) return
-    setBentoCollapsed(prev => {
-      const next = { ...prev, [id]: !prev[id] }
-      setBentoOrder(order => { persistPrefs(order, next); return order })
-      return next
-    })
+    const next = { ...bentoCollapsedRef.current, [id]: !bentoCollapsedRef.current[id] }
+    setBentoCollapsed(next)
+    persistPrefs(bentoOrderRef.current, next)
   }, [persistPrefs, layoutRestored])
 
   const orderedBentosRef = useRef<{ id: string; entry: { colSpan: number; minHeight: number; node: React.ReactNode } }[]>([])
@@ -165,7 +172,7 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
     const next = { ...bentoCollapsedRef.current }
     ids.forEach(id => { next[id] = !allCollapsed })
     setBentoCollapsed(next)
-    setBentoOrder(order => { persistPrefs(order, next); return order })
+    persistPrefs(bentoOrderRef.current, next)
   }, [persistPrefs, layoutRestored])
 
   // Gated like handleReorder/toggleCollapse/toggleAll. Without this, a reset
@@ -292,6 +299,7 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
             bentoCollapsed={bentoCollapsed}
             onToggleCollapse={toggleCollapse}
             onReorder={handleReorder}
+            controlsDisabled={!layoutRestored}
           />
         ) : (
           <div className="flex flex-col gap-3">
@@ -304,6 +312,7 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
                 colSpan={entry.colSpan}
                 minHeight={entry.minHeight}
                 cardStyle={entry.cardStyle}
+                controlsDisabled={!layoutRestored}
                 disableDrag
               >
                 {entry.node}

--- a/app/(dashboard)/profile/components/ProfileClient.tsx
+++ b/app/(dashboard)/profile/components/ProfileClient.tsx
@@ -19,6 +19,7 @@ import { EmailPrefsSection } from './EmailPrefsSection'
 import { InvitesBento } from './InvitesBento'
 import { BENTO_IDS, DEFAULT_ORDER, BENTO_META, BENTO_HEIGHT, type BentoId } from './bento-registry'
 import { apiClient } from '@/lib/apiClient'
+import { toast } from '@/lib/toast'
 import { useProfile } from '../useProfile'
 
 // dnd-kit (@dnd-kit/core, /sortable, /utilities) lives entirely inside
@@ -38,6 +39,10 @@ type Props = {
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const DESKTOP_QUERY = '(min-width: 768px)' // matches Tailwind `md` breakpoint used below
+
+// Layout changes coalesce for this long before hitting /api/profile. Anything
+// still pending is flushed on unmount and on pagehide — see flushPrefs below.
+const PERSIST_DEBOUNCE_MS = 500
 
 function metaFor(id: BentoId) {
   const meta = BENTO_META[id]
@@ -60,6 +65,7 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
   const [layoutRestored, setLayoutRestored] = useState(false)
   const [isDesktop, setIsDesktop]           = useState(false)
   const persistDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingPrefsRef = useRef<{ order: string[]; collapsed: Record<string, boolean> } | null>(null)
 
   useEffect(() => {
     const mql = window.matchMedia(DESKTOP_QUERY)
@@ -69,11 +75,36 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
     return () => mql.removeEventListener('change', handler)
   }, [])
 
-  useEffect(() => {
-    return () => {
-      if (persistDebounceRef.current) clearTimeout(persistDebounceRef.current)
+  // Sends whatever is pending right now, if anything. `keepalive` so the
+  // request survives the document being torn down (pagehide); apiClient
+  // spreads RequestInit straight into fetch.
+  const flushPrefs = useCallback((opts?: { keepalive?: boolean }) => {
+    if (persistDebounceRef.current) {
+      clearTimeout(persistDebounceRef.current)
+      persistDebounceRef.current = null
     }
+    const pending = pendingPrefsRef.current
+    if (pending === null) return null
+    pendingPrefsRef.current = null
+
+    return apiClient('/api/profile', {
+      method: 'PATCH',
+      body: JSON.stringify({ ui_prefs: { bento_order: pending.order, bento_collapsed: pending.collapsed } }),
+      keepalive: opts?.keepalive ?? false,
+    })
   }, [])
+
+  // A pending write must not be thrown away. The previous cleanup called
+  // clearTimeout and nothing else, so collapsing a bento and navigating within
+  // the debounce window silently lost the change. Flush instead of discard.
+  useEffect(() => {
+    const onPageHide = () => { flushPrefs({ keepalive: true })?.catch(() => { /* page is going away */ }) }
+    window.addEventListener('pagehide', onPageHide)
+    return () => {
+      window.removeEventListener('pagehide', onPageHide)
+      flushPrefs({ keepalive: true })?.catch(() => { /* unmounted */ })
+    }
+  }, [flushPrefs])
 
   useEffect(() => {
     if (layoutRestored || !fullProfile?.id) return
@@ -94,14 +125,15 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
   }, [fullProfile?.id])
 
   const persistPrefs = useCallback((order: string[], collapsed: Record<string, boolean>) => {
+    pendingPrefsRef.current = { order, collapsed }
     if (persistDebounceRef.current) clearTimeout(persistDebounceRef.current)
     persistDebounceRef.current = setTimeout(() => {
-      apiClient('/api/profile', {
-        method: 'PATCH',
-        body: JSON.stringify({ ui_prefs: { bento_order: order, bento_collapsed: collapsed } }),
-      }).catch(() => { /* silent */ })
-    }, 500)
-  }, [])
+      // Was `.catch(() => {})`, which made a failed save look identical to a
+      // slow one — to the user and to the e2e suite alike. Surface it so the
+      // layout is not silently lost at the next reload.
+      flushPrefs()?.catch(() => { toast.error(t('profile.layoutSaveError')) })
+    }, PERSIST_DEBOUNCE_MS)
+  }, [flushPrefs, t])
 
   const bentoCollapsedRef = useRef(bentoCollapsed)
   useEffect(() => {
@@ -136,11 +168,16 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
     setBentoOrder(order => { persistPrefs(order, next); return order })
   }, [persistPrefs, layoutRestored])
 
+  // Gated like handleReorder/toggleCollapse/toggleAll. Without this, a reset
+  // clicked before useProfile() resolves persists DEFAULT_ORDER while the
+  // restore effect above then overwrites local state with the saved order —
+  // the user sees the old layout return and the DB disagrees until reload.
   const resetLayout = useCallback(() => {
+    if (!layoutRestored) return
     setBentoOrder(DEFAULT_ORDER)
     setBentoCollapsed({})
     persistPrefs(DEFAULT_ORDER, {})
-  }, [persistPrefs])
+  }, [persistPrefs, layoutRestored])
 
   type BentoEntry = { colSpan: number; minHeight: number; node: React.ReactNode; cardStyle?: React.CSSProperties }
 
@@ -222,16 +259,21 @@ export function ProfileClient({ profileId, role, aboNumber, hasInvites }: Props)
       <div className="max-w-[1280px] mx-auto px-4 sm:px-6 xl:px-8">
 
         <div className="flex justify-end gap-4 mb-3">
+          {/* Disabled until the saved layout is restored: these handlers all
+              early-return before then, and a control that silently does
+              nothing is worse than one that shows it is not ready yet. */}
           <button
             onClick={toggleAll}
-            className="text-xs font-medium hover:opacity-70 transition-opacity"
+            disabled={!layoutRestored}
+            className="text-xs font-medium hover:opacity-70 transition-opacity disabled:opacity-40 disabled:cursor-default"
             style={{ color: 'var(--text-secondary)' }}
           >
             {allCollapsed ? t('profile.expandAll') : t('profile.collapseAll')}
           </button>
           <button
             onClick={resetLayout}
-            className="text-xs font-medium hover:opacity-70 transition-opacity"
+            disabled={!layoutRestored}
+            className="text-xs font-medium hover:opacity-70 transition-opacity disabled:opacity-40 disabled:cursor-default"
             style={{ color: 'var(--text-secondary)' }}
           >
             {t('profile.resetLayout')}

--- a/app/(dashboard)/profile/components/SortableBento.tsx
+++ b/app/(dashboard)/profile/components/SortableBento.tsx
@@ -59,6 +59,7 @@ export function SortableBento({
   colSpan,
   minHeight,
   disableDrag,
+  controlsDisabled,
   children,
   cardRef,
   dragStyle,
@@ -71,6 +72,10 @@ export function SortableBento({
   colSpan: number
   minHeight: number
   disableDrag?: boolean
+  // True until ProfileClient has restored the saved layout. onToggleCollapse and
+  // the reorder handler both early-return before then, so the controls are shown
+  // disabled rather than silently doing nothing.
+  controlsDisabled?: boolean
   children: ReactNode
   // Drag wiring — supplied only by BentoGrid.tsx's dnd-kit wrapper (desktop path).
   cardRef?: (node: HTMLDivElement | null) => void
@@ -96,7 +101,7 @@ export function SortableBento({
         style={{ paddingTop: 12, paddingBottom: 12, ...dragStyle, ...cardStyle }}
       >
         <div className="flex items-center gap-3">
-          {!disableDrag && dragHandle}
+          {!disableDrag && !controlsDisabled && dragHandle}
           {Icon && <Icon size={14} style={{ color: 'var(--text-secondary)', opacity: 0.6, flexShrink: 0 }} />}
           <span className="text-xs font-semibold tracking-[0.2em] uppercase" style={{ color: 'var(--text-secondary)' }}>
             {label}
@@ -107,6 +112,7 @@ export function SortableBento({
           variant="ghost"
           size="icon"
           onClick={onToggleCollapse}
+          disabled={controlsDisabled}
           title={t('profile.bento.expand')}
           aria-label={t('profile.bento.expand')}
           style={{ fontSize: 12, lineHeight: 1, opacity: 0.5, flexShrink: 0 }}
@@ -130,12 +136,13 @@ export function SortableBento({
       }}
     >
       <div style={{ position: 'absolute', top: 12, right: 12, display: 'flex', alignItems: 'center', gap: 6, zIndex: 10 }}>
-        {!disableDrag && dragHandle}
+        {!disableDrag && !controlsDisabled && dragHandle}
         <Button
           type="button"
           variant="ghost"
           size="icon"
           onClick={onToggleCollapse}
+          disabled={controlsDisabled}
           title={t('profile.bento.collapse')}
           aria-label={t('profile.bento.collapse')}
           style={{ fontSize: 12, lineHeight: 1, opacity: 0.5, flexShrink: 0 }}

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -8,3 +8,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 |---|---|---|---|
 | #671 | `dev/2607-DEV-671` | `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx`; migration: no | 2026-07-27T00:00:00Z |
 | #673 | `dev/2607-DEV-673` | `app/(dashboard)/components/tiles/AnnouncementTile.tsx`, `app/(dashboard)/components/tiles/LocationTile.tsx`; migration: no | 2026-07-27T00:00:00Z |
+| #679 | `dev/2607-DEV-679` | `.github/workflows/ci.yml` (e2e-authenticated job env export); migration: no | 2026-07-31T00:00:00Z |

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -4,7 +4,6 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 **Race window (known limitation):** this is a plain markdown file, not a lock — reading it, checking for overlap, and adding a row are three separate, non-atomic steps. Two agents can both read "no overlap" before either has committed their row. Mitigation, not a guarantee: `git pull` and re-read this file immediately before committing the new row (last step, right before the commit), so the window is only as wide as that final pull-and-check. If this repo's actual concurrent-agent volume ever makes that race a real recurring problem (not just theoretical), switch to a stronger primitive — e.g. GitHub issue assignment, which GitHub applies atomically server-side — instead of hardening this file further.
 
-_No claims in flight._
-
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
+| #683 | `dev/2607-DEV-683` | `app/(dashboard)/profile/components/ProfileClient.tsx`, `e2e/profile-bento-auth.spec.ts`, `lib/i18n/domains/profile.ts`; migration: no | 2026-07-31T00:00:00Z |

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -4,8 +4,7 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 **Race window (known limitation):** this is a plain markdown file, not a lock — reading it, checking for overlap, and adding a row are three separate, non-atomic steps. Two agents can both read "no overlap" before either has committed their row. Mitigation, not a guarantee: `git pull` and re-read this file immediately before committing the new row (last step, right before the commit), so the window is only as wide as that final pull-and-check. If this repo's actual concurrent-agent volume ever makes that race a real recurring problem (not just theoretical), switch to a stronger primitive — e.g. GitHub issue assignment, which GitHub applies atomically server-side — instead of hardening this file further.
 
+_No claims in flight._
+
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #671 | `dev/2607-DEV-671` | `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx`; migration: no | 2026-07-27T00:00:00Z |
-| #673 | `dev/2607-DEV-673` | `app/(dashboard)/components/tiles/AnnouncementTile.tsx`, `app/(dashboard)/components/tiles/LocationTile.tsx`; migration: no | 2026-07-27T00:00:00Z |
-| #679 | `dev/2607-DEV-679` | `.github/workflows/ci.yml` (e2e-authenticated job env export); migration: no | 2026-07-31T00:00:00Z |

--- a/e2e/profile-bento-auth.spec.ts
+++ b/e2e/profile-bento-auth.spec.ts
@@ -24,16 +24,37 @@ import { BENTO_IDS } from '../app/(dashboard)/profile/components/bento-registry'
 
 const MEMBER_EMAIL = process.env.E2E_CLERK_MEMBER_EMAIL ?? 'e2e-member-tevd-portal@example.com'
 
-// ProfileClient debounces ui_prefs PATCH by 500ms after every reorder/
-// collapse/reset call — give it margin before reload or the write races
-// the navigation.
-const PERSIST_DEBOUNCE_MARGIN_MS = 800
+// ProfileClient debounces the ui_prefs PATCH after every reorder/collapse/
+// reset. This suite used to bridge that with a fixed 800ms sleep, which
+// raced the debounce on a loaded CI runner. Every wait now polls observable
+// state — see expectPersisted below.
 
 async function signInAndOpenProfile(page: Page) {
   await page.goto('/')
   await clerk.signIn({ page, emailAddress: MEMBER_EMAIL })
   await page.goto('/profile')
-  await expect(page.locator('body')).toBeVisible()
+  // Waiting on `body` proved nothing: it is visible long before useProfile()
+  // resolves, and Playwright's webServer runs `npm run dev`, so /profile is
+  // compiled on demand and the first hit is slow. The layout controls are
+  // disabled until layoutRestored, so an enabled Reset button is the real
+  // signal that the saved layout is in and interaction is safe.
+  await expect(page.getByRole('button', { name: 'Reset layout' })).toBeEnabled({ timeout: 60_000 })
+}
+
+/**
+ * Persistence is debounced (PERSIST_DEBOUNCE_MS in ProfileClient), so the
+ * write lands some time after the click. Poll the persisted state instead of
+ * sleeping a fixed interval — a fixed sleep races the debounce on a loaded CI
+ * runner, which is exactly how this suite failed on #682.
+ */
+async function expectPersisted(
+  page: Page,
+  predicate: (prefs: { bento_order?: string[]; bento_collapsed?: Record<string, boolean> }) => boolean,
+  message: string,
+) {
+  await expect
+    .poll(async () => predicate(await getPersistedUiPrefs(page)), { message, timeout: 15_000 })
+    .toBe(true)
 }
 
 async function getPersistedUiPrefs(page: Page) {
@@ -52,7 +73,14 @@ test.describe('desktop bento grid — drag, collapse, layout persistence', () =>
     await signInAndOpenProfile(page)
 
     await page.getByRole('button', { name: 'Reset layout' }).click()
-    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+    // Wait for the reset to actually land, rather than assuming 800ms is
+    // enough. Previously this asserted on `bento_order: []` and compared
+    // indexOf -1 < -1, which reported a race as a logic failure.
+    await expectPersisted(
+      page,
+      prefs => (prefs.bento_order ?? []).includes(BENTO_IDS.PERSONAL_DETAILS),
+      'reset layout should persist bento_order',
+    )
 
     const prefs = await getPersistedUiPrefs(page)
     expect(prefs.bento_collapsed ?? {}).toEqual({})
@@ -67,12 +95,16 @@ test.describe('desktop bento grid — drag, collapse, layout persistence', () =>
     await signInAndOpenProfile(page)
 
     await page.getByRole('button', { name: 'Reset layout' }).click()
-    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+    await expectPersisted(
+      page,
+      prefs => (prefs.bento_order ?? []).includes(BENTO_IDS.PERSONAL_DETAILS),
+      'reset layout should persist before dragging',
+    )
     // Collapse all first: fixed-size bars make the drag geometry
     // deterministic and keep the assertion independent of each bento's
     // (soon to change, per Step 3) internal content layout.
     await page.getByRole('button', { name: 'Collapse all' }).click()
-    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+    await expect(page.getByRole('button', { name: 'Expand all' })).toBeVisible()
 
     const handles = page.locator('[title="Drag to reorder"]')
     await expect(handles.first()).toBeVisible()
@@ -94,7 +126,14 @@ test.describe('desktop bento grid — drag, collapse, layout persistence', () =>
     await page.mouse.move(secondBox!.x + secondBox!.width / 2, secondBox!.y + secondBox!.height / 2 + 4, { steps: 10 })
     await page.mouse.move(secondBox!.x + secondBox!.width / 2, secondBox!.y + secondBox!.height / 2 + 8, { steps: 5 })
     await page.mouse.up()
-    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+    await expectPersisted(
+      page,
+      prefs => {
+        const o = prefs.bento_order ?? []
+        return o.indexOf(secondId) < o.indexOf(firstId)
+      },
+      `drag should persist ${secondId} before ${firstId}`,
+    )
 
     await page.reload()
     const afterOrder = (await getPersistedUiPrefs(page)).bento_order ?? []
@@ -104,10 +143,20 @@ test.describe('desktop bento grid — drag, collapse, layout persistence', () =>
   test('collapsing a bento persists after reload', async ({ page }) => {
     await signInAndOpenProfile(page)
     await page.getByRole('button', { name: 'Reset layout' }).click()
-    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+    await expectPersisted(
+      page,
+      prefs => Object.values(prefs.bento_collapsed ?? {}).every(v => !v),
+      'reset should clear collapse state',
+    )
 
-    await page.getByRole('button', { name: 'Collapse', exact: true }).first().click()
-    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+    const collapseButton = page.getByRole('button', { name: 'Collapse', exact: true }).first()
+    await expect(collapseButton).toBeVisible()
+    await collapseButton.click()
+    await expectPersisted(
+      page,
+      prefs => Object.values(prefs.bento_collapsed ?? {}).some(Boolean),
+      'collapsing one bento should persist',
+    )
 
     const beforeReload = await getPersistedUiPrefs(page)
     const collapsedIds = Object.entries(beforeReload.bento_collapsed ?? {}).filter(([, v]) => v).map(([k]) => k)
@@ -124,11 +173,14 @@ test.describe('desktop bento grid — drag, collapse, layout persistence', () =>
   test('expand-all toggles every bento back open', async ({ page }) => {
     await signInAndOpenProfile(page)
     await page.getByRole('button', { name: 'Collapse all' }).click()
-    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
     await expect(page.getByRole('button', { name: 'Expand all' })).toBeVisible()
 
     await page.getByRole('button', { name: 'Expand all' }).click()
-    await page.waitForTimeout(PERSIST_DEBOUNCE_MARGIN_MS)
+    await expectPersisted(
+      page,
+      prefs => Object.values(prefs.bento_collapsed ?? {}).every(v => !v),
+      'expand all should clear every collapsed flag',
+    )
 
     const prefs = await getPersistedUiPrefs(page)
     const anyCollapsed = Object.values(prefs.bento_collapsed ?? {}).some(Boolean)

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -64,6 +64,7 @@ export const profile = {
   'profile.spouseLinkBanner.review':      { en: 'Review →',          bg: 'Преглед →'                    },
   'profile.incompleteHint':     { en: 'Complete your profile to get started.', bg: 'Попълнете профила си, за да започнете.' },
   'profile.resetLayout':        { en: 'Reset layout',            bg: 'Нулирай оформлението'     },
+  'profile.layoutSaveError':    { en: 'Could not save your layout. It may not persist after a reload.', bg: 'Оформлението не беше запазено. Възможно е да не се запази след презареждане.' },
   'profile.collapseAll':        { en: 'Collapse all',            bg: 'Свий всички'              },
   'profile.expandAll':          { en: 'Expand all',              bg: 'Разгъни всички'           },
   'profile.tile.personalDetails': { en: 'Personal Details', bg: 'Лични данни'           },

--- a/scripts/seed-clerk-test-users.js
+++ b/scripts/seed-clerk-test-users.js
@@ -59,7 +59,10 @@ const ADMIN_EMAIL = process.env.E2E_CLERK_ADMIN_EMAIL || 'e2e-admin-tevd-portal@
 // this value, and `onConflict: 'clerk_id'` does not resolve a violation of the
 // separate profiles_abo_number_key constraint. assertAboNumberFree() below turns
 // that into an actionable error instead of a raw constraint failure.
-const MEMBER_ABO = process.env.E2E_CLERK_MEMBER_ABO || 'E2E-MEMBER-0001'
+// `??` not `||`: an explicitly-empty E2E_CLERK_MEMBER_ABO must not be silently
+// swapped for the default. It is rejected in main() instead — the DB trigger only
+// rejects NULL, so a blank string would otherwise be inserted as a real value.
+const MEMBER_ABO = process.env.E2E_CLERK_MEMBER_ABO ?? 'E2E-MEMBER-0001'
 
 const TEST_USERS = [
   { email: MEMBER_EMAIL, role: 'member', firstName: 'E2E', lastName: 'Member', aboNumber: MEMBER_ABO },
@@ -149,6 +152,15 @@ async function main() {
   }
   if (!serviceRoleKey) {
     console.error('seed-clerk-test-users: SUPABASE_SERVICE_ROLE_KEY is not set.')
+    process.exitCode = 1
+    return
+  }
+  if (MEMBER_ABO.trim() === '') {
+    console.error(
+      'seed-clerk-test-users: E2E_CLERK_MEMBER_ABO is set but empty. Unset it to use the ' +
+        'default fixture value, or give it a real reserved value — a blank abo_number would ' +
+        'satisfy the NOT NULL trigger and be stored as a real one.',
+    )
     process.exitCode = 1
     return
   }

--- a/scripts/seed-clerk-test-users.js
+++ b/scripts/seed-clerk-test-users.js
@@ -52,10 +52,17 @@ const ADMIN_EMAIL = process.env.E2E_CLERK_ADMIN_EMAIL || 'e2e-admin-tevd-portal@
 // abo_number: trg_guard_abo_number_null (20260716000100_normalize_prod_schema_drift.sql)
 // rejects a NULL abo_number on a primary profile with role member or core. Admin is
 // exempt by design there ("ops role, no LOS identity"), so it stays NULL. The value is
-// text and UNIQUE (baseline.sql:31,47) with no format check — this reserved-looking
-// string cannot collide with a real ABO number on the hosted DEV project.
+// text and UNIQUE (baseline.sql:31,47) with no format check. The reserved-looking
+// string will not collide with a real ABO number, but uniqueness is NOT guaranteed
+// on the hosted DEV project this script also targets: a stale fixture row (same
+// email re-created in Clerk after a wipe, hence a new clerk_id) would still hold
+// this value, and `onConflict: 'clerk_id'` does not resolve a violation of the
+// separate profiles_abo_number_key constraint. assertAboNumberFree() below turns
+// that into an actionable error instead of a raw constraint failure.
+const MEMBER_ABO = process.env.E2E_CLERK_MEMBER_ABO || 'E2E-MEMBER-0001'
+
 const TEST_USERS = [
-  { email: MEMBER_EMAIL, role: 'member', firstName: 'E2E', lastName: 'Member', aboNumber: 'E2E-MEMBER-0001' },
+  { email: MEMBER_EMAIL, role: 'member', firstName: 'E2E', lastName: 'Member', aboNumber: MEMBER_ABO },
   { email: ADMIN_EMAIL, role: 'admin', firstName: 'E2E', lastName: 'Admin', aboNumber: null },
 ]
 
@@ -79,7 +86,34 @@ async function ensureClerkUser(clerk, { email, role, firstName, lastName }) {
   })
 }
 
+// profiles.abo_number is UNIQUE, but the upsert below conflict-resolves on clerk_id
+// only — a row holding this abo_number under a DIFFERENT clerk_id raises a raw
+// constraint error naming neither the fixture nor the remedy. Check first and fail
+// with something actionable. Read-only: never mutate a row this script does not own
+// (and nulling the holder's abo_number would itself trip trg_guard_abo_number_null).
+async function assertAboNumberFree(supabase, clerkId, aboNumber, email) {
+  if (aboNumber == null) return
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('clerk_id')
+    .eq('abo_number', aboNumber)
+    .maybeSingle()
+
+  if (error) throw new Error(`abo_number precheck failed for ${email}: ${error.message}`)
+  if (data == null || data.clerk_id === clerkId) return
+
+  throw new Error(
+    `abo_number "${aboNumber}" (fixture for ${email}) is already held by profile ` +
+      `clerk_id=${data.clerk_id}. This is a stale fixture from an earlier Clerk test ` +
+      `instance. Clear or reassign that profile's abo_number, or set ` +
+      `E2E_CLERK_MEMBER_ABO to a different reserved value.`,
+  )
+}
+
 async function upsertProfile(supabase, clerkId, { role, firstName, lastName, email, aboNumber }) {
+  await assertAboNumberFree(supabase, clerkId, aboNumber, email)
+
   const { error } = await supabase.from('profiles').upsert(
     {
       clerk_id: clerkId,

--- a/scripts/seed-clerk-test-users.js
+++ b/scripts/seed-clerk-test-users.js
@@ -49,9 +49,14 @@ loadEnvFile(path.join(root, '.env.local'))
 const MEMBER_EMAIL = process.env.E2E_CLERK_MEMBER_EMAIL || 'e2e-member-tevd-portal@example.com'
 const ADMIN_EMAIL = process.env.E2E_CLERK_ADMIN_EMAIL || 'e2e-admin-tevd-portal@example.com'
 
+// abo_number: trg_guard_abo_number_null (20260716000100_normalize_prod_schema_drift.sql)
+// rejects a NULL abo_number on a primary profile with role member or core. Admin is
+// exempt by design there ("ops role, no LOS identity"), so it stays NULL. The value is
+// text and UNIQUE (baseline.sql:31,47) with no format check — this reserved-looking
+// string cannot collide with a real ABO number on the hosted DEV project.
 const TEST_USERS = [
-  { email: MEMBER_EMAIL, role: 'member', firstName: 'E2E', lastName: 'Member' },
-  { email: ADMIN_EMAIL, role: 'admin', firstName: 'E2E', lastName: 'Admin' },
+  { email: MEMBER_EMAIL, role: 'member', firstName: 'E2E', lastName: 'Member', aboNumber: 'E2E-MEMBER-0001' },
+  { email: ADMIN_EMAIL, role: 'admin', firstName: 'E2E', lastName: 'Admin', aboNumber: null },
 ]
 
 const DEV_PROJECT_REF = 'iymwxdewcpvpjgzewtzk'
@@ -74,13 +79,14 @@ async function ensureClerkUser(clerk, { email, role, firstName, lastName }) {
   })
 }
 
-async function upsertProfile(supabase, clerkId, { role, firstName, lastName, email }) {
+async function upsertProfile(supabase, clerkId, { role, firstName, lastName, email, aboNumber }) {
   const { error } = await supabase.from('profiles').upsert(
     {
       clerk_id: clerkId,
       first_name: firstName,
       last_name: lastName,
       role,
+      abo_number: aboNumber ?? null,
       contact_email: email,
       display_names: { en: `${firstName} ${lastName}` },
     },


### PR DESCRIPTION
Fixes #683. Unblocks #682.

## Why

`e2e/profile-bento-auth.spec.ts` failed on #682 — the first CI run that suite has ever had (it was dormant until the Clerk secrets landed, see #679). Rather than assume a test race, I looked at the code underneath. Both things turned out to be true: the spec is flaky by construction **and** the code it covers has three real defects.

## Product fixes — `app/(dashboard)/profile/components/ProfileClient.tsx`

**1. Write failures were swallowed.** The persist call ended in `.catch(() => { /* silent */ })`, so a failed save was indistinguishable from a slow one — for the user and for the suite. This is exactly why the CI log showed `bento_order: []` with no way to tell whether the PATCH errored or was still in flight. Failures now surface via toast (`profile.layoutSaveError`, EN + BG).

**2. Pending writes were dropped on unmount.** The cleanup called `clearTimeout` and nothing else, and there is no `beforeunload`/`pagehide`/`visibilitychange` handler anywhere in the profile tree (verified by grep). A change made inside the 500ms debounce window and followed by a navigation was silently lost — real data loss in normal use: collapse a bento, click away immediately, gone.

Now flushed rather than discarded, on both unmount and `pagehide`, using `keepalive: true` so the request survives document teardown (`apiClient` spreads `RequestInit` straight into `fetch`).

**3. `resetLayout` was not gated on `layoutRestored`.** `handleReorder`, `toggleCollapse` and `toggleAll` all early-return before restore; `resetLayout` did not. For a user with a saved order:

1. Click "Reset layout" before `useProfile()` resolves → schedules a PATCH of `DEFAULT_ORDER`
2. The restore effect fires, sees a saved order, overwrites local state with the **old** order
3. The PATCH lands with `DEFAULT_ORDER`

The user sees their old layout return — reset looks broken — while the DB was in fact reset, and the two stay divergent until reload.

Since all four handlers early-return before `layoutRestored`, the two layout controls are now `disabled` until then. A control that silently does nothing is worse than one that shows it is not ready.

## Spec fixes — `e2e/profile-bento-auth.spec.ts`

Replaced every fixed `waitForTimeout(800)` with `expect.poll` on the persisted state. A fixed sleep racing a debounced write is flaky by construction on a loaded CI runner.

`signInAndOpenProfile` waited on `body` being visible, which happens long before `useProfile()` resolves — and Playwright's `webServer` runs `npm run dev`, so `/profile` is compiled on demand and the first hit is slow. That is what made `:104` time out at 60s waiting for a Collapse button. It now waits for the Reset button to be **enabled**, which is the genuine readiness signal.

Explicitly **not** fixed by raising the timeout, adding a skip, or bumping `retries`. `retries: 1` is what let this report as "flaky" on one run and hard-fail on the next; silencing it would re-hide what the newly-enabled job just caught.

## Verification

| check | result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | 0 errors; 476 pre-existing warnings, none in the changed files |
| fixed sleeps remaining in the spec | none |

The authenticated suite cannot run on this machine (no local Docker for Supabase), so **CI is the verification** for the e2e behavior. What matters on this PR's run: `Authenticated E2E (Clerk)` green with **no `flaky` line** — a pass that depends on a retry is not a pass.

## Notes

- Also drops the `docs/CLAIMS.md` rows for #671 (`c840963`) and #673 (`282aa93`), whose PRs already merged — folded into a merging PR rather than a standalone cleanup.
- #682 rebases onto this and re-runs against fixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving profile layout preferences, including pending-change handling during navigation.
  * Added an error notification when layout preferences cannot be saved.
  * Reset and bulk layout controls now remain unavailable until preferences finish loading.

* **Tests**
  * Improved end-to-end profile tests by waiting for confirmed saved state instead of using fixed delays.

* **Localization**
  * Added English and Bulgarian text for layout-save errors.

* **Chores**
  * Improved test-user setup validation for unique member identification numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->