### PR TITLE
[2608-DEV-625] Guest-invite rate limits: atomic check-then-act

### DIFF
--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,4 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #690 | `dev/2608-DEV-690` | `app/api/admin/members/route.ts` + its test (new) · `app/admin/payments/components/members.test.ts` (new) — **migration: no** | 2026-08-04 |
+| #625 | `dev/2608-DEV-625` | `lib/rate-limit.ts` (+ new test) · `lib/actions/guest-registration.ts` · `lib/notifications/guest-event-changes.ts` (+ both tests) · `supabase/migrations/20260804000000_2608_feat_625_atomic_rate_limits.sql` (new) · `types/supabase.ts` — **migration: yes** | 2026-08-04 |

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,207 +1,191 @@
 ## Goal
-BUILD issue #688 (2608-DEV-688, branch `dev/2608-DEV-688`): keep on-behalf payment attribution
-visible AFTER admin approval, collapse an approved on-behalf group to the one bank transfer it
-was, add a `/profile/payments` drill-down ledger (status filter, debounced search, date range,
-lifetime totals, CSV export), and fix the trip-payment "always EUR" mislabel on the way.
+BUILD issue #625 (2608-DEV-625, branch `dev/2608-DEV-625`): replace the two JS-side
+count-then-decide guest-invite rate limits with ONE atomic `SECURITY DEFINER` RPC
+(`consume_rate_limit`) over a self-pruning `rate_limit_events` ledger, so a parallel burst is
+actually capped instead of every caller reading the same stale count.
 
 ## Now
-BUILD steps 1-3 are CODE-COMPLETE and statically verified; step 4's spec is WRITTEN but has
-never been EXECUTED. All 9 files in the DoD are edited. Nothing is committed yet.
-BUILD complete, pushed (`83dc0f6`), authenticated E2E confirmed passing by the user, DRAFT PR
-open. Waiting on CI green + Vercel preview READY before marking it ready for review.
+BUILD steps 1-5 COMPLETE and verified (see Done). All 8 DoD files edited, migration applied to
+DEV, types regenerated, concurrency proof passed. Nothing committed yet.
 
 ## Next
-1. DRAFT PR open (requested by the user 2026-08-03: "Where is the PR at? Maybe create that").
-   Wait for CI green + Vercel preview READY, then mark it ready for review.
-2. One CodeRabbit pass — fetch its INLINE comments, not just the check status.
-3. Merge, then GCR: drop the `docs/CLAIMS.md` row IN the merging PR, close #688.
-4. Before #688 reaches prod, execute the #677 prod tail below — it has a migration that never
-   landed.
+0. Run the review pass (`/security-review` — this touches RLS, a SECURITY DEFINER function and a
+   migration), fix findings locally, THEN ask the user before any commit/push.
+
+## Next (original build order, all done)
+1. Step 1: write `supabase/migrations/20260804000000_2608_feat_625_atomic_rate_limits.sql`
+   (table + RPC + grants + nightly cron sweep + `-- ROLLBACK:` header). Check: file reads back
+   clean; real check is step 5's `supabase db push`.
+2. Step 2: rewrite `lib/rate-limit.ts` — `checkEmailCap` -> `consumeEmailCap`,
+   `checkRegistrationThrottle` -> `consumeRegistrationSlot`, both calling the RPC, both
+   fail-closed, plus the transitional `PGRST202`/`42883` fallback to the old count path.
+   Check: `npm run check-types`.
+3. Step 3: REFERENCE SWEEP + call sites — `lib/actions/guest-registration.ts:12,112,192,278,287`
+   and `lib/notifications/guest-event-changes.ts:12,99,138`. Check: `npm run check-types`.
+4. Step 4: tests — new `lib/rate-limit.test.ts`; switch `guest-registration.test.ts` and
+   `guest-event-changes.test.ts` to module-mock the new export names. Check:
+   `npx vitest run lib/rate-limit lib/actions/guest-registration.test.ts lib/notifications/guest-event-changes.test.ts`.
+5. Step 5: `supabase db push` to DEV, regenerate `types/supabase.ts`, run the 40-parallel
+   concurrency proof (exactly 30 true), `npm run lint` + `npm run build`.
+6. `/code-review low` on the diff (auth/RLS/migration -> escalate per BUILD.md), then ASK the
+   user before any push.
 
 ## Constraints
-- Never push to `main`; `dev/2608-DEV-688` only.
-- No `git push` unless the user asks for a push in this conversation (quote required).
-  GRANTED 2026-08-03, verbatim: "push to github so I can start tomorrow ready to go with BUILD".
-  Scope: push `dev/2608-DEV-688`. Does NOT cover opening a PR or merging — ask again for both.
-  RE-GRANTED 2026-08-03 for the BUILD commit, user selected "Push now" ("Push
-  dev/2608-DEV-688 to origin now. Does not open a PR"). Opening the PR still needs its own ask.
+- Never push to `main`; `dev/2608-DEV-625` only. The branch has NO upstream configured
+  (`git rev-parse --abbrev-ref @{u}` -> fatal), so a bare `git push` cannot hit main.
+- No `git push` unless the user asks for a push in THIS conversation, quoted beside the command.
+  GRANTED 2026-08-04, verbatim: "draft PR, commit everything necessary". Scope: commit the #625
+  work, push `dev/2608-DEV-625`, open the PR AS A DRAFT. Does NOT cover marking the PR ready for
+  review or merging — ask again for both.
 - Never weaken a check to make it pass.
 - Fold the `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR — NEVER a
   standalone cleanup PR.
 - Change only what the DoD requires; log other findings as `NOTED (not done): <thing> <file:line>`.
 - Ask before editing `docs/guardrails/PROJECT.md`.
-- Issue-stated out of scope, must NOT be fixed here and must NOT be propagated into the new page
-  or the CSV export: `shared.tsx:131-133` renders `proof_url` as an `href` although it is a
-  private-bucket storage KEY, not a URL (`lib/payments/proof.ts:1-10`).
-- Issue-stated: NO new API route, NO schema change, NO TanStack Table, and `abo_number` is
-  deliberately NOT added to the embeds (it is null for exactly the people it would identify).
-- Issue-stated: ONE responsive layout file for the ledger table. 6 columns permits a dual layout
-  under the Layout Decision Rules but does not require one; two files would duplicate ~40 lines.
+- Issue-stated: preserve existing scoping exactly — email+template for the 3/h resend cap, email
+  alone for the 10/day cap, `share_link_id` else `event_id` for the 30/h throttle — and preserve
+  fail-closed-on-error.
+- Issue-stated `NOTED (not done)`: the two `consumeEmailCap` calls in `resendGuestLink` keep their
+  current order (daily cap second, so a daily-blocked recipient burns an hourly slot). Do NOT
+  reorder — the tests deliberately assert that order.
+- No RLS policy is written on `rate_limit_events` at all (deny-by-default, service-role only), so
+  the Pattern A / `auth.jwt()` trap is avoided by construction.
 
 ## Decisions
-- DECISION (PLAN 2026-08-03): #677 landed FIRST (`5311a9c`), so #688 is the second lander and owns
-  the guest extension. The NAMING half already ships — `payment_guests(id, name)` is in the
-  `/api/payments` select, `beneficiary_guest_id`/`payment_guests` are on `GenericPayment`, and
-  `beneficiaryLabel()` in `lib/payments/labels.ts` already prefers the guest name. What #688 adds
-  is the TOTALS half.
-- DECISION: totals reduce over RAW rows, not over collapsed entries — reducing over entries
-  double-counts the payer's own share. Lifetime, unaffected by the filters, labelled as such.
-- DECISION: `VARIABLE_CAP` now caps collapsed ENTRIES, not raw rows. The bento's unit is "latest
-  transactions" and a group IS one transaction.
-- DECISION: the new client component lives at
-  `app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx`, matching
-  `profile/spouse-link/SpouseLinkClient.tsx` — not under `profile/components/`.
-- DECISION: the page reuses query key `['profile-generic-payments']`, so client-side navigation
-  from the bento mounts it warm off the existing cache. No second route, no refetch per keystroke.
-- DECISION: `payment.allPayments` is reused as the new page's title, so removing the "show more"
-  Drawer orphans no translation key.
+- DECISION (PLAN 2026-08-04): ledger + advisory lock, NOT a fixed-window counter table. A counter
+  keyed by `(key, bucket)` turns the sliding window into a fixed one and lets a burst straddling a
+  bucket boundary pass `2 x max`; the current guards are sliding and the issue requires preserving
+  them.
+- DECISION (PLAN 2026-08-04): the counting source moves off `notification_delivery_log` /
+  `guest_registrations` onto the new ledger — that move is what makes check-and-act one statement.
+  Two intended behavior changes follow (see Facts).
+- DECISION (PLAN 2026-08-04): rename `check*` -> `consume*` is mandatory, not cosmetic. Calling a
+  consuming operation `check` invites a double-call that burns two slots.
+- DECISION (PLAN 2026-08-04): ship the migration and the code in ONE PR with a `PGRST202` fallback,
+  rather than a migration-only PR followed by a code-only PR. Vercel deploys on merge while
+  `migrate-prod` waits for manual approval, so prod would briefly run new code against a schema
+  with no `consume_rate_limit` — and these guards fail CLOSED, which would deny every guest
+  registration and guest email on a public flow. The fallback closes that window; the two-PR
+  alternative costs a second full CI/preview cycle.
+- DECISION (BUILD 2026-08-04): `guest-registration.test.ts` and `guest-event-changes.test.ts`
+  module-mock `@/lib/rate-limit` (prior art: `guest-event-changes.test.ts:17-19` already does),
+  rather than driving the caps through the Supabase client fixture. The RPC no longer issues a
+  count query, so the fixtures' `notification_delivery_log` branches and their count-call-index
+  bookkeeping (`buildCapacityClient` assumes the throttle count runs BEFORE the capacity count)
+  would otherwise all be wrong. Key/window/max assertions live in the new `lib/rate-limit.test.ts`.
 
 ## Facts
-- Branch `dev/2608-DEV-688`, cut from `origin/main` @ `5311a9c`, upstream
-  `origin/dev/2608-DEV-688`. `git checkout -b X origin/main` sets the upstream to `origin/main` —
-  a bare `git push` would then target main; this branch was corrected with
-  `git branch --unset-upstream` before its first push.
-- BUILD BASELINE, captured 2026-08-03 before any edit:
-  `npx vitest run lib/payments` -> `Test Files 4 passed (4)`, `Tests 58 passed (58)`.
-- WIDER baseline is RED and NOT caused by any current work:
-  `lib/actions/guest-registration.test.ts` fails 2-3 of its 24 tests non-deterministically (spy
-  pollution surfacing under this machine's slowness). Run
-  `npx vitest run --exclude lib/actions/guest-registration.test.ts` and compare against that, never
-  against green.
-- Key symbols: `payerOf` -> `lib/payments/proof.ts:43`; `guestLabel`/`beneficiaryLabel` ->
-  `lib/payments/labels.ts`; `personalApprovedTotal` -> `lib/payments/totals.ts:30`;
-  CSV quoting prior art -> `lib/csv-export.ts:70-99` + `app/admin/members/components/MembersTable.tsx:88-93`;
-  300 ms search debounce prior art -> `app/admin/calendar/components/AdminCalendarClient.tsx:54-69`;
-  `GenericPayment` -> `app/(dashboard)/profile/types.ts:113-152`.
-- `e2e/payments-on-behalf.spec.ts` is already in the `authenticated` `testMatch` and BOTH
-  `testIgnore` regexes (`playwright.config.ts:64,78,85`). A new spec file would cost three regex
-  edits for nothing.
-- A guest payment row satisfies `profile_id = paid_by_profile_id` (`payments_guest_ledger_check`,
-  `20260801000000_2607_feat_677_pay_guests.sql:120`), so it LOOKS like the payer's own row. The
-  "paid" bucket must exclude `beneficiary_guest_id != null`; those rows belong in "paid on behalf
-  of others". This is the highest-risk item in the ticket.
-- DEV Supabase project ref `iymwxdewcpvpjgzewtzk`. Apply migrations with `supabase db push`;
-  ad-hoc SQL with `supabase db query --linked -f <file>`. #688 needs NO migration.
-- If `npm run build` dies with `Fatal process out of memory: Zone` or times out on a warm `.next`,
-  first response is `rm -rf .next` — the OS, not the V8 heap, is the limit. Do NOT raise
-  `--max-old-space-size`.
+- BUILD BASELINE, captured 2026-08-04 before any edit:
+  `npx vitest run lib/actions/guest-registration.test.ts lib/notifications/guest-event-changes.test.ts`
+  -> `Test Files 2 passed (2)`, `Tests 33 passed (33)`. Green, despite the old STATE.md's
+  "guest-registration.test.ts is flaky" note.
+- Branch `dev/2608-DEV-625` @ `b39773e`, clean, NO upstream configured.
+- DEV Supabase project ref `iymwxdewcpvpjgzewtzk`. Migrations: `supabase db push`. Types:
+  `supabase gen types typescript --project-id iymwxdewcpvpjgzewtzk > types/supabase.ts` — run the
+  redirect through Git Bash, NOT PowerShell `Out-File -Encoding utf8` (CRLF+BOM rewrites ~3100 lines).
+- Migration filename counter: `supabase/migrations/` has no `20260804*` file (last is
+  `20260801000000`), so today starts at `000000`.
+- Two INTENDED behavior changes, both stated in the issue: (1) the registration throttle now counts
+  SUBMISSIONS, not distinct registrants — `guest_registrations` is upserted on `(event_id, email)`,
+  so a re-submitting guest never incremented the old count, which is exactly why a scripted burst
+  slid under it; (2) a slot is consumed at check time, not send time, so a later
+  `sendTransactionalEmail` failure (`lib/actions/guest-registration.ts:221`) spends the slot anyway.
+- Key symbols: guards -> `lib/rate-limit.ts:7,44`; call sites ->
+  `lib/actions/guest-registration.ts:112,192,278,287` and
+  `lib/notifications/guest-event-changes.ts:99,138`; limits ->
+  `guest-registration.ts:44-47,246-248`, `guest-event-changes.ts:20-21`.
+- Structural prior art: `supabase/migrations/20260714000000_2607_feat_claim_los_submissions.sql`
+  (SECURITY DEFINER + `auth.role()` guard + REVOKE/GRANT), `20260705000900_notification_cron.sql`
+  (pg_cron unschedule-then-schedule), `20260801000000_2607_feat_677_pay_guests.sql`
+  (`-- ROLLBACK:` header + table style).
+- If `npm run build` dies with `Fatal process out of memory: Zone`, first response is `rm -rf .next`
+  — the OS, not the V8 heap, is the limit. Do NOT raise `--max-old-space-size`.
 - NEVER paste an absolute Windows path into a tracked file. Tailwind v4 scans every source file
-  (including .md) for utility candidates; a backslash followed by hex-digit characters parses as a
-  CSS unicode escape and kills `npm run build` with `Invalid code point <n>` pointed at
-  `app/globals.css:1:1` — nowhere near the real file. Describe the path, never paste it.
-- Regenerate `types/supabase.ts` through Git Bash (`>` redirect), NOT PowerShell
-  `Out-File -Encoding utf8` — the latter writes CRLF + BOM and rewrites all ~3100 lines.
+  (including .md) for utility candidates; a backslash + hex digits parses as a CSS unicode escape
+  and kills `npm run build` with `Invalid code point <n>` pointed at `app/globals.css:1:1`.
+- E2E coverage for #625: none, by design — server-side abuse guard, no UI surface, nothing renders
+  differently at 390px. Verification is vitest + the DEV concurrency proof.
 
 ## Done
-- PLAN #688 (2026-08-03) — RESULT: READY. Premise re-verified on `main` @ `5311a9c`: `types.ts`
-  declares no `currency` while `app/api/payments/route.ts:29` selects it, and both `shared.tsx:114`
-  and `PaymentsSection.tsx:44` fall back to `payable_items?.currency ?? 'EUR'` — and a trip
-  payment's `payable_items` is NULL, so every trip payment is force-labelled EUR.
-  `PaymentsSection.tsx:35` filters `admin_status !== 'pending'`, which is where attribution is
-  lost at approval. Issue line refs were 1-3 lines stale (written pre-#677-merge); every code
-  claim holds. 9 files, ~600 lines estimated, migration: no, E2E project: `authenticated`.
-- BUILD #688 steps 1-3 (2026-08-03) — RESULT: code-complete, statically green.
-  `npx vitest run lib/payments` -> 5 files / 88 tests passed (baseline was 4 / 58; +30 in the
-  new `lib/payments/ledger.test.ts`). `npx vitest run --exclude lib/actions/guest-registration.test.ts`
-  -> 23 files / 311 tests passed. `npm run check-types` -> clean. `npm run lint` -> 0 errors
-  (476 warnings, all pre-existing; the two new files contribute none). `npm run build` -> success,
-  `ƒ /profile/payments` present in the route table.
-  Matrix status: L1, L2, L4, L5, L6, L7 asserted in unit tests; L3 asserted at the helper level
-  (`payerName`) plus an E2E spec that has not run; L8 has NO evidence — it needs a real 390px
-  render behind Clerk auth.
-  Design notes worth keeping: filtering on the new page happens at ENTRY level, never row level
-  (row-level filtering would render a 3-person group with a partial total); `lifetimeTotals`
-  counts `admin_status === 'approved'` only, matching `personalApprovedTotal`, and
-  `payment.lifetimeNote` says so in both languages; `PaymentRow` now takes
-  `{ entry, me, cancelledTripIds }` instead of `{ pay, cancelledTripIds }`.
-- CLAIM #688 (2026-08-03) — RESULT: complete and pushed. `docs/CLAIMS.md` registry was EMPTY, so no
-  scope overlap and no in-flight `migration: yes` row to sequence against. Issue #688 updated with
-  DoD + affected files + gotchas + `## Design Checklist` (4/4) + `## Branch`; row committed at
-  `716b4ad`; branch pushed (`* [new branch] dev/2608-DEV-688 -> dev/2608-DEV-688`).
+- CLAIM #625 (2026-08-04) — RESULT: complete. Issue #625 carries `## Design Checklist` 4/4 and
+  `## Branch`; `docs/CLAIMS.md` row committed at `b39773e` (which also pruned the merged #690 row).
+- PLAN #625 (2026-08-04) — RESULT: READY. Verdict, DoD, affected files, gotchas and the two
+  behavior-change notes are in the issue body.
+- BUILD #625 steps 1-5 (2026-08-04) — RESULT: code-complete and verified.
+  `npx vitest run lib/rate-limit.test.ts lib/actions/guest-registration.test.ts lib/notifications/guest-event-changes.test.ts`
+  -> 3 files / 45 tests passed (baseline was 2 / 33; +12 in the new `lib/rate-limit.test.ts`).
+  `npm run check-types` -> clean. `npm run lint` -> 0 errors, 475 warnings (baseline 476, all
+  pre-existing); `npx eslint` on all six changed TS files -> zero output. `npm run build` -> success.
+  Migration applied to DEV via `supabase db push`; `types/supabase.ts` regenerated (+22 lines only,
+  no CRLF/BOM rewrite) carrying `rate_limit_events` and `consume_rate_limit`.
+- CONCURRENCY PROOF #625 (2026-08-04) — RESULT: PASSED, stronger than the DoD asked.
+  Driven by 40 pg_cron jobs on a '10 seconds' schedule against key `test:cronproof-1`,
+  `consume_rate_limit(key, 3600000, 30)`: 5 rounds x EXACTLY 40 callers firing in the same second
+  (`date_trunc('second', start_time)` buckets: 11:49:24, :34, :44, :54, 11:50:04), 200 runs across
+  200 distinct backends, 0 job failures — and `rate_limit_events` held EXACTLY 30 rows for the key.
+  Over-issue would have shown as >30. Object-level guards verified on DEV in the same session:
+  `rls_enabled=true`, `policy_count=0`, function `prosecdef=true`, function ACL
+  `postgres=X | service_role=X` (no PUBLIC/anon/authenticated), table ACL free of anon/authenticated,
+  and `rate-limit-events-sweep @ 15 3 * * *` scheduled. All proof jobs unscheduled and all proof
+  rows deleted afterwards (`remaining_jobs=0`, `total_rows=0`).
 
 ## Open items
-- BLOCKING #688's Done gate: the `authenticated` Playwright project has never executed the new
-  L3/L8 specs. `playwright.config.ts:10-20` loads `.env.development.local` FIRST and never
-  overwrites, and that file sets `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321` — so a local
-  run targets LOCAL Supabase, not `.env.local`'s prod project. Local Supabase is down because
-  Docker Desktop is not running. Three ways forward: (a) start Docker Desktop, `npx supabase
-  start`, `npm run e2e:seed-clerk`, then `npx playwright test --project=authenticated`;
-  (b) point the run at DEV (`iymwxdewcpvpjgzewtzk`) by pulling the Pre-Production env vars —
-  do NOT let that overwrite `.env.local`, which holds prod credentials; (c) accept the Vercel
-  PR preview as the 390px check and run the specs after merge.
-  RESOLVED 2026-08-03: the user ran the authenticated E2E and reports it passing, so L3 and L8
-  ARE covered by an executed run — it was this session's environment (Docker down) that could
-  not execute it, not the suite. No further local run is owed.
-  SUPERSEDED 2026-08-03 (GCR PR691): option (a) is gone — there is no local Docker setup on this
-  machine any more, so `http://127.0.0.1:54321` in `.env.development.local` is a dead target and
-  every local E2E run must go through option (b), the hosted DEV project `iymwxdewcpvpjgzewtzk`.
-- DONE 2026-08-03 (GCR PR691): `e2e/payments-on-behalf.spec.ts` no longer skips ANY of its three
-  tests, and all three were EXECUTED against DEV — `3 passed, 0 skipped`, run against
-  `iymwxdewcpvpjgzewtzk` with a `npm run dev` whose Supabase env was overridden on the command
-  line (`playwright.config.ts:10-20` only fills vars that are `undefined`, so an exported var
-  wins over the dead `.env.development.local`). Three skips were removed:
-  - L3's `test.skip(await paidBy.count() === 0)`, and the row it was skipping for is now seeded:
-    a co-owner profile plus one `submit_payment_group` call that co-owner makes FOR the member.
-    A co-owner and not a second downline because `get_payable_beneficiaries` reaches DOWNWARD
-    only; the `household` branch is bidirectional and needs no `tree_nodes` change, so the #676
-    picker fixture is untouched (the co-owner's `abo_number` stays NULL, which both satisfies
-    `trg_guard_abo_number_null`'s co-owner exemption and keeps the row out of that spec's
-    `.filter({ hasText: /·/ })` locator). Written through the RPC, not a direct INSERT, so the
-    fixture is one the application could actually produce and `can_pay_for` is exercised.
-  - The #676 flow's two `test.skip`s on `.count()`. **Those were races, not data checks**:
-    `.count()` does not auto-wait, so a cold picker read 0 before `get_payable_beneficiaries`
-    resolved and the test stood itself down — observed live, skipping in a 3-test run and passing
-    when run alone. Replaced with `expect(...).toBeVisible()` / `.toBeAttached()` waits.
-- GOTCHA, cost an hour: `profiles.primary_profile_id` is UNIQUE
-  (`profiles_primary_profile_id_key`) — a primary profile may have AT MOST ONE co-owner. DEV
-  already carried one for the E2E member (`clerk_id = e2e_member_coowner`, planted outside any
-  script in this repo), so creating one unconditionally died on a raw duplicate-key error.
-  `ensureCoowner` now reuses whatever co-owner the member already has and only creates when there
-  is none — which is also the more honest fixture, since whoever the co-owner IS, is who can pay.
-- The seed is idempotent and was re-run to prove it (`co-owner reused` / `paid-for-me payment
-  present` on the second pass). To run it: export
-  `NEXT_PUBLIC_SUPABASE_URL=https://iymwxdewcpvpjgzewtzk.supabase.co` plus the DEV `service_role`
-  and `anon` keys from `supabase projects api-keys --project-ref iymwxdewcpvpjgzewtzk`, then
-  `npm run e2e:seed-clerk`.
-- FLAKE, seen once, not fixed: L8's `viewAll.first().click()` did not navigate on the very first
-  run against a cold Turbopack dev server (13 polls still on `/profile`), and passed on every run
-  afterwards. Cold-compile hydration race in the harness, not a defect in the link — the `<a>`
-  carries the right `href` in the failure snapshot. CI runs with `retries: 1`, so it is covered
-  there; local first runs may need a warm server.
-- NOTED (not done): `app/(dashboard)/profile/components/PaymentsSection.tsx:30`
-  `pendingGroupsIPaidFor` still filters `paid_by_profile_id !== myProfileId` directly rather
-  than through `payerOf`, so a legacy pending group with a NULL `paid_by_profile_id` is not
-  offered a withdraw card. Pre-existing, untouched by #688.
+- At GCR: open a follow-up issue to REMOVE the transitional `PGRST202`/`42883` fallback from
+  `lib/rate-limit.ts` once `consume_rate_limit` is live in prod. The fallback is dead weight after
+  that and silently re-opens the race if it ever fires.
+- OPEN QUESTION FOR THE USER — the `price_checker` DB role. Findings (DEV `iymwxdewcpvpjgzewtzk`,
+  2026-08-04): it is a LOGIN role, not superuser, `rolbypassrls = false`, no role memberships, owns
+  0 objects, no password expiry (`rolvaliduntil` null), no connection limit. It holds `arwdDxtm` on
+  ALL 41 public tables — including the brand-new `rate_limit_events` — because of an
+  `ALTER DEFAULT PRIVILEGES IN SCHEMA public` rule owned by `postgres` that lists it alongside
+  anon/authenticated/service_role, for both TABLES and SEQUENCES. So every future table this repo
+  ever creates is auto-granted to it. `grep -ri price_checker` over the whole repo returns ZERO hits
+  outside this file: no migration creates the role, no code connects as it. It was created out of
+  band (dashboard/SQL editor) and is unversioned. Postgres keeps no role-creation timestamp, so
+  "when" is not recoverable from the catalog. NOT a #625 regression — #625 merely inherits the rule.
+  Containment today: RLS enabled + zero policies + `rolbypassrls = false` means it cannot read
+  `rate_limit_events`. But it CAN read every pre-existing table whose RLS policies admit it.
+  UNVERIFIED: whether the role also exists in PROD (`ynykjpnetfwqzdnsgkkg`). To check, run in the
+  prod dashboard SQL editor (read-only):
+  `select rolname, rolcanlogin, rolbypassrls from pg_roles where rolname = 'price_checker';`
+  and `select defaclrole::regrole, defaclobjtype, array_to_string(defaclacl,' | ') from pg_default_acl;`
 - CARRIED FROM #677, NOT DONE — the prod tail. PR #689 is merged (`5311a9c` on `main`) but the
   post-merge sequence was never executed: approve the gated `migrate-prod` run (GitHub Actions,
   `production` environment, manual approval — #677 HAS a migration), confirm it applied,
-  smoke-check `https://www.teamenjoyvd.com`, then close issue #677. Do this BEFORE #688 reaches
-  prod, or #688 ships against a schema its migration never landed on.
-- CARRIED FROM #677, NEVER VERIFIED (G4): admin guest link/unlink has NO automated coverage and has
-  never been exercised against a real database. `e2e/payments-guest.spec.ts` covers the member side
-  only. Do it by hand: `/admin/payments` -> Guest links -> pick a member -> Link -> Unlink.
-- CARRIED FROM #677: DEV fixtures still present and still uncleaned — `seed_676_*` (7 profiles,
-  ABOs 6760001-6760004, deferred by the user 2026-07-31) and a `payment_guests` row named
-  `E2E Guest Nadia` written by `e2e/payments-guest.spec.ts` (uniquely indexed, so re-runs reuse it
-  rather than accumulate). Both are still NEEDED for the authenticated E2E — do not delete before
-  #688's step 4 runs.
+  smoke-check `https://www.teamenjoyvd.com`, then close issue #677. #625 ALSO has a migration, so
+  its gated run will queue behind the same approval.
+- CARRIED FROM #677, NEVER VERIFIED: admin guest link/unlink has NO automated coverage and has
+  never been exercised against a real database. Do it by hand: `/admin/payments` -> Guest links ->
+  pick a member -> Link -> Unlink.
+- CARRIED FROM #677: DEV fixtures still present and uncleaned — `seed_676_*` (7 profiles, ABOs
+  6760001-6760004) and a `payment_guests` row named `E2E Guest Nadia`. Both still needed by the
+  authenticated E2E.
 - CARRIED FROM #676, UNMEASURED: does PROD have `payments` rows? If yes, `/profile` was crashing in
   production for every such user between 2026-07-27 (`570d587`, #670) and the #676 merge. One
   read-only query answers it: `select count(*), count(distinct profile_id) from payments`.
-- NOTED (not done), in scope of the FILES #688 touches but explicitly excluded by the issue:
-  `shared.tsx:103` gates the cancelled-trip info marker on `payable_items?.item_type === 'trip'`,
-  which is always false for a real trip payment (its `payable_items` is NULL).
-- NOTED (not done): `app/admin/payments/components/LogPaymentDrawer.tsx:60` merges
-  `membersData.manual_members_no_abo`, but `GET /api/admin/members` never emits that key — the
-  admin log-payment dropdown silently excludes ABO-less profiles.
-- NOTED (not done): `app/(dashboard)/profile/types.ts:80` declares a SECOND `TripPayment` type,
-  unrelated to the one in `app/(dashboard)/trips/[id]/page.tsx`. Name collision, left alone.
-- REFERENCE SWEEP owed at BUILD step 2, per CLAUDE.md iron rule 3: `groupByItem` (single caller)
-  and the removed `listDrawerOpen` Drawer. `ShowMoreButton` keeps its other three callers
-  (`TripsSection.tsx:61`, `VitalsSection.tsx:96`, `ParticipationSection.tsx:70`) — do not delete it.
+- NOTED (not done): `app/(dashboard)/profile/components/PaymentsSection.tsx:30`
+  `pendingGroupsIPaidFor` filters `paid_by_profile_id !== myProfileId` directly rather than through
+  `payerOf`, so a legacy pending group with a NULL `paid_by_profile_id` is not offered a withdraw
+  card.
+- NOTED (not done): `app/(dashboard)/profile/components/shared.tsx:103` gates the cancelled-trip
+  info marker on `payable_items?.item_type === 'trip'`, always false for a real trip payment (its
+  `payable_items` is NULL). Same file `:131-133` renders `proof_url` as an `href` although it is a
+  private-bucket storage KEY, not a URL (`lib/payments/proof.ts:1-10`).
 - The CI check `Authenticated E2E (Clerk)` has historically gone green in seconds WITHOUT running
-  the specs (tracked as #679). It ran for real on #677's PR, but do not treat a green tick as
-  proof: confirm the run reports 0 skipped, and run step 4 locally against DEV regardless.
+  the specs (tracked as #679). Never treat a green tick as proof: confirm the run reports 0 skipped.
 
 ## Failed attempts
-(none for #688 — no code written yet)
+Both are about the PROOF HARNESS only — no attempt failed against the migration or the TS code.
+- ATTEMPT 1 [L1]: ran 40 parallel `supabase db query --linked` after `cd`-ing to the script's own
+  directory -> all 41 invocations returned
+  `{"code":"LegacyProjectNotLinkedError","message":"Cannot find project ref"}`. The CLI resolves
+  the ref from `<cwd>/supabase/.temp/project-ref`. Fix: `supabase --workdir <repo> ...`.
+- ATTEMPT 2 [L1]: same 40-process shape with `--workdir` -> only 25 of 40 sessions ever returned a
+  verdict; the other 15 hung for 12+ minutes with empty output files. The Management API will not
+  serve 40 simultaneous sessions. Structural change (D7), not a third retry: drive the callers from
+  INSIDE Postgres with pg_cron background workers and read the verdict off the ledger row count.
+  That is the run recorded under Done.
+- ATTEMPT 3 [L1]: put `cron.schedule` x40, `pg_sleep(20)` and the measurement in ONE `-f` file ->
+  `job_runs = 0`. The Management API runs a file as a single transaction, so the `cron.job` inserts
+  were invisible to the pg_cron scheduler until COMMIT — which happened after the sleep. Fix: split
+  scheduling and measurement into separate calls/transactions.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -5,12 +5,20 @@ count-then-decide guest-invite rate limits with ONE atomic `SECURITY DEFINER` RP
 actually capped instead of every caller reading the same stale count.
 
 ## Now
-BUILD steps 1-5 COMPLETE and verified (see Done). All 8 DoD files edited, migration applied to
-DEV, types regenerated, concurrency proof passed. Nothing committed yet.
+PR #693 is OPEN and NOT a draft (the user marked it ready_for_review at 2026-08-04 14:46Z from the
+GitHub UI). All 9 CI checks green. CodeRabbit's single pass returned 3 inline comments; all 3 are
+applied and pushed as one batched commit. Awaiting CodeRabbit's re-review, then merge.
 
 ## Next
-0. Run the review pass (`/security-review` — this touches RLS, a SECURITY DEFINER function and a
-   migration), fix findings locally, THEN ask the user before any commit/push.
+1. Confirm CodeRabbit's incremental re-review is clean and all 3 threads are resolved.
+2. Merge #693 — needs the user's explicit go-ahead.
+3. Post-merge: drop the `docs/CLAIMS.md` #625 row, close #625.
+4. PROD TAIL, in this order: approve #677's pending `migrate-prod` run FIRST (it has never landed),
+   then #625's. Smoke-check `https://www.teamenjoyvd.com`.
+5. ONLY after #625's migration is confirmed applied on prod: open + action the issue to delete the
+   `PGRST202`/`42883` fallback from `lib/rate-limit.ts`. It CANNOT be removed at GCR time — between
+   merge and migrate-prod approval, prod runs the new code against a schema with no
+   `consume_rate_limit`, and the guards fail closed on a public flow.
 
 ## Next (original build order, all done)
 1. Step 1: write `supabase/migrations/20260804000000_2608_feat_625_atomic_rate_limits.sql`
@@ -130,25 +138,46 @@ DEV, types regenerated, concurrency proof passed. Nothing committed yet.
   rows deleted afterwards (`remaining_jobs=0`, `total_rows=0`).
 
 ## Open items
+- FLAKE, seen once on PR #693's CI, NOT caused by #625: `e2e/payments-on-behalf.spec.ts:169`
+  ("L3: a row someone else paid for me is labelled with the payer") failed a `toBeVisible()` at
+  36.3s then passed on retry #1 in 6.2s — a cold-server timing profile, same file and same shape as
+  the L8 flake logged during #688. The run was otherwise honest: `Running 21 tests using 2 workers`
+  -> `20 passed`, `1 flaky`, **0 skipped**, so this was NOT the vacuous green tracked as #679.
+  #625 touches rate limiting only; that spec asserts payment attribution labels.
 - At GCR: open a follow-up issue to REMOVE the transitional `PGRST202`/`42883` fallback from
   `lib/rate-limit.ts` once `consume_rate_limit` is live in prod. The fallback is dead weight after
   that and silently re-opens the race if it ever fires.
-- OPEN QUESTION FOR THE USER — the `price_checker` DB role. Findings (DEV `iymwxdewcpvpjgzewtzk`,
-  2026-08-04): it is a LOGIN role, not superuser, `rolbypassrls = false`, no role memberships, owns
-  0 objects, no password expiry (`rolvaliduntil` null), no connection limit. It holds `arwdDxtm` on
-  ALL 41 public tables — including the brand-new `rate_limit_events` — because of an
-  `ALTER DEFAULT PRIVILEGES IN SCHEMA public` rule owned by `postgres` that lists it alongside
-  anon/authenticated/service_role, for both TABLES and SEQUENCES. So every future table this repo
-  ever creates is auto-granted to it. `grep -ri price_checker` over the whole repo returns ZERO hits
-  outside this file: no migration creates the role, no code connects as it. It was created out of
-  band (dashboard/SQL editor) and is unversioned. Postgres keeps no role-creation timestamp, so
-  "when" is not recoverable from the catalog. NOT a #625 regression — #625 merely inherits the rule.
-  Containment today: RLS enabled + zero policies + `rolbypassrls = false` means it cannot read
-  `rate_limit_events`. But it CAN read every pre-existing table whose RLS policies admit it.
-  UNVERIFIED: whether the role also exists in PROD (`ynykjpnetfwqzdnsgkkg`). To check, run in the
-  prod dashboard SQL editor (read-only):
-  `select rolname, rolcanlogin, rolbypassrls from pg_roles where rolname = 'price_checker';`
-  and `select defaclrole::regrole, defaclobjtype, array_to_string(defaclacl,' | ') from pg_default_acl;`
+- OPEN — the `price_checker` DB role. A dormant, unversioned LOGIN credential on DEV only.
+  DEV-ONLY: the user confirmed 2026-08-04 it does NOT exist on prod. On DEV `iymwxdewcpvpjgzewtzk`
+  it is a LOGIN role WITH A PASSWORD SET (`pg_authid.rolpassword is not null`), not superuser,
+  `rolbypassrls = false`, no role memberships, owns 0 objects, no password expiry, no connection
+  limit. It is the ONLY non-Supabase-standard role on the project (the others —
+  `cli_login_postgres`, `supabase_etl_admin`, `supabase_functions_admin`,
+  `supabase_privileged_role` — are all stock).
+  IT HAS BEEN USED, EXACTLY ONCE, AND NEVER SINCE. `pg_stat_statements` holds 4 statements for its
+  `userid`, and `stats_since` dates every one of them to **2026-07-29**:
+    11:09:04.100 — `select b.oid, b.typarray from pg_catalog.pg_type a left join ... where
+                    a.typcategory = $1 group by b.oid, b.typarray order by b.oid`  (2 calls)
+    11:09:04.169 — `SELECT current_user, current_database(), current_schemas($1)`  (1 call)
+    11:09:04.231 — `SELECT table_schema,table_name FROM information_schema.tables
+                    WHERE table_name IN ($1,$2)`                                    (1 call)
+    11:13:34.884 — `SELECT datname FROM pg_database WHERE datistemplate=$1`         (1 call)
+  That is a client-library/GUI CONNECTION HANDSHAKE, not application traffic: type-catalog
+  bootstrap, identity probe, an existence check for two specific named tables, then a
+  list-databases 4.5 minutes later. Zero queries against any business table, ever. So: someone
+  pointed a tool at the DEV database as this role on 2026-07-29, it introspected, and it was never
+  used again. Literals are normalised to $1/$2 so WHICH two tables it looked for is not recoverable.
+  Grants: `arwdDxtm` on ALL 41 public tables. Old tables came from an explicit
+  `GRANT ALL ON ALL TABLES IN SCHEMA public`; NEW tables (including `rate_limit_events`) come from
+  an `ALTER DEFAULT PRIVILEGES IN SCHEMA public` rule owned by `postgres` that lists it beside
+  anon/authenticated/service_role for both TABLES and SEQUENCES — so every table this repo will
+  ever create is auto-granted to it.
+  NOT a #625 regression; #625 merely inherits the default-privileges rule, and RLS (enabled, zero
+  policies, `rolbypassrls = false`) still blocks it from `rate_limit_events`. It CAN read every
+  pre-existing table whose RLS policies admit it.
+  DECIDE: revoke it (`DROP ROLE price_checker` + drop the default-privileges entry) or, if the tool
+  is wanted, recreate it in a migration with least-privilege grants so it stops being invisible.
+  Either way it is a separate ticket, not #625.
 - CARRIED FROM #677, NOT DONE — the prod tail. PR #689 is merged (`5311a9c` on `main`) but the
   post-merge sequence was never executed: approve the gated `migrate-prod` run (GitHub Actions,
   `production` environment, manual approval — #677 HAS a migration), confirm it applied,
@@ -173,6 +202,26 @@ DEV, types regenerated, concurrency proof passed. Nothing committed yet.
   private-bucket storage KEY, not a URL (`lib/payments/proof.ts:1-10`).
 - The CI check `Authenticated E2E (Clerk)` has historically gone green in seconds WITHOUT running
   the specs (tracked as #679). Never treat a green tick as proof: confirm the run reports 0 skipped.
+
+## Done (GCR)
+- GCR PR #693 (2026-08-04) — RESULT: all 3 CodeRabbit inline comments applied in ONE batch.
+  (1) MAJOR/security, `lib/rate-limit.ts:40` — the failure log wrote the whole bucket key, which
+  embeds the recipient email (CWE-532). Now logs `{ scope, key: keyDigest(key) }` — a 12-char
+  SHA-256 prefix — so repeated failures for one recipient still correlate without recording who.
+  Backed by a regression test PROVEN RED first: reverting the fix gave
+  `AssertionError: expected '["consume_rate_limit failed, denying"…' not to contain 'jane@example.com'`.
+  (2) MINOR/correctness, `lib/rate-limit.ts:66,90` — truthiness checks on `template` / `shareLinkId`,
+  a direct CLAUDE.md iron-rule violation. Now `template != null` / `shareLinkId !== null`. The SAME
+  defect class was folded in for the two legacy fallback functions, which must scope identically or
+  the fallback would count a different bucket than the RPC path.
+  (3) MAJOR/performance, migration — `idx_rate_limit_events_key_created` leads with `bucket_key` and
+  cannot serve the nightly sweep's global `created_at` predicate; since `bucket_key` is composed
+  from a public form's email field, an abuser can mint unlimited distinct keys whose rows only the
+  sweep ever collects. Added `idx_rate_limit_events_created_at` in a SEPARATE migration
+  (`20260804000100`) rather than editing `20260804000000`, which is already applied on DEV — both
+  ship in the same PR so prod applies them together. Verified on DEV: all 3 indexes present.
+  Re-verified after the fixes: 45 tests -> 46 (13 in `lib/rate-limit.test.ts`), `tsc --noEmit`
+  clean, `npx eslint` on the changed files silent.
 
 ## Failed attempts
 Both are about the PROOF HARNESS only — no attempt failed against the migration or the TS code.

--- a/lib/actions/guest-registration.test.ts
+++ b/lib/actions/guest-registration.test.ts
@@ -36,6 +36,17 @@ vi.mock('next/headers', () => ({
   headers: () => Promise.resolve(new Map([['host', 'req-host.example']])),
 }))
 
+// Since 2608-DEV-625 the abuse guards CONSUME a slot through the
+// consume_rate_limit RPC instead of running a count query, so there is no
+// count for a Supabase fixture to fake. They are mocked at the module boundary
+// here; the key/window/max they send lives in lib/rate-limit.test.ts.
+const mockConsumeEmailCap = vi.fn()
+const mockConsumeRegistrationSlot = vi.fn()
+vi.mock('@/lib/rate-limit', () => ({
+  consumeEmailCap:         (...args: unknown[]) => mockConsumeEmailCap(...args),
+  consumeRegistrationSlot: (...args: unknown[]) => mockConsumeRegistrationSlot(...args),
+}))
+
 // -- Supabase mock ------------------------------------------------------------
 
 type Row = Record<string, unknown> | null
@@ -63,8 +74,8 @@ function buildClient(existing: Row) {
       if (table === 'guest_registrations') {
         return {
           select: (_cols: string, sel?: { count?: string; head?: boolean }) => {
-            // Abuse-protection throttle count (2607-DEV-591) — always under
-            // the limit here; these fixtures exercise other behavior.
+            // Capacity count only — the throttle is module-mocked above and no
+            // longer issues a count query (2608-DEV-625).
             if (sel?.count) return countChain(0)
             const selectChain: Record<string, unknown> = {
               eq: () => selectChain,
@@ -75,10 +86,6 @@ function buildClient(existing: Row) {
           update: updateSpy,
           upsert: upsertSpy,
         }
-      }
-      // Overall daily email cap (2607-DEV-591) — always under the limit here.
-      if (table === 'notification_delivery_log') {
-        return { select: () => countChain(0) }
       }
       throw new Error(`unexpected table ${table}`)
     },
@@ -100,6 +107,9 @@ const HOUR = 60 * 60 * 1000
 beforeEach(() => {
   vi.clearAllMocks()
   capturedMagicLink = ''
+  // Under every limit by default; the abuse-protection describes override this.
+  mockConsumeEmailCap.mockResolvedValue(true)
+  mockConsumeRegistrationSlot.mockResolvedValue(true)
   process.env.NEXT_PUBLIC_APP_URL = 'https://portal.example'
 })
 
@@ -227,10 +237,6 @@ function countChain(count: number) {
 function buildResendClient(opts: {
   event?: Record<string, unknown> | null
   reg?: Record<string, unknown> | null
-  deliveryCount?: number
-  // [hourly-cap call count, daily-cap call count] — call order matches
-  // checkEmailCap invocation order in resendGuestLink.
-  deliveryCounts?: [number, number]
 }) {
   const event = opts.event === undefined
     ? { id: 'e', title: 'Trip Kickoff', allow_guest_registration: true, end_time: new Date(Date.now() + 24 * HOUR).toISOString() }
@@ -238,8 +244,6 @@ function buildResendClient(opts: {
   const reg = opts.reg === undefined
     ? { id: 'r1', name: 'Jane Guest', token: 'tok-123', lang: 'en' }
     : opts.reg
-  const counts = opts.deliveryCounts ?? [opts.deliveryCount ?? 0, opts.deliveryCount ?? 0]
-  let callIndex = 0
 
   const updateSpy = vi.fn(() => ({ eq: () => Promise.resolve({ error: null }) }))
 
@@ -252,15 +256,6 @@ function buildResendClient(opts: {
         return {
           select: () => ({ eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: reg, error: null }) }) }) }),
           update: updateSpy,
-        }
-      }
-      if (table === 'notification_delivery_log') {
-        return {
-          select: () => {
-            const count = counts[callIndex] ?? counts[counts.length - 1]
-            callIndex++
-            return countChain(count)
-          },
         }
       }
       throw new Error(`unexpected table ${table}`)
@@ -300,7 +295,7 @@ describe('resendGuestLink — neutrality', () => {
 
 describe('resendGuestLink — rate cap', () => {
   it('sends when under the hourly cap', async () => {
-    const { client } = buildResendClient({ deliveryCount: 2 })
+    const { client } = buildResendClient({})
     mockCreateServiceClient.mockReturnValue(client)
     const sendModule = await import('@/lib/email/send')
     const { resendGuestLink } = await import('@/lib/actions/guest-registration')
@@ -310,7 +305,9 @@ describe('resendGuestLink — rate cap', () => {
   })
 
   it('no-ops (does not send a 4th email) once the hourly cap is reached', async () => {
-    const { client } = buildResendClient({ deliveryCount: 3 })
+    const { client } = buildResendClient({})
+    // First consume call in resendGuestLink is the hourly template-scoped cap.
+    mockConsumeEmailCap.mockResolvedValueOnce(false)
     mockCreateServiceClient.mockReturnValue(client)
     const sendModule = await import('@/lib/email/send')
     const { resendGuestLink } = await import('@/lib/actions/guest-registration')
@@ -321,7 +318,13 @@ describe('resendGuestLink — rate cap', () => {
   })
 
   it('no-ops once the overall daily cap is reached, even under the hourly cap (2607-DEV-591)', async () => {
-    const { client } = buildResendClient({ deliveryCounts: [0, 10] })
+    const { client } = buildResendClient({})
+    // Call order is load-bearing: hourly template-scoped cap first (allows),
+    // overall daily cap second (denies). Asserted here so a reordering of the
+    // two consumeEmailCap calls in resendGuestLink fails this test.
+    mockConsumeEmailCap
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
     mockCreateServiceClient.mockReturnValue(client)
     const sendModule = await import('@/lib/email/send')
     const { resendGuestLink } = await import('@/lib/actions/guest-registration')
@@ -344,11 +347,6 @@ function buildCapacityClient(opts: { guestCapacity: number | null; activeCount: 
   }
   const upsertSpy = vi.fn(() => Promise.resolve({ error: null }))
   const updateSpy = vi.fn(() => ({ eq: () => ({ eq: () => Promise.resolve({ error: null }) }) }))
-  // The throttle check (2607-DEV-591) runs a count query before the capacity
-  // count query — first count-style select is the throttle (always under
-  // limit here), the next is the real capacity count.
-  let countCallIndex = 0
-
   const client = {
     from: (table: string) => {
       if (table === 'calendar_events') {
@@ -357,19 +355,14 @@ function buildCapacityClient(opts: { guestCapacity: number | null; activeCount: 
       if (table === 'guest_registrations') {
         return {
           select: (_cols: string, sel?: { count?: string; head?: boolean }) => {
-            if (sel?.count) {
-              const count = countCallIndex === 0 ? 0 : opts.activeCount
-              countCallIndex++
-              return countChain(count)
-            }
+            // The capacity count is now the ONLY count query registerGuest
+            // runs — the throttle became an RPC in 2608-DEV-625.
+            if (sel?.count) return countChain(opts.activeCount)
             return { eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: opts.existing ?? null, error: null }) }) }) }
           },
           update: updateSpy,
           upsert: upsertSpy,
         }
-      }
-      if (table === 'notification_delivery_log') {
-        return { select: () => countChain(0) }
       }
       throw new Error(`unexpected table ${table}`)
     },
@@ -503,9 +496,9 @@ describe('cancelGuestRegistration', () => {
 
 // -- registerGuest — abuse protection (2607-DEV-591) --------------------------
 
-function buildAbuseClient(opts: { throttleCount?: number; dailyCount?: number; existing?: Row }) {
-  const throttleCount = opts.throttleCount ?? 0
-  const dailyCount = opts.dailyCount ?? 0
+// Both guards are module-mocked (see the seams block) — this fixture only has
+// to keep the surrounding registration flow alive while they allow or deny.
+function buildAbuseClient(opts: { existing?: Row } = {}) {
   const existing = opts.existing ?? null
 
   const event = {
@@ -526,15 +519,13 @@ function buildAbuseClient(opts: { throttleCount?: number; dailyCount?: number; e
       if (table === 'guest_registrations') {
         return {
           select: (_cols: string, sel?: { count?: string; head?: boolean }) => {
-            if (sel?.count) return countChain(throttleCount)
+            // guest_capacity is null in this fixture, so no capacity count runs.
+            if (sel?.count) return countChain(0)
             return { eq: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: existing, error: null }) }) }) }
           },
           update: updateSpy,
           upsert: upsertSpy,
         }
-      }
-      if (table === 'notification_delivery_log') {
-        return { select: () => countChain(dailyCount) }
       }
       throw new Error(`unexpected table ${table}`)
     },
@@ -561,7 +552,8 @@ describe('registerGuest — honeypot', () => {
 
 describe('registerGuest — registration throttle', () => {
   it('rejects with a bilingual message once the per-link/event throttle is reached', async () => {
-    const { client, upsertSpy } = buildAbuseClient({ throttleCount: 30 })
+    const { client, upsertSpy } = buildAbuseClient()
+    mockConsumeRegistrationSlot.mockResolvedValue(false)
     mockCreateServiceClient.mockReturnValue(client)
     const { registerGuest } = await import('@/lib/actions/guest-registration')
 
@@ -573,7 +565,7 @@ describe('registerGuest — registration throttle', () => {
   })
 
   it('allows registration when under the throttle', async () => {
-    const { client, upsertSpy } = buildAbuseClient({ throttleCount: 5 })
+    const { client, upsertSpy } = buildAbuseClient()
     mockCreateServiceClient.mockReturnValue(client)
     const { registerGuest } = await import('@/lib/actions/guest-registration')
 
@@ -586,7 +578,8 @@ describe('registerGuest — registration throttle', () => {
 
 describe('registerGuest — overall email cap', () => {
   it('registers but skips the send once the daily email cap is reached', async () => {
-    const { client, upsertSpy } = buildAbuseClient({ dailyCount: 10 })
+    const { client, upsertSpy } = buildAbuseClient()
+    mockConsumeEmailCap.mockResolvedValue(false)
     mockCreateServiceClient.mockReturnValue(client)
     const sendModule = await import('@/lib/email/send')
     const { registerGuest } = await import('@/lib/actions/guest-registration')

--- a/lib/actions/guest-registration.ts
+++ b/lib/actions/guest-registration.ts
@@ -9,7 +9,7 @@ import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { GuestEventMagicLinkEmail } from '@/lib/email/templates/GuestEventMagicLinkEmail'
 import { notifySharerOfRegistration, notifySharerOfCancellation } from '@/lib/notifications/share-events'
 import { getBaseUrl } from '@/lib/utils/base-url'
-import { checkEmailCap, checkRegistrationThrottle } from '@/lib/rate-limit'
+import { consumeEmailCap, consumeRegistrationSlot } from '@/lib/rate-limit'
 
 // -- Types --------------------------------------------------------------------
 
@@ -109,7 +109,9 @@ export async function registerGuest(
 
   // Per-link (or per-event for token-less loads) registration throttle —
   // guards against a script hammering one share link / event with submissions.
-  const withinThrottle = await checkRegistrationThrottle({
+  // Consuming, not merely reading: this submission has now spent a slot whether
+  // or not the rest of the action succeeds (2608-DEV-625).
+  const withinThrottle = await consumeRegistrationSlot({
     shareLinkId,
     eventId,
     windowMs: REGISTRATION_THROTTLE_WINDOW_MS,
@@ -189,7 +191,9 @@ export async function registerGuest(
   // (neutral, same shape as a real send so probing reveals nothing). The
   // registration itself already succeeded above, so the sharer still gets
   // notified below regardless of this guest's own cap.
-  const withinDailyCap = await checkEmailCap({
+  // The slot is spent here, not at send time — if sendTransactionalEmail below
+  // fails, this attempt still counted (2608-DEV-625).
+  const withinDailyCap = await consumeEmailCap({
     recipient: email,
     windowMs:  GUEST_EMAIL_DAILY_WINDOW_MS,
     max:       GUEST_EMAIL_DAILY_CAP,
@@ -275,7 +279,7 @@ export async function resendGuestLink(eventId: string, email: string): Promise<R
 
   // Rate cap — count sends to this recipient in the trailing hour, regardless
   // of which event they were for (per-recipient, not per-event).
-  const withinResendCap = await checkEmailCap({
+  const withinResendCap = await consumeEmailCap({
     recipient: email,
     template:  MAGIC_LINK_TEMPLATE,
     windowMs:  RESEND_RATE_WINDOW_MS,
@@ -283,8 +287,10 @@ export async function resendGuestLink(eventId: string, email: string): Promise<R
   })
   if (!withinResendCap) return NEUTRAL_RESULT
 
-  // Overall guest-email cap (all templates), shared with registerGuest.
-  const withinDailyCap = await checkEmailCap({
+  // Overall guest-email cap (all templates), shared with registerGuest. Order
+  // is deliberate and asserted by the tests: a recipient already over the daily
+  // cap has burned an hourly slot above. Harmless — they are blocked either way.
+  const withinDailyCap = await consumeEmailCap({
     recipient: email,
     windowMs:  GUEST_EMAIL_DAILY_WINDOW_MS,
     max:       GUEST_EMAIL_DAILY_CAP,

--- a/lib/notifications/guest-event-changes.test.ts
+++ b/lib/notifications/guest-event-changes.test.ts
@@ -2,20 +2,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Unit coverage for the event-change/cancel guest notifier (issue 2607-DEV-592):
 //  - diffEventFields: pure diff of the tracked fields.
-//  - notifyGuestsOfEventUpdate: no-op on an empty diff; respects checkEmailCap
+//  - notifyGuestsOfEventUpdate: no-op on an empty diff; respects consumeEmailCap
 //    per recipient; sends to all active (non-cancelled, non-expired) registrants.
 
 // -- Seams --------------------------------------------------------------------
 
 const mockCreateServiceClient = vi.fn()
-const mockCheckEmailCap = vi.fn()
+const mockConsumeEmailCap = vi.fn()
 const sentEmails: { to: string; template: string }[] = []
 
 vi.mock('@/lib/supabase/service', () => ({
   createServiceClient: () => mockCreateServiceClient(),
 }))
 vi.mock('@/lib/rate-limit', () => ({
-  checkEmailCap: (...args: unknown[]) => mockCheckEmailCap(...args),
+  consumeEmailCap: (...args: unknown[]) => mockConsumeEmailCap(...args),
 }))
 vi.mock('@/lib/email/send', () => ({
   sendTransactionalEmail: vi.fn((opts: { to: string; template: string }) => {
@@ -36,7 +36,7 @@ vi.mock('@/lib/email/templates/GuestEventCancelledEmail', () => ({
 beforeEach(() => {
   vi.clearAllMocks()
   sentEmails.length = 0
-  mockCheckEmailCap.mockResolvedValue(true)
+  mockConsumeEmailCap.mockResolvedValue(true)
 })
 
 // -- diffEventFields ------------------------------------------------------------
@@ -126,7 +126,7 @@ describe('notifyGuestsOfEventUpdate', () => {
     mockCreateServiceClient.mockReturnValue(buildClient({
       regs: [{ email: 'capped@example.com', name: 'Capped', lang: 'en' }],
     }))
-    mockCheckEmailCap.mockResolvedValue(false)
+    mockConsumeEmailCap.mockResolvedValue(false)
     const { notifyGuestsOfEventUpdate } = await import('@/lib/notifications/guest-event-changes')
 
     notifyGuestsOfEventUpdate('event-1', [{ field: 'start_time', oldValue: 'old', newValue: 'new' }])

--- a/lib/notifications/guest-event-changes.ts
+++ b/lib/notifications/guest-event-changes.ts
@@ -9,7 +9,7 @@ import { sendTransactionalEmail } from '@/lib/email/send'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { GuestEventUpdatedEmail, type ChangedField } from '@/lib/email/templates/GuestEventUpdatedEmail'
 import { GuestEventCancelledEmail } from '@/lib/email/templates/GuestEventCancelledEmail'
-import { checkEmailCap } from '@/lib/rate-limit'
+import { consumeEmailCap } from '@/lib/rate-limit'
 import { formatDateTime } from '@/lib/format'
 
 type Lang = 'en' | 'bg'
@@ -96,7 +96,7 @@ export function notifyGuestsOfEventUpdate(eventId: string, changedFields: Change
     .then(async ctx => {
       if (!ctx) return
       for (const recipient of ctx.recipients) {
-        const withinDailyCap = await checkEmailCap({
+        const withinDailyCap = await consumeEmailCap({
           recipient: recipient.email,
           windowMs:  GUEST_EMAIL_DAILY_WINDOW_MS,
           max:       GUEST_EMAIL_DAILY_CAP,
@@ -135,7 +135,7 @@ export function notifyGuestsOfEventCancellation(eventTitle: string, recipients: 
 
   ;(async () => {
     for (const recipient of recipients) {
-      const withinDailyCap = await checkEmailCap({
+      const withinDailyCap = await consumeEmailCap({
         recipient: recipient.email,
         windowMs:  GUEST_EMAIL_DAILY_WINDOW_MS,
         max:       GUEST_EMAIL_DAILY_CAP,

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -177,6 +177,30 @@ describe('fail-closed behaviour', () => {
       .resolves.toBe(false)
   })
 
+  it('never writes the recipient address into the failure log (PR #693 review)', async () => {
+    const { client } = buildClient({
+      rpcResult: { data: null, error: { code: '57014', message: 'statement timeout' } },
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const errorSpy = vi.mocked(console.error)
+    const { consumeEmailCap } = await import('@/lib/rate-limit')
+
+    await consumeEmailCap({
+      recipient: 'jane@example.com',
+      template:  'guest_event_magic_link',
+      windowMs:  HOUR,
+      max:       3,
+    })
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    const logged = JSON.stringify(errorSpy.mock.calls[0])
+    expect(logged).not.toContain('jane@example.com')
+    expect(logged).not.toContain('jane')
+    // The scope still identifies WHICH guard tripped, and the digest still lets
+    // repeated failures for one recipient be correlated.
+    expect(logged).toContain('email+template')
+  })
+
   it('denies when the RPC error carries no code at all', async () => {
     const { client } = buildClient({
       rpcResult: { data: null, error: { message: 'network unreachable' } },

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Unit coverage for the atomic rate-limit guards (issue 2608-DEV-625):
+//  - each guard builds the documented bucket key and forwards window/max
+//    unchanged to the consume_rate_limit RPC;
+//  - the RPC's boolean is the answer, and anything that is not an explicit
+//    `true` denies (fail closed);
+//  - only the "function is not deployed" codes fall back to the pre-625
+//    count-based path — every other RPC error denies without falling back.
+
+// -- Seams --------------------------------------------------------------------
+
+const mockCreateServiceClient = vi.fn()
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: () => mockCreateServiceClient(),
+}))
+
+type RpcResult = { data: boolean | null; error: { code?: string | null; message?: string } | null }
+
+/** Thenable chain accepting any sequence of .eq()/.gte(), resolving to { count }. */
+function countChain(count: number, error: { message: string } | null = null) {
+  const chain: Record<string, unknown> = {
+    eq:  () => chain,
+    gte: () => chain,
+    then: (resolve: (v: { count: number | null; error: unknown }) => void) =>
+      resolve({ count: error ? null : count, error }),
+  }
+  return chain
+}
+
+/**
+ * `rpc` answers with `rpcResult`; `from` serves the legacy count path, so a
+ * single client covers both the RPC branch and the fallback branch.
+ */
+function buildClient(opts: {
+  rpcResult: RpcResult
+  count?: number
+  countError?: { message: string } | null
+}) {
+  const rpcSpy = vi.fn(() => Promise.resolve(opts.rpcResult))
+  const client = {
+    rpc: rpcSpy,
+    from: (table: string) => {
+      if (table === 'notification_delivery_log' || table === 'guest_registrations') {
+        return { select: () => countChain(opts.count ?? 0, opts.countError ?? null) }
+      }
+      throw new Error(`unexpected table ${table}`)
+    },
+  }
+  return { client, rpcSpy }
+}
+
+const HOUR = 60 * 60 * 1000
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // The fail-closed paths log deliberately; keep the suite output readable.
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// -- consumeEmailCap ----------------------------------------------------------
+
+describe('consumeEmailCap', () => {
+  it('keys on the recipient alone when no template is given, forwarding window and max', async () => {
+    const { client, rpcSpy } = buildClient({ rpcResult: { data: true, error: null } })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeEmailCap } = await import('@/lib/rate-limit')
+
+    const allowed = await consumeEmailCap({
+      recipient: 'jane@example.com',
+      windowMs:  24 * HOUR,
+      max:       10,
+    })
+
+    expect(allowed).toBe(true)
+    expect(rpcSpy).toHaveBeenCalledWith('consume_rate_limit', {
+      p_key:       'email:jane@example.com',
+      p_window_ms: 24 * HOUR,
+      p_max:       10,
+    })
+  })
+
+  it('narrows the key with the template so the two caps count independently', async () => {
+    const { client, rpcSpy } = buildClient({ rpcResult: { data: true, error: null } })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeEmailCap } = await import('@/lib/rate-limit')
+
+    await consumeEmailCap({
+      recipient: 'jane@example.com',
+      template:  'guest_event_magic_link',
+      windowMs:  HOUR,
+      max:       3,
+    })
+
+    expect(rpcSpy).toHaveBeenCalledWith('consume_rate_limit', {
+      p_key:       'email:jane@example.com:guest_event_magic_link',
+      p_window_ms: HOUR,
+      p_max:       3,
+    })
+  })
+
+  it('denies when the RPC refuses the slot', async () => {
+    const { client } = buildClient({ rpcResult: { data: false, error: null } })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeEmailCap } = await import('@/lib/rate-limit')
+
+    await expect(consumeEmailCap({ recipient: 'jane@example.com', windowMs: HOUR, max: 3 }))
+      .resolves.toBe(false)
+  })
+
+  it('denies when the RPC returns null rather than a boolean', async () => {
+    const { client } = buildClient({ rpcResult: { data: null, error: null } })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeEmailCap } = await import('@/lib/rate-limit')
+
+    await expect(consumeEmailCap({ recipient: 'jane@example.com', windowMs: HOUR, max: 3 }))
+      .resolves.toBe(false)
+  })
+})
+
+// -- consumeRegistrationSlot --------------------------------------------------
+
+describe('consumeRegistrationSlot', () => {
+  it('keys on the share link when the load carried one', async () => {
+    const { client, rpcSpy } = buildClient({ rpcResult: { data: true, error: null } })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeRegistrationSlot } = await import('@/lib/rate-limit')
+
+    const allowed = await consumeRegistrationSlot({
+      shareLinkId: 'link-1',
+      eventId:     'event-1',
+      windowMs:    HOUR,
+      max:         30,
+    })
+
+    expect(allowed).toBe(true)
+    expect(rpcSpy).toHaveBeenCalledWith('consume_rate_limit', {
+      p_key:       'guest-reg:link:link-1',
+      p_window_ms: HOUR,
+      p_max:       30,
+    })
+  })
+
+  it('falls back to the event key for token-less loads', async () => {
+    const { client, rpcSpy } = buildClient({ rpcResult: { data: true, error: null } })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeRegistrationSlot } = await import('@/lib/rate-limit')
+
+    await consumeRegistrationSlot({ shareLinkId: null, eventId: 'event-1', windowMs: HOUR, max: 30 })
+
+    expect(rpcSpy).toHaveBeenCalledWith('consume_rate_limit', {
+      p_key:       'guest-reg:event:event-1',
+      p_window_ms: HOUR,
+      p_max:       30,
+    })
+  })
+})
+
+// -- Fail closed --------------------------------------------------------------
+
+describe('fail-closed behaviour', () => {
+  it('denies on an arbitrary RPC error without consulting the legacy count path', async () => {
+    const { client } = buildClient({
+      rpcResult: { data: null, error: { code: '57014', message: 'canceling statement due to statement timeout' } },
+      // A count low enough to ALLOW — proving the fallback was not taken.
+      count: 0,
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeEmailCap } = await import('@/lib/rate-limit')
+
+    await expect(consumeEmailCap({ recipient: 'jane@example.com', windowMs: HOUR, max: 3 }))
+      .resolves.toBe(false)
+  })
+
+  it('denies when the RPC error carries no code at all', async () => {
+    const { client } = buildClient({
+      rpcResult: { data: null, error: { message: 'network unreachable' } },
+      count: 0,
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeEmailCap } = await import('@/lib/rate-limit')
+
+    await expect(consumeEmailCap({ recipient: 'jane@example.com', windowMs: HOUR, max: 3 }))
+      .resolves.toBe(false)
+  })
+})
+
+// -- Transitional fallback ----------------------------------------------------
+// Covers the window where Vercel has deployed this code but the gated
+// migrate-prod run has not yet created the function.
+
+describe('missing-RPC fallback', () => {
+  it('PGRST202 falls back to the count path and allows when under the cap', async () => {
+    const { client } = buildClient({
+      rpcResult: { data: null, error: { code: 'PGRST202', message: 'Could not find the function' } },
+      count: 2,
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeEmailCap } = await import('@/lib/rate-limit')
+
+    await expect(consumeEmailCap({ recipient: 'jane@example.com', windowMs: HOUR, max: 3 }))
+      .resolves.toBe(true)
+  })
+
+  it('PGRST202 falls back and denies once the count has reached the cap', async () => {
+    const { client } = buildClient({
+      rpcResult: { data: null, error: { code: 'PGRST202', message: 'Could not find the function' } },
+      count: 3,
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeEmailCap } = await import('@/lib/rate-limit')
+
+    await expect(consumeEmailCap({ recipient: 'jane@example.com', windowMs: HOUR, max: 3 }))
+      .resolves.toBe(false)
+  })
+
+  it('42883 falls back for the registration throttle too', async () => {
+    const { client } = buildClient({
+      rpcResult: { data: null, error: { code: '42883', message: 'function does not exist' } },
+      count: 29,
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeRegistrationSlot } = await import('@/lib/rate-limit')
+
+    await expect(consumeRegistrationSlot({ shareLinkId: 'link-1', eventId: 'event-1', windowMs: HOUR, max: 30 }))
+      .resolves.toBe(true)
+  })
+
+  it('denies when the fallback count query itself errors', async () => {
+    const { client } = buildClient({
+      rpcResult: { data: null, error: { code: 'PGRST202', message: 'Could not find the function' } },
+      count: 0,
+      countError: { message: 'relation does not exist' },
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { consumeEmailCap } = await import('@/lib/rate-limit')
+
+    await expect(consumeEmailCap({ recipient: 'jane@example.com', windowMs: HOUR, max: 3 }))
+      .resolves.toBe(false)
+  })
+})

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,20 +1,110 @@
 import { createServiceClient } from '@/lib/supabase/service'
 
-// -- Email send caps (counts notification_delivery_log) -----------------------
-// `template` narrows to one email type (e.g. the 3/h magic-link resend cap);
-// omit it to count all templates sent to that recipient (the 10/day overall cap).
+// Guest-invite abuse guards (2607-DEV-591), reworked atomic in 2608-DEV-625.
+//
+// These used to COUNT rows and let the caller write afterwards, which meant N
+// concurrent submissions all read a count below `max` and all proceeded — the
+// exact burst the guards exist to stop. They now delegate to the
+// `consume_rate_limit` RPC, where prune/count/insert happen inside one
+// transaction holding a per-key advisory lock.
+//
+// Hence `consume*`, not `check*`: every allowed call has SPENT a slot. Calling
+// one of these twice for the same action burns two slots.
 
-export async function checkEmailCap({
-  recipient,
-  template,
-  windowMs,
-  max,
-}: {
+const RPC = 'consume_rate_limit'
+
+// PostgREST reports an unresolvable function as PGRST202; Postgres' own
+// undefined_function is 42883. Nothing else falls back — see legacy* below.
+const MISSING_FUNCTION_CODES = new Set(['PGRST202', '42883'])
+
+function isMissingFunction(error: { code?: string | null } | null): boolean {
+  return error?.code != null && MISSING_FUNCTION_CODES.has(error.code)
+}
+
+/** `true`/`false` = the RPC decided; `'rpc-missing'` = it isn't deployed yet. */
+type Outcome = boolean | 'rpc-missing'
+
+async function consumeSlot(key: string, windowMs: number, max: number): Promise<Outcome> {
+  const supabase = createServiceClient()
+
+  const { data, error } = await supabase.rpc(RPC, {
+    p_key:       key,
+    p_window_ms: windowMs,
+    p_max:       max,
+  })
+
+  if (error) {
+    if (isMissingFunction(error)) return 'rpc-missing'
+    // Fail closed: a broken guard must not silently unblock the abuse it is
+    // meant to enforce.
+    console.error('consume_rate_limit failed, denying', { key, error })
+    return false
+  }
+  // `data` is boolean | null. A null here means the RPC returned no row at all,
+  // which it cannot do — treat anything but an explicit true as a denial.
+  return data === true
+}
+
+// -- Email send caps ----------------------------------------------------------
+// `template` narrows to one email type (e.g. the 3/h magic-link resend cap);
+// omit it to cap all templates sent to that recipient (the 10/day overall cap).
+// The two scopes are separate keys, so they count independently.
+
+type EmailCapArgs = {
   recipient: string
   template?: string
   windowMs: number
   max: number
-}): Promise<boolean> {
+}
+
+export async function consumeEmailCap({
+  recipient,
+  template,
+  windowMs,
+  max,
+}: EmailCapArgs): Promise<boolean> {
+  const key = template ? `email:${recipient}:${template}` : `email:${recipient}`
+
+  const outcome = await consumeSlot(key, windowMs, max)
+  if (outcome !== 'rpc-missing') return outcome
+  return legacyEmailCap({ recipient, template, windowMs, max })
+}
+
+// -- Registration throttle ----------------------------------------------------
+// Keyed by share_link_id when the load carried one, else by event_id (covers
+// token-less / direct-URL loads).
+
+type RegistrationSlotArgs = {
+  shareLinkId: string | null
+  eventId: string
+  windowMs: number
+  max: number
+}
+
+export async function consumeRegistrationSlot({
+  shareLinkId,
+  eventId,
+  windowMs,
+  max,
+}: RegistrationSlotArgs): Promise<boolean> {
+  const key = shareLinkId ? `guest-reg:link:${shareLinkId}` : `guest-reg:event:${eventId}`
+
+  const outcome = await consumeSlot(key, windowMs, max)
+  if (outcome !== 'rpc-missing') return outcome
+  return legacyRegistrationThrottle({ shareLinkId, eventId, windowMs, max })
+}
+
+// -- Transitional fallback (remove once the RPC is live in production) --------
+// Vercel deploys on merge while `migrate-prod` waits for manual approval, so
+// production briefly runs this code against a schema with no
+// `consume_rate_limit`. Both guards fail CLOSED, which on a public flow would
+// deny every guest registration and every guest email. These two functions are
+// the pre-2608-DEV-625 count-based implementations, kept verbatim to cover that
+// window only — they are racy, which is the whole point of the rework, so they
+// run for the missing-function codes above and for nothing else.
+// Removal is tracked by the follow-up issue opened at GCR.
+
+async function legacyEmailCap({ recipient, template, windowMs, max }: EmailCapArgs): Promise<boolean> {
   const supabase = createServiceClient()
   const windowStart = new Date(Date.now() - windowMs).toISOString()
 
@@ -28,30 +118,19 @@ export async function checkEmailCap({
   if (template) query = query.eq('template', template)
 
   const { count, error } = await query
-  // Fail closed: a broken count query must not silently unblock the abuse
-  // guard it's meant to enforce.
   if (error) {
-    console.error('checkEmailCap query failed, denying', { recipient, template, error })
+    console.error('legacyEmailCap query failed, denying', { recipient, template, error })
     return false
   }
   return (count ?? 0) < max
 }
 
-// -- Registration throttle (counts guest_registrations.created_at) ------------
-// Keyed by share_link_id when the load carried one, else by event_id (covers
-// token-less / direct-URL loads).
-
-export async function checkRegistrationThrottle({
+async function legacyRegistrationThrottle({
   shareLinkId,
   eventId,
   windowMs,
   max,
-}: {
-  shareLinkId: string | null
-  eventId: string
-  windowMs: number
-  max: number
-}): Promise<boolean> {
+}: RegistrationSlotArgs): Promise<boolean> {
   const supabase = createServiceClient()
   const windowStart = new Date(Date.now() - windowMs).toISOString()
 
@@ -63,10 +142,8 @@ export async function checkRegistrationThrottle({
   query = shareLinkId ? query.eq('share_link_id', shareLinkId) : query.eq('event_id', eventId)
 
   const { count, error } = await query
-  // Fail closed: a broken count query must not silently unblock the abuse
-  // guard it's meant to enforce.
   if (error) {
-    console.error('checkRegistrationThrottle query failed, denying', { shareLinkId, eventId, error })
+    console.error('legacyRegistrationThrottle query failed, denying', { shareLinkId, eventId, error })
     return false
   }
   return (count ?? 0) < max

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { createServiceClient } from '@/lib/supabase/service'
 
 // Guest-invite abuse guards (2607-DEV-591), reworked atomic in 2608-DEV-625.
@@ -21,10 +22,19 @@ function isMissingFunction(error: { code?: string | null } | null): boolean {
   return error?.code != null && MISSING_FUNCTION_CODES.has(error.code)
 }
 
+/**
+ * A bucket key embeds the recipient's email address, so it must never reach a
+ * log. This yields the scope plus a short digest — enough to correlate repeated
+ * failures for one recipient without recording who they are.
+ */
+function keyDigest(key: string): string {
+  return createHash('sha256').update(key).digest('hex').slice(0, 12)
+}
+
 /** `true`/`false` = the RPC decided; `'rpc-missing'` = it isn't deployed yet. */
 type Outcome = boolean | 'rpc-missing'
 
-async function consumeSlot(key: string, windowMs: number, max: number): Promise<Outcome> {
+async function consumeSlot(key: string, scope: string, windowMs: number, max: number): Promise<Outcome> {
   const supabase = createServiceClient()
 
   const { data, error } = await supabase.rpc(RPC, {
@@ -37,7 +47,7 @@ async function consumeSlot(key: string, windowMs: number, max: number): Promise<
     if (isMissingFunction(error)) return 'rpc-missing'
     // Fail closed: a broken guard must not silently unblock the abuse it is
     // meant to enforce.
-    console.error('consume_rate_limit failed, denying', { key, error })
+    console.error('consume_rate_limit failed, denying', { scope, key: keyDigest(key), error })
     return false
   }
   // `data` is boolean | null. A null here means the RPC returned no row at all,
@@ -63,9 +73,12 @@ export async function consumeEmailCap({
   windowMs,
   max,
 }: EmailCapArgs): Promise<boolean> {
-  const key = template ? `email:${recipient}:${template}` : `email:${recipient}`
+  // Explicit null check, not truthiness: '' is a supplied template, not an
+  // absent one, and must not silently collapse into the recipient-wide bucket.
+  const scoped = template != null
+  const key = scoped ? `email:${recipient}:${template}` : `email:${recipient}`
 
-  const outcome = await consumeSlot(key, windowMs, max)
+  const outcome = await consumeSlot(key, scoped ? 'email+template' : 'email', windowMs, max)
   if (outcome !== 'rpc-missing') return outcome
   return legacyEmailCap({ recipient, template, windowMs, max })
 }
@@ -87,9 +100,10 @@ export async function consumeRegistrationSlot({
   windowMs,
   max,
 }: RegistrationSlotArgs): Promise<boolean> {
-  const key = shareLinkId ? `guest-reg:link:${shareLinkId}` : `guest-reg:event:${eventId}`
+  const byLink = shareLinkId !== null
+  const key = byLink ? `guest-reg:link:${shareLinkId}` : `guest-reg:event:${eventId}`
 
-  const outcome = await consumeSlot(key, windowMs, max)
+  const outcome = await consumeSlot(key, byLink ? 'guest-reg:link' : 'guest-reg:event', windowMs, max)
   if (outcome !== 'rpc-missing') return outcome
   return legacyRegistrationThrottle({ shareLinkId, eventId, windowMs, max })
 }
@@ -107,6 +121,9 @@ export async function consumeRegistrationSlot({
 async function legacyEmailCap({ recipient, template, windowMs, max }: EmailCapArgs): Promise<boolean> {
   const supabase = createServiceClient()
   const windowStart = new Date(Date.now() - windowMs).toISOString()
+  // Same explicit null check as consumeEmailCap — the two paths must scope
+  // identically, or the fallback would count a different bucket.
+  const scoped = template != null
 
   let query = supabase
     .from('notification_delivery_log')
@@ -115,11 +132,15 @@ async function legacyEmailCap({ recipient, template, windowMs, max }: EmailCapAr
     .eq('recipient', recipient)
     .gte('created_at', windowStart)
 
-  if (template) query = query.eq('template', template)
+  if (scoped) query = query.eq('template', template)
 
   const { count, error } = await query
   if (error) {
-    console.error('legacyEmailCap query failed, denying', { recipient, template, error })
+    console.error('legacyEmailCap query failed, denying', {
+      scope: scoped ? 'email+template' : 'email',
+      key:   keyDigest(scoped ? `email:${recipient}:${template}` : `email:${recipient}`),
+      error,
+    })
     return false
   }
   return (count ?? 0) < max
@@ -139,7 +160,7 @@ async function legacyRegistrationThrottle({
     .select('id', { count: 'exact', head: true })
     .gte('created_at', windowStart)
 
-  query = shareLinkId ? query.eq('share_link_id', shareLinkId) : query.eq('event_id', eventId)
+  query = shareLinkId !== null ? query.eq('share_link_id', shareLinkId) : query.eq('event_id', eventId)
 
   const { count, error } = await query
   if (error) {

--- a/supabase/migrations/20260804000000_2608_feat_625_atomic_rate_limits.sql
+++ b/supabase/migrations/20260804000000_2608_feat_625_atomic_rate_limits.sql
@@ -1,0 +1,142 @@
+-- ROLLBACK: SELECT cron.unschedule(jobname) FROM cron.job WHERE jobname = 'rate-limit-events-sweep';
+--           DROP FUNCTION IF EXISTS public.consume_rate_limit(text, bigint, integer);
+--           DROP TABLE IF EXISTS public.rate_limit_events;
+-- ============================================================
+-- [2608-DEV-625] Guest-invite rate limits: atomic check-then-act
+--
+-- The T5 abuse guards (lib/rate-limit.ts) were a JS-side read-then-decide:
+-- COUNT matching rows, compare to max, and the caller does its own write
+-- afterward. Nothing holds between the count and that write, so N concurrent
+-- submissions all read a count below max and all proceed — which is precisely
+-- the burst these guards exist to stop. They only slowed a serial abuser.
+--
+-- consume_rate_limit() collapses count-and-decide-and-record into ONE statement
+-- from the caller's point of view. One RPC call is one transaction:
+-- pg_advisory_xact_lock serializes same-key callers for its duration, and the
+-- lock is released on commit — so prune -> count -> insert is atomic per key
+-- while different keys stay fully parallel.
+--
+-- WHY A LEDGER AND NOT A COUNTER: a counter row keyed by (key, window-bucket)
+-- would be one UPSERT ... RETURNING with no lock at all, but it turns a SLIDING
+-- window into a FIXED one — a burst straddling a bucket boundary passes 2x max.
+-- The guards being replaced are sliding (created_at >= now() - window) and the
+-- issue requires preserving their scoping, so the ledger keeps one row per
+-- consumed slot and the window slides with now().
+--
+-- The ledger does not grow: each call first deletes ITS OWN key's expired rows,
+-- so a live key holds at most p_max rows. The nightly sweep in section 4 exists
+-- only for keys that are never called again (a one-off abuser's email address),
+-- which would otherwise sit there forever with no one to prune them.
+--
+-- Guard style, grants and header modeled on
+-- 20260714000000_2607_feat_claim_los_submissions.sql.
+-- ============================================================
+
+-- ── 1. rate_limit_events — one row per consumed slot ──────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.rate_limit_events (
+  id         uuid        NOT NULL DEFAULT gen_random_uuid(),
+  -- Opaque, caller-composed scope: 'email:<recipient>',
+  -- 'email:<recipient>:<template>', 'guest-reg:link:<id>', 'guest-reg:event:<id>'.
+  -- Deliberately not parsed here — the DB enforces the limit, the caller owns
+  -- the scoping.
+  bucket_key text        NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT rate_limit_events_pkey PRIMARY KEY (id),
+  -- A blank key is not a scope, and an unbounded one is an index-bloat vector
+  -- reachable from a public form (the email caps key on user-supplied text).
+  CONSTRAINT rate_limit_events_bucket_key_check
+    CHECK (btrim(bucket_key) <> '' AND char_length(bucket_key) <= 512)
+);
+
+-- Every read and every prune is (bucket_key = ?, created_at </>= ?).
+CREATE INDEX IF NOT EXISTS idx_rate_limit_events_key_created
+  ON public.rate_limit_events (bucket_key, created_at);
+
+-- Deny by default, with NO policies at all: nothing but the service role (which
+-- bypasses RLS) and the SECURITY DEFINER function below ever touches this table.
+-- Writing no policy is what keeps the Pattern A / auth.jwt() trap out of reach.
+ALTER TABLE public.rate_limit_events ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.rate_limit_events FROM anon, authenticated;
+
+-- ── 2. consume_rate_limit — atomically take a slot, or refuse ─────────────────
+-- Returns true when a slot was consumed (caller may proceed), false when the
+-- key is at its limit for the window. NOT idempotent by design: every true
+-- return has recorded a row. This is why the TypeScript callers are named
+-- consume*, not check* — calling it twice burns two slots.
+
+CREATE OR REPLACE FUNCTION public.consume_rate_limit(
+  p_key       text,
+  p_window_ms bigint,
+  p_max       integer
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_window interval;
+  v_count  integer;
+BEGIN
+  -- SECURITY DEFINER bypasses RLS, so the authorization check lives in the body.
+  -- coalesce is load-bearing: auth.role() is NULL when there is no JWT at all,
+  -- and NULL <> 'service_role' evaluates to NULL, which would skip the RAISE and
+  -- let an unauthenticated caller through. is_admin() is deliberately NOT part
+  -- of this check — no admin path calls it.
+  IF coalesce(auth.role(), '') <> 'service_role' THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  IF p_key IS NULL OR btrim(p_key) = ''
+     OR p_window_ms IS NULL OR p_window_ms <= 0
+     OR p_max IS NULL OR p_max < 0 THEN
+    RAISE EXCEPTION 'consume_rate_limit: invalid arguments (key=%, window_ms=%, max=%)',
+      p_key, p_window_ms, p_max;
+  END IF;
+
+  v_window := make_interval(secs => p_window_ms::double precision / 1000.0);
+
+  -- Serializes concurrent callers of THIS key only; released on commit. A
+  -- hashtext collision between two unrelated keys costs a little serialization
+  -- and nothing else — the queries below are still filtered by bucket_key.
+  PERFORM pg_advisory_xact_lock(hashtext(p_key)::bigint);
+
+  DELETE FROM public.rate_limit_events
+  WHERE bucket_key = p_key
+    AND created_at < now() - v_window;
+
+  SELECT count(*) INTO v_count
+  FROM public.rate_limit_events
+  WHERE bucket_key = p_key;
+
+  IF v_count >= p_max THEN
+    RETURN false;
+  END IF;
+
+  INSERT INTO public.rate_limit_events (bucket_key) VALUES (p_key);
+  RETURN true;
+END;
+$$;
+
+-- ── 3. Grants — service_role only (server actions call via the service client) ─
+
+REVOKE EXECUTE ON FUNCTION public.consume_rate_limit(text, bigint, integer) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.consume_rate_limit(text, bigint, integer) TO service_role;
+
+-- ── 4. Nightly sweep — bound keys that are never called again ─────────────────
+-- Two days is well past the longest window in use (24h daily email cap), so this
+-- can never prune a slot that is still counting.
+
+SELECT cron.unschedule(jobname)
+FROM cron.job
+WHERE jobname = 'rate-limit-events-sweep';
+
+SELECT cron.schedule(
+  'rate-limit-events-sweep',
+  '15 3 * * *',
+  $$
+  DELETE FROM public.rate_limit_events
+  WHERE created_at < now() - interval '2 days';
+  $$
+);

--- a/supabase/migrations/20260804000100_2608_feat_625_rate_limit_created_at_index.sql
+++ b/supabase/migrations/20260804000100_2608_feat_625_rate_limit_created_at_index.sql
@@ -1,0 +1,26 @@
+-- ROLLBACK: DROP INDEX IF EXISTS public.idx_rate_limit_events_created_at;
+-- ============================================================
+-- [2608-DEV-625] Index the nightly rate_limit_events sweep
+--
+-- Follow-up to 20260804000000, raised in review of PR #693.
+--
+-- idx_rate_limit_events_key_created leads with bucket_key, so it serves the
+-- per-key prune inside consume_rate_limit but NOT the sweep in section 4 of
+-- that migration, whose only predicate is a global `created_at < now() - 2
+-- days`. Leading-column mismatch means the planner falls back to a sequential
+-- scan.
+--
+-- That is cheap while the table is small, and the per-key self-prune keeps live
+-- keys at most p_max rows. But bucket_key is caller-composed from a public
+-- form's email field, so an abuser can mint effectively unlimited DISTINCT
+-- keys — each leaving rows that no subsequent call for that key will ever come
+-- back to prune. The sweep is the only thing that collects them, and it is
+-- exactly the query the existing index cannot serve.
+--
+-- Separate file rather than an edit to 20260804000000 because that migration is
+-- already applied on DEV; both ship in the same PR, so production applies them
+-- together in one gated run.
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_events_created_at
+  ON public.rate_limit_events (created_at);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1627,6 +1627,24 @@ export type Database = {
           },
         ]
       }
+      rate_limit_events: {
+        Row: {
+          bucket_key: string
+          created_at: string
+          id: string
+        }
+        Insert: {
+          bucket_key: string
+          created_at?: string
+          id?: string
+        }
+        Update: {
+          bucket_key?: string
+          created_at?: string
+          id?: string
+        }
+        Relationships: []
+      }
       role_change_audit: {
         Row: {
           changed_at: string
@@ -2277,6 +2295,10 @@ export type Database = {
           root_abo_number: string
           rows: Json
         }[]
+      }
+      consume_rate_limit: {
+        Args: { p_key: string; p_max: number; p_window_ms: number }
+        Returns: boolean
       }
       dissolve_partnership: {
         Args: { p_changed_by: string; p_profile_id: string }


### PR DESCRIPTION
Closes #625

## What this changes

`lib/rate-limit.ts` implemented the T5 abuse guards as a JS-side read-then-decide: COUNT matching rows, compare to `max`, then the caller does its own write. Nothing holds between the count and that write, so N concurrent submissions all read a count below `max` and all proceed — the exact burst these guards exist to stop. They only slowed a serial abuser.

`consume_rate_limit(p_key, p_window_ms, p_max)` collapses that into one transaction: `pg_advisory_xact_lock(hashtext(p_key))`, then prune → count → insert, over a self-pruning `rate_limit_events` ledger.

**Why a ledger and not a counter table.** A counter keyed by `(key, window-bucket)` would be a single `UPSERT … RETURNING` with no lock at all, but it turns the sliding window into a fixed one — a burst straddling a bucket boundary passes `2 x max`. The guards being replaced are sliding (`created_at >= now() - window`) and the issue requires preserving their scoping.

The ledger does not grow: each call first deletes its own key's expired rows, so a live key holds at most `p_max` rows. The nightly `rate-limit-events-sweep` job only bounds keys that are never called again.

**The rename is load-bearing.** `checkEmailCap` → `consumeEmailCap`, `checkRegistrationThrottle` → `consumeRegistrationSlot`. Calling a consuming operation `check` invites a double-call that burns two slots.

## Concurrency proof (DEV `iymwxdewcpvpjgzewtzk`)

Static analysis cannot show this, so it was measured. 40 pg_cron jobs on a `'10 seconds'` schedule, all calling `consume_rate_limit('test:cronproof-1', 3600000, 30)`:

| metric | value |
|---|---|
| rounds x callers, per `date_trunc('second', start_time)` | 5 x **exactly 40**, at 11:49:24 / :34 / :44 / :54 / 11:50:04 |
| total runs / distinct backends | 200 / 200 |
| job failures | 0 |
| **`rate_limit_events` rows for the key** | **exactly 30** |

Over-issue would have shown as >30. All proof jobs were unscheduled and all proof rows deleted afterwards (`remaining_jobs = 0`, `total_rows = 0`).

Driven from inside Postgres rather than from 40 client processes because the Management API would not serve 40 simultaneous sessions — it stalled at 25.

## Security posture, verified against the live DEV catalog

- `rls_enabled = true`, `policy_count = 0` — deny by default, and writing no policy at all keeps the Pattern A / `auth.jwt()` trap out of reach by construction
- function `prosecdef = true`, ACL `postgres=X/postgres | service_role=X/postgres` — no PUBLIC, anon or authenticated
- table ACL carries no anon/authenticated
- the in-body guard is `coalesce(auth.role(), '') <> 'service_role'`. The `coalesce` is deliberate and stronger than the existing repo pattern: bare `auth.role() <> 'service_role'` evaluates to `NULL` when there is no JWT, which skips the `RAISE` entirely
- `is_admin()` is deliberately not part of the guard — no admin path calls this

`/security-review` on the branch: no HIGH or MEDIUM findings.

## Two intended behaviour changes

1. **The throttle counts submissions, not registrants.** It used to count `guest_registrations` rows, but that table is upserted on `(event_id, email)` — a guest re-submitting never incremented the count and `created_at` never moved. So it counted *distinct new guests per hour*, which is precisely why a scripted burst slid under it. Same numbers (30/h), stricter and correct meaning; a legitimate re-submit now consumes a slot.
2. **A slot is consumed at check time, not send time.** If `sendTransactionalEmail` later fails, the slot is spent. Correct direction for an abuse guard, but the email caps now measure attempts rather than delivered mail.

Scoping preserved exactly: email+template for the 3/h resend cap, email alone for the 10/day cap, `share_link_id` else `event_id` for the throttle, fail-closed on error.

## The transitional fallback — please read before merging

`lib/rate-limit.ts` falls back to the old count-based path on `PGRST202` / `42883` **only**.

Vercel deploys on merge while `migrate-prod` waits for manual approval, so production would briefly run this code against a schema with no `consume_rate_limit` — and these guards fail *closed*, denying every guest registration and every guest email on a public flow. The fallback closes that window. The clean alternative (migration-only PR approved in prod first, then a code-only PR) costs a second full CI/preview cycle and was rejected for this ticket.

**This fallback cannot be removed by this PR's own GCR** — it must outlive the merge until `migrate-prod` has actually applied on production. A follow-up issue to delete it will be opened once that run is confirmed.

⚠️ **#677's migration has never landed in prod.** Its gated `migrate-prod` run is still pending approval and must be approved before this one.

## Verification

| gate | result |
|---|---|
| `npx vitest run lib/rate-limit.test.ts lib/actions/guest-registration.test.ts lib/notifications/guest-event-changes.test.ts` | `Test Files 3 passed (3)` / `Tests 45 passed (45)` — baseline was 2 / 33 |
| `npm run check-types` | clean |
| `npm run lint` | 0 errors, 475 warnings (baseline 476, all pre-existing); `npx eslint` on all six changed TS files → zero output |
| `npm run build` | success |
| migration | applied to DEV via `supabase db push`; `types/supabase.ts` regenerated (+22 lines) |

**E2E coverage: none, by design.** Server-side abuse guard, no UI surface — nothing renders differently at 390px and no authenticated route changes.

## Noted, not fixed here

The DEV role `price_checker` (login role, `rolbypassrls = false`) is auto-granted `arwdDxtm` on every new public table — including `rate_limit_events` — by an `ALTER DEFAULT PRIVILEGES IN SCHEMA public` rule that lists it beside anon/authenticated/service_role. It appears nowhere in this repo: no migration creates it, no code connects as it. Not a regression from this PR, which merely inherits the rule, and RLS still blocks it from the new table. Flagged for a separate audit, including whether it exists in production.

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] Migration: `rate_limit_events` + `consume_rate_limit` + grants + nightly sweep + `-- ROLLBACK:` header
- [x] `lib/rate-limit.ts` reworked onto the RPC, fail-closed preserved, transitional fallback added
- [x] REFERENCE SWEEP: both call-site files updated, no other importers exist
- [x] New `lib/rate-limit.test.ts` (12 tests); both existing test files moved to module mocks
- [x] Applied to DEV, types regenerated, 40-way concurrency proof passed
- [x] `/security-review` — no HIGH/MEDIUM findings

**Next:** wait for CI green + Vercel preview READY, then ask the user before marking ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registration and email rate limiting with atomic quota consumption.
  * Failed email sends now count toward applicable limits.
  * Rate-limit errors are handled more safely to prevent unintended limit bypasses.
  * Preserved temporary fallback behavior when enhanced rate limiting is unavailable.

* **New Features**
  * Added sliding-window tracking for registration attempts and email notifications.
  * Enforced hourly and daily email caps consistently across guest registration, resend, update, and cancellation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->