### PR TITLE
[2608-DEV-688] Payment attribution on the profile ledger + /profile/payments drill-down

### DIFF
--- a/app/(dashboard)/profile/components/PaymentsSection.tsx
+++ b/app/(dashboard)/profile/components/PaymentsSection.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { formatCurrency } from '@/lib/format'
 import { beneficiaryLabel } from '@/lib/payments/labels'
-import { currencyOf, ledgerEntries } from '@/lib/payments/ledger'
+import { currencyOf, ledgerEntries, titleOf } from '@/lib/payments/ledger'
 import { PaymentForm } from '@/components/payment/PaymentForm'
 import { BentoHeader } from './BentoHeader'
 import { BentoSkeleton } from './BentoSkeleton'
@@ -44,7 +44,7 @@ function pendingGroupsIPaidFor(payments: GenericPayment[], myProfileId: string) 
     rows,
     total: rows.reduce((acc, r) => acc + Number(r.amount), 0),
     currency: currencyOf(rows[0]),
-    title: rows[0].payable_items?.title ?? rows[0].trips?.title ?? '',
+    title: titleOf(rows[0]),
   }))
 }
 

--- a/app/(dashboard)/profile/components/PaymentsSection.tsx
+++ b/app/(dashboard)/profile/components/PaymentsSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useCallback } from 'react'
+import Link from 'next/link'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { CreditCard } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
@@ -11,12 +12,13 @@ import {
 } from '@/components/ui/alert-dialog'
 import { formatCurrency } from '@/lib/format'
 import { beneficiaryLabel } from '@/lib/payments/labels'
+import { currencyOf, ledgerEntries } from '@/lib/payments/ledger'
 import { PaymentForm } from '@/components/payment/PaymentForm'
 import { BentoHeader } from './BentoHeader'
 import { BentoSkeleton } from './BentoSkeleton'
 import { BentoEmpty } from './BentoEmpty'
 import { type TripEntry, type GenericPayment, type PayableItem, VARIABLE_CAP } from '../types'
-import { PaymentRow, ShowMoreButton } from './shared'
+import { PaymentRow } from './shared'
 import { apiClient } from '@/lib/apiClient'
 
 /**
@@ -41,51 +43,15 @@ function pendingGroupsIPaidFor(payments: GenericPayment[], myProfileId: string) 
     groupId,
     rows,
     total: rows.reduce((acc, r) => acc + Number(r.amount), 0),
-    currency: rows[0].payable_items?.currency ?? 'EUR',
+    currency: currencyOf(rows[0]),
     title: rows[0].payable_items?.title ?? rows[0].trips?.title ?? '',
   }))
-}
-
-function groupByItem(payments: GenericPayment[]): Record<string, GenericPayment[]> {
-  const map: Record<string, GenericPayment[]> = {}
-  for (const pay of payments) {
-    // Trip payments have no payable_item, so keying on payable_items alone
-    // filed every one of them under "Unknown".
-    const key = pay.payable_items?.title ?? pay.trips?.title ?? 'Unknown'
-    if (!map[key]) map[key] = []
-    map[key].push(pay)
-  }
-  return map
-}
-
-function PaymentGroups({
-  groups,
-  cancelledTripIds,
-}: {
-  groups: Record<string, GenericPayment[]>
-  cancelledTripIds: Set<string>
-}) {
-  return (
-    <div className="space-y-4">
-      {Object.entries(groups).map(([itemTitle, itemPayments]) => (
-        <div key={itemTitle}>
-          <p className="text-[11px] font-semibold tracking-widest uppercase mb-1.5" style={{ color: 'var(--text-secondary)' }}>{itemTitle}</p>
-          <div className="space-y-1.5">
-            {itemPayments.map(pay => (
-              <PaymentRow key={pay.id} pay={pay} cancelledTripIds={cancelledTripIds} />
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  )
 }
 
 export function PaymentsSection({ profileId, role }: { profileId: string; role: string }) {
   const { t } = useLanguage()
   const qc = useQueryClient()
   const [submitDrawerOpen, setSubmitDrawerOpen] = useState(false)
-  const [listDrawerOpen, setListDrawerOpen]     = useState(false)
 
   const enabled = !!profileId && role !== 'guest'
 
@@ -162,11 +128,10 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
       !(pay.payment_group_id && paidGroupIds.has(pay.payment_group_id)),
   )
 
-  const visiblePayments = ledgerPayments.slice(0, VARIABLE_CAP)
-  const overflow = ledgerPayments.length - VARIABLE_CAP
-
-  const visibleByItem = groupByItem(visiblePayments)
-  const allByItem     = groupByItem(ledgerPayments)
+  // VARIABLE_CAP now caps collapsed ENTRIES, not raw rows: the bento's unit is
+  // "latest transactions", and one on-behalf group IS one transaction.
+  const entries = ledgerEntries(ledgerPayments, profileId)
+  const visibleEntries = entries.slice(0, VARIABLE_CAP)
 
   return (
     <>
@@ -215,12 +180,27 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
           </div>
         )}
 
-        {Object.keys(visibleByItem).length === 0 && paidGroups.length === 0 ? (
+        {visibleEntries.length === 0 && paidGroups.length === 0 ? (
           <BentoEmpty message={t('payment.none')} />
         ) : (
-          <PaymentGroups groups={visibleByItem} cancelledTripIds={cancelledTripIds} />
+          <div className="space-y-1.5">
+            {visibleEntries.map(entry => (
+              <PaymentRow key={entry.key} entry={entry} me={profileId} cancelledTripIds={cancelledTripIds} />
+            ))}
+          </div>
         )}
-        {overflow > 0 && <ShowMoreButton count={overflow} onClick={() => setListDrawerOpen(true)} />}
+        {/* A link, not a drawer: /profile/payments shares the
+            ['profile-generic-payments'] query key, so client-side navigation
+            mounts it warm off this cache with no refetch. */}
+        {entries.length > 0 && (
+          <Link
+            href="/profile/payments"
+            className="inline-block mt-3 text-xs font-semibold hover:opacity-70 transition-opacity"
+            style={{ color: 'var(--brand-crimson)' }}
+          >
+            {t('payment.viewAll')}
+          </Link>
+        )}
       </div>
 
       <Drawer open={submitDrawerOpen} onClose={closeSubmitDrawer} title={t('payment.submit')}>
@@ -275,20 +255,6 @@ export function PaymentsSection({ profileId, role }: { profileId: string; role: 
         </AlertDialogContent>
       </AlertDialog>
 
-      <Drawer open={listDrawerOpen} onClose={() => setListDrawerOpen(false)} title={t('payment.allPayments')}>
-        <div className="space-y-4 mb-6">
-          <PaymentGroups groups={allByItem} cancelledTripIds={cancelledTripIds} />
-        </div>
-        <div className="border-t pt-4" style={{ borderColor: 'var(--border-default)' }}>
-          <button
-            onClick={() => { setListDrawerOpen(false); setSubmitDrawerOpen(true) }}
-            className="w-full py-2.5 rounded-xl text-sm font-semibold hover:opacity-90 transition-opacity"
-            style={{ backgroundColor: 'var(--brand-forest)', color: 'var(--brand-parchment)' }}
-          >
-            {t('payment.submitShort')}
-          </button>
-        </div>
-      </Drawer>
     </>
   )
 }

--- a/app/(dashboard)/profile/components/shared.tsx
+++ b/app/(dashboard)/profile/components/shared.tsx
@@ -120,6 +120,15 @@ export function PaymentRow({
   // scope for 2608-DEV-688 and left as found.
   const linkedTripCancelled = head.payable_items?.item_type === 'trip' && cancelledTripIds.size > 0
 
+  // Exactly one of these two ever says anything, so they need no separator
+  // between them. `paidBy` is non-null only when somebody else paid, and such an
+  // entry is never collapsed (ledgerEntries collapses only for the payer), so it
+  // holds one row — which must be on MY ledger, since GET /api/payments returns
+  // nothing where I am neither owner nor payer. `beneficiaryNames` then filters
+  // that row out on `profile_id !== me`, and it cannot be a guest row either:
+  // payments_guest_ledger_check forces profile_id = paid_by_profile_id, which
+  // contradicts somebody else having paid. The same invariant is what lets
+  // `Attribution` on /profile/payments return early on `paidBy`.
   const forNames = beneficiaryNames(entry, me, t('payment.guestTag'))
   const paidBy = payerName(entry, me)
   // An admin note explains a rejection. '' is not an explanation, so it must not

--- a/app/(dashboard)/profile/components/shared.tsx
+++ b/app/(dashboard)/profile/components/shared.tsx
@@ -16,8 +16,8 @@ import {
 } from '@/components/ui/alert-dialog'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatDate, formatCurrency } from '@/lib/format'
-import { guestLabel } from '@/lib/payments/labels'
-import { type TripEntry, type GenericPayment } from '../types'
+import { beneficiaryNames, payerName, type LedgerEntry } from '@/lib/payments/ledger'
+import { type TripEntry } from '../types'
 import { StatusBadge } from './StatusBadge'
 
 export function ShowMoreButton({ count, onClick }: { count: number; onClick: () => void }) {
@@ -92,45 +92,66 @@ export function TripRow({
   )
 }
 
+/**
+ * One line of the payments bento (2608-DEV-688).
+ *
+ * Takes a `LedgerEntry`, not a raw row: an on-behalf group is ONE bank transfer
+ * and must render as one line whether or not an admin has approved it yet. The
+ * previous version took a row and lost every trace of who a payment was for the
+ * moment the group left `pending`.
+ *
+ * Two lines rather than one: attribution ("for Ana, Nadia (guest)") plus the
+ * item title does not fit beside amount/date/status at 390px, and truncating
+ * the names away would reinstate exactly the gap this issue closes.
+ */
 export function PaymentRow({
-  pay,
+  entry,
+  me,
   cancelledTripIds,
 }: {
-  pay: GenericPayment
+  entry: LedgerEntry
+  me: string
   cancelledTripIds: Set<string>
 }) {
   const { t } = useLanguage()
-  const linkedTripCancelled = pay.payable_items?.item_type === 'trip' && cancelledTripIds.size > 0
-  // A guest row sits on the PAYER's ledger (2607-DEV-677), so without this it
-  // appears in their own history as an unexplained second payment of the same
-  // fee. Null on every ordinary row, which is every row that existed before.
-  const guestMarker = guestLabel(pay, t('payment.guestTag'))
+  const head = entry.rows[0]
+  // Unchanged from the row-based version, including its known defect: a real
+  // trip payment has payable_items === null, so this is always false. Out of
+  // scope for 2608-DEV-688 and left as found.
+  const linkedTripCancelled = head.payable_items?.item_type === 'trip' && cancelledTripIds.size > 0
+
+  const forNames = beneficiaryNames(entry, me, t('payment.guestTag'))
+  const paidBy = payerName(entry, me)
+  const detail = entry.title || null
+
   return (
-    <div
-      className="flex items-center gap-2 text-xs rounded-xl px-3 py-2"
-      style={{ backgroundColor: 'var(--bg-global)' }}
-    >
-      <span className="font-semibold flex-shrink-0" style={{ color: 'var(--text-primary)' }}>
-        {formatCurrency(pay.amount, pay.payable_items?.currency ?? 'EUR')}
-      </span>
-      <span style={{ color: 'var(--text-secondary)' }}>{formatDate(pay.transaction_date)}</span>
-      {pay.payment_method && <span style={{ color: 'var(--text-secondary)' }}>{pay.payment_method}</span>}
-      {/* min-w-0 + truncate: at 390px this row is already tight, and an
-          untruncatable name would push the status badge past the viewport. */}
-      {guestMarker !== null && (
-        <span className="truncate min-w-0" style={{ color: 'var(--text-secondary)' }}>
-          {t('payment.for')} {guestMarker}
+    <div className="text-xs rounded-xl px-3 py-2" style={{ backgroundColor: 'var(--bg-global)' }}>
+      <div className="flex items-center gap-2">
+        <span className="font-semibold flex-shrink-0" style={{ color: 'var(--text-primary)' }}>
+          {formatCurrency(entry.amount, entry.currency)}
         </span>
-      )}
-      <StatusBadge status={pay.admin_status} className="ml-auto font-semibold px-2 py-0.5 rounded-full flex-shrink-0 flex items-center gap-1">
-        {pay.admin_status}
-        {(pay.admin_note || linkedTripCancelled) && (
-          <span title={linkedTripCancelled ? t('home.shared.tripCancelled') : (pay.admin_note ?? '')} style={{ cursor: 'help', fontSize: 10, lineHeight: 1 }}>ⓘ</span>
+        <span style={{ color: 'var(--text-secondary)' }}>{formatDate(entry.transaction_date)}</span>
+        {entry.payment_method && <span className="truncate min-w-0" style={{ color: 'var(--text-secondary)' }}>{entry.payment_method}</span>}
+        <StatusBadge status={entry.status} className="ml-auto font-semibold px-2 py-0.5 rounded-full flex-shrink-0 flex items-center gap-1">
+          {entry.status}
+          {(entry.admin_note || linkedTripCancelled) && (
+            <span title={linkedTripCancelled ? t('home.shared.tripCancelled') : (entry.admin_note ?? '')} style={{ cursor: 'help', fontSize: 10, lineHeight: 1 }}>ⓘ</span>
+          )}
+        </StatusBadge>
+        {head.proof_url && (
+          <a href={head.proof_url} target="_blank" rel="noopener noreferrer"
+            className="flex-shrink-0 hover:underline" style={{ color: 'var(--brand-teal)' }}>{t('home.shared.proofLink')}</a>
         )}
-      </StatusBadge>
-      {pay.proof_url && (
-        <a href={pay.proof_url} target="_blank" rel="noopener noreferrer"
-          className="flex-shrink-0 hover:underline" style={{ color: 'var(--brand-teal)' }}>{t('home.shared.proofLink')}</a>
+      </div>
+      {/* truncate + min-w-0: at 390px an untruncatable list of names would push
+          the card past the viewport. */}
+      {(detail || forNames.length > 0 || paidBy) && (
+        <p className="mt-1 truncate min-w-0 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+          {detail}
+          {detail && (forNames.length > 0 || paidBy) ? ' · ' : ''}
+          {forNames.length > 0 && `${t('payment.for')} ${forNames.join(', ')}`}
+          {paidBy && `${t('payment.paidBy')} ${paidBy}`}
+        </p>
       )}
     </div>
   )

--- a/app/(dashboard)/profile/components/shared.tsx
+++ b/app/(dashboard)/profile/components/shared.tsx
@@ -122,7 +122,13 @@ export function PaymentRow({
 
   const forNames = beneficiaryNames(entry, me, t('payment.guestTag'))
   const paidBy = payerName(entry, me)
-  const detail = entry.title || null
+  // An admin note explains a rejection. '' is not an explanation, so it must not
+  // raise the ⓘ affordance that promises one.
+  const hasAdminNote = entry.admin_note != null && entry.admin_note !== ''
+  // `titleOf` returns '' for a row naming neither item nor trip, so the empty
+  // string is the real "no title" signal here — compared explicitly rather than
+  // truthiness-tested, per the repo's zero-is-data rule.
+  const detail = entry.title !== '' ? entry.title : null
 
   return (
     <div className="text-xs rounded-xl px-3 py-2" style={{ backgroundColor: 'var(--bg-global)' }}>
@@ -131,10 +137,10 @@ export function PaymentRow({
           {formatCurrency(entry.amount, entry.currency)}
         </span>
         <span style={{ color: 'var(--text-secondary)' }}>{formatDate(entry.transaction_date)}</span>
-        {entry.payment_method && <span className="truncate min-w-0" style={{ color: 'var(--text-secondary)' }}>{entry.payment_method}</span>}
+        {entry.payment_method != null && entry.payment_method !== '' && <span className="truncate min-w-0" style={{ color: 'var(--text-secondary)' }}>{entry.payment_method}</span>}
         <StatusBadge status={entry.status} className="ml-auto font-semibold px-2 py-0.5 rounded-full flex-shrink-0 flex items-center gap-1">
           {entry.status}
-          {(entry.admin_note || linkedTripCancelled) && (
+          {(hasAdminNote || linkedTripCancelled) && (
             <span title={linkedTripCancelled ? t('home.shared.tripCancelled') : (entry.admin_note ?? '')} style={{ cursor: 'help', fontSize: 10, lineHeight: 1 }}>ⓘ</span>
           )}
         </StatusBadge>
@@ -145,12 +151,12 @@ export function PaymentRow({
       </div>
       {/* truncate + min-w-0: at 390px an untruncatable list of names would push
           the card past the viewport. */}
-      {(detail || forNames.length > 0 || paidBy) && (
+      {(detail != null || forNames.length > 0 || paidBy != null) && (
         <p className="mt-1 truncate min-w-0 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
           {detail}
-          {detail && (forNames.length > 0 || paidBy) ? ' · ' : ''}
+          {detail != null && (forNames.length > 0 || paidBy != null) ? ' · ' : ''}
           {forNames.length > 0 && `${t('payment.for')} ${forNames.join(', ')}`}
-          {paidBy && `${t('payment.paidBy')} ${paidBy}`}
+          {paidBy != null && `${t('payment.paidBy')} ${paidBy}`}
         </p>
       )}
     </div>

--- a/app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx
+++ b/app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx
@@ -287,10 +287,10 @@ export function PaymentsLedgerClient() {
                 <tr style={{ backgroundColor: 'var(--bg-global)' }}>
                   <SortableHeader label={t('payment.date')} active={sortKey === 'date'} dir={sortDir} onClick={() => toggleSort('date')} />
                   <SortableHeader label={t('payment.amount')} active={sortKey === 'amount'} dir={sortDir} onClick={() => toggleSort('amount')} />
-                  <HeaderCell label={t('payment.item')} />
-                  <HeaderCell label={t('payment.attribution')} />
-                  <HeaderCell label={t('payment.method')} />
-                  <HeaderCell label={t('payment.status')} />
+                  <HeaderCell>{t('payment.item')}</HeaderCell>
+                  <HeaderCell>{t('payment.attribution')}</HeaderCell>
+                  <HeaderCell>{t('payment.method')}</HeaderCell>
+                  <HeaderCell>{t('payment.status')}</HeaderCell>
                 </tr>
               </thead>
               <tbody>
@@ -338,10 +338,12 @@ function Attribution({ entry, me, guestTag }: { entry: LedgerEntry; me: string; 
   return null
 }
 
-function HeaderCell({ label }: { label: string }) {
+const HEADER_CELL_CLASS = 'px-3 py-2 text-left text-[11px] font-semibold tracking-wide uppercase'
+
+function HeaderCell({ children }: { children: React.ReactNode }) {
   return (
-    <th className="px-3 py-2 text-left text-[11px] font-semibold tracking-wide uppercase" style={{ color: 'var(--text-secondary)' }}>
-      {label}
+    <th className={HEADER_CELL_CLASS} style={{ color: 'var(--text-secondary)' }}>
+      {children}
     </th>
   )
 }
@@ -358,12 +360,12 @@ function SortableHeader({
   onClick: () => void
 }) {
   return (
-    <th className="px-3 py-2 text-left text-[11px] font-semibold tracking-wide uppercase" style={{ color: 'var(--text-secondary)' }}>
-      <button type="button" onClick={onClick} className="hover:opacity-70 transition-opacity uppercase">
+    <HeaderCell>
+      <button type="button" onClick={onClick} className="uppercase hover:opacity-70 transition-opacity">
         {label}
         {active && (dir === 'asc' ? ' ↑' : ' ↓')}
       </button>
-    </th>
+    </HeaderCell>
   )
 }
 

--- a/app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx
+++ b/app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx
@@ -1,0 +1,428 @@
+'use client'
+
+/**
+ * The full payment ledger (2608-DEV-688).
+ *
+ * The bento shows the latest handful of transactions; this is the drill-down
+ * behind it. No new API route: it reuses GET /api/payments under the same
+ * ['profile-generic-payments'] query key the bento populates, so arriving here
+ * by client-side navigation mounts warm off that cache.
+ *
+ * Filtering happens at ENTRY level, never at row level. Filtering rows first
+ * would let a search term match one beneficiary of a three-person transfer and
+ * then render that group with a partial total — a number no bank statement
+ * would agree with. An entry either survives whole or not at all.
+ *
+ * One responsive file, not two: a `<table>` from md: up, stacked cards below.
+ * Six columns permits a split under the Layout Decision Rules but does not
+ * require one, and two files would duplicate the same mapping twice.
+ */
+
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Download } from 'lucide-react'
+import { useLanguage } from '@/lib/hooks/useLanguage'
+import { apiClient } from '@/lib/apiClient'
+import { formatCurrency, formatDate } from '@/lib/format'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  beneficiaryNames,
+  ledgerEntries,
+  lifetimeTotals,
+  payerName,
+  toLedgerCSV,
+  type CurrencyTotals,
+  type LedgerEntry,
+} from '@/lib/payments/ledger'
+import { useProfile } from '../useProfile'
+import { type GenericPayment } from '../types'
+import { BentoSkeleton } from '../components/BentoSkeleton'
+import { StatusBadge } from '../components/StatusBadge'
+
+type SortKey = 'date' | 'amount'
+type SortDir = 'asc' | 'desc'
+
+const STATUS_OPTIONS = ['all', 'approved', 'pending', 'rejected'] as const
+
+export function PaymentsLedgerClient() {
+  const { t } = useLanguage()
+  const { data: profile } = useProfile()
+  const me = profile?.id ?? ''
+
+  const { data: payments, isLoading } = useQuery<GenericPayment[]>({
+    queryKey: ['profile-generic-payments'],
+    queryFn: () => apiClient('/api/payments'),
+    enabled: !!me,
+    staleTime: 2 * 60 * 1000,
+  })
+
+  // ── Filter state ────────────────────────────────────────────────────────────
+  const [status, setStatus] = useState<string>('all')
+  const [search, setSearch] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('date')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  // 300 ms, matching AdminCalendarClient — long enough that typing does not
+  // re-filter per keystroke, short enough to feel immediate.
+  const handleSearchChange = useCallback((value: string) => {
+    setSearch(value)
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
+    searchDebounceRef.current = setTimeout(() => setDebouncedSearch(value), 300)
+  }, [])
+
+  const guestTag = t('payment.guestTag')
+  const rows = useMemo(() => payments ?? [], [payments])
+
+  // Lifetime, over RAW rows and deliberately outside every filter above:
+  // collapsing first would double-count a payer's own share of their own group.
+  const totals = useMemo(() => lifetimeTotals(rows, me), [rows, me])
+
+  const allEntries = useMemo(() => ledgerEntries(rows, me), [rows, me])
+
+  const visibleEntries = useMemo(() => {
+    const needle = debouncedSearch.trim().toLowerCase()
+
+    const filtered = allEntries.filter(entry => {
+      if (status !== 'all' && entry.status !== status) return false
+
+      // Inclusive [from, to] on the calendar day. transaction_date is a DATE, so
+      // comparing the leading 10 characters is a plain lexicographic ISO
+      // comparison — no timezone shifts the day here.
+      const day = entry.transaction_date.slice(0, 10)
+      if (dateFrom && day < dateFrom) return false
+      if (dateTo && day > dateTo) return false
+
+      if (needle) {
+        const haystack = [
+          entry.title,
+          entry.payment_method ?? '',
+          ...beneficiaryNames(entry, me, guestTag),
+          payerName(entry, me) ?? '',
+          ...entry.rows.map(r => r.note ?? ''),
+        ]
+          .join(' ')
+          .toLowerCase()
+        if (!haystack.includes(needle)) return false
+      }
+
+      return true
+    })
+
+    // Copy before sorting: .sort() mutates, and `filtered` is derived from the
+    // memoised allEntries whose order other readers depend on.
+    const sorted = [...filtered]
+    sorted.sort((a, b) => {
+      const cmp =
+        sortKey === 'amount'
+          ? a.amount - b.amount
+          : a.transaction_date.localeCompare(b.transaction_date)
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+    return sorted
+  }, [allEntries, status, debouncedSearch, dateFrom, dateTo, sortKey, sortDir, me, guestTag])
+
+  // Read sortKey directly rather than nesting setSortDir inside a setSortKey
+  // updater: updaters are double-invoked under strict mode, which would flip
+  // the direction twice and leave it unchanged.
+  const toggleSort = useCallback((key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir('desc')
+    }
+  }, [sortKey])
+
+  const handleExport = useCallback(() => {
+    // The RAW rows behind the visible entries: an export is an audit artifact,
+    // so a collapsed group must still export as its individual shares.
+    const csv = toLedgerCSV(visibleEntries.flatMap(e => e.rows), guestTag)
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `payments-${new Date().toISOString().slice(0, 10)}.csv`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }, [visibleEntries, guestTag])
+
+  if (isLoading || !me) {
+    return (
+      <div>
+        <h1 className="text-xl font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>
+          {t('payment.allPayments')}
+        </h1>
+        <BentoSkeleton rows={5} />
+      </div>
+    )
+  }
+
+  const statusLabel = (value: string) =>
+    value === 'all' ? t('payment.allStatuses')
+      : value === 'approved' ? t('payment.approved')
+      : value === 'pending' ? t('payment.pending')
+      : t('payment.rejected')
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3 mb-4">
+        <h1 className="text-xl font-semibold" style={{ color: 'var(--text-primary)' }}>
+          {t('payment.allPayments')}
+        </h1>
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={visibleEntries.length === 0}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-semibold hover:opacity-90 transition-opacity disabled:opacity-40 flex-shrink-0"
+          style={{ backgroundColor: 'var(--brand-forest)', color: 'var(--brand-parchment)', minHeight: '32px' }}
+        >
+          <Download size={14} />
+          {t('payment.exportCsv')}
+        </button>
+      </div>
+
+      {/* Lifetime totals. Rendered above the filters and labelled, because a
+          total that ignores the filter sitting next to it is otherwise read as
+          a bug. */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mb-4">
+        <TotalCard label={t('payment.totalPaid')} totals={totals.paid} />
+        <TotalCard label={t('payment.totalOnBehalf')} totals={totals.onBehalf} />
+        <TotalCard label={t('payment.totalPaidForMe')} totals={totals.paidForMe} />
+      </div>
+      <p className="text-[11px] mb-5" style={{ color: 'var(--text-secondary)' }}>
+        {t('payment.lifetimeNote')}
+      </p>
+
+      {/* Filters. Stacked at 390px, one row from sm: up. */}
+      <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2 mb-4">
+        <input
+          type="search"
+          value={search}
+          onChange={e => handleSearchChange(e.target.value)}
+          placeholder={t('payment.search')}
+          className="flex-1 min-w-0 sm:min-w-[220px] rounded-xl px-3 py-2 text-xs"
+          style={{
+            backgroundColor: 'var(--bg-card)',
+            border: '1px solid var(--border-default)',
+            color: 'var(--text-primary)',
+            minHeight: '40px',
+          }}
+        />
+        <Select value={status} onValueChange={setStatus}>
+          <SelectTrigger className="w-full sm:w-[160px] h-10 text-xs">
+            <SelectValue placeholder={t('payment.filterStatus')} />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map(option => (
+              <SelectItem key={option} value={option}>
+                {statusLabel(option)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <div className="flex gap-2">
+          <label className="flex-1 min-w-0 flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+            {t('payment.dateFrom')}
+            <input
+              type="date"
+              value={dateFrom}
+              onChange={e => setDateFrom(e.target.value)}
+              className="w-full min-w-0 rounded-xl px-2 py-2 text-xs"
+              style={{
+                backgroundColor: 'var(--bg-card)',
+                border: '1px solid var(--border-default)',
+                color: 'var(--text-primary)',
+                minHeight: '40px',
+              }}
+            />
+          </label>
+          <label className="flex-1 min-w-0 flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+            {t('payment.dateTo')}
+            <input
+              type="date"
+              value={dateTo}
+              onChange={e => setDateTo(e.target.value)}
+              className="w-full min-w-0 rounded-xl px-2 py-2 text-xs"
+              style={{
+                backgroundColor: 'var(--bg-card)',
+                border: '1px solid var(--border-default)',
+                color: 'var(--text-primary)',
+                minHeight: '40px',
+              }}
+            />
+          </label>
+        </div>
+      </div>
+
+      {visibleEntries.length === 0 ? (
+        <p className="text-sm py-8 text-center" style={{ color: 'var(--text-secondary)' }}>
+          {t('payment.noResults')}
+        </p>
+      ) : (
+        <>
+          {/* ── Stacked cards, below md ─────────────────────────────────────── */}
+          <div className="space-y-2 md:hidden">
+            {visibleEntries.map(entry => (
+              <EntryCard key={entry.key} entry={entry} me={me} guestTag={guestTag} />
+            ))}
+          </div>
+
+          {/* ── Table, md and up. overflow-x-auto so a long name scrolls the
+                table, never the page. ───────────────────────────────────────── */}
+          <div className="hidden md:block overflow-x-auto rounded-2xl" style={{ border: '1px solid var(--border-default)' }}>
+            <table className="w-full text-xs">
+              <thead>
+                <tr style={{ backgroundColor: 'var(--bg-global)' }}>
+                  <SortableHeader label={t('payment.date')} active={sortKey === 'date'} dir={sortDir} onClick={() => toggleSort('date')} />
+                  <SortableHeader label={t('payment.amount')} active={sortKey === 'amount'} dir={sortDir} onClick={() => toggleSort('amount')} />
+                  <HeaderCell label={t('payment.item')} />
+                  <HeaderCell label={t('payment.attribution')} />
+                  <HeaderCell label={t('payment.method')} />
+                  <HeaderCell label={t('payment.status')} />
+                </tr>
+              </thead>
+              <tbody>
+                {visibleEntries.map(entry => (
+                  <tr key={entry.key} style={{ borderTop: '1px solid var(--border-default)' }}>
+                    <td className="px-3 py-2 whitespace-nowrap" style={{ color: 'var(--text-secondary)' }}>
+                      {formatDate(entry.transaction_date)}
+                    </td>
+                    <td className="px-3 py-2 whitespace-nowrap font-semibold" style={{ color: 'var(--text-primary)' }}>
+                      {formatCurrency(entry.amount, entry.currency)}
+                    </td>
+                    <td className="px-3 py-2" style={{ color: 'var(--text-secondary)' }}>{entry.title}</td>
+                    <td className="px-3 py-2" style={{ color: 'var(--text-secondary)' }}>
+                      <Attribution entry={entry} me={me} guestTag={guestTag} />
+                    </td>
+                    <td className="px-3 py-2" style={{ color: 'var(--text-secondary)' }}>{entry.payment_method ?? ''}</td>
+                    <td className="px-3 py-2">
+                      <StatusBadge status={entry.status} className="font-semibold px-2 py-0.5 rounded-full whitespace-nowrap">
+                        {entry.status}
+                      </StatusBadge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Who the entry was for, or who paid it. Exactly one of the two applies: an
+ * entry the viewer paid names its beneficiaries, an entry someone else paid
+ * names the payer.
+ */
+function Attribution({ entry, me, guestTag }: { entry: LedgerEntry; me: string; guestTag: string }) {
+  const { t } = useLanguage()
+  const forNames = beneficiaryNames(entry, me, guestTag)
+  const paidBy = payerName(entry, me)
+
+  if (paidBy) return <>{t('payment.paidBy')} {paidBy}</>
+  if (forNames.length > 0) return <>{t('payment.for')} {forNames.join(', ')}</>
+  return null
+}
+
+function HeaderCell({ label }: { label: string }) {
+  return (
+    <th className="px-3 py-2 text-left text-[11px] font-semibold tracking-wide uppercase" style={{ color: 'var(--text-secondary)' }}>
+      {label}
+    </th>
+  )
+}
+
+function SortableHeader({
+  label,
+  active,
+  dir,
+  onClick,
+}: {
+  label: string
+  active: boolean
+  dir: SortDir
+  onClick: () => void
+}) {
+  return (
+    <th className="px-3 py-2 text-left text-[11px] font-semibold tracking-wide uppercase" style={{ color: 'var(--text-secondary)' }}>
+      <button type="button" onClick={onClick} className="hover:opacity-70 transition-opacity uppercase">
+        {label}
+        {active && (dir === 'asc' ? ' ↑' : ' ↓')}
+      </button>
+    </th>
+  )
+}
+
+function EntryCard({ entry, me, guestTag }: { entry: LedgerEntry; me: string; guestTag: string }) {
+  const { t } = useLanguage()
+  return (
+    <div
+      className="rounded-xl px-3 py-2.5 text-xs"
+      style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+    >
+      <div className="flex items-center gap-2">
+        <span className="font-semibold flex-shrink-0" style={{ color: 'var(--text-primary)' }}>
+          {formatCurrency(entry.amount, entry.currency)}
+        </span>
+        <span style={{ color: 'var(--text-secondary)' }}>{formatDate(entry.transaction_date)}</span>
+        <StatusBadge status={entry.status} className="ml-auto font-semibold px-2 py-0.5 rounded-full flex-shrink-0">
+          {entry.status}
+        </StatusBadge>
+      </div>
+      <p className="mt-1 truncate min-w-0 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+        {entry.title}
+        {entry.title && entry.payment_method ? ' · ' : ''}
+        {entry.payment_method}
+      </p>
+      <p className="truncate min-w-0 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+        <Attribution entry={entry} me={me} guestTag={guestTag} />
+      </p>
+      {entry.admin_note && (
+        <p className="mt-1 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
+          {t('payment.note')}: {entry.admin_note}
+        </p>
+      )}
+    </div>
+  )
+}
+
+/** One lifetime bucket. Renders every currency it holds — a member who paid in
+ *  EUR and USD must not be shown one number that silently adds them. */
+function TotalCard({ label, totals }: { label: string; totals: CurrencyTotals }) {
+  const codes = Object.keys(totals).sort()
+  return (
+    <div
+      className="rounded-xl px-3 py-2.5"
+      style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
+    >
+      <p className="text-[11px] font-semibold tracking-wide uppercase" style={{ color: 'var(--text-secondary)' }}>
+        {label}
+      </p>
+      {codes.length === 0 ? (
+        <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+          {formatCurrency(0, 'EUR')}
+        </p>
+      ) : (
+        codes.map(code => (
+          <p key={code} className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            {formatCurrency(totals[code], code)}
+          </p>
+        ))
+      )}
+    </div>
+  )
+}

--- a/app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx
+++ b/app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx
@@ -18,7 +18,7 @@
  * require one, and two files would duplicate the same mapping twice.
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Download } from 'lucide-react'
 import { useLanguage } from '@/lib/hooks/useLanguage'
@@ -58,7 +58,9 @@ export function PaymentsLedgerClient() {
   const { data: payments, isLoading } = useQuery<GenericPayment[]>({
     queryKey: ['profile-generic-payments'],
     queryFn: () => apiClient('/api/payments'),
-    enabled: !!me,
+    // `me` is '' until useProfile resolves — compared explicitly rather than
+    // truthiness-tested, per the repo's zero-is-data rule.
+    enabled: me !== '',
     staleTime: 2 * 60 * 1000,
   })
 
@@ -80,6 +82,12 @@ export function PaymentsLedgerClient() {
     searchDebounceRef.current = setTimeout(() => setDebouncedSearch(value), 300)
   }, [])
 
+  // The pending timer must not outlive the component: navigating away mid-type
+  // would otherwise fire setDebouncedSearch on an unmounted tree.
+  useEffect(() => () => {
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current)
+  }, [])
+
   const guestTag = t('payment.guestTag')
   const rows = useMemo(() => payments ?? [], [payments])
 
@@ -99,10 +107,12 @@ export function PaymentsLedgerClient() {
       // comparing the leading 10 characters is a plain lexicographic ISO
       // comparison — no timezone shifts the day here.
       const day = entry.transaction_date.slice(0, 10)
-      if (dateFrom && day < dateFrom) return false
-      if (dateTo && day > dateTo) return false
+      // '' is the unset state of a <input type="date"> and of the search box —
+      // compared explicitly so an empty bound is never read as a filter.
+      if (dateFrom !== '' && day < dateFrom) return false
+      if (dateTo !== '' && day > dateTo) return false
 
-      if (needle) {
+      if (needle !== '') {
         const haystack = [
           entry.title,
           entry.payment_method ?? '',
@@ -158,7 +168,7 @@ export function PaymentsLedgerClient() {
     URL.revokeObjectURL(url)
   }, [visibleEntries, guestTag])
 
-  if (isLoading || !me) {
+  if (isLoading || me === '') {
     return (
       <div>
         <h1 className="text-xl font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>
@@ -268,7 +278,10 @@ export function PaymentsLedgerClient() {
 
       {visibleEntries.length === 0 ? (
         <p className="text-sm py-8 text-center" style={{ color: 'var(--text-secondary)' }}>
-          {t('payment.noResults')}
+          {/* An untouched ledger is not a filter miss. `noResults` reads "No
+              payments match these filters", which blames a filter a member with
+              zero payments never set. */}
+          {allEntries.length === 0 ? t('payment.none') : t('payment.noResults')}
         </p>
       ) : (
         <>
@@ -333,7 +346,7 @@ function Attribution({ entry, me, guestTag }: { entry: LedgerEntry; me: string; 
   const forNames = beneficiaryNames(entry, me, guestTag)
   const paidBy = payerName(entry, me)
 
-  if (paidBy) return <>{t('payment.paidBy')} {paidBy}</>
+  if (paidBy != null) return <>{t('payment.paidBy')} {paidBy}</>
   if (forNames.length > 0) return <>{t('payment.for')} {forNames.join(', ')}</>
   return null
 }
@@ -387,13 +400,15 @@ function EntryCard({ entry, me, guestTag }: { entry: LedgerEntry; me: string; gu
       </div>
       <p className="mt-1 truncate min-w-0 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
         {entry.title}
-        {entry.title && entry.payment_method ? ' · ' : ''}
+        {/* The separator earns its place only when both sides are present; '' is
+            "no title" and null is "no method", so neither may be truthy-tested. */}
+        {entry.title !== '' && entry.payment_method != null && entry.payment_method !== '' ? ' · ' : ''}
         {entry.payment_method}
       </p>
       <p className="truncate min-w-0 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
         <Attribution entry={entry} me={me} guestTag={guestTag} />
       </p>
-      {entry.admin_note && (
+      {entry.admin_note != null && entry.admin_note !== '' && (
         <p className="mt-1 text-[11px]" style={{ color: 'var(--text-secondary)' }}>
           {t('payment.note')}: {entry.admin_note}
         </p>

--- a/app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx
+++ b/app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx
@@ -196,7 +196,7 @@ export function PaymentsLedgerClient() {
       {/* Lifetime totals. Rendered above the filters and labelled, because a
           total that ignores the filter sitting next to it is otherwise read as
           a bug. */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mb-4">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mb-4" data-testid="ledger-totals">
         <TotalCard label={t('payment.totalPaid')} totals={totals.paid} />
         <TotalCard label={t('payment.totalOnBehalf')} totals={totals.onBehalf} />
         <TotalCard label={t('payment.totalPaidForMe')} totals={totals.paidForMe} />
@@ -273,7 +273,7 @@ export function PaymentsLedgerClient() {
       ) : (
         <>
           {/* ── Stacked cards, below md ─────────────────────────────────────── */}
-          <div className="space-y-2 md:hidden">
+          <div className="space-y-2 md:hidden" data-testid="ledger-cards">
             {visibleEntries.map(entry => (
               <EntryCard key={entry.key} entry={entry} me={me} guestTag={guestTag} />
             ))}

--- a/app/(dashboard)/profile/payments/page.tsx
+++ b/app/(dashboard)/profile/payments/page.tsx
@@ -1,0 +1,16 @@
+import { auth } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+import { ProfileBackLink } from '../components/ProfileBackLink'
+import { PaymentsLedgerClient } from './PaymentsLedgerClient'
+
+export default async function ProfilePaymentsPage() {
+  const { userId } = await auth()
+  if (!userId) redirect('/sign-in')
+
+  return (
+    <div className="py-8 pb-16 px-4 md:px-6 xl:px-8 md:max-w-[1280px] md:mx-auto">
+      <ProfileBackLink />
+      <PaymentsLedgerClient />
+    </div>
+  )
+}

--- a/app/(dashboard)/profile/types.ts
+++ b/app/(dashboard)/profile/types.ts
@@ -118,6 +118,11 @@ export type GenericPayment = {
   // admin_status/member_status. admin_status is the status every other payment
   // surface displays (trips AttendeeView/ArchivedView, admin/payments).
   admin_status: string
+  // GET /api/payments has always selected this; the type never declared it, so
+  // every reader fell back to `payable_items?.currency ?? 'EUR'` — and a trip
+  // payment has no payable_item, which force-labelled every one of them EUR
+  // (2608-DEV-688). Read it through `currencyOf` in lib/payments/ledger.ts.
+  currency: string
   payment_method: string | null
   proof_url: string | null
   note: string | null

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,3 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
+| #688 | `dev/2608-DEV-688` | `lib/payments/ledger.ts` (new) + its test · `app/(dashboard)/profile/types.ts` · `profile/components/{PaymentsSection,shared}.tsx` · `app/(dashboard)/profile/payments/**` (new route) · `lib/i18n/domains/payment.ts` · `e2e/payments-on-behalf.spec.ts` — **migration: no** | 2026-08-03 |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,260 +1,154 @@
 ## Goal
-BUILD issue #677 (2607-DEV-677, branch `dev/2607-DEV-677`): payments on behalf of others — ad-hoc
-guests with NO account. A `payment_guests` row remembers the person; their `payments` row keeps
-`profile_id = the payer` (a guest has no ledger) but must be EXCLUDED from the payer's own trip
-total; an admin can later link a guest to a real member as a record only.
+BUILD issue #688 (2608-DEV-688, branch `dev/2608-DEV-688`): keep on-behalf payment attribution
+visible AFTER admin approval, collapse an approved on-behalf group to the one bank transfer it
+was, add a `/profile/payments` drill-down ledger (status filter, debounced search, date range,
+lifetime totals, CSV export), and fix the trip-payment "always EUR" mislabel on the way.
 
 ## Now
-PR #689 is READY and ALL 11 CHECKS ARE GREEN at `cecf884` — the post-GCR commit, so the review
-fixes are themselves verified in CI (`Build` 1m6s, `Authenticated E2E (Clerk)` 5m3s, `390px smoke`
-2m23s, `Replay migrations from scratch` 2m22s, Vercel READY). CodeRabbit ran its one pass:
-10 actionable threads, 8 applied and resolved, 2 rejected with the trace and left OPEN on purpose.
-
-The `docs/CLAIMS.md` row for #677 is removed in this same PR (folded, never a standalone cleanup
-PR). The registry is now empty.
-
-AWAITING THE MERGE. `migrate-prod` is gated on `main`, so it cannot be approved until #689 is
-merged — the order is merge -> approve the gated run -> smoke-check prod -> close #677.
-
-Two things still have no evidence and both need the preview by hand: admin link/unlink (G4), and a
-390px look at the new surfaces.
-
-VERIFIED on the current tree (2026-08-02): `npx tsc --noEmit` exit 0; `npx eslint` on every changed
-area exit 0, 0 problems; `npx vitest run --exclude lib/actions/guest-registration.test.ts` =
-`Test Files 21 passed (21)`, `Tests 268 passed (268)`; the excluded file alone = `3 failed | 21
-passed (24)`, byte-identical to the red baseline and untouched by this branch. The arithmetic ties
-out: 280 baseline - 24 excluded + 6 new `totals.test.ts` + 6 new guest route cases = 268.
-
-NOTE on running the build here: `npm run build` timed out at 10 minutes on a warm `.next`. Per the
-carried note, `rm -rf .next` first — the OS, not the V8 heap, is the limit. Do NOT raise
-`--max-old-space-size`.
+CLAIM is COMPLETE and PUSHED. Nothing is built yet — zero code files touched.
+Issue #688 carries the full DoD, affected-file list, gotchas and `## Design Checklist` (4/4
+checked) + `## Branch`; `docs/CLAIMS.md` has the claim row (`migration: no`) at `716b4ad`;
+branch `dev/2608-DEV-688` is pushed and tracks `origin/dev/2608-DEV-688` (NOT main).
+Next session opens with BUILD step 1 below. Read issue #688's body first — it is the spec.
 
 ## Next
-1. G4 (admin link/unlink) still has NO evidence of any kind — no test, never run against a database.
-   Do it on the preview: `/admin/payments` → Guest links → pick a member → Link → Unlink.
-2. Manual 390px pass on the preview: add a guest from the picker, submit, confirm the payer's trip
-   progress bar counts only their own share (G3 in the real UI), confirm the `/profile` group card
-   names the GUEST and not the payer, admin link + unlink.
-3. DONE — marked ready, one CodeRabbit pass, all findings addressed in ONE batched commit. Push it,
-   resolve the 8 applied threads, reply on the 2 rejected ones, then merge.
-4. `docs/CLAIMS.md` row REMOVED in this PR (`cecf884`+1). Still to do, in this order and only after
-   the merge: approve the gated `migrate-prod` run (this PR HAS a migration — Actions `production`
-   environment gate), confirm it applied, smoke-check `https://www.teamenjoyvd.com`, close #677.
+BUILD in four steps, each ending with its own check. Never carry two failing steps.
+1. `lib/payments/ledger.ts` + `lib/payments/ledger.test.ts` (new), and add `currency: string` to
+   `GenericPayment` in `app/(dashboard)/profile/types.ts`.
+   Helpers: `currencyOf(pay)` = `pay.currency ?? payable_items?.currency ?? 'EUR'`;
+   `ledgerEntries(rows, me)` keyed `payment_group_id && payerOf(row) === me -> g:${id}` else
+   `p:${row.id}`, each raw row emitted exactly once, group status = shared status when uniform
+   else `'pending'` (NEVER `undefined` — `StatusBadge` calls `.toLowerCase()` and throws);
+   `lifetimeTotals(rows, me)` reduces over RAW rows into three per-currency buckets;
+   `toLedgerCSV(rows)` = one line per raw row, no `proof_url` column, RFC-4180 quoting.
+   CHECK: `npx vitest run lib/payments`
+2. `app/(dashboard)/profile/components/shared.tsx` (`PaymentRow`: `currencyOf` + `for A, B` /
+   `Paid by X`) and `PaymentsSection.tsx` (`groupByItem` -> `ledgerEntries`; the "show more"
+   Drawer -> a `next/link` to `/profile/payments`); new i18n keys in en + bg.
+   CHECK: `npm run build`
+3. `app/(dashboard)/profile/payments/page.tsx` + `PaymentsLedgerClient.tsx` (new route).
+   CHECK: `npm run build` + a manual 390px pass
+4. Append the L3 + L8 specs to `e2e/payments-on-behalf.spec.ts`.
+   CHECK: `npx playwright test --project=authenticated` against DEV
+Then: /code-review low -> push -> DRAFT PR -> CI green + preview READY -> ready -> one CodeRabbit
+pass -> merge -> GCR (drop the CLAIMS.md row IN the merging PR, close #688).
 
 ## Constraints
-- Never push to `main`; `dev/2607-DEV-677` only.
-- No `git push` unless the user asks for a push in this conversation (quote required). GRANTED
-  2026-08-02, verbatim: "Address all security and non-security items discovered and open a draft PR".
-  Scope: push `dev/2607-DEV-677` and open a DRAFT PR. Nothing else.
-- GRANTED 2026-08-02 (GCR pass, asked and answered): "Push, then resolve threads". Scope: push
-  `dev/2607-DEV-677`, then resolve the 8 applied CodeRabbit threads and reply on the 2 rejected
-  ones. Does NOT cover merging the PR or approving the gated `migrate-prod` run — ask again for both.
+- Never push to `main`; `dev/2608-DEV-688` only.
+- No `git push` unless the user asks for a push in this conversation (quote required).
+  GRANTED 2026-08-03, verbatim: "push to github so I can start tomorrow ready to go with BUILD".
+  Scope: push `dev/2608-DEV-688`. Does NOT cover opening a PR or merging — ask again for both.
 - Never weaken a check to make it pass.
-- Fold the `docs/CLAIMS.md` row + `docs/STATE.md` updates into this PR — no standalone cleanup PR.
-- Change only what the DoD requires; log other findings as NOTED.
+- Fold the `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR — NEVER a
+  standalone cleanup PR.
+- Change only what the DoD requires; log other findings as `NOTED (not done): <thing> <file:line>`.
 - Ask before editing `docs/guardrails/PROJECT.md`.
-- Issue-stated non-goal: linking a guest to a member is a RECORD ONLY — it moves no money and
-  rewrites no `payments` row. Do not invent a migration of payment rows.
-- Issue-stated: `get_payable_beneficiaries` is deliberately NOT touched — guests merge in TypeScript
-  so the RPC's LOS semantics stay pure.
+- Issue-stated out of scope, must NOT be fixed here and must NOT be propagated into the new page
+  or the CSV export: `shared.tsx:131-133` renders `proof_url` as an `href` although it is a
+  private-bucket storage KEY, not a URL (`lib/payments/proof.ts:1-10`).
+- Issue-stated: NO new API route, NO schema change, NO TanStack Table, and `abo_number` is
+  deliberately NOT added to the embeds (it is null for exactly the people it would identify).
+- Issue-stated: ONE responsive layout file for the ledger table. 6 columns permits a dual layout
+  under the Layout Decision Rules but does not require one; two files would duplicate ~40 lines.
 
 ## Decisions
-- DECISION (from PLAN, settled with the user 2026-08-01): the accounting correction lives in the
-  REDUCERS, not the query — `page.tsx` keeps fetching the guest row so the payer still sees money
-  they really paid; only `approvedTotal` skips it.
-- DECISION: ad-hoc people carry `kind: 'guest'` + `relation: 'external'` (new `payment.relExternal`
-  label). `relation: 'guest'` is already taken by #676 for ABO-less approved MEMBERS
-  (`20260731000000_2607_feat_676_pay_on_behalf.sql:173`); nothing shipped by #676 is renamed.
-- DECISION: `GuestLinkPanel` reuses the `['admin-members']` react-query key + a hoisted dedupe
-  helper. `allMembers` is NOT a reusable array — it is computed inside `LogPaymentDrawer.tsx:50-67`
-  with `enabled: open`.
-- DECISION: migration filename `20260801000000_...` — 2026-08-01 is a new day (latest existing is
-  `20260731000000`), so the counter resets to `000000` per GOTCHAS row 14.
+- DECISION (PLAN 2026-08-03): #677 landed FIRST (`5311a9c`), so #688 is the second lander and owns
+  the guest extension. The NAMING half already ships — `payment_guests(id, name)` is in the
+  `/api/payments` select, `beneficiary_guest_id`/`payment_guests` are on `GenericPayment`, and
+  `beneficiaryLabel()` in `lib/payments/labels.ts` already prefers the guest name. What #688 adds
+  is the TOTALS half.
+- DECISION: totals reduce over RAW rows, not over collapsed entries — reducing over entries
+  double-counts the payer's own share. Lifetime, unaffected by the filters, labelled as such.
+- DECISION: `VARIABLE_CAP` now caps collapsed ENTRIES, not raw rows. The bento's unit is "latest
+  transactions" and a group IS one transaction.
+- DECISION: the new client component lives at
+  `app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx`, matching
+  `profile/spouse-link/SpouseLinkClient.tsx` — not under `profile/components/`.
+- DECISION: the page reuses query key `['profile-generic-payments']`, so client-side navigation
+  from the bento mounts it warm off the existing cache. No second route, no refetch per keystroke.
+- DECISION: `payment.allPayments` is reused as the new page's title, so removing the "show more"
+  Drawer orphans no translation key.
 
 ## Facts
-- DEV Supabase project ref `iymwxdewcpvpjgzewtzk`; `supabase/.temp/project-ref` confirms the CLI is
-  linked to DEV. Apply with `supabase db push`; ad-hoc SQL with `supabase db query --linked -f <file>`.
+- Branch `dev/2608-DEV-688`, cut from `origin/main` @ `5311a9c`, upstream
+  `origin/dev/2608-DEV-688`. `git checkout -b X origin/main` sets the upstream to `origin/main` —
+  a bare `git push` would then target main; this branch was corrected with
+  `git branch --unset-upstream` before its first push.
+- BUILD BASELINE, captured 2026-08-03 before any edit:
+  `npx vitest run lib/payments` -> `Test Files 4 passed (4)`, `Tests 58 passed (58)`.
+- WIDER baseline is RED and NOT caused by any current work:
+  `lib/actions/guest-registration.test.ts` fails 2-3 of its 24 tests non-deterministically (spy
+  pollution surfacing under this machine's slowness). Run
+  `npx vitest run --exclude lib/actions/guest-registration.test.ts` and compare against that, never
+  against green.
+- Key symbols: `payerOf` -> `lib/payments/proof.ts:43`; `guestLabel`/`beneficiaryLabel` ->
+  `lib/payments/labels.ts`; `personalApprovedTotal` -> `lib/payments/totals.ts:30`;
+  CSV quoting prior art -> `lib/csv-export.ts:70-99` + `app/admin/members/components/MembersTable.tsx:88-93`;
+  300 ms search debounce prior art -> `app/admin/calendar/components/AdminCalendarClient.tsx:54-69`;
+  `GenericPayment` -> `app/(dashboard)/profile/types.ts:113-152`.
+- `e2e/payments-on-behalf.spec.ts` is already in the `authenticated` `testMatch` and BOTH
+  `testIgnore` regexes (`playwright.config.ts:64,78,85`). A new spec file would cost three regex
+  edits for nothing.
+- A guest payment row satisfies `profile_id = paid_by_profile_id` (`payments_guest_ledger_check`,
+  `20260801000000_2607_feat_677_pay_guests.sql:120`), so it LOOKS like the payer's own row. The
+  "paid" bucket must exclude `beneficiary_guest_id != null`; those rows belong in "paid on behalf
+  of others". This is the highest-risk item in the ticket.
+- DEV Supabase project ref `iymwxdewcpvpjgzewtzk`. Apply migrations with `supabase db push`;
+  ad-hoc SQL with `supabase db query --linked -f <file>`. #688 needs NO migration.
+- If `npm run build` dies with `Fatal process out of memory: Zone` or times out on a warm `.next`,
+  first response is `rm -rf .next` — the OS, not the V8 heap, is the limit. Do NOT raise
+  `--max-old-space-size`.
 - NEVER paste an absolute Windows path into a tracked file. Tailwind v4 scans every source file
   (including .md) for utility candidates; a backslash followed by hex-digit characters parses as a
-  CSS unicode escape, and `String.fromCodePoint` on the result exceeds the Unicode maximum and kills
-  `npm run build` with `Invalid code point <n>` pointed at `app/globals.css:1:1` — nowhere near the
-  real file. Describe the path, never paste it; writing the sequence out even as an example
-  re-breaks the build.
-- If `npm run build` dies with `Fatal process out of memory: Zone`, first response is `rm -rf .next`
-  — the OS, not the V8 heap, was the limit; do not raise `--max-old-space-size`.
-- Premise anchors verified on `main` @ `dd91007`: `app/(dashboard)/trips/[id]/page.tsx:84-87` is the
-  ONLY payments query feeding a money total; `AttendeeView.tsx:118-120` and `ArchivedView.tsx:17-19`
-  both reduce that same prop into `approvedTotal`.
-- `payments` already has THREE FKs to `profiles` (`profile_id`, `logged_by_admin`,
-  `paid_by_profile_id`) — every PostgREST embed must be hinted. `payment_guests` will add a table
-  with TWO FKs to `profiles` (`owner_profile_id`, `linked_profile_id`), same class of trap.
-- `MAX_TOTAL_CENTS` = 100000000 is asserted in three places that must stay in step:
-  `lib/payments/split.ts`, `app/api/payments/route.ts:110`, `submit_payment_group`.
+  CSS unicode escape and kills `npm run build` with `Invalid code point <n>` pointed at
+  `app/globals.css:1:1` — nowhere near the real file. Describe the path, never paste it.
+- Regenerate `types/supabase.ts` through Git Bash (`>` redirect), NOT PowerShell
+  `Out-File -Encoding utf8` — the latter writes CRLF + BOM and rewrites all ~3100 lines.
 
 ## Done
-- BASELINE (before any code edit, `npm run verify`) — RESULT: RED. `Test Files 1 failed | 20 passed
-  (21)`, `Tests 3 failed | 277 passed (280)`, all in `lib/actions/guest-registration.test.ts`. NOT
-  caused by #677 (only `docs/STATE.md` and the new migration existed at that point) and NOT stable:
-  a second run of that file alone gave `2 failed | 22 passed (24)` with a DIFFERENT test hitting the
-  5000ms timeout and the spy count differing (`upsertSpy` called 3 times, then 2, expected 1). Reads
-  as cross-test spy pollution surfacing under this machine's slowness (68-128s transform/import).
-  Compare every later run against this line, not against green.
-- Step 1 DONE — `supabase/migrations/20260801000000_2607_feat_677_pay_guests.sql` applied to DEV via
-  `supabase db push`. RESULT: 13/13 probes pass, DEV left at `payments_left=2 guests_left=0` (its
-  pre-probe state). G1 `rows=2 guest_rows=1 guest_table=1 all_ledgers_on_payer=t`; G2 a re-typed
-  guest (case + whitespace) reuses the row; G2b `guest_id` reuses it; G5 a guest row on a foreign
-  ledger is rejected by `payments_guest_ledger_check`; G5b a guest row outside a group is rejected by
-  `payments_group_pair_check`; G6 the same guest twice in one group rejected; G7 another payer using
-  my guest rejected; G8 an entry naming two kinds rejected; G9 a blank guest name rejected; G10 the
-  pure #676 payload still accepted; G11 paying for your upline still rejected; G12 the guest row
-  survives `withdraw_payment_group`.
-- BUG FOUND AND FIXED BY THE PROBES (G8): the "exactly one of profile_id / guest_id / guest" check
-  computed `1 + 1 + (jsonb_typeof(e -> 'guest') = 'object')::int`, and `jsonb_typeof(NULL)` is NULL
-  when the key is absent, so the sum was NULL and `NULL <> 1` filtered nothing. An entry naming BOTH
-  a profile and a guest passed. Fixed with `coalesce(jsonb_typeof(...), '')`; re-applied to DEV via
-  `supabase migration repair --status reverted 20260801000000` + `db push` (the migration is
-  re-runnable throughout: IF NOT EXISTS / DROP+ADD / CREATE OR REPLACE).
-- Step 2 DONE — `types/supabase.ts` regenerated from DEV (3044 -> 3110 lines), diff purely additive:
-  the `payment_guests` table, `payments.beneficiary_guest_id` in Row/Insert/Update, and the FK
-  relationships. `npx tsc --noEmit` exit 0. NOTE: regenerate through Git Bash (`>` redirect), NOT
-  PowerShell `Out-File -Encoding utf8` — the latter writes CRLF + BOM and rewrites all 3100 lines.
-- Steps 3-4 DONE — RESULT: `npx vitest run app/api/payments lib/payments` = `Test Files 5 passed (5)`,
-  `Tests 79 passed (79)`; `npx tsc --noEmit` exit 0. Server: `eligibility.ts` gained `PayableGuest` /
-  `fetchPayableGuests` / `guestIdentityKey` and `assertGroupAllowed` now takes `GroupEntry[]` (all
-  three shapes) instead of a `string[]` of profile ids; `beneficiaries/route.ts` appends the caller's
-  guests (never for a guest-ROLE caller); `payments/route.ts` rebuilds each entry key by key before
-  it reaches the RPC. Accounting: the duplicated `approvedTotal` reducer was extracted to
-  `lib/payments/totals.ts` (`personalApprovedTotal`) so G3 is testable directly — 6 cases in
-  `lib/payments/totals.test.ts`, which is where the DoD's "route-level vitest case for G3" landed,
-  since after the PLAN correction the arithmetic is in the reducers and not in any route.
-- Steps 5-6 DONE (picker + admin), plus `e2e/payments-guest.spec.ts` and the REF/GOTCHAS updates.
-  Picker: `components/payment/types.ts` now exports a DISCRIMINATED UNION (`kind: 'profile' |
-  'guest'`) plus `rowKeyOf`/`displayNameOf`/`guestIdentity`; a guest rides `SplitRow.profileId` as an
-  opaque prefixed row KEY (`guest:<uuid>` / `newguest:<n>`), so `lib/payments/split.ts` and its 27
-  tests needed no change and a profile-only submission is byte-identical to #676's. Admin: the
-  `allMembers` dedupe was hoisted to `app/admin/payments/components/members.ts` and is now shared by
-  `LogPaymentDrawer` and the new `GuestLinkPanel` off one `['admin-members']` cache entry.
-- BUG FOUND (invisible, would have broken the build tooling): `guestIdentityKey` in
-  `lib/payments/eligibility.ts` was written with a literal NUL byte (U+0000) as its separator. Git
-  classified the file as BINARY — `git diff` showed `Bin 3289 -> 9646 bytes` instead of a reviewable
-  diff, which would have made the whole file unreviewable in the PR. Both copies (server
-  `guestIdentityKey`, client `guestIdentity`) now use `JSON.stringify([name, email])`, which is also
-  collision-free: any plain delimiter can appear inside a name a user typed. A NUL scan over every
-  tracked .ts/.tsx/.sql/.md found no other instance.
-- CLAIM complete: #677 has `## Design Checklist` (four checked) + `## Branch`; branch
-  `dev/2607-DEV-677` checked out; `docs/CLAIMS.md` row registered at `a2e36ff`.
-- SECURITY REVIEW done on the branch diff (BUILD EXECUTE gate; warranted by the new table, the new
-  RLS policies and the replaced SECURITY DEFINER RPC). RESULT: no finding at confidence >= 8.
-  Checked and cleared: the RPC keeps the GOTCHAS-34 guard and re-validates guest ownership inside
-  the write transaction; `owner_profile_id` scopes every guest read; the "not yours" 403 is uniform
-  and so is not an enumeration oracle; `payments_guest_ledger_check` makes a cross-ledger guest row
-  unrepresentable; the #676 proof-URL disclosure class is unreachable because `payerOf()` resolves a
-  guest row to the payer; no dynamic SQL; no `dangerouslySetInnerHTML`; Pattern A helpers only.
-- CI, first run of PR #689: 10 of 11 checks green — `Build` (51s), `Type Check`, `Lint`, `Test`,
-  `Security Audit`, `Replay migrations from scratch`, `Authenticated E2E (Clerk)` (5m8s, so it really
-  ran; the vacuous-skip problem from #679 is gone), Vercel READY. `npm run build` therefore PASSES —
-  the 10-minute failure was this machine, not the code, and that UNVERIFIED item is now closed.
-- The guest name is now rendered through `lib/payments/labels.ts` (`guestLabel` /
-  `beneficiaryLabel`), tested by 10 cases in `labels.test.ts`. Extracted rather than inlined because
-  the repo has NO component-test infrastructure — `vitest.config.ts` is `environment: 'node'` with
-  `include` limited to `.ts`, and there is no jsdom or testing-library — so a pure helper is the only
-  part of that render a test can reach. The pixels still need the preview.
-- `PaymentRow` in `shared.tsx` now carries the same marker, so a guest row in the payer's per-item
-  history no longer reads as an unexplained second payment of their own fee. `truncate min-w-0`,
-  because at 390px that row is already tight and an untruncatable name would push the status badge
-  past the viewport.
-- FIX from that review (non-security, found while tracing the guest name through every surface):
-  `PaymentsSection.tsx` rendered a pending group card's beneficiary list from `r.beneficiary`, the
-  `profiles!profile_id` embed. On a guest row that IS the payer, so a card for "me + guest Ivan"
-  listed the payer's name twice instead of naming Ivan. GET `/api/payments` now selects
-  `beneficiary_guest_id, payment_guests(id, name)`, `GenericPayment` declares both, and the card
-  prefers the guest name with a `payment.guestTag` suffix. Same class as the admin-side fix already
-  made in `PaymentGroupCard.tsx` / `PaymentsClient.tsx`.
-
-- GCR on PR #689 (2026-08-02) — CodeRabbit's 10 threads. BASELINE first:
-  `npx vitest run app/api/payments lib/payments` = `6 passed (6)` / `87 passed (87)`, green.
-  APPLIED 8. The one that mattered: `assertGroupAllowed` validated `guest.name` with `.trim()` on a
-  value taken straight off `req.json()`, and `??` substitutes only null/undefined — so
-  `{"guest":{"name":123}}` evaluated `(123).trim()` and threw a TypeError out of a POST handler with
-  NO try/catch. Any authenticated member could turn a bad request into a framework 500. The
-  `String(...)` rebuild at `app/api/payments/route.ts:145` looked like a defense but runs AFTER the
-  validator, so it never executed. Now type-checked before any string method and REJECTED rather
-  than coerced (`String(123)` would have remembered a guest named "123"); `GroupEntry.guest` fields
-  are typed `unknown` so the compiler stops blessing `.trim()` on them. 5 `G13` cases cover it.
-  Also: the picker's duplicate error was rendered only inside the add-guest form, but the second
-  path that sets it (tapping an already-added remembered guest) leaves that form closed, so the tap
-  returned in silence; guest-form inputs had a placeholder as their only accessible name;
-  `/api/payments/beneficiaries` forwarded raw PostgREST `error.message` to the client on BOTH
-  branches (the profile one was pre-existing — same class, folded in per the standing rule);
-  `GuestLinkPanel` rendered a failed fetch as "no guests to link" and left the server-rendered
-  payment rows stale after a link (`router.refresh()` added); `ArchivedView`'s guest attribution was
-  hardcoded English; `PaymentsClient`'s comment claimed the panel renders nothing while empty.
-- REJECTED 2 of the 10, both with the trace, both replied to on the thread rather than resolved:
-  (a) `components/payment/types.ts` "align `guestIdentity` with the SQL normalization" — real
-  asymmetry (JS `trim()` strips the full ECMAScript whitespace set, SQL `btrim()` only the ASCII
-  space) but NOT REACHABLE: `app/api/payments/route.ts:145-146` rebuilds every inline guest as
-  `String(...).trim()` before the RPC, and `submit_payment_group` is service_role-only with that
-  route as its sole caller, so SQL never receives an untrimmed name and `btrim` is a no-op on it.
-  Changing JS to ASCII-space-only would make "Ivan" and "Ivan\t" two different people — worse, not
-  better. Documented the dependency in both copies instead, since it was load-bearing and unstated.
-  (b) migration `payment_guests_admin_core_all` grants FOR ALL to `admin` AND `core` — deliberate:
-  `app/api/admin/payment-guests/[id]/route.ts:26` authorizes `adminOrCore`, so restricting the
-  policy to `admin` would desynchronize RLS from the rule actually enforced, on a table every server
-  path reaches through the service client (RLS bypassed) anyway. Also would mean re-editing an
-  already-applied migration for zero behavior change.
-- NOT applied, CodeRabbit "nitpick" tier, logged not done: `app/api/admin/payment-guests/route.ts`
-  GET is unbounded and feeds every guest id into one `.in()` filter (414 risk at scale); the two
-  independent fetches in `assertGroupAllowed` could run under `Promise.all`. Neither is a defect at
-  the current row counts and both change shapes this issue did not open.
+- PLAN #688 (2026-08-03) — RESULT: READY. Premise re-verified on `main` @ `5311a9c`: `types.ts`
+  declares no `currency` while `app/api/payments/route.ts:29` selects it, and both `shared.tsx:114`
+  and `PaymentsSection.tsx:44` fall back to `payable_items?.currency ?? 'EUR'` — and a trip
+  payment's `payable_items` is NULL, so every trip payment is force-labelled EUR.
+  `PaymentsSection.tsx:35` filters `admin_status !== 'pending'`, which is where attribution is
+  lost at approval. Issue line refs were 1-3 lines stale (written pre-#677-merge); every code
+  claim holds. 9 files, ~600 lines estimated, migration: no, E2E project: `authenticated`.
+- CLAIM #688 (2026-08-03) — RESULT: complete and pushed. `docs/CLAIMS.md` registry was EMPTY, so no
+  scope overlap and no in-flight `migration: yes` row to sequence against. Issue #688 updated with
+  DoD + affected files + gotchas + `## Design Checklist` (4/4) + `## Branch`; row committed at
+  `716b4ad`; branch pushed (`* [new branch] dev/2608-DEV-688 -> dev/2608-DEV-688`).
 
 ## Open items
-- NOT RUN: G4 (admin link/unlink) has no automated coverage and has never been exercised against a
-  real database. `e2e/payments-guest.spec.ts` covers the member side only. Do it manually on the
-  preview: `/admin/payments` → Guest links → pick a member → Link → Unlink.
-- DONE: `e2e/payments-guest.spec.ts` PASSED in CI at `4c921ef` — `✓ 12 [authenticated] ›
-  e2e/payments-guest.spec.ts:48:7 … (16.0s)`. Executed, not skipped, so the carried #676 worry about
-  the payments E2E passing vacuously does not apply to this spec.
-- The spec writes a real `payment_guests` row named `E2E Guest Nadia` on whichever database it runs
-  against. It is uniquely indexed, so re-runs reuse the one row rather than accumulating — but on
-  DEV it is a fixture that will need removing at GCR alongside `seed_676_*`.
-- NOTED (not done): `app/(dashboard)/profile/types.ts:80` declares a SECOND `TripPayment` type,
-  unrelated to the one in `app/(dashboard)/trips/[id]/page.tsx`. Left alone — no personal-balance
-  reducer consumes it, so the guest correction does not apply, but the name collision is a trap.
-- Deliberately NOT changed: `PaymentsSection.tsx:42` sums `amount` across a group INCLUDING guest
-  rows. That is correct — it is the total of a transfer the payer made, shown on the withdraw card,
-  not a personal balance.
-- Carried from #676, still open: `e2e/payments-on-behalf.spec.ts` had never executed as of the #676
-  merge — the seed extension in `scripts/seed-clerk-test-users.js` was EDITED-UNVERIFIED against a
-  real database. Confirm on this PR's CI run that the payments E2E reports 0 skipped.
-- Carried from #676, unmeasured: does PROD have `payments` rows? If yes, `/profile` was crashing in
+- CARRIED FROM #677, NOT DONE — the prod tail. PR #689 is merged (`5311a9c` on `main`) but the
+  post-merge sequence was never executed: approve the gated `migrate-prod` run (GitHub Actions,
+  `production` environment, manual approval — #677 HAS a migration), confirm it applied,
+  smoke-check `https://www.teamenjoyvd.com`, then close issue #677. Do this BEFORE #688 reaches
+  prod, or #688 ships against a schema its migration never landed on.
+- CARRIED FROM #677, NEVER VERIFIED (G4): admin guest link/unlink has NO automated coverage and has
+  never been exercised against a real database. `e2e/payments-guest.spec.ts` covers the member side
+  only. Do it by hand: `/admin/payments` -> Guest links -> pick a member -> Link -> Unlink.
+- CARRIED FROM #677: DEV fixtures still present and still uncleaned — `seed_676_*` (7 profiles,
+  ABOs 6760001-6760004, deferred by the user 2026-07-31) and a `payment_guests` row named
+  `E2E Guest Nadia` written by `e2e/payments-guest.spec.ts` (uniquely indexed, so re-runs reuse it
+  rather than accumulate). Both are still NEEDED for the authenticated E2E — do not delete before
+  #688's step 4 runs.
+- CARRIED FROM #676, UNMEASURED: does PROD have `payments` rows? If yes, `/profile` was crashing in
   production for every such user between 2026-07-27 (`570d587`, #670) and the #676 merge. One
   read-only query answers it: `select count(*), count(distinct profile_id) from payments`.
-- Carried NOTED (not done), unrelated to #677: trip payments display currency `'EUR'` by fallback
-  (`PaymentsSection.tsx:43`, `shared.tsx:109` both read `payable_items?.currency ?? 'EUR'`, and a
-  trip payment's `payable_items` is NULL); `shared.tsx:102` gates the cancelled-trip ⓘ on
-  `payable_items?.item_type === 'trip'`, always false for a real trip payment;
-  `shared.tsx:120` and `ArchivedView.tsx:70` render `proof_url` directly as an `href` although it is
-  a storage KEY, not a URL, since `20260517000200` made `trip-proofs` private.
-- DEV fixture `seed_676_*` (7 profiles, ABOs 6760001-6760004) is still present on DEV and is still
-  needed for the E2E/manual passes. Its GCR cleanup was deferred by the user on 2026-07-31.
+- NOTED (not done), in scope of the FILES #688 touches but explicitly excluded by the issue:
+  `shared.tsx:103` gates the cancelled-trip info marker on `payable_items?.item_type === 'trip'`,
+  which is always false for a real trip payment (its `payable_items` is NULL).
+- NOTED (not done): `app/admin/payments/components/LogPaymentDrawer.tsx:60` merges
+  `membersData.manual_members_no_abo`, but `GET /api/admin/members` never emits that key — the
+  admin log-payment dropdown silently excludes ABO-less profiles.
+- NOTED (not done): `app/(dashboard)/profile/types.ts:80` declares a SECOND `TripPayment` type,
+  unrelated to the one in `app/(dashboard)/trips/[id]/page.tsx`. Name collision, left alone.
+- REFERENCE SWEEP owed at BUILD step 2, per CLAUDE.md iron rule 3: `groupByItem` (single caller)
+  and the removed `listDrawerOpen` Drawer. `ShowMoreButton` keeps its other three callers
+  (`TripsSection.tsx:61`, `VitalsSection.tsx:96`, `ParticipationSection.tsx:70`) — do not delete it.
+- The CI check `Authenticated E2E (Clerk)` has historically gone green in seconds WITHOUT running
+  the specs (tracked as #679). It ran for real on #677's PR, but do not treat a green tick as
+  proof: confirm the run reports 0 skipped, and run step 4 locally against DEV regardless.
 
 ## Failed attempts
-- ATTEMPT 1 [L1] — first CI run of PR #689: `390px smoke vs preview` FAILED (both the initial run and
-  retry #1) with `The Clerk Frontend API URL is required to bypass bot protection`, thrown at
-  `e2e/payments-guest.spec.ts:37` inside `clerk.signIn`. NOT a product bug and NOT a 390px layout
-  failure: `playwright.config.ts` routes Clerk-authenticated specs to the `authenticated` project via
-  three regexes, and the new spec was never added to them, so `mobile-390` collected it and ran it
-  against a live Vercel Preview that has no Clerk secrets. The spec's own docstring already said it
-  belonged to `authenticated`; the config was never told. Fixed by adding `payments-guest` to all
-  three. Everything else in that run was green, `Build` included. FIXED — `390px smoke vs preview`
-  passed on the re-run (2m22s).
-- ATTEMPT 1 [L1] on a SECOND, different failure, exposed only once the routing fix let the spec run
-  for the first time: `Authenticated E2E (Clerk)` failed at `payments-guest.spec.ts:117` with
-  `strict mode violation: getByText(/guests \(no account\)/i) resolved to 2 elements`. A TEST bug,
-  not a product bug — and the failure output is itself evidence the feature works, because element 2
-  was the remembered guest's own row (`e2e-guest-nadia@example.com · Guests (no account)`). The
-  picker prints the relation label as the section header AND inside every row's subtitle. The
-  assertion above it — line 114, the actual memory requirement — PASSED, so add-guest → submit →
-  withdraw → guest-survives is now proven end to end against a real database. Fixed by matching the
-  header exactly. 18 other authenticated tests passed in that run. FIXED — `✓ 12 [authenticated] ›
-  e2e/payments-guest.spec.ts:48:7 … (16.0s)`, `19 passed`, at `4c921ef`.
+(none for #688 — no code written yet)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -5,33 +5,20 @@ was, add a `/profile/payments` drill-down ledger (status filter, debounced searc
 lifetime totals, CSV export), and fix the trip-payment "always EUR" mislabel on the way.
 
 ## Now
-CLAIM is COMPLETE and PUSHED. Nothing is built yet — zero code files touched.
-Issue #688 carries the full DoD, affected-file list, gotchas and `## Design Checklist` (4/4
-checked) + `## Branch`; `docs/CLAIMS.md` has the claim row (`migration: no`) at `716b4ad`;
-branch `dev/2608-DEV-688` is pushed and tracks `origin/dev/2608-DEV-688` (NOT main).
-Next session opens with BUILD step 1 below. Read issue #688's body first — it is the spec.
+BUILD steps 1-3 are CODE-COMPLETE and statically verified; step 4's spec is WRITTEN but has
+never been EXECUTED. All 9 files in the DoD are edited. Nothing is committed yet.
+BLOCKED on one decision only: the authenticated E2E cannot run in this session — Docker
+Desktop is down, so local Supabase (`127.0.0.1:54321`, which `.env.development.local`
+selects) is unavailable, and DEV credentials are not in any local env file. See `## Open
+items` for the three ways forward.
 
 ## Next
-BUILD in four steps, each ending with its own check. Never carry two failing steps.
-1. `lib/payments/ledger.ts` + `lib/payments/ledger.test.ts` (new), and add `currency: string` to
-   `GenericPayment` in `app/(dashboard)/profile/types.ts`.
-   Helpers: `currencyOf(pay)` = `pay.currency ?? payable_items?.currency ?? 'EUR'`;
-   `ledgerEntries(rows, me)` keyed `payment_group_id && payerOf(row) === me -> g:${id}` else
-   `p:${row.id}`, each raw row emitted exactly once, group status = shared status when uniform
-   else `'pending'` (NEVER `undefined` — `StatusBadge` calls `.toLowerCase()` and throws);
-   `lifetimeTotals(rows, me)` reduces over RAW rows into three per-currency buckets;
-   `toLedgerCSV(rows)` = one line per raw row, no `proof_url` column, RFC-4180 quoting.
-   CHECK: `npx vitest run lib/payments`
-2. `app/(dashboard)/profile/components/shared.tsx` (`PaymentRow`: `currencyOf` + `for A, B` /
-   `Paid by X`) and `PaymentsSection.tsx` (`groupByItem` -> `ledgerEntries`; the "show more"
-   Drawer -> a `next/link` to `/profile/payments`); new i18n keys in en + bg.
-   CHECK: `npm run build`
-3. `app/(dashboard)/profile/payments/page.tsx` + `PaymentsLedgerClient.tsx` (new route).
-   CHECK: `npm run build` + a manual 390px pass
-4. Append the L3 + L8 specs to `e2e/payments-on-behalf.spec.ts`.
-   CHECK: `npx playwright test --project=authenticated` against DEV
-Then: /code-review low -> push -> DRAFT PR -> CI green + preview READY -> ready -> one CodeRabbit
-pass -> merge -> GCR (drop the CLAIMS.md row IN the merging PR, close #688).
+1. Decide how to execute `npx playwright test --project=authenticated` (see `## Open items`),
+   then run it and record the result. L8 is the ONLY matrix item with no evidence yet.
+2. /code-review low.
+3. Commit, then ASK before pushing (the 2026-08-03 push grant was scoped to the CLAIM push).
+4. DRAFT PR -> CI green + Vercel preview READY -> mark ready -> one CodeRabbit pass -> merge
+   -> GCR (drop the CLAIMS.md row IN the merging PR, close #688).
 
 ## Constraints
 - Never push to `main`; `dev/2608-DEV-688` only.
@@ -113,12 +100,39 @@ pass -> merge -> GCR (drop the CLAIMS.md row IN the merging PR, close #688).
   `PaymentsSection.tsx:35` filters `admin_status !== 'pending'`, which is where attribution is
   lost at approval. Issue line refs were 1-3 lines stale (written pre-#677-merge); every code
   claim holds. 9 files, ~600 lines estimated, migration: no, E2E project: `authenticated`.
+- BUILD #688 steps 1-3 (2026-08-03) — RESULT: code-complete, statically green.
+  `npx vitest run lib/payments` -> 5 files / 88 tests passed (baseline was 4 / 58; +30 in the
+  new `lib/payments/ledger.test.ts`). `npx vitest run --exclude lib/actions/guest-registration.test.ts`
+  -> 23 files / 311 tests passed. `npm run check-types` -> clean. `npm run lint` -> 0 errors
+  (476 warnings, all pre-existing; the two new files contribute none). `npm run build` -> success,
+  `ƒ /profile/payments` present in the route table.
+  Matrix status: L1, L2, L4, L5, L6, L7 asserted in unit tests; L3 asserted at the helper level
+  (`payerName`) plus an E2E spec that has not run; L8 has NO evidence — it needs a real 390px
+  render behind Clerk auth.
+  Design notes worth keeping: filtering on the new page happens at ENTRY level, never row level
+  (row-level filtering would render a 3-person group with a partial total); `lifetimeTotals`
+  counts `admin_status === 'approved'` only, matching `personalApprovedTotal`, and
+  `payment.lifetimeNote` says so in both languages; `PaymentRow` now takes
+  `{ entry, me, cancelledTripIds }` instead of `{ pay, cancelledTripIds }`.
 - CLAIM #688 (2026-08-03) — RESULT: complete and pushed. `docs/CLAIMS.md` registry was EMPTY, so no
   scope overlap and no in-flight `migration: yes` row to sequence against. Issue #688 updated with
   DoD + affected files + gotchas + `## Design Checklist` (4/4) + `## Branch`; row committed at
   `716b4ad`; branch pushed (`* [new branch] dev/2608-DEV-688 -> dev/2608-DEV-688`).
 
 ## Open items
+- BLOCKING #688's Done gate: the `authenticated` Playwright project has never executed the new
+  L3/L8 specs. `playwright.config.ts:10-20` loads `.env.development.local` FIRST and never
+  overwrites, and that file sets `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321` — so a local
+  run targets LOCAL Supabase, not `.env.local`'s prod project. Local Supabase is down because
+  Docker Desktop is not running. Three ways forward: (a) start Docker Desktop, `npx supabase
+  start`, `npm run e2e:seed-clerk`, then `npx playwright test --project=authenticated`;
+  (b) point the run at DEV (`iymwxdewcpvpjgzewtzk`) by pulling the Pre-Production env vars —
+  do NOT let that overwrite `.env.local`, which holds prod credentials; (c) accept the Vercel
+  PR preview as the 390px check and run the specs after merge. (a) is the honest one.
+- NOTED (not done): `app/(dashboard)/profile/components/PaymentsSection.tsx:30`
+  `pendingGroupsIPaidFor` still filters `paid_by_profile_id !== myProfileId` directly rather
+  than through `payerOf`, so a legacy pending group with a NULL `paid_by_profile_id` is not
+  offered a withdraw card. Pre-existing, untouched by #688.
 - CARRIED FROM #677, NOT DONE — the prod tail. PR #689 is merged (`5311a9c` on `main`) but the
   post-merge sequence was never executed: approve the gated `migrate-prod` run (GitHub Actions,
   `production` environment, manual approval — #677 HAS a migration), confirm it applied,

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -7,18 +7,16 @@ lifetime totals, CSV export), and fix the trip-payment "always EUR" mislabel on 
 ## Now
 BUILD steps 1-3 are CODE-COMPLETE and statically verified; step 4's spec is WRITTEN but has
 never been EXECUTED. All 9 files in the DoD are edited. Nothing is committed yet.
-Committed at `4fb02da` and pushed. The authenticated E2E could NOT run this session — Docker
-Desktop is down, so local Supabase (`127.0.0.1:54321`, which `.env.development.local` selects)
-is unavailable, and DEV credentials are in no local env file. The user chose to defer the
-390px check to the Vercel PR preview; see `## Open items`.
+BUILD complete, pushed (`83dc0f6`), authenticated E2E confirmed passing by the user, DRAFT PR
+open. Waiting on CI green + Vercel preview READY before marking it ready for review.
 
 ## Next
-1. /code-review low.
-2. ASK before opening the PR — the push grant does not cover it. Then DRAFT PR -> CI green +
-   Vercel preview READY -> open the preview at 390px BY HAND and confirm
-   `document.scrollingElement.scrollWidth <= 390` on `/profile/payments` (this is L8's only
-   evidence under the user's option (c)) -> mark ready -> one CodeRabbit pass -> merge.
-3. GCR: drop the `docs/CLAIMS.md` row IN the merging PR, close #688.
+1. DRAFT PR open (requested by the user 2026-08-03: "Where is the PR at? Maybe create that").
+   Wait for CI green + Vercel preview READY, then mark it ready for review.
+2. One CodeRabbit pass — fetch its INLINE comments, not just the check status.
+3. Merge, then GCR: drop the `docs/CLAIMS.md` row IN the merging PR, close #688.
+4. Before #688 reaches prod, execute the #677 prod tail below — it has a migration that never
+   landed.
 
 ## Constraints
 - Never push to `main`; `dev/2608-DEV-688` only.
@@ -131,10 +129,9 @@ is unavailable, and DEV credentials are in no local env file. The user chose to 
   (b) point the run at DEV (`iymwxdewcpvpjgzewtzk`) by pulling the Pre-Production env vars —
   do NOT let that overwrite `.env.local`, which holds prod credentials; (c) accept the Vercel
   PR preview as the 390px check and run the specs after merge.
-  DECIDED BY THE USER 2026-08-03: option (c). L8 therefore ships UNPROVEN by an executed test —
-  check the preview by hand at 390px before marking Done, and do not read a green
-  `Authenticated E2E (Clerk)` tick as proof (it has gone green in 6s without running the specs;
-  tracked as #679). Confirm the run reports 0 skipped, or treat it as no evidence.
+  RESOLVED 2026-08-03: the user ran the authenticated E2E and reports it passing, so L3 and L8
+  ARE covered by an executed run — it was this session's environment (Docker down) that could
+  not execute it, not the suite. No further local run is owed.
 - NOTED (not done): `app/(dashboard)/profile/components/PaymentsSection.tsx:30`
   `pendingGroupsIPaidFor` still filters `paid_by_profile_id !== myProfileId` directly rather
   than through `payerOf`, so a legacy pending group with a NULL `paid_by_profile_id` is not

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -135,21 +135,39 @@ open. Waiting on CI green + Vercel preview READY before marking it ready for rev
   SUPERSEDED 2026-08-03 (GCR PR691): option (a) is gone — there is no local Docker setup on this
   machine any more, so `http://127.0.0.1:54321` in `.env.development.local` is a dead target and
   every local E2E run must go through option (b), the hosted DEV project `iymwxdewcpvpjgzewtzk`.
-- BLOCKING, one command: `npm run e2e:seed-clerk` has NOT run since the L3 fixture was added to
-  it, and L3 no longer skips. The GCR pass removed the `test.skip(await paidBy.count() === 0)`
-  guard (CodeRabbit, and the repo forbids skipping a test to make it pass) and seeded the row it
-  was skipping for — a co-owner profile plus one `submit_payment_group` call that co-owner makes
-  FOR the member. A co-owner and not a second downline because `get_payable_beneficiaries`
-  reaches DOWNWARD only; the `household` branch is bidirectional and needs no `tree_nodes`
-  change, so the #676 picker fixture is untouched (the co-owner's `abo_number` stays NULL, which
-  both satisfies `trg_guard_abo_number_null`'s co-owner exemption and keeps the row out of that
-  spec's `.filter({ hasText: /·/ })` locator). Written through the RPC rather than as a direct
-  INSERT, so the fixture is one the application could actually produce and `can_pay_for` is
-  exercised. Statically verified ONLY: the seed's write to DEV was refused by this session's
-  permission layer. Run it before the next authenticated run or L3 fails instead of skipping —
+- DONE 2026-08-03 (GCR PR691): `e2e/payments-on-behalf.spec.ts` no longer skips ANY of its three
+  tests, and all three were EXECUTED against DEV — `3 passed, 0 skipped`, run against
+  `iymwxdewcpvpjgzewtzk` with a `npm run dev` whose Supabase env was overridden on the command
+  line (`playwright.config.ts:10-20` only fills vars that are `undefined`, so an exported var
+  wins over the dead `.env.development.local`). Three skips were removed:
+  - L3's `test.skip(await paidBy.count() === 0)`, and the row it was skipping for is now seeded:
+    a co-owner profile plus one `submit_payment_group` call that co-owner makes FOR the member.
+    A co-owner and not a second downline because `get_payable_beneficiaries` reaches DOWNWARD
+    only; the `household` branch is bidirectional and needs no `tree_nodes` change, so the #676
+    picker fixture is untouched (the co-owner's `abo_number` stays NULL, which both satisfies
+    `trg_guard_abo_number_null`'s co-owner exemption and keeps the row out of that spec's
+    `.filter({ hasText: /·/ })` locator). Written through the RPC, not a direct INSERT, so the
+    fixture is one the application could actually produce and `can_pay_for` is exercised.
+  - The #676 flow's two `test.skip`s on `.count()`. **Those were races, not data checks**:
+    `.count()` does not auto-wait, so a cold picker read 0 before `get_payable_beneficiaries`
+    resolved and the test stood itself down — observed live, skipping in a 3-test run and passing
+    when run alone. Replaced with `expect(...).toBeVisible()` / `.toBeAttached()` waits.
+- GOTCHA, cost an hour: `profiles.primary_profile_id` is UNIQUE
+  (`profiles_primary_profile_id_key`) — a primary profile may have AT MOST ONE co-owner. DEV
+  already carried one for the E2E member (`clerk_id = e2e_member_coowner`, planted outside any
+  script in this repo), so creating one unconditionally died on a raw duplicate-key error.
+  `ensureCoowner` now reuses whatever co-owner the member already has and only creates when there
+  is none — which is also the more honest fixture, since whoever the co-owner IS, is who can pay.
+- The seed is idempotent and was re-run to prove it (`co-owner reused` / `paid-for-me payment
+  present` on the second pass). To run it: export
   `NEXT_PUBLIC_SUPABASE_URL=https://iymwxdewcpvpjgzewtzk.supabase.co` plus the DEV `service_role`
-  key from `supabase projects api-keys --project-ref iymwxdewcpvpjgzewtzk`, then
-  `npm run e2e:seed-clerk`. Idempotent on the (beneficiary, payer) pair.
+  and `anon` keys from `supabase projects api-keys --project-ref iymwxdewcpvpjgzewtzk`, then
+  `npm run e2e:seed-clerk`.
+- FLAKE, seen once, not fixed: L8's `viewAll.first().click()` did not navigate on the very first
+  run against a cold Turbopack dev server (13 polls still on `/profile`), and passed on every run
+  afterwards. Cold-compile hydration race in the harness, not a defect in the link — the `<a>`
+  carries the right `href` in the failure snapshot. CI runs with `retries: 1`, so it is covered
+  there; local first runs may need a warm server.
 - NOTED (not done): `app/(dashboard)/profile/components/PaymentsSection.tsx:30`
   `pendingGroupsIPaidFor` still filters `paid_by_profile_id !== myProfileId` directly rather
   than through `payerOf`, so a legacy pending group with a NULL `paid_by_profile_id` is not

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -7,24 +7,26 @@ lifetime totals, CSV export), and fix the trip-payment "always EUR" mislabel on 
 ## Now
 BUILD steps 1-3 are CODE-COMPLETE and statically verified; step 4's spec is WRITTEN but has
 never been EXECUTED. All 9 files in the DoD are edited. Nothing is committed yet.
-BLOCKED on one decision only: the authenticated E2E cannot run in this session — Docker
-Desktop is down, so local Supabase (`127.0.0.1:54321`, which `.env.development.local`
-selects) is unavailable, and DEV credentials are not in any local env file. See `## Open
-items` for the three ways forward.
+Committed at `4fb02da` and pushed. The authenticated E2E could NOT run this session — Docker
+Desktop is down, so local Supabase (`127.0.0.1:54321`, which `.env.development.local` selects)
+is unavailable, and DEV credentials are in no local env file. The user chose to defer the
+390px check to the Vercel PR preview; see `## Open items`.
 
 ## Next
-1. Decide how to execute `npx playwright test --project=authenticated` (see `## Open items`),
-   then run it and record the result. L8 is the ONLY matrix item with no evidence yet.
-2. /code-review low.
-3. Commit, then ASK before pushing (the 2026-08-03 push grant was scoped to the CLAIM push).
-4. DRAFT PR -> CI green + Vercel preview READY -> mark ready -> one CodeRabbit pass -> merge
-   -> GCR (drop the CLAIMS.md row IN the merging PR, close #688).
+1. /code-review low.
+2. ASK before opening the PR — the push grant does not cover it. Then DRAFT PR -> CI green +
+   Vercel preview READY -> open the preview at 390px BY HAND and confirm
+   `document.scrollingElement.scrollWidth <= 390` on `/profile/payments` (this is L8's only
+   evidence under the user's option (c)) -> mark ready -> one CodeRabbit pass -> merge.
+3. GCR: drop the `docs/CLAIMS.md` row IN the merging PR, close #688.
 
 ## Constraints
 - Never push to `main`; `dev/2608-DEV-688` only.
 - No `git push` unless the user asks for a push in this conversation (quote required).
   GRANTED 2026-08-03, verbatim: "push to github so I can start tomorrow ready to go with BUILD".
   Scope: push `dev/2608-DEV-688`. Does NOT cover opening a PR or merging — ask again for both.
+  RE-GRANTED 2026-08-03 for the BUILD commit, user selected "Push now" ("Push
+  dev/2608-DEV-688 to origin now. Does not open a PR"). Opening the PR still needs its own ask.
 - Never weaken a check to make it pass.
 - Fold the `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR — NEVER a
   standalone cleanup PR.
@@ -128,7 +130,11 @@ items` for the three ways forward.
   start`, `npm run e2e:seed-clerk`, then `npx playwright test --project=authenticated`;
   (b) point the run at DEV (`iymwxdewcpvpjgzewtzk`) by pulling the Pre-Production env vars —
   do NOT let that overwrite `.env.local`, which holds prod credentials; (c) accept the Vercel
-  PR preview as the 390px check and run the specs after merge. (a) is the honest one.
+  PR preview as the 390px check and run the specs after merge.
+  DECIDED BY THE USER 2026-08-03: option (c). L8 therefore ships UNPROVEN by an executed test —
+  check the preview by hand at 390px before marking Done, and do not read a green
+  `Authenticated E2E (Clerk)` tick as proof (it has gone green in 6s without running the specs;
+  tracked as #679). Confirm the run reports 0 skipped, or treat it as no evidence.
 - NOTED (not done): `app/(dashboard)/profile/components/PaymentsSection.tsx:30`
   `pendingGroupsIPaidFor` still filters `paid_by_profile_id !== myProfileId` directly rather
   than through `payerOf`, so a legacy pending group with a NULL `paid_by_profile_id` is not

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -132,6 +132,24 @@ open. Waiting on CI green + Vercel preview READY before marking it ready for rev
   RESOLVED 2026-08-03: the user ran the authenticated E2E and reports it passing, so L3 and L8
   ARE covered by an executed run — it was this session's environment (Docker down) that could
   not execute it, not the suite. No further local run is owed.
+  SUPERSEDED 2026-08-03 (GCR PR691): option (a) is gone — there is no local Docker setup on this
+  machine any more, so `http://127.0.0.1:54321` in `.env.development.local` is a dead target and
+  every local E2E run must go through option (b), the hosted DEV project `iymwxdewcpvpjgzewtzk`.
+- BLOCKING, one command: `npm run e2e:seed-clerk` has NOT run since the L3 fixture was added to
+  it, and L3 no longer skips. The GCR pass removed the `test.skip(await paidBy.count() === 0)`
+  guard (CodeRabbit, and the repo forbids skipping a test to make it pass) and seeded the row it
+  was skipping for — a co-owner profile plus one `submit_payment_group` call that co-owner makes
+  FOR the member. A co-owner and not a second downline because `get_payable_beneficiaries`
+  reaches DOWNWARD only; the `household` branch is bidirectional and needs no `tree_nodes`
+  change, so the #676 picker fixture is untouched (the co-owner's `abo_number` stays NULL, which
+  both satisfies `trg_guard_abo_number_null`'s co-owner exemption and keeps the row out of that
+  spec's `.filter({ hasText: /·/ })` locator). Written through the RPC rather than as a direct
+  INSERT, so the fixture is one the application could actually produce and `can_pay_for` is
+  exercised. Statically verified ONLY: the seed's write to DEV was refused by this session's
+  permission layer. Run it before the next authenticated run or L3 fails instead of skipping —
+  `NEXT_PUBLIC_SUPABASE_URL=https://iymwxdewcpvpjgzewtzk.supabase.co` plus the DEV `service_role`
+  key from `supabase projects api-keys --project-ref iymwxdewcpvpjgzewtzk`, then
+  `npm run e2e:seed-clerk`. Idempotent on the (beneficiary, payer) pair.
 - NOTED (not done): `app/(dashboard)/profile/components/PaymentsSection.tsx:30`
   `pendingGroupsIPaidFor` still filters `paid_by_profile_id !== myProfileId` directly rather
   than through `payerOf`, so a legacy pending group with a NULL `paid_by_profile_id` is not

--- a/e2e/payments-on-behalf.spec.ts
+++ b/e2e/payments-on-behalf.spec.ts
@@ -129,34 +129,48 @@ test.describe('profile payments ledger @390', () => {
   test('L8: renders at 390px with no horizontal overflow', async ({ page }) => {
     await signInAndOpenProfile(page)
 
+    // Deliberately NOT guarded by "does this member have payments". The page
+    // renders its heading, the three lifetime total cards, the filter row and
+    // the empty-state on a ledger with zero rows, and those blocks are the
+    // widest thing on it — so the 390px assertion is meaningful either way.
+    // An earlier version reached the page only through the bento link and
+    // therefore skipped outright on CI's empty fixture: a green tick that had
+    // measured nothing, which is the failure mode issue #679 tracks.
     const viewAll = page.getByRole('link', { name: /view all payments/i })
-    // The link only renders when the member has at least one payment. An
-    // account with an empty ledger cannot exercise the page, so skip rather
-    // than pass vacuously.
-    test.skip(await viewAll.count() === 0, 'signed-in member has no payments — seed one before trusting this run')
+    if (await viewAll.count() > 0) {
+      // Prefer the real click when there IS data: the link replacing the old
+      // "show more" drawer is part of what this issue changed.
+      await viewAll.first().click()
+    } else {
+      await page.goto('/profile/payments')
+    }
 
-    await viewAll.first().click()
     await expect(page).toHaveURL(/\/profile\/payments$/)
     await expect(page.getByRole('heading', { name: /all payments/i })).toBeVisible({ timeout: 15_000 })
+    // The totals grid renders on an empty ledger too, so this holds whether or
+    // not the member has payments — and it is one of the two widest blocks the
+    // scrollWidth assertion below is actually measuring.
+    await expect(page.getByTestId('ledger-totals')).toBeVisible()
 
-    // The lifetime totals and the filter row are the two widest blocks; both
-    // must fit. html{overflow-x:hidden} clips visually but does NOT mask this.
     const scrollWidth = await page.evaluate(() => document.scrollingElement?.scrollWidth ?? 0)
     expect(scrollWidth, 'no horizontal overflow at 390px').toBeLessThanOrEqual(390)
   })
 
   test('L3: a row someone else paid for me is labelled with the payer', async ({ page }) => {
     await signInAndOpenProfile(page)
-
-    const viewAll = page.getByRole('link', { name: /view all payments/i })
-    test.skip(await viewAll.count() === 0, 'signed-in member has no payments — seed one before trusting this run')
-
-    await viewAll.first().click()
+    await page.goto('/profile/payments')
     await expect(page.getByRole('heading', { name: /all payments/i })).toBeVisible({ timeout: 15_000 })
 
-    // Attribution after approval is the entire point of the issue, so this must
-    // never report success on a ledger that has no foreign-payer row at all.
-    const paidBy = page.getByText(/paid by /i)
+    // Scoped to the below-md card list on purpose. The md: <table> renders the
+    // same attribution text into the DOM while display:none, so an unscoped
+    // getByText would match a hidden node and fail toBeVisible() at 390px.
+    const paidBy = page.getByTestId('ledger-cards').getByText(/paid by /i)
+
+    // Data-dependent by nature: attribution can only be asserted on a ledger
+    // that HAS a row someone else paid. CI's fixture member has an empty
+    // ledger, so this skips there — treat a green run as coverage ONLY when
+    // the report shows it executed. Seeding that row is tracked in
+    // docs/STATE.md.
     test.skip(await paidBy.count() === 0, 'no row on this ledger was paid by someone else — seed one before trusting this run')
 
     await expect(paidBy.first()).toBeVisible()

--- a/e2e/payments-on-behalf.spec.ts
+++ b/e2e/payments-on-behalf.spec.ts
@@ -152,6 +152,9 @@ test.describe('profile payments ledger @390', () => {
     // scrollWidth assertion below is actually measuring.
     await expect(page.getByTestId('ledger-totals')).toBeVisible()
 
+    // 390 is not the running project's width by coincidence: the module-level
+    // test.use() above pins the viewport for every test in this file, so this
+    // measurement means the same thing under any project that picks the file up.
     const scrollWidth = await page.evaluate(() => document.scrollingElement?.scrollWidth ?? 0)
     expect(scrollWidth, 'no horizontal overflow at 390px').toBeLessThanOrEqual(390)
   })
@@ -166,13 +169,11 @@ test.describe('profile payments ledger @390', () => {
     // getByText would match a hidden node and fail toBeVisible() at 390px.
     const paidBy = page.getByTestId('ledger-cards').getByText(/paid by /i)
 
-    // Data-dependent by nature: attribution can only be asserted on a ledger
-    // that HAS a row someone else paid. CI's fixture member has an empty
-    // ledger, so this skips there — treat a green run as coverage ONLY when
-    // the report shows it executed. Seeding that row is tracked in
-    // docs/STATE.md.
-    test.skip(await paidBy.count() === 0, 'no row on this ledger was paid by someone else — seed one before trusting this run')
-
+    // Unconditional. scripts/seed-clerk-test-users.js seeds a co-owner and one
+    // payment group that co-owner paid for this member, so the row is part of
+    // the fixture rather than something the environment might happen to have.
+    // An earlier version skipped when the ledger was empty, which made a green
+    // run mean nothing — the failure mode issue #679 tracks.
     await expect(paidBy.first()).toBeVisible()
   })
 })

--- a/e2e/payments-on-behalf.spec.ts
+++ b/e2e/payments-on-behalf.spec.ts
@@ -14,15 +14,15 @@ import { clerk } from '@clerk/testing/playwright'
  * matters.
  *
  * REQUIRES a signed-in member who has at least one other payable beneficiary —
- * a downline, or a co-owner. The DEV fixture seeded for this issue
- * (`clerk_id LIKE 'seed_676_%'`) provides exactly that shape. With only
- * themselves eligible the picker legitimately shows one row and the split path
- * is unreachable, so the suite SKIPS rather than passing vacuously — a green
- * run must mean the flow was actually exercised.
+ * a downline, or a co-owner — and one ACTIVE payable item. Both are seeded by
+ * scripts/seed-clerk-test-users.js, so their absence is a broken environment
+ * this file FAILS on. It used to skip instead, on `.count()` reads taken before
+ * the picker's query had resolved, which made the skip a race rather than a
+ * statement about the data: a green run meant nothing in particular.
  *
- * Requires local Supabase + a seeded Clerk test-instance member (see
- * scripts/seed-clerk-test-users.js). Never target a preview/prod-DB
- * deployment — same rule as admin-auth.spec.ts.
+ * Run `npm run e2e:seed-clerk` first, against local Supabase or the hosted DEV
+ * project. Never target a preview/prod-DB deployment — same rule as
+ * admin-auth.spec.ts.
  */
 
 const MEMBER_EMAIL = process.env.E2E_CLERK_MEMBER_EMAIL ?? 'e2e-member-tevd-portal@example.com'
@@ -55,9 +55,13 @@ test.describe('payments on behalf of others @390', () => {
 
     // Rows are buttons; the payer's own row renders disabled once selected.
     const candidates = page.locator('button:not([disabled])').filter({ hasText: /·/ })
-    const count = await candidates.count()
-    test.skip(count === 0, 'signed-in member has no other payable beneficiary — seed one before trusting this run')
 
+    // Waited for, not counted. `.count()` does not auto-wait, so on a cold
+    // picker it read 0 before get_payable_beneficiaries had resolved and the
+    // test skipped itself — intermittently, which is worse than never running.
+    // The downline fixture is seeded by scripts/seed-clerk-test-users.js, so
+    // its absence is a failure, not a reason to stand down.
+    await expect(candidates.first()).toBeVisible({ timeout: 15_000 })
     await candidates.first().click()
 
     // Back on the form: Amount is now labelled Total and the breakdown appears.
@@ -97,7 +101,10 @@ test.describe('payments on behalf of others @390', () => {
     const itemSelect = page.locator('select')
     if (await itemSelect.count() > 0) {
       const options = itemSelect.locator('option')
-      test.skip(await options.count() < 2, 'no active payable item on this environment')
+      // Same reasoning as the picker above: the seed guarantees one ACTIVE EUR
+      // payable item, so a placeholder-only <select> is a broken environment to
+      // fail on, not a condition to skip past.
+      await expect(options.nth(1)).toBeAttached({ timeout: 15_000 })
       await itemSelect.selectOption({ index: 1 })
       await amountInput.fill('200')
     }

--- a/e2e/payments-on-behalf.spec.ts
+++ b/e2e/payments-on-behalf.spec.ts
@@ -116,3 +116,49 @@ test.describe('payments on behalf of others @390', () => {
     await expect(page.getByRole('button', { name: /^withdraw$/i })).toHaveCount(0, { timeout: 15_000 })
   })
 })
+
+/**
+ * The /profile/payments drill-down ledger (2608-DEV-688). L8 and L3 from the
+ * issue's verification matrix.
+ *
+ * Reached by clicking the bento's link rather than by page.goto: the link
+ * existing and being a client-side navigation is half of what replaced the old
+ * "show more" drawer, and a direct goto would not notice if it broke.
+ */
+test.describe('profile payments ledger @390', () => {
+  test('L8: renders at 390px with no horizontal overflow', async ({ page }) => {
+    await signInAndOpenProfile(page)
+
+    const viewAll = page.getByRole('link', { name: /view all payments/i })
+    // The link only renders when the member has at least one payment. An
+    // account with an empty ledger cannot exercise the page, so skip rather
+    // than pass vacuously.
+    test.skip(await viewAll.count() === 0, 'signed-in member has no payments — seed one before trusting this run')
+
+    await viewAll.first().click()
+    await expect(page).toHaveURL(/\/profile\/payments$/)
+    await expect(page.getByRole('heading', { name: /all payments/i })).toBeVisible({ timeout: 15_000 })
+
+    // The lifetime totals and the filter row are the two widest blocks; both
+    // must fit. html{overflow-x:hidden} clips visually but does NOT mask this.
+    const scrollWidth = await page.evaluate(() => document.scrollingElement?.scrollWidth ?? 0)
+    expect(scrollWidth, 'no horizontal overflow at 390px').toBeLessThanOrEqual(390)
+  })
+
+  test('L3: a row someone else paid for me is labelled with the payer', async ({ page }) => {
+    await signInAndOpenProfile(page)
+
+    const viewAll = page.getByRole('link', { name: /view all payments/i })
+    test.skip(await viewAll.count() === 0, 'signed-in member has no payments — seed one before trusting this run')
+
+    await viewAll.first().click()
+    await expect(page.getByRole('heading', { name: /all payments/i })).toBeVisible({ timeout: 15_000 })
+
+    // Attribution after approval is the entire point of the issue, so this must
+    // never report success on a ledger that has no foreign-payer row at all.
+    const paidBy = page.getByText(/paid by /i)
+    test.skip(await paidBy.count() === 0, 'no row on this ledger was paid by someone else — seed one before trusting this run')
+
+    await expect(paidBy.first()).toBeVisible()
+  })
+})

--- a/lib/csv-export.ts
+++ b/lib/csv-export.ts
@@ -29,9 +29,18 @@ function fmtDot(n: number | null): string {
   return String(n ?? 0)
 }
 
-/** Text-prefix a non-empty value */
+/**
+ * Text-prefix a non-empty value.
+ *
+ * Shaped by the Amway format, but it doubles as this export's formula-injection
+ * guard: every user-controlled column below (name, email, address, phone, ABO
+ * numbers, dates) goes through `tick`, so a value opening with `=`, `+`, `-`,
+ * `@`, TAB or CR reaches the spreadsheet as text. The columns that skip `tick`
+ * are the numeric ones, which must stay numeric — see `csvSafe` for the general
+ * form of the same rule.
+ */
 function tick(v: string): string {
-  return v ? `'${v}` : ''
+  return v !== '' ? `'${v}` : ''
 }
 
 // ── Column spec (exact Amway order) ───────────────────────────────────────────
@@ -70,6 +79,24 @@ const EXPORT_COLUMNS: { header: string; value: (m: LOSMember) => string }[] = [
 export function csvQuote(value: string): string {
   // Escape any double-quotes inside the value, then wrap in double-quotes
   return `"${value.replace(/"/g, '""')}"`
+}
+
+/**
+ * Neutralises a leading formula character.
+ *
+ * Excel, LibreOffice and Google Sheets evaluate a cell opening with `=`, `+`,
+ * `-`, `@`, TAB or CR as a formula — quoting per RFC 4180 does not stop that,
+ * because the quotes are consumed by the CSV parser before the spreadsheet ever
+ * sees the value. A leading apostrophe forces the cell to text and is stripped
+ * from the display, so the value still reads as written.
+ *
+ * Lives next to `csvQuote` so the repo's two exports share one rule rather than
+ * growing two. Apply to user-controlled TEXT only: prefixing a number would
+ * turn a numeric cell into text, which is why `buildMembersCSV`'s numeric
+ * columns go through neither this nor `tick`.
+ */
+export function csvSafe(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value
 }
 
 export function buildMembersCSV(members: LOSMember[]): string {

--- a/lib/csv-export.ts
+++ b/lib/csv-export.ts
@@ -67,7 +67,7 @@ const EXPORT_COLUMNS: { header: string; value: (m: LOSMember) => string }[] = [
 
 // ── CSV builder ───────────────────────────────────────────────────────────────
 
-function csvQuote(value: string): string {
+export function csvQuote(value: string): string {
   // Escape any double-quotes inside the value, then wrap in double-quotes
   return `"${value.replace(/"/g, '""')}"`
 }

--- a/lib/i18n/domains/payment.ts
+++ b/lib/i18n/domains/payment.ts
@@ -80,4 +80,23 @@ export const payment = {
   'payment.guestUnlinkTitle':   { en: 'Unlink this guest?',              bg: 'Да се премахне ли връзката?'                },
   'payment.guestUnlinkBody':    { en: 'The guest stays, along with every payment made for them. Only the link to the member is removed.', bg: 'Гостът остава заедно с всички плащания за него. Премахва се само връзката с члена.' },
   'payment.guestPayments':      { en: 'payments',                        bg: 'плащания'                                   },
+
+  // The /profile/payments drill-down ledger (2608-DEV-688). 'payment.allPayments'
+  // above is reused as the page title, so replacing the bento's "show more"
+  // drawer with a link orphans no key.
+  'payment.viewAll':            { en: 'View all payments',               bg: 'Виж всички плащания'                        },
+  'payment.filterStatus':       { en: 'Status',                          bg: 'Статус'                                     },
+  'payment.allStatuses':        { en: 'All statuses',                    bg: 'Всички статуси'                             },
+  'payment.rejected':           { en: 'Rejected',                        bg: 'Отхвърлено'                                 },
+  'payment.search':             { en: 'Search item, name or note',       bg: 'Търсене по артикул, име или бележка'        },
+  'payment.dateFrom':           { en: 'From',                            bg: 'От'                                         },
+  'payment.dateTo':             { en: 'To',                              bg: 'До'                                         },
+  'payment.noResults':          { en: 'No payments match these filters.', bg: 'Няма плащания, отговарящи на филтрите.'     },
+  'payment.totalPaid':          { en: 'Paid',                            bg: 'Платено'                                    },
+  'payment.totalOnBehalf':      { en: 'Paid for others',                 bg: 'Платено за други'                           },
+  'payment.totalPaidForMe':     { en: 'Paid for me by others',           bg: 'Платено за мен от други'                    },
+  'payment.lifetimeNote':       { en: 'Lifetime approved totals — not affected by the filters above.', bg: 'Общо одобрени суми за целия период — филтрите по-горе не ги променят.' },
+  'payment.exportCsv':          { en: 'Export CSV',                      bg: 'Експорт CSV'                                },
+  'payment.status':             { en: 'Status',                          bg: 'Статус'                                     },
+  'payment.attribution':        { en: 'For / by',                        bg: 'За / от'                                    },
 } as const

--- a/lib/payments/ledger.test.ts
+++ b/lib/payments/ledger.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from 'vitest'
+import {
+  beneficiaryNames,
+  currencyOf,
+  ledgerEntries,
+  lifetimeTotals,
+  payerName,
+  toLedgerCSV,
+  type LedgerRow,
+} from './ledger'
+
+/**
+ * The L-numbers are the verification matrix from 2608-DEV-688. Each test names
+ * the one it discharges so a failure points at the requirement, not just at a
+ * line of code.
+ */
+
+const ME = 'prf_me'
+const FRIEND = 'prf_friend'
+
+/** A plain approved self-payment. Override only what a case is about. */
+function row(over: Partial<LedgerRow> = {}): LedgerRow {
+  return {
+    id: 'pay_1',
+    amount: 100,
+    transaction_date: '2026-07-01',
+    admin_status: 'approved',
+    payment_method: 'bank_transfer',
+    note: null,
+    admin_note: null,
+    currency: 'EUR',
+    profile_id: ME,
+    paid_by_profile_id: null,
+    payment_group_id: null,
+    beneficiary_guest_id: null,
+    beneficiary: { first_name: 'Me', last_name: 'Myself' },
+    payer: null,
+    payment_guests: null,
+    payable_items: { title: 'Membership 2026', item_type: 'membership', currency: 'EUR' },
+    trips: null,
+    ...over,
+  }
+}
+
+/** The three sibling rows of one transfer: me, a friend, and an ad-hoc guest. */
+function groupOfThree(): LedgerRow[] {
+  return [
+    row({ id: 'p_me', payment_group_id: 'grp_1', paid_by_profile_id: ME, amount: 100 }),
+    row({
+      id: 'p_friend',
+      payment_group_id: 'grp_1',
+      profile_id: FRIEND,
+      paid_by_profile_id: ME,
+      amount: 80,
+      beneficiary: { first_name: 'Ana', last_name: 'Petrova' },
+    }),
+    row({
+      id: 'p_guest',
+      payment_group_id: 'grp_1',
+      paid_by_profile_id: ME,
+      amount: 60,
+      beneficiary_guest_id: 'gst_1',
+      payment_guests: { name: 'Nadia' },
+    }),
+  ]
+}
+
+describe('currencyOf', () => {
+  it('L5: a trip payment with no payable_item reports its own currency, not EUR', () => {
+    // The whole reason this helper exists. A trip payment has payable_items
+    // === null, so the old `payable_items?.currency ?? "EUR"` read labelled a
+    // USD charge as EUR.
+    const trip = row({
+      currency: 'USD',
+      payable_items: null,
+      trips: { title: 'Achievers Cancún' },
+    })
+
+    expect(currencyOf(trip)).toBe('USD')
+  })
+
+  it('falls back to the payable item when the row column was not selected', () => {
+    const legacy = row({ currency: undefined, payable_items: { title: 'x', item_type: 'fee', currency: 'BGN' } })
+
+    expect(currencyOf(legacy)).toBe('BGN')
+  })
+
+  it('falls back to EUR only when neither source carries a currency', () => {
+    expect(currencyOf(row({ currency: undefined, payable_items: null }))).toBe('EUR')
+  })
+})
+
+describe('ledgerEntries', () => {
+  it('L1: a 3-row approved group I paid collapses to one entry with the summed amount', () => {
+    const entries = ledgerEntries(groupOfThree(), ME)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].key).toBe('g:grp_1')
+    expect(entries[0].isGroup).toBe(true)
+    expect(entries[0].amount).toBe(240)
+    expect(entries[0].rows.map(r => r.id)).toEqual(['p_me', 'p_friend', 'p_guest'])
+  })
+
+  it('L2: the payer own row inside that group is not emitted twice', () => {
+    const rows = groupOfThree()
+    const entries = ledgerEntries(rows, ME)
+
+    // Entries partition the input: every raw row appears in exactly one entry.
+    const emitted = entries.flatMap(e => e.rows.map(r => r.id))
+    expect(emitted).toHaveLength(rows.length)
+    expect(emitted.filter(id => id === 'p_me')).toHaveLength(1)
+  })
+
+  it('does not collapse a group for a beneficiary who did not pay it', () => {
+    // Ana holds one row of grp_1. Collapsing for her would show a 240 total she
+    // never transferred.
+    const entries = ledgerEntries(groupOfThree(), FRIEND)
+
+    expect(entries).toHaveLength(3)
+    expect(entries.map(e => e.key)).toEqual(['p:p_me', 'p:p_friend', 'p:p_guest'])
+    expect(entries.every(e => e.isGroup === false)).toBe(true)
+  })
+
+  it('leaves an ungrouped payment as its own entry', () => {
+    const entries = ledgerEntries([row({ id: 'solo' })], ME)
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0].key).toBe('p:solo')
+    expect(entries[0].amount).toBe(100)
+  })
+
+  it('L6: a mixed-status group renders pending, never undefined', () => {
+    const rows = groupOfThree()
+    rows[1].admin_status = 'rejected'
+
+    const [entry] = ledgerEntries(rows, ME)
+
+    expect(entry.status).toBe('pending')
+    // StatusBadge calls .toLowerCase() on this value; undefined throws.
+    expect(entry.status).toBeTypeOf('string')
+  })
+
+  it('L6: a uniformly approved group keeps approved', () => {
+    expect(ledgerEntries(groupOfThree(), ME)[0].status).toBe('approved')
+  })
+
+  it('surfaces an admin note that only exists on a later row of the group', () => {
+    const rows = groupOfThree()
+    rows[2].admin_note = 'Amount does not match the transfer'
+
+    expect(ledgerEntries(rows, ME)[0].admin_note).toBe('Amount does not match the transfer')
+  })
+
+  it('keeps two separate groups separate and preserves input order', () => {
+    const rows = [
+      ...groupOfThree(),
+      row({ id: 'p_other', payment_group_id: 'grp_2', paid_by_profile_id: ME, amount: 25 }),
+    ]
+
+    expect(ledgerEntries(rows, ME).map(e => e.key)).toEqual(['g:grp_1', 'g:grp_2'])
+  })
+
+  it('is empty on an empty ledger rather than throwing', () => {
+    expect(ledgerEntries([], ME)).toEqual([])
+  })
+})
+
+describe('beneficiaryNames / payerName', () => {
+  it('L1: a group I paid names every beneficiary except my own share', () => {
+    const [entry] = ledgerEntries(groupOfThree(), ME)
+
+    expect(beneficiaryNames(entry, ME, 'guest')).toEqual(['Ana Petrova', 'Nadia (guest)'])
+  })
+
+  it('names nobody on an ordinary self-payment, so "for …" stays hidden', () => {
+    const [entry] = ledgerEntries([row()], ME)
+
+    expect(beneficiaryNames(entry, ME, 'guest')).toEqual([])
+  })
+
+  it('still names an ad-hoc guest on a single row that sits on my own ledger', () => {
+    const [entry] = ledgerEntries(
+      [row({ beneficiary_guest_id: 'gst_1', payment_guests: { name: 'Nadia' } })],
+      ME,
+    )
+
+    expect(beneficiaryNames(entry, ME, 'guest')).toEqual(['Nadia (guest)'])
+  })
+
+  it('L3: a row on my ledger with a foreign payer reports that payer name', () => {
+    const [entry] = ledgerEntries(
+      [row({ paid_by_profile_id: FRIEND, payer: { first_name: 'Ivan', last_name: 'Dimov' } })],
+      ME,
+    )
+
+    expect(payerName(entry, ME)).toBe('Ivan Dimov')
+  })
+
+  it('L3: reports null on a payment I made myself', () => {
+    expect(payerName(ledgerEntries([row()], ME)[0], ME)).toBeNull()
+  })
+
+  it('L3: reports null rather than a placeholder when the payer embed is missing', () => {
+    const [entry] = ledgerEntries([row({ paid_by_profile_id: FRIEND, payer: null })], ME)
+
+    expect(payerName(entry, ME)).toBeNull()
+  })
+})
+
+describe('lifetimeTotals', () => {
+  it('L4: does not double-count the payer own share of a group they paid', () => {
+    const totals = lifetimeTotals(groupOfThree(), ME)
+
+    // 100 towards my own fee; 80 for Ana + 60 for the guest paid on their behalf.
+    expect(totals.paid).toEqual({ EUR: 100 })
+    expect(totals.onBehalf).toEqual({ EUR: 140 })
+    expect(totals.paidForMe).toEqual({})
+  })
+
+  it('L4: counts a guest row as on-behalf despite it sitting on my own profile_id', () => {
+    // payments_guest_ledger_check forces profile_id = paid_by_profile_id on a
+    // guest row, so it looks like a self-payment. Counting it as "paid" is the
+    // 2607-DEV-677 miscount.
+    const guestOnly = [
+      row({ id: 'g1', paid_by_profile_id: ME, beneficiary_guest_id: 'gst_1', amount: 60 }),
+    ]
+
+    const totals = lifetimeTotals(guestOnly, ME)
+
+    expect(totals.paid).toEqual({})
+    expect(totals.onBehalf).toEqual({ EUR: 60 })
+  })
+
+  it('L4: buckets per currency instead of summing across them', () => {
+    const rows = [
+      row({ id: 'a', amount: 100, currency: 'EUR' }),
+      row({ id: 'b', amount: 40, currency: 'USD', payable_items: null, trips: { title: 'Cancún' } }),
+    ]
+
+    expect(lifetimeTotals(rows, ME).paid).toEqual({ EUR: 100, USD: 40 })
+  })
+
+  it('L4: money someone else paid for me lands in paidForMe, not in paid', () => {
+    const rows = [
+      row({ id: 'x', profile_id: ME, paid_by_profile_id: FRIEND, amount: 75 }),
+    ]
+
+    const totals = lifetimeTotals(rows, ME)
+
+    expect(totals.paid).toEqual({})
+    expect(totals.paidForMe).toEqual({ EUR: 75 })
+  })
+
+  it('counts approved rows only', () => {
+    const rows = [
+      row({ id: 'p', admin_status: 'pending', amount: 100 }),
+      row({ id: 'r', admin_status: 'rejected', amount: 100 }),
+      row({ id: 'a', admin_status: 'approved', amount: 10 }),
+    ]
+
+    expect(lifetimeTotals(rows, ME).paid).toEqual({ EUR: 10 })
+  })
+
+  it('is three empty buckets on an empty ledger rather than NaN', () => {
+    expect(lifetimeTotals([], ME)).toEqual({ paid: {}, onBehalf: {}, paidForMe: {} })
+  })
+})
+
+describe('toLedgerCSV', () => {
+  it('L7: emits one line per RAW row, never per collapsed entry', () => {
+    const csv = toLedgerCSV(groupOfThree())
+
+    // 1 header + 3 data lines. A collapsed group would hide which share went to
+    // whom, which is the point of exporting an on-behalf ledger.
+    expect(csv.trimEnd().split('\r\n')).toHaveLength(4)
+  })
+
+  it('L7: never emits proof_url', () => {
+    const csv = toLedgerCSV([row({ id: 'p', proof_url: `${ME}/abc.png` })])
+
+    expect(csv).not.toContain('abc.png')
+    expect(csv.toLowerCase()).not.toContain('proof')
+  })
+
+  it('L7: a note containing commas and quotes round-trips', () => {
+    const csv = toLedgerCSV([row({ id: 'p', note: 'Paid 50, then 50; said "later"' })])
+    const dataLine = csv.trimEnd().split('\r\n')[1]
+
+    // RFC 4180: the comma stays inside the quoted field and each embedded quote
+    // is doubled.
+    expect(dataLine).toContain('"Paid 50, then 50; said ""later"""')
+  })
+
+  it('names the guest rather than the payer on a guest row', () => {
+    const csv = toLedgerCSV(
+      [row({ id: 'p', beneficiary_guest_id: 'gst_1', payment_guests: { name: 'Nadia' } })],
+      'guest',
+    )
+
+    expect(csv).toContain('"Nadia (guest)"')
+  })
+
+  it('starts with a BOM and uses CRLF so Excel reads Cyrillic correctly', () => {
+    const csv = toLedgerCSV([row()])
+
+    expect(csv.charCodeAt(0)).toBe(0xfeff)
+    expect(csv.endsWith('\r\n')).toBe(true)
+  })
+
+  it('emits a header-only file for an empty ledger', () => {
+    expect(toLedgerCSV([]).trimEnd().split('\r\n')).toHaveLength(1)
+  })
+})

--- a/lib/payments/ledger.test.ts
+++ b/lib/payments/ledger.test.ts
@@ -95,7 +95,7 @@ describe('ledgerEntries', () => {
     const entries = ledgerEntries(groupOfThree(), ME)
 
     expect(entries).toHaveLength(1)
-    expect(entries[0].key).toBe('g:grp_1')
+    expect(entries[0].key).toBe('g:grp_1:EUR')
     expect(entries[0].isGroup).toBe(true)
     expect(entries[0].amount).toBe(240)
     expect(entries[0].rows.map(r => r.id)).toEqual(['p_me', 'p_friend', 'p_guest'])
@@ -157,7 +157,24 @@ describe('ledgerEntries', () => {
       row({ id: 'p_other', payment_group_id: 'grp_2', paid_by_profile_id: ME, amount: 25 }),
     ]
 
-    expect(ledgerEntries(rows, ME).map(e => e.key)).toEqual(['g:grp_1', 'g:grp_2'])
+    expect(ledgerEntries(rows, ME).map(e => e.key)).toEqual(['g:grp_1:EUR', 'g:grp_2:EUR'])
+  })
+
+  it('never sums two currencies into one total, even inside one group', () => {
+    // submit_payment_group writes one currency per group, so this shape should
+    // not exist — but `amount` sums the whole bucket while `currency` reports a
+    // single code, and a total in the wrong denomination is wrong money that
+    // formatCurrency would render with a plausible symbol. Keying on the
+    // currency makes that arithmetic rather than an assumption.
+    const rows = [
+      row({ id: 'p_eur', payment_group_id: 'grp_x', paid_by_profile_id: ME, amount: 100, currency: 'EUR' }),
+      row({ id: 'p_usd', payment_group_id: 'grp_x', paid_by_profile_id: ME, amount: 40, currency: 'USD' }),
+    ]
+
+    const entries = ledgerEntries(rows, ME)
+
+    expect(entries.map(e => e.key)).toEqual(['g:grp_x:EUR', 'g:grp_x:USD'])
+    expect(entries.map(e => [e.currency, e.amount])).toEqual([['EUR', 100], ['USD', 40]])
   })
 
   it('is empty on an empty ledger rather than throwing', () => {
@@ -309,5 +326,37 @@ describe('toLedgerCSV', () => {
 
   it('emits a header-only file for an empty ledger', () => {
     expect(toLedgerCSV([]).trimEnd().split('\r\n')).toHaveLength(1)
+  })
+
+  it('neutralises a formula in member-supplied free text', () => {
+    // `note` is typed by a member, so it is the one column an attacker fully
+    // controls. RFC-4180 quoting does not help: the parser strips the quotes
+    // before the spreadsheet evaluates the cell.
+    const csv = toLedgerCSV([row({ id: 'p', note: '=HYPERLINK("http://evil","click")' })])
+
+    expect(csv).toContain(`"'=HYPERLINK(""http://evil"",""click"")"`)
+  })
+
+  it('neutralises a formula in a name and a title too', () => {
+    const csv = toLedgerCSV([
+      row({
+        id: 'p',
+        payable_items: { title: '+SUM(A1:A9)', item_type: 'membership', currency: 'EUR' },
+        paid_by_profile_id: FRIEND,
+        payer: { first_name: '@cmd', last_name: 'Petrov' },
+      }),
+    ])
+
+    expect(csv).toContain(`"'+SUM(A1:A9)"`)
+    expect(csv).toContain(`"'@cmd Petrov"`)
+  })
+
+  it('leaves a negative amount numeric rather than prefixing it', () => {
+    // The guard is for text only. Prefixing '-27.5' would demote a number to a
+    // text cell, which is the one place the fix would do damage.
+    const csv = toLedgerCSV([row({ id: 'p', amount: -27.5 })])
+
+    expect(csv).toContain('"-27.5"')
+    expect(csv).not.toContain(`"'-27.5"`)
   })
 })

--- a/lib/payments/ledger.test.ts
+++ b/lib/payments/ledger.test.ts
@@ -222,6 +222,20 @@ describe('beneficiaryNames / payerName', () => {
 
     expect(payerName(entry, ME)).toBeNull()
   })
+
+  it('never names beneficiaries and a payer at once — the two are exclusive', () => {
+    // What lets both surfaces render them without a separator between them, and
+    // lets Attribution on /profile/payments return early on the payer. An entry
+    // somebody else paid is never collapsed, so it holds one row; that row is on
+    // my ledger, so beneficiaryNames filters it out on `profile_id !== me`.
+    const [entry] = ledgerEntries(
+      [row({ paid_by_profile_id: FRIEND, payer: { first_name: 'Ivan', last_name: 'Dimov' } })],
+      ME,
+    )
+
+    expect(payerName(entry, ME)).toBe('Ivan Dimov')
+    expect(beneficiaryNames(entry, ME, 'guest')).toEqual([])
+  })
 })
 
 describe('lifetimeTotals', () => {

--- a/lib/payments/ledger.ts
+++ b/lib/payments/ledger.ts
@@ -36,6 +36,9 @@
 
 import { payerOf } from './proof'
 import { beneficiaryLabel } from './labels'
+// The repo's one RFC-4180 field quoter. Reused rather than re-implemented so a
+// correction to the escaping rule cannot land in only one of two exports.
+import { csvQuote } from '../csv-export'
 
 /**
  * The columns this module reads. Declared structurally rather than importing
@@ -258,11 +261,6 @@ export function lifetimeTotals(rows: readonly LedgerRow[], me: string): Lifetime
 /** U+FEFF byte-order mark, constructed rather than pasted so this source file
  *  does not itself contain a stray BOM in the middle of a line. */
 const BOM = String.fromCharCode(0xfeff)
-
-/** RFC 4180: wrap every field, double any embedded quote. Matches lib/csv-export.ts. */
-function csvQuote(value: string): string {
-  return `"${value.replace(/"/g, '""')}"`
-}
 
 const CSV_HEADERS = [
   'Date',

--- a/lib/payments/ledger.ts
+++ b/lib/payments/ledger.ts
@@ -1,0 +1,322 @@
+/**
+ * The member-facing payment ledger (2608-DEV-688).
+ *
+ * Three things happen to a payment row between the database and the profile
+ * bento, and each of them used to lose information:
+ *
+ *   1. CURRENCY. `payments.currency` is selected by GET /api/payments but was
+ *      never declared on the client type, so every reader fell back to
+ *      `payable_items?.currency ?? 'EUR'` — and a TRIP payment has no
+ *      payable_item at all, which force-labelled every trip payment EUR
+ *      regardless of what was actually charged. `currencyOf` is the single
+ *      read; nothing else may reach for the currency directly.
+ *
+ *   2. GROUPING. One bank transfer paid on behalf of N people is N sibling rows
+ *      sharing a `payment_group_id`. The old key was the item/trip TITLE, which
+ *      both split one transfer across items and merged unrelated transfers of
+ *      the same item. `ledgerEntries` keys on the group instead — but only for
+ *      the payer, because a beneficiary sees exactly one row of that group and
+ *      must not be shown a collapsed total they did not pay.
+ *
+ *   3. TOTALS. An ad-hoc guest (2607-DEV-677) has no ledger of their own, so a
+ *      guest row sits on the PAYER's `profile_id` and looks indistinguishable
+ *      from money the payer paid towards their own fee. `lifetimeTotals` splits
+ *      on that explicitly; it is the highest-risk arithmetic in this module.
+ *
+ * Framework-free on purpose, like `labels.ts` and `totals.ts` next door: the
+ * repo has no jsdom/testing-library setup, so a plain .ts helper is the only
+ * part of this feature a unit test can reach at all.
+ *
+ * Money note: amounts are JS numbers because that is what PostgREST returns for
+ * `numeric` and what `formatCurrency` consumes — the same representation
+ * `personalApprovedTotal` already sums. This module does not introduce minor
+ * units; it only adds, never multiplies or divides, so no new rounding error is
+ * created here.
+ */
+
+import { payerOf } from './proof'
+import { beneficiaryLabel } from './labels'
+
+/**
+ * The columns this module reads. Declared structurally rather than importing
+ * `GenericPayment` from app/: lib/ must not depend on a route's view model, and
+ * every field is optional for the same reason `ProofRow`'s are — a narrower
+ * caller that forgot a column must fail closed, not throw.
+ */
+export type LedgerRow = {
+  id: string
+  amount: number
+  transaction_date: string
+  admin_status: string
+  payment_method?: string | null
+  note?: string | null
+  admin_note?: string | null
+  currency?: string | null
+  /** Present on the rows callers hand in, read by nothing here, and pointedly
+   *  absent from the CSV — see `toLedgerCSV`. */
+  proof_url?: string | null
+  profile_id?: string | null
+  paid_by_profile_id?: string | null
+  payment_group_id?: string | null
+  beneficiary_guest_id?: string | null
+  beneficiary?: { first_name: string; last_name: string } | null
+  payer?: { first_name: string; last_name: string } | null
+  payment_guests?: { name: string } | null
+  payable_items?: { title: string; item_type: string; currency: string } | null
+  trips?: { title: string } | null
+}
+
+/** One line in the ledger: either a single payment or one collapsed group. */
+export type LedgerEntry = {
+  /** `g:${payment_group_id}` for a collapsed group, `p:${row.id}` otherwise. */
+  key: string
+  /** Every raw row this entry stands for, in input order. Never empty. */
+  rows: LedgerRow[]
+  isGroup: boolean
+  /** Summed across `rows` — for a single entry, that row's amount. */
+  amount: number
+  currency: string
+  /** Uniform status when the group agrees, else 'pending'. Never undefined. */
+  status: string
+  transaction_date: string
+  /** Payable item or trip title; '' when the row carries neither. */
+  title: string
+  payment_method: string | null
+  admin_note: string | null
+}
+
+/** Per-currency sums. Keyed by ISO currency code, e.g. `{ EUR: 250, USD: 40 }`. */
+export type CurrencyTotals = Record<string, number>
+
+export type LifetimeTotals = {
+  /** Approved money towards the viewer's OWN fee. */
+  paid: CurrencyTotals
+  /** Approved money the viewer paid for other people, guests included. */
+  onBehalf: CurrencyTotals
+  /** Approved money someone else paid towards the viewer's fee. */
+  paidForMe: CurrencyTotals
+}
+
+/**
+ * The currency a row is denominated in.
+ *
+ * `??` not `||`: an empty string is not a currency but it is also not a value
+ * PostgREST produces for a `text NOT NULL DEFAULT 'EUR'` column, and swallowing
+ * it silently would hide a data bug behind a plausible-looking 'EUR'.
+ */
+export function currencyOf(row: LedgerRow): string {
+  return row.currency ?? row.payable_items?.currency ?? 'EUR'
+}
+
+/** The item this row was for, as display text; '' when it names neither. */
+export function titleOf(row: LedgerRow): string {
+  return row.payable_items?.title ?? row.trips?.title ?? ''
+}
+
+/**
+ * Collapses the viewer's own on-behalf groups to one entry each and leaves
+ * everything else alone.
+ *
+ * A group is ONE bank transfer. Rendering it as N rows was the original lie
+ * this issue exists to correct — but only from the payer's side: a beneficiary
+ * holds a single row of that group and, for them, one row is the truth.
+ *
+ * Every input row is emitted in exactly one entry (L2): entries partition the
+ * input, so the payer's own share inside a group they paid is folded into the
+ * group total rather than also standing alone.
+ *
+ * Order is first-appearance order of each entry's first row, so a caller that
+ * sorted its rows before calling keeps that sort.
+ */
+export function ledgerEntries(rows: readonly LedgerRow[], me: string): LedgerEntry[] {
+  const order: string[] = []
+  const buckets = new Map<string, LedgerRow[]>()
+
+  for (const row of rows) {
+    // Collapse only when BOTH hold: the row belongs to a group, and the viewer
+    // is the one who transferred the money. Anything else is its own entry.
+    const collapse = row.payment_group_id != null && payerOf(row) === me
+    const key = collapse ? `g:${row.payment_group_id}` : `p:${row.id}`
+    const bucket = buckets.get(key)
+    if (bucket) {
+      bucket.push(row)
+    } else {
+      buckets.set(key, [row])
+      order.push(key)
+    }
+  }
+
+  return order.map((key) => {
+    const entryRows = buckets.get(key)!
+    const head = entryRows[0]
+    const statuses = new Set(entryRows.map((r) => r.admin_status))
+    return {
+      key,
+      rows: entryRows,
+      isGroup: entryRows.length > 1,
+      amount: entryRows.reduce((sum, r) => sum + Number(r.amount), 0),
+      currency: currencyOf(head),
+      // A mixed group is not yet resolved, so it reads as pending. NEVER
+      // undefined: StatusBadge calls .toLowerCase() on this and would throw
+      // (the crash fixed by 21558be).
+      status: statuses.size === 1 ? head.admin_status : 'pending',
+      transaction_date: head.transaction_date,
+      title: titleOf(head),
+      payment_method: head.payment_method ?? null,
+      // Surfaced from the first row that carries one: an admin note explains a
+      // rejection, and a group whose note only lives on row 3 would otherwise
+      // render as an unexplained refusal.
+      admin_note: entryRows.find((r) => r.admin_note != null)?.admin_note ?? null,
+    }
+  })
+}
+
+/**
+ * The people this entry was paid FOR, excluding the viewer's own share.
+ *
+ * A guest row is included even though it sits on the viewer's `profile_id` —
+ * that placement is a storage detail (`payments_guest_ledger_check`), not a
+ * statement about who the money was for.
+ *
+ * Empty for an ordinary self-payment, which is what makes `for …` render only
+ * when it says something.
+ */
+export function beneficiaryNames(entry: LedgerEntry, me: string, guestTag: string): string[] {
+  return entry.rows
+    .filter((r) => r.beneficiary_guest_id != null || r.profile_id !== me)
+    .map((r) => beneficiaryLabel(r, guestTag))
+}
+
+/**
+ * The name of whoever paid this entry when it was NOT the viewer, else null.
+ *
+ * Null rather than a placeholder when the `payer` embed is missing: a query
+ * that forgot the hint should render nothing, not "Paid by —", which reads like
+ * a data loss the member is expected to act on.
+ */
+export function payerName(entry: LedgerEntry, me: string): string | null {
+  const head = entry.rows[0]
+  if (payerOf(head) === me) return null
+  const p = head.payer
+  if (p == null) return null
+  return `${p.first_name} ${p.last_name}`
+}
+
+function addTo(bucket: CurrencyTotals, row: LedgerRow): void {
+  const currency = currencyOf(row)
+  bucket[currency] = (bucket[currency] ?? 0) + Number(row.amount)
+}
+
+/**
+ * Lifetime approved totals, reduced over RAW rows.
+ *
+ * Reducing over `ledgerEntries` instead would double-count: a payer who
+ * included themselves in a group of three sees one entry worth all three
+ * shares, and their own share is simultaneously their own fee and part of the
+ * transfer. Raw rows have no such overlap — every row lands in exactly one
+ * bucket.
+ *
+ * The guest case is the subtle one. `payments_guest_ledger_check` forces a
+ * guest row to satisfy `profile_id = paid_by_profile_id`, so it LOOKS like the
+ * payer paying themselves. It is money paid for somebody else and belongs in
+ * `onBehalf`; counting it in `paid` is exactly the miscount 2607-DEV-677 was
+ * filed for.
+ *
+ * Approved only, matching `personalApprovedTotal` — pending money has not moved
+ * as far as the club is concerned, and rejected money never will.
+ */
+export function lifetimeTotals(rows: readonly LedgerRow[], me: string): LifetimeTotals {
+  const totals: LifetimeTotals = { paid: {}, onBehalf: {}, paidForMe: {} }
+
+  for (const row of rows) {
+    if (row.admin_status !== 'approved') continue
+
+    const payer = payerOf(row)
+    const isMine = row.profile_id === me
+    // == null covers both null and undefined: a caller that failed to select
+    // the column must not have guest money counted as the viewer's own.
+    const isForGuest = row.beneficiary_guest_id != null
+
+    if (payer === me) {
+      // TRUE when the row sits on my ledger AND names no guest — the only
+      // shape that is money towards my own fee.
+      if (isMine && !isForGuest) addTo(totals.paid, row)
+      else addTo(totals.onBehalf, row)
+    } else if (isMine) {
+      addTo(totals.paidForMe, row)
+    }
+    // Neither payer nor owner: not the viewer's money in either direction.
+    // GET /api/payments does not return such rows today; ignoring them keeps
+    // the reduce correct if it ever does.
+  }
+
+  return totals
+}
+
+// ── CSV export ────────────────────────────────────────────────────────────────
+
+/** U+FEFF byte-order mark, constructed rather than pasted so this source file
+ *  does not itself contain a stray BOM in the middle of a line. */
+const BOM = String.fromCharCode(0xfeff)
+
+/** RFC 4180: wrap every field, double any embedded quote. Matches lib/csv-export.ts. */
+function csvQuote(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`
+}
+
+const CSV_HEADERS = [
+  'Date',
+  'Amount',
+  'Currency',
+  'Status',
+  'Method',
+  'Item',
+  'Paid for',
+  'Paid by',
+  'Note',
+] as const
+
+/**
+ * One line per RAW payment row — never per collapsed entry.
+ *
+ * An export is an audit artifact: the reader wants the rows as recorded, and a
+ * collapsed group would hide which share went to whom, which is the entire
+ * point of exporting an on-behalf ledger.
+ *
+ * `proof_url` is deliberately absent. It is a key into a private bucket, not a
+ * URL (see proof.ts), and a column of unusable storage paths in a spreadsheet
+ * is worse than no column: it invites someone to paste one into a browser and
+ * conclude the proof is gone.
+ *
+ * `guestTag` is a parameter for the same reason `beneficiaryLabel`'s is: this
+ * module is framework-free and the tag is translated by the caller. The default
+ * keeps the helper usable from a test without a translation table.
+ */
+export function toLedgerCSV(rows: readonly LedgerRow[], guestTag = 'guest'): string {
+  const lines: string[] = [CSV_HEADERS.map(csvQuote).join(',')]
+
+  for (const row of rows) {
+    lines.push(
+      [
+        row.transaction_date,
+        // Not toFixed(): the amount is written for a spreadsheet, and a locale
+        // that reads '.' as a thousands separator is a formatting concern of
+        // the file's reader, not something a fixed decimal count fixes.
+        String(row.amount),
+        currencyOf(row),
+        row.admin_status,
+        row.payment_method ?? '',
+        titleOf(row),
+        beneficiaryLabel(row, guestTag),
+        row.payer ? `${row.payer.first_name} ${row.payer.last_name}` : '',
+        row.note ?? '',
+      ]
+        .map(csvQuote)
+        .join(','),
+    )
+  }
+
+  // BOM + CRLF, matching buildMembersCSV: without the BOM, Excel renders
+  // Cyrillic names as mojibake.
+  return BOM + lines.join('\r\n') + '\r\n'
+}

--- a/lib/payments/ledger.ts
+++ b/lib/payments/ledger.ts
@@ -38,7 +38,7 @@ import { payerOf } from './proof'
 import { beneficiaryLabel } from './labels'
 // The repo's one RFC-4180 field quoter. Reused rather than re-implemented so a
 // correction to the escaping rule cannot land in only one of two exports.
-import { csvQuote } from '../csv-export'
+import { csvQuote, csvSafe } from '../csv-export'
 
 /**
  * The columns this module reads. Declared structurally rather than importing
@@ -71,7 +71,8 @@ export type LedgerRow = {
 
 /** One line in the ledger: either a single payment or one collapsed group. */
 export type LedgerEntry = {
-  /** `g:${payment_group_id}` for a collapsed group, `p:${row.id}` otherwise. */
+  /** `g:${payment_group_id}:${currency}` for a collapsed group, `p:${row.id}`
+   *  otherwise. Currency is in the key because the total sums the bucket. */
   key: string
   /** Every raw row this entry stands for, in input order. Never empty. */
   rows: LedgerRow[]
@@ -139,7 +140,13 @@ export function ledgerEntries(rows: readonly LedgerRow[], me: string): LedgerEnt
     // Collapse only when BOTH hold: the row belongs to a group, and the viewer
     // is the one who transferred the money. Anything else is its own entry.
     const collapse = row.payment_group_id != null && payerOf(row) === me
-    const key = collapse ? `g:${row.payment_group_id}` : `p:${row.id}`
+    // Currency is part of the key, not just of the head row: `amount` sums the
+    // whole bucket while `currency` reports one code, so a group holding two
+    // denominations would render a single total in the head's currency and
+    // formatCurrency would give that wrong number a plausible symbol.
+    // submit_payment_group writes one currency per group today; keying on it
+    // means this stays arithmetic rather than an assumption.
+    const key = collapse ? `g:${row.payment_group_id}:${currencyOf(row)}` : `p:${row.id}`
     const bucket = buckets.get(key)
     if (bucket) {
       bucket.push(row)
@@ -300,14 +307,21 @@ export function toLedgerCSV(rows: readonly LedgerRow[], guestTag = 'guest'): str
         // Not toFixed(): the amount is written for a spreadsheet, and a locale
         // that reads '.' as a thousands separator is a formatting concern of
         // the file's reader, not something a fixed decimal count fixes.
+        //
+        // NOT csvSafe'd, unlike the text columns below: a negative amount opens
+        // with '-', and prefixing it would demote a numeric cell to text — the
+        // one place the guard would do harm. The value is a JS number rendered
+        // by String(), so it cannot carry a formula in the first place.
         String(row.amount),
         currencyOf(row),
         row.admin_status,
-        row.payment_method ?? '',
-        titleOf(row),
-        beneficiaryLabel(row, guestTag),
-        row.payer ? `${row.payer.first_name} ${row.payer.last_name}` : '',
-        row.note ?? '',
+        // Everything from here down is free text a member or admin typed, or a
+        // name they chose, so each is a formula-injection vector on its own.
+        csvSafe(row.payment_method ?? ''),
+        csvSafe(titleOf(row)),
+        csvSafe(beneficiaryLabel(row, guestTag)),
+        csvSafe(row.payer ? `${row.payer.first_name} ${row.payer.last_name}` : ''),
+        csvSafe(row.note ?? ''),
       ]
         .map(csvQuote)
         .join(','),

--- a/scripts/seed-clerk-test-users.js
+++ b/scripts/seed-clerk-test-users.js
@@ -112,6 +112,11 @@ const DOWNLINE_ABO = process.env.E2E_CLERK_DOWNLINE_ABO ?? 'E2E-DOWNLINE-0001'
 // and BeneficiaryPicker renders `{abo_number ? `${abo} · ` : ''}{relation}`, so
 // an ABO-less row carries no '·' and cannot be picked up by the #676 spec's
 // `.filter({ hasText: /·/ })` locator — which must keep selecting the downline.
+//
+// Only used when the member has NO co-owner yet. profiles.primary_profile_id is
+// UNIQUE (profiles_primary_profile_id_key), so a primary profile may have at
+// most one — creating unconditionally raised a raw duplicate-key error against
+// the co-owner the hosted DEV project already carried. See ensureCoowner.
 const COOWNER_CLERK_ID = 'seed_e2e_coowner_tevd_portal'
 
 // 50.00 EUR. Cents, because that is the only unit submit_payment_group accepts.
@@ -272,6 +277,39 @@ async function ensurePayableItem(supabase, createdByProfileId) {
   return { id: created.id, status: 'created' }
 }
 
+// The member's co-owner, reused when one already exists.
+//
+// profiles.primary_profile_id is UNIQUE, so "create a co-owner for the member"
+// is only valid when the member has none — the hosted DEV project already
+// carries one (`e2e_member_coowner`, planted outside this script), and creating
+// a second raised profiles_primary_profile_id_key. Reusing is also the more
+// honest fixture: whoever the member's co-owner IS, is who can pay for them.
+//
+// Returns the profile id either way; the caller does not care which happened
+// beyond the log line.
+async function ensureCoowner(supabase, memberProfileId) {
+  const { data: existing, error: readError } = await supabase
+    .from('profiles')
+    .select('id, first_name, last_name')
+    .eq('primary_profile_id', memberProfileId)
+    .maybeSingle()
+  if (readError) throw new Error(`co-owner lookup failed: ${readError.message}`)
+  if (existing != null) {
+    return { id: existing.id, status: `reused ${existing.first_name} ${existing.last_name}` }
+  }
+
+  const id = await upsertProfile(supabase, COOWNER_CLERK_ID, {
+    role: 'member',
+    firstName: 'E2E',
+    lastName: 'Coowner',
+    email: 'e2e-coowner-tevd-portal@example.com',
+    // NULL by design — see COOWNER_CLERK_ID above.
+    aboNumber: null,
+    primaryProfileId: memberProfileId,
+  })
+  return { id, status: 'created' }
+}
+
 // One payment group the CO-OWNER paid for the MEMBER, so the member's ledger
 // carries a row attributable to somebody else (L3, 2608-DEV-688).
 //
@@ -406,21 +444,13 @@ async function main() {
   )
 
   // ── paid-for-me fixture (L3, 2608-DEV-688) ─────────────────────────────────
-  const coownerProfileId = await upsertProfile(supabase, COOWNER_CLERK_ID, {
-    role: 'member',
-    firstName: 'E2E',
-    lastName: 'Coowner',
-    email: 'e2e-coowner-tevd-portal@example.com',
-    // NULL by design — see COOWNER_CLERK_ID above.
-    aboNumber: null,
-    primaryProfileId: memberProfileId,
-  })
-  console.log(`seed-clerk-test-users: co-owner ready — linked to ${MEMBER_EMAIL}`)
+  const coowner = await ensureCoowner(supabase, memberProfileId)
+  console.log(`seed-clerk-test-users: co-owner ${coowner.status} — linked to ${MEMBER_EMAIL}`)
 
   const paidForMe = await ensurePaidForMePayment(
     supabase,
     memberProfileId,
-    coownerProfileId,
+    coowner.id,
     payableItem.id,
   )
   console.log(

--- a/scripts/seed-clerk-test-users.js
+++ b/scripts/seed-clerk-test-users.js
@@ -13,6 +13,12 @@
  * vacuously, so the #676 happy path is never exercised. The downline never
  * signs in, so it gets no Clerk user — only a profiles row.
  *
+ * And the mirror image of that, for L3 of 2608-DEV-688: a CO-OWNER profile plus
+ * one payment group that co-owner paid FOR the member. Without it the member's
+ * ledger holds nothing anybody else paid, "Paid by X" never renders, and the L3
+ * spec had to skip — a green run that had asserted nothing. Neither fixture
+ * signs in; both are profiles rows only.
+ *
  * Idempotent: looks up each user by email before creating. Users are created
  * with skipPasswordRequirement — the suite signs in via Clerk's ticket
  * strategy (@clerk/testing's `clerk.signIn({ emailAddress })`), never a
@@ -91,6 +97,26 @@ const TEST_USERS = [
 const DOWNLINE_CLERK_ID = 'seed_e2e_downline_tevd_portal'
 const DOWNLINE_ABO = process.env.E2E_CLERK_DOWNLINE_ABO ?? 'E2E-DOWNLINE-0001'
 
+// The co-owner fixture: the profile that pays FOR the member, so the member's
+// ledger carries a row they did not pay themselves (L3, 2608-DEV-688).
+//
+// A co-owner, not a second downline, because `get_payable_beneficiaries`
+// reaches DOWNWARD only — "nothing here ever reaches UPWARD" — so no downline
+// of the member may pay for them. The `household` branch
+// (`p.id = v_viewer.primary_profile_id`, both directions) is the one relation
+// that makes the member payable BY someone else without restructuring the LOS
+// tree the specs above depend on.
+//
+// abo_number stays NULL on purpose, and that is load-bearing twice over:
+// trg_guard_abo_number_null exempts co-owners (primary_profile_id IS NOT NULL),
+// and BeneficiaryPicker renders `{abo_number ? `${abo} · ` : ''}{relation}`, so
+// an ABO-less row carries no '·' and cannot be picked up by the #676 spec's
+// `.filter({ hasText: /·/ })` locator — which must keep selecting the downline.
+const COOWNER_CLERK_ID = 'seed_e2e_coowner_tevd_portal'
+
+// 50.00 EUR. Cents, because that is the only unit submit_payment_group accepts.
+const PAID_FOR_ME_CENTS = 5000
+
 // The generic payment form always renders its item <select>, so with no active
 // payable item the only options are the placeholder and nothing — which the
 // spec treats as an unusable environment and skips
@@ -140,7 +166,11 @@ async function assertAboNumberFree(supabase, clerkId, aboNumber, email) {
 // Returns the profile id — the downline fixture below needs both the member's
 // and the admin's, and re-selecting them afterwards would be a second round trip
 // that can disagree with what was just written.
-async function upsertProfile(supabase, clerkId, { role, firstName, lastName, email, aboNumber }) {
+async function upsertProfile(
+  supabase,
+  clerkId,
+  { role, firstName, lastName, email, aboNumber, primaryProfileId = null },
+) {
   await assertAboNumberFree(supabase, clerkId, aboNumber, email)
 
   const { data, error } = await supabase
@@ -152,6 +182,10 @@ async function upsertProfile(supabase, clerkId, { role, firstName, lastName, ema
         last_name: lastName,
         role,
         abo_number: aboNumber ?? null,
+        // Non-null only on the co-owner fixture. It is what makes the profile a
+        // co-owner at all: `get_payable_beneficiaries`'s household branch reads
+        // it, and trg_guard_abo_number_null keys its exemption off it.
+        primary_profile_id: primaryProfileId,
         contact_email: email,
         display_names: { en: `${firstName} ${lastName}` },
       },
@@ -193,6 +227,10 @@ async function ensureTreeNode(supabase, profileId, aboNumber, sponsorAboNumber, 
 
 // payable_items has no natural unique key, so guard on title — the same shape
 // supabase/seed.sql uses for its sample trip.
+//
+// Returns { id, status }: the on-behalf payment fixture below needs the id, and
+// re-selecting it afterwards would be a second round trip that can disagree
+// with what was just written (same reasoning as upsertProfile's return).
 async function ensurePayableItem(supabase, createdByProfileId) {
   const { data: existing, error: readError } = await supabase
     .from('payable_items')
@@ -207,24 +245,72 @@ async function ensurePayableItem(supabase, createdByProfileId) {
   // key), so repair the row in place; inserting would leave two items sharing a
   // title and break the .maybeSingle() above on the next run.
   if (existing != null) {
-    if (existing.is_active === true && existing.currency === 'EUR') return 'present'
+    if (existing.is_active === true && existing.currency === 'EUR') {
+      return { id: existing.id, status: 'present' }
+    }
     const { error: repairError } = await supabase
       .from('payable_items')
       .update({ is_active: true, currency: 'EUR' })
       .eq('id', existing.id)
     if (repairError) throw new Error(`payable_items repair failed: ${repairError.message}`)
-    return 'repaired'
+    return { id: existing.id, status: 'repaired' }
   }
 
-  const { error } = await supabase.from('payable_items').insert({
-    title: PAYABLE_ITEM_TITLE,
-    amount: 100,
-    currency: 'EUR',
-    item_type: 'other',
-    is_active: true,
-    created_by: createdByProfileId,
-  })
+  const { data: created, error } = await supabase
+    .from('payable_items')
+    .insert({
+      title: PAYABLE_ITEM_TITLE,
+      amount: 100,
+      currency: 'EUR',
+      item_type: 'other',
+      is_active: true,
+      created_by: createdByProfileId,
+    })
+    .select('id')
+    .single()
   if (error) throw new Error(`payable_items insert failed: ${error.message}`)
+  return { id: created.id, status: 'created' }
+}
+
+// One payment group the CO-OWNER paid for the MEMBER, so the member's ledger
+// carries a row attributable to somebody else (L3, 2608-DEV-688).
+//
+// Written through submit_payment_group rather than a direct insert. A hand-built
+// row could set paid_by_profile_id to anyone at all and would be a fixture the
+// application itself could never produce; going through the RPC means the seed
+// exercises can_pay_for and the group-pair CHECK, so if eligibility ever changes
+// shape this fails loudly here instead of quietly rendering an impossible ledger.
+//
+// Idempotent on the (beneficiary, payer) pair, not on the group id: the id is
+// generated inside the RPC, so re-running would otherwise stack a fresh group
+// per invocation and the ledger would grow without bound on a shared DEV project.
+async function ensurePaidForMePayment(supabase, memberProfileId, coownerProfileId, payableItemId) {
+  const { data: existing, error: readError } = await supabase
+    .from('payments')
+    .select('id')
+    .eq('profile_id', memberProfileId)
+    .eq('paid_by_profile_id', coownerProfileId)
+    .limit(1)
+  if (readError) throw new Error(`paid-for-me payment lookup failed: ${readError.message}`)
+  if (existing.length > 0) return 'present'
+
+  const { error } = await supabase.rpc('submit_payment_group', {
+    p_payer: coownerProfileId,
+    p_payload: {
+      payable_item_id: payableItemId,
+      trip_id: null,
+      currency: 'EUR',
+      transaction_date: new Date().toISOString().slice(0, 10),
+      payment_method: 'bank transfer',
+      // No proof_url: assertOwnProofPath would require a real object under the
+      // payer's storage prefix, and this fixture uploads nothing.
+      proof_url: null,
+      note: 'E2E fixture: paid on behalf of the member',
+      total_cents: PAID_FOR_ME_CENTS,
+      beneficiaries: [{ profile_id: memberProfileId, amount_cents: PAID_FOR_ME_CENTS }],
+    },
+  })
+  if (error) throw new Error(`submit_payment_group failed for the paid-for-me fixture: ${error.message}`)
   return 'created'
 }
 
@@ -314,9 +400,32 @@ async function main() {
   // Names which of the three outcomes happened: the spec skips unless this row
   // is active and EUR, so "repaired" is the line that explains a run that used
   // to skip and now does not.
-  const itemStatus = await ensurePayableItem(supabase, profileIdByRole.admin)
+  const payableItem = await ensurePayableItem(supabase, profileIdByRole.admin)
   console.log(
-    `seed-clerk-test-users: payable item "${PAYABLE_ITEM_TITLE}" ${itemStatus} — active, EUR`,
+    `seed-clerk-test-users: payable item "${PAYABLE_ITEM_TITLE}" ${payableItem.status} — active, EUR`,
+  )
+
+  // ── paid-for-me fixture (L3, 2608-DEV-688) ─────────────────────────────────
+  const coownerProfileId = await upsertProfile(supabase, COOWNER_CLERK_ID, {
+    role: 'member',
+    firstName: 'E2E',
+    lastName: 'Coowner',
+    email: 'e2e-coowner-tevd-portal@example.com',
+    // NULL by design — see COOWNER_CLERK_ID above.
+    aboNumber: null,
+    primaryProfileId: memberProfileId,
+  })
+  console.log(`seed-clerk-test-users: co-owner ready — linked to ${MEMBER_EMAIL}`)
+
+  const paidForMe = await ensurePaidForMePayment(
+    supabase,
+    memberProfileId,
+    coownerProfileId,
+    payableItem.id,
+  )
+  console.log(
+    `seed-clerk-test-users: paid-for-me payment ${paidForMe} — ` +
+      `${PAID_FOR_ME_CENTS / 100} EUR from the co-owner onto the member's ledger`,
   )
 }
 


### PR DESCRIPTION
Closes #688.

## Problem

Attribution on an on-behalf payment survived only while the group was `pending`. `pendingGroupsIPaidFor` filtered on `admin_status === 'pending'`, so the moment an admin approved, the rows fell through to `groupByItem`, which keyed purely on item/trip title. After acceptance the payer saw N anonymous rows and could not tell whom they had paid for, and the beneficiary saw a row on their own ledger with no sign that someone else had paid it. The data was already on the wire — `/api/payments` selects both FK-hinted embeds — and was being thrown away.

## What changed

**`lib/payments/ledger.ts`** (new) is the single source for the three reads that were losing information:

- `currencyOf()` — `payments.currency` was selected by the API but never declared on the client type, so every reader fell back to `payable_items?.currency ?? 'EUR'`. A trip payment has no payable item, so **every trip payment was force-labelled EUR**. Fixed in passing.
- `ledgerEntries()` — collapses a group to the one bank transfer it was, but only for the payer: a beneficiary holds a single row of that group and, for them, one row is the truth. Entries partition the input, so the payer's own share inside a group they paid is never emitted twice. A mixed-status group reads `pending`, never `undefined` — `StatusBadge` calls `.toLowerCase()` on it.
- `lifetimeTotals()` — reduces over RAW rows into three per-currency buckets. Reducing over collapsed entries would double-count the payer's own share. A guest row satisfies `profile_id = paid_by_profile_id`, so it looks like a self-payment; counting it as one is the 2607-DEV-677 miscount, and it is bucketed as paid-on-behalf instead.
- `toLedgerCSV()` — one line per raw row, because an export is an audit artifact and a collapsed group hides which share went to whom. No `proof_url` column: it is a private-bucket key, not a URL.

**Bento** — `groupByItem` replaced by `ledgerEntries`; `VARIABLE_CAP` now caps collapsed entries, since a group *is* one transaction. `PaymentRow` gained a second line carrying `for A, B` / `Paid by X`. The "show more" drawer became a `next/link`.

**`/profile/payments`** (new) — status filter, 300 ms-debounced search, date range, lifetime totals, CSV export. No new API route: it reuses `GET /api/payments` under the same `['profile-generic-payments']` query key, so client-side navigation from the bento mounts it warm. Filtering happens at **entry** level, never row level — filtering rows first would render a three-person group with a partial total. One responsive file: `<table>` from `md:` up, stacked cards below.

## Decisions worth a reviewer's attention

- **Lifetime totals count `admin_status === 'approved'` only**, matching `personalApprovedTotal`. `payment.lifetimeNote` states this in both languages rather than leaving it implied.
- **No schema change, no migration, no new route, no TanStack Table.** `abo_number` deliberately stays out of the embeds — it is null for exactly the people it would identify.
- `PaymentRow`'s signature changed from `{ pay, cancelledTripIds }` to `{ entry, me, cancelledTripIds }`. Sole caller updated; `ShowMoreButton` keeps its three other callers.

## Out of scope (noted, not fixed)

- `shared.tsx` renders `proof_url` as an `href` although it is a storage key. Already broken; deliberately not propagated into the new page or the CSV.
- `shared.tsx` gates the cancelled-trip marker on `payable_items?.item_type === 'trip'`, always false for a real trip payment. Carried through unchanged.
- `LogPaymentDrawer.tsx:60` merges `membersData.manual_members_no_abo`, a key `/api/admin/members` never emits.
- `pendingGroupsIPaidFor` compares `paid_by_profile_id` directly instead of via `payerOf`, so a legacy pending group with a NULL payer gets no withdraw card.

## Verification

| Check | Result |
|---|---|
| `npx vitest run lib/payments` | 5 files / 88 passed (baseline 4 / 58) |
| `npx vitest run --exclude lib/actions/guest-registration.test.ts` | 23 files / 311 passed |
| `npm run check-types` | clean |
| `npm run lint` | 0 errors; new files add no warnings |
| `npm run build` | success, `/profile/payments` in the route table |
| `playwright --project=authenticated` | passing (run by the author) |

Matrix L1–L7 asserted in unit tests; L3 and L8 in `e2e/payments-on-behalf.spec.ts`, appended to the existing file since it is already in the `authenticated` `testMatch` and both `testIgnore` regexes.

**Gate:** not Done until the Vercel preview is READY and CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated payments ledger with lifetime totals, search, status/date filters, sorting, and responsive layouts.
  * Added CSV export with safer spreadsheet handling.
  * Added payer and beneficiary attribution, payment methods, notes, statuses, and currency details.
  * Added navigation from the profile payments section to view all payments.
  * Added English and Bulgarian translations.

* **Bug Fixes**
  * Improved handling of multi-currency, guest, and incomplete payment records.
  * Prevented horizontal overflow on mobile payment views.

* **Tests**
  * Added comprehensive ledger and export coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->