### PR TITLE
[2608-DEV-690] Admin members route emits manual_members_no_abo

### DIFF
--- a/app/admin/payments/components/members.test.ts
+++ b/app/admin/payments/components/members.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import type { MembersResponse } from '@/lib/types/payments'
+import { dedupeMembers } from './members'
+
+describe('dedupeMembers', () => {
+  it('returns [] when data is undefined', () => {
+    expect(dedupeMembers(undefined)).toEqual([])
+  })
+
+  it('merges both halves and sorts by last_name', () => {
+    const data: MembersResponse = {
+      los_members: [
+        { profile: { id: 'p1', first_name: 'Zed', last_name: 'Zephyr', abo_number: '111' } },
+      ],
+      manual_members_no_abo: [
+        { id: 'p2', first_name: 'Amy', last_name: 'Adams', upline_abo_number: null },
+      ],
+    }
+
+    expect(dedupeMembers(data)).toEqual([
+      { id: 'p2', first_name: 'Amy', last_name: 'Adams', abo_number: null },
+      { id: 'p1', first_name: 'Zed', last_name: 'Zephyr', abo_number: '111' },
+    ])
+  })
+
+  it('keeps the ABO-carrying entry when an id appears in both halves', () => {
+    const data: MembersResponse = {
+      los_members: [
+        { profile: { id: 'p1', first_name: 'Jo', last_name: 'Co', abo_number: '999' } },
+      ],
+      manual_members_no_abo: [
+        { id: 'p1', first_name: 'Jo', last_name: 'Co', upline_abo_number: null },
+      ],
+    }
+
+    expect(dedupeMembers(data)).toEqual([
+      { id: 'p1', first_name: 'Jo', last_name: 'Co', abo_number: '999' },
+    ])
+  })
+
+  it('skips los_members rows with no linked profile', () => {
+    const data: MembersResponse = {
+      los_members: [{ profile: null }],
+      manual_members_no_abo: [],
+    }
+
+    expect(dedupeMembers(data)).toEqual([])
+  })
+})

--- a/app/api/admin/members/route.test.ts
+++ b/app/api/admin/members/route.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+// Regression coverage for #690: the route's second `profiles` query
+// (manual_members_no_abo) was never built, so the key was silently absent
+// from the response. Extends the chainable-mock template from
+// app/api/admin/members/[id]/route.test.ts with the .is/.in/.not passthroughs
+// that template lacked, and routes `profiles` results by call order since
+// this route queries `profiles` three times (admin guard, LOS-linked,
+// manual no-ABO) with different filters each time.
+
+type QueryResult = { data: unknown; error: { message: string } | null }
+
+function chainable(result: QueryResult): Record<string, unknown> {
+  const obj: Record<string, unknown> = {}
+  const passthrough = () => vi.fn(() => obj)
+  obj.select = passthrough()
+  obj.eq = passthrough()
+  obj.order = passthrough()
+  obj.not = passthrough()
+  obj.in = passthrough()
+  obj.is = passthrough()
+  obj.single = () => Promise.resolve(result)
+  obj.then = (resolve: (v: QueryResult) => void, reject: (e: unknown) => void) =>
+    Promise.resolve(result).then(resolve, reject)
+  return obj
+}
+
+const mockAuth = vi.fn()
+const mockCreateServiceClient = vi.fn()
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: () => mockAuth(),
+}))
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: () => mockCreateServiceClient(),
+}))
+
+beforeEach(() => {
+  mockAuth.mockReset()
+  mockCreateServiceClient.mockReset()
+})
+
+/**
+ * `profiles` is queried three times in order: admin guard (`.eq().single()`),
+ * LOS-linked profiles (`.not()`), manual no-ABO profiles (`.in().is()`).
+ * `profilesResults` supplies results for each call in that order.
+ */
+function mockSupabase(
+  losResult: QueryResult,
+  profilesResults: QueryResult[]
+): { client: SupabaseClient; profilesBuilders: Record<string, unknown>[] } {
+  let callIndex = 0
+  const profilesBuilders: Record<string, unknown>[] = []
+  const from = (table: string) => {
+    if (table === 'los_members') return chainable(losResult)
+    if (table === 'profiles') {
+      const result = profilesResults[callIndex] ?? profilesResults[profilesResults.length - 1]
+      callIndex++
+      const builder = chainable(result)
+      profilesBuilders.push(builder)
+      return builder
+    }
+    throw new Error(`unexpected table: ${table}`)
+  }
+  return { client: { from } as unknown as SupabaseClient, profilesBuilders }
+}
+
+const adminGuard: QueryResult = { data: { id: 'p_admin', role: 'admin' }, error: null }
+const memberGuard: QueryResult = { data: { id: 'p_member', role: 'member' }, error: null }
+const emptyLos: QueryResult = { data: [], error: null }
+
+describe('GET /api/admin/members', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockAuth.mockResolvedValue({ userId: null })
+    const { GET } = await import('@/app/api/admin/members/route')
+
+    const res = await GET()
+    expect(res.status).toBe(401)
+    expect(mockCreateServiceClient).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 for a non-admin caller', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client } = mockSupabase(emptyLos, [memberGuard])
+    mockCreateServiceClient.mockReturnValue(client)
+    const { GET } = await import('@/app/api/admin/members/route')
+
+    const res = await GET()
+    expect(res.status).toBe(403)
+  })
+
+  it('admin response carries both keys, with the ABO-less query role- and null-filtered', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_admin' })
+    const manualResult: QueryResult = {
+      data: [{ id: 'p_coowner', first_name: 'Jo', last_name: 'Co', upline_abo_number: '123' }],
+      error: null,
+    }
+    const abolinkedResult: QueryResult = { data: [], error: null }
+    const { client, profilesBuilders } = mockSupabase(emptyLos, [
+      adminGuard,
+      abolinkedResult,
+      manualResult,
+    ])
+    mockCreateServiceClient.mockReturnValue(client)
+    const { GET } = await import('@/app/api/admin/members/route')
+
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({
+      los_members: [],
+      manual_members_no_abo: manualResult.data,
+    })
+
+    const manualBuilder = profilesBuilders[2]
+    expect(manualBuilder.in).toHaveBeenCalledWith('role', ['member', 'core'])
+    expect(manualBuilder.is).toHaveBeenCalledWith('abo_number', null)
+  })
+})

--- a/app/api/admin/members/route.ts
+++ b/app/api/admin/members/route.ts
@@ -38,5 +38,15 @@ export async function GET() {
     profile: profilesByAbo[m.abo_number] ?? null,
   }))
 
-  return Response.json({ los_members: enrichedLOS })
+  // Household co-owners: role-guarded to have no abo_number (trg_guard_abo_number_null),
+  // so they can never appear in the LOS-joined list above.
+  const { data: manualMembers, error: manualErr } = await supabase
+    .from('profiles')
+    .select('id, first_name, last_name, upline_abo_number')
+    .in('role', ['member', 'core'])
+    .is('abo_number', null)
+
+  if (manualErr) return Response.json({ error: manualErr.message }, { status: 500 })
+
+  return Response.json({ los_members: enrichedLOS, manual_members_no_abo: manualMembers ?? [] })
 }

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #688 | `dev/2608-DEV-688` | `lib/payments/ledger.ts` (new) + its test · `app/(dashboard)/profile/types.ts` · `profile/components/{PaymentsSection,shared}.tsx` · `app/(dashboard)/profile/payments/**` (new route) · `lib/i18n/domains/payment.ts` · `e2e/payments-on-behalf.spec.ts` — **migration: no** | 2026-08-03 |
+| #690 | `dev/2608-DEV-690` | `app/api/admin/members/route.ts` + its test (new) · `app/admin/payments/components/members.test.ts` (new) — **migration: no** | 2026-08-04 |


### PR DESCRIPTION
## Summary
- `app/api/admin/members/route.ts` adds the missing second `profiles` query (`role IN ('member','core')` and `abo_number IS NULL`) and returns it as `manual_members_no_abo`, so household co-owners are reachable from `GuestLinkPanel` and `LogPaymentDrawer` for the first time.
- `lib/types/payments.ts` is unchanged — `manual_members_no_abo` was already declared required; it's just true now.

Closes #690

## Test plan
- [x] `npm run check-types` clean
- [x] `npm run lint` 0 errors
- [x] `npx vitest run --exclude lib/actions/guest-registration.test.ts` green (25 files / 323 tests)
- [x] New `app/api/admin/members/route.test.ts`: 401 / 403 / admin response carries both keys, ABO-less query asserted role- and null-filtered
- [x] New `app/admin/payments/components/members.test.ts`: `dedupeMembers` merge, first-occurrence-wins, sort by last_name
- [ ] Vercel preview READY
- [ ] On DEV, `/admin/payments` log-payment dropdown lists the ABO-less co-owner (`clerk_id = e2e_member_coowner`)

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] Route change + tests, all local checks green
**Next:** Verify Vercel preview READY + CI green, manual DEV dropdown check, then mark ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin member listings now include manual members without an ABO number, alongside existing LOS members.
  * Added appropriate role and profile filtering for these member records.
  * Failed profile lookups now return a server error response.

* **Tests**
  * Added coverage for member deduplication, sorting, data retention, authentication, authorization, filtering, and API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->