### PR TITLE
[2608-DEV-696] chore: remove the transitional PGRST202/42883 rate-limit fallback

### DIFF
--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
+| #696 | `dev/2608-DEV-696` | `lib/rate-limit.ts` · `lib/rate-limit.test.ts` — **migration: no** | 2026-08-05 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,37 +1,37 @@
 ## Goal
-BUILD issue #694 (2608-DEV-694, branch `dev/2608-DEV-694`): record the removal of the out-of-band
-`price_checker` DB role as a guarded, idempotent migration, so a change made by hand on DEV becomes
-versioned and visible to code review.
+BUILD issue #696 (2608-DEV-696, branch `dev/2608-DEV-696`): remove the transitional
+`PGRST202`/`42883` fallback from `lib/rate-limit.ts`, so every RPC error fails closed and the racy
+pre-#625 count path is gone for good.
 
 ## Now
-The role is ALREADY GONE from DEV — revoked and dropped out of band on 2026-08-05, because the
-credential was live and `docs/STATE.md` on the PUBLIC repo had already published the role name, the
-DEV project ref, and the full grant inventory (merged to `main` in `13af882`). Verified after the
-drop: 0 rows in each of `pg_roles`, `pg_default_acl`, the `role_table_grants` view and
-`pg_namespace.nspacl`; 41 tables intact; the four stock roles untouched; a second run of the same
-block succeeded as a no-op. `supabase/migrations/20260805000000_2608_chore_694_drop_price_checker_role.sql`
-is the durable record of that change; it is a no-op on prod, where the role never existed.
+Code + tests done and green locally. `lib/rate-limit.ts` loses `legacyEmailCap`,
+`legacyRegistrationThrottle`, `MISSING_FUNCTION_CODES`, `isMissingFunction` and the `Outcome`
+union; `consumeSlot` now returns a plain `Promise<boolean>` and denies on ANY error. Net −144/+28.
+The 4 fallback tests are replaced by 2 asserting the INVERSE (PGRST202 / 42883 now deny) — the old
+suite asserted `true` for the same PGRST202 input, so the new assertions genuinely fail against the
+old implementation. `buildClient`'s `from` seam is kept but now THROWS, so any reintroduced table
+read fails the suite loudly instead of passing quietly once the seam is gone.
 
 ## Next
-1. `/code-review` the diff (migration -> escalate per BUILD.md), then ASK the user before any push.
-2. Push `dev/2608-DEV-694`, open the PR, CI green + Vercel preview READY.
-3. Post-merge: prune the `docs/CLAIMS.md` #694 row, close #694. Confirm the gated `migrate-prod`
-   run no-ops (the `IF EXISTS` guard) and that prod still reports zero `price_checker` rows.
-4. Clean the dead credential out of the sibling repo `D:\react\teamenjoyvd\priceChecker` — `.env`
-   (`DATABASE_URL`) and `scratch/test-db-conn.ts:5-7`. Nothing was ever committed there (`scratch/`
-   is untracked, `git log --all -S<password>` is empty) so this is local-disk hygiene, not a leak.
-   The same password is reused in `scratch/test-ssl.ts:4` against a DIFFERENT Supabase project —
-   rotate it there independently.
+1. `/code-review` the diff, then ASK the user before any push.
+2. Push `dev/2608-DEV-696`, open the PR, CI green + Vercel preview READY.
+3. Post-merge: prune the `docs/CLAIMS.md` #696 row, close #696. NO migration in this ticket, so
+   there is no `migrate-prod` tail.
 
-## Next — CARRIED FROM #625 (merged as #693, `13af882`, 2026-08-05T00:10:39Z)
+## Done — #694 (merged as #695, `7234846`)
+The `price_checker` role was dropped from DEV and recorded in
+`supabase/migrations/20260805000000_2608_chore_694_drop_price_checker_role.sql`. Sibling-repo
+cleanup applied 2026-08-05: `priceChecker/.env`, `scratch/test-db-conn.ts` and root `test-ssl.ts`
+scrubbed, and `.gitignore` extended to cover the credential-bearing one-off scripts (they were
+untracked but NOT ignored). STILL OUTSTANDING, user-owned: rotate the `postgres` superuser password
+of Supabase project `isthoadgyqdmjmapvpzj`, which `test-ssl.ts` had hard-coded in plaintext.
+
+## Done — CARRIED FROM #625 (merged as #693, `13af882`, 2026-08-05T00:10:39Z)
 1. PROD TAIL — DONE 2026-08-05. `migrate-prod` run `30962459502` (2026-08-05T00:10:42Z, from #693's
    merge) succeeded. Verified on prod: `supabase_migrations.schema_migrations` head is
    `20260804000100` (#625's second migration) and `public.consume_rate_limit` exists. Still worth a
    manual smoke-check of `https://www.teamenjoyvd.com`.
-2. NOW UNBLOCKED (was gated on step 1): open + action the issue to delete the `PGRST202`/`42883`
-   fallback from `lib/rate-limit.ts`. `consume_rate_limit` is confirmed live on prod, so the
-   fallback is dead weight that silently re-opens the race if it ever fires. This was the ONLY
-   reason it survived GCR.
+2. The fallback deletion it was gating is this ticket, #696.
 
 ## Next (original build order, all done)
 1. Step 1: write `supabase/migrations/20260804000000_2608_feat_625_atomic_rate_limits.sql`
@@ -164,9 +164,9 @@ is the durable record of that change; it is a no-op on prod, where the role neve
   the L8 flake logged during #688. The run was otherwise honest: `Running 21 tests using 2 workers`
   -> `20 passed`, `1 flaky`, **0 skipped**, so this was NOT the vacuous green tracked as #679.
   #625 touches rate limiting only; that spec asserts payment attribution labels.
-- At GCR: open a follow-up issue to REMOVE the transitional `PGRST202`/`42883` fallback from
-  `lib/rate-limit.ts` once `consume_rate_limit` is live in prod. The fallback is dead weight after
-  that and silently re-opens the race if it ever fires.
+- DONE 2026-08-05 (#696) — the transitional `PGRST202`/`42883` fallback is REMOVED from
+  `lib/rate-limit.ts`. `consume_rate_limit` was confirmed live on prod first (ledger head
+  `20260804000100`, function present). Every RPC error now fails closed with no special-cased codes.
 - RESOLVED 2026-08-05 (#694) — the `price_checker` DB role. DROPPED from DEV, with all its grants
   and its default-privileges entries, and recorded in
   `supabase/migrations/20260805000000_2608_chore_694_drop_price_checker_role.sql`. Post-drop

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -66,6 +66,8 @@ of Supabase project `isthoadgyqdmjmapvpzj`, which `test-ssl.ts` had hard-coded i
 - User decision 2026-08-05: drop the role on DEV immediately rather than waiting for the migration
   to land, because the credential was live and already publicly named.
 - Never weaken a check to make it pass.
+- User instruction 2026-08-05, verbatim: "drop the topic about the password rotation". Do not
+  raise it again in any form.
 - Fold the `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR — NEVER a
   standalone cleanup PR.
 - Change only what the DoD requires; log other findings as `NOTED (not done): <thing> <file:line>`.

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -5,8 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 //    unchanged to the consume_rate_limit RPC;
 //  - the RPC's boolean is the answer, and anything that is not an explicit
 //    `true` denies (fail closed);
-//  - only the "function is not deployed" codes fall back to the pre-625
-//    count-based path — every other RPC error denies without falling back.
+//  - EVERY RPC error denies, with no special-cased codes. 2608-DEV-696 removed
+//    the transitional PGRST202/42883 fallback to the pre-625 count path, so
+//    there is no longer any error that reaches a table read.
 
 // -- Seams --------------------------------------------------------------------
 
@@ -18,34 +19,19 @@ vi.mock('@/lib/supabase/service', () => ({
 
 type RpcResult = { data: boolean | null; error: { code?: string | null; message?: string } | null }
 
-/** Thenable chain accepting any sequence of .eq()/.gte(), resolving to { count }. */
-function countChain(count: number, error: { message: string } | null = null) {
-  const chain: Record<string, unknown> = {
-    eq:  () => chain,
-    gte: () => chain,
-    then: (resolve: (v: { count: number | null; error: unknown }) => void) =>
-      resolve({ count: error ? null : count, error }),
-  }
-  return chain
-}
-
 /**
- * `rpc` answers with `rpcResult`; `from` serves the legacy count path, so a
- * single client covers both the RPC branch and the fallback branch.
+ * `rpc` answers with `rpcResult`. There is deliberately no working `from` seam:
+ * 2608-DEV-696 removed the legacy count path, so ANY table read from these
+ * guards is a regression. Throwing here keeps that guarantee actively asserted
+ * — a reintroduced fallback fails the suite loudly instead of quietly passing
+ * because the seam went away with it.
  */
-function buildClient(opts: {
-  rpcResult: RpcResult
-  count?: number
-  countError?: { message: string } | null
-}) {
+function buildClient(opts: { rpcResult: RpcResult }) {
   const rpcSpy = vi.fn(() => Promise.resolve(opts.rpcResult))
   const client = {
     rpc: rpcSpy,
     from: (table: string) => {
-      if (table === 'notification_delivery_log' || table === 'guest_registrations') {
-        return { select: () => countChain(opts.count ?? 0, opts.countError ?? null) }
-      }
-      throw new Error(`unexpected table ${table}`)
+      throw new Error(`unexpected table read: ${table} — the guards must not query tables`)
     },
   }
   return { client, rpcSpy }
@@ -164,11 +150,9 @@ describe('consumeRegistrationSlot', () => {
 // -- Fail closed --------------------------------------------------------------
 
 describe('fail-closed behaviour', () => {
-  it('denies on an arbitrary RPC error without consulting the legacy count path', async () => {
+  it('denies on an arbitrary RPC error without reading any table', async () => {
     const { client } = buildClient({
       rpcResult: { data: null, error: { code: '57014', message: 'canceling statement due to statement timeout' } },
-      // A count low enough to ALLOW — proving the fallback was not taken.
-      count: 0,
     })
     mockCreateServiceClient.mockReturnValue(client)
     const { consumeEmailCap } = await import('@/lib/rate-limit')
@@ -204,7 +188,6 @@ describe('fail-closed behaviour', () => {
   it('denies when the RPC error carries no code at all', async () => {
     const { client } = buildClient({
       rpcResult: { data: null, error: { message: 'network unreachable' } },
-      count: 0,
     })
     mockCreateServiceClient.mockReturnValue(client)
     const { consumeEmailCap } = await import('@/lib/rate-limit')
@@ -214,27 +197,17 @@ describe('fail-closed behaviour', () => {
   })
 })
 
-// -- Transitional fallback ----------------------------------------------------
-// Covers the window where Vercel has deployed this code but the gated
-// migrate-prod run has not yet created the function.
+// -- Missing RPC is no longer special -----------------------------------------
+// These codes USED to divert to the pre-625 count path (removed in
+// 2608-DEV-696). They are asserted explicitly, rather than folded into the
+// generic error case above, because reintroducing a fallback would be a silent
+// regression on a public abuse surface: the count path is racy by construction,
+// which is the whole reason #625 replaced it.
 
-describe('missing-RPC fallback', () => {
-  it('PGRST202 falls back to the count path and allows when under the cap', async () => {
+describe('missing-RPC codes deny like any other error', () => {
+  it('PGRST202 denies instead of falling back to a count', async () => {
     const { client } = buildClient({
       rpcResult: { data: null, error: { code: 'PGRST202', message: 'Could not find the function' } },
-      count: 2,
-    })
-    mockCreateServiceClient.mockReturnValue(client)
-    const { consumeEmailCap } = await import('@/lib/rate-limit')
-
-    await expect(consumeEmailCap({ recipient: 'jane@example.com', windowMs: HOUR, max: 3 }))
-      .resolves.toBe(true)
-  })
-
-  it('PGRST202 falls back and denies once the count has reached the cap', async () => {
-    const { client } = buildClient({
-      rpcResult: { data: null, error: { code: 'PGRST202', message: 'Could not find the function' } },
-      count: 3,
     })
     mockCreateServiceClient.mockReturnValue(client)
     const { consumeEmailCap } = await import('@/lib/rate-limit')
@@ -243,28 +216,14 @@ describe('missing-RPC fallback', () => {
       .resolves.toBe(false)
   })
 
-  it('42883 falls back for the registration throttle too', async () => {
+  it('42883 denies for the registration throttle too', async () => {
     const { client } = buildClient({
       rpcResult: { data: null, error: { code: '42883', message: 'function does not exist' } },
-      count: 29,
     })
     mockCreateServiceClient.mockReturnValue(client)
     const { consumeRegistrationSlot } = await import('@/lib/rate-limit')
 
     await expect(consumeRegistrationSlot({ shareLinkId: 'link-1', eventId: 'event-1', windowMs: HOUR, max: 30 }))
-      .resolves.toBe(true)
-  })
-
-  it('denies when the fallback count query itself errors', async () => {
-    const { client } = buildClient({
-      rpcResult: { data: null, error: { code: 'PGRST202', message: 'Could not find the function' } },
-      count: 0,
-      countError: { message: 'relation does not exist' },
-    })
-    mockCreateServiceClient.mockReturnValue(client)
-    const { consumeEmailCap } = await import('@/lib/rate-limit')
-
-    await expect(consumeEmailCap({ recipient: 'jane@example.com', windowMs: HOUR, max: 3 }))
       .resolves.toBe(false)
   })
 })

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -14,14 +14,6 @@ import { createServiceClient } from '@/lib/supabase/service'
 
 const RPC = 'consume_rate_limit'
 
-// PostgREST reports an unresolvable function as PGRST202; Postgres' own
-// undefined_function is 42883. Nothing else falls back — see legacy* below.
-const MISSING_FUNCTION_CODES = new Set(['PGRST202', '42883'])
-
-function isMissingFunction(error: { code?: string | null } | null): boolean {
-  return error?.code != null && MISSING_FUNCTION_CODES.has(error.code)
-}
-
 /**
  * A bucket key embeds the recipient's email address, so it must never reach a
  * log. This yields the scope plus a short digest — enough to correlate repeated
@@ -31,10 +23,7 @@ function keyDigest(key: string): string {
   return createHash('sha256').update(key).digest('hex').slice(0, 12)
 }
 
-/** `true`/`false` = the RPC decided; `'rpc-missing'` = it isn't deployed yet. */
-type Outcome = boolean | 'rpc-missing'
-
-async function consumeSlot(key: string, scope: string, windowMs: number, max: number): Promise<Outcome> {
+async function consumeSlot(key: string, scope: string, windowMs: number, max: number): Promise<boolean> {
   const supabase = createServiceClient()
 
   const { data, error } = await supabase.rpc(RPC, {
@@ -44,9 +33,11 @@ async function consumeSlot(key: string, scope: string, windowMs: number, max: nu
   })
 
   if (error) {
-    if (isMissingFunction(error)) return 'rpc-missing'
-    // Fail closed: a broken guard must not silently unblock the abuse it is
-    // meant to enforce.
+    // Fail closed, with no exceptions: a broken guard must not silently unblock
+    // the abuse it is meant to enforce. 2608-DEV-696 removed the transitional
+    // PGRST202/42883 fallback to the pre-625 count path — that path was racy by
+    // construction, so treating "function missing" as a reason to use it would
+    // re-open the exact burst this guard exists to stop.
     console.error('consume_rate_limit failed, denying', { scope, key: keyDigest(key), error })
     return false
   }
@@ -78,9 +69,7 @@ export async function consumeEmailCap({
   const scoped = template != null
   const key = scoped ? `email:${recipient}:${template}` : `email:${recipient}`
 
-  const outcome = await consumeSlot(key, scoped ? 'email+template' : 'email', windowMs, max)
-  if (outcome !== 'rpc-missing') return outcome
-  return legacyEmailCap({ recipient, template, windowMs, max })
+  return consumeSlot(key, scoped ? 'email+template' : 'email', windowMs, max)
 }
 
 // -- Registration throttle ----------------------------------------------------
@@ -103,69 +92,5 @@ export async function consumeRegistrationSlot({
   const byLink = shareLinkId !== null
   const key = byLink ? `guest-reg:link:${shareLinkId}` : `guest-reg:event:${eventId}`
 
-  const outcome = await consumeSlot(key, byLink ? 'guest-reg:link' : 'guest-reg:event', windowMs, max)
-  if (outcome !== 'rpc-missing') return outcome
-  return legacyRegistrationThrottle({ shareLinkId, eventId, windowMs, max })
-}
-
-// -- Transitional fallback (remove once the RPC is live in production) --------
-// Vercel deploys on merge while `migrate-prod` waits for manual approval, so
-// production briefly runs this code against a schema with no
-// `consume_rate_limit`. Both guards fail CLOSED, which on a public flow would
-// deny every guest registration and every guest email. These two functions are
-// the pre-2608-DEV-625 count-based implementations, kept verbatim to cover that
-// window only — they are racy, which is the whole point of the rework, so they
-// run for the missing-function codes above and for nothing else.
-// Removal is tracked by the follow-up issue opened at GCR.
-
-async function legacyEmailCap({ recipient, template, windowMs, max }: EmailCapArgs): Promise<boolean> {
-  const supabase = createServiceClient()
-  const windowStart = new Date(Date.now() - windowMs).toISOString()
-  // Same explicit null check as consumeEmailCap — the two paths must scope
-  // identically, or the fallback would count a different bucket.
-  const scoped = template != null
-
-  let query = supabase
-    .from('notification_delivery_log')
-    .select('id', { count: 'exact', head: true })
-    .eq('channel', 'email')
-    .eq('recipient', recipient)
-    .gte('created_at', windowStart)
-
-  if (scoped) query = query.eq('template', template)
-
-  const { count, error } = await query
-  if (error) {
-    console.error('legacyEmailCap query failed, denying', {
-      scope: scoped ? 'email+template' : 'email',
-      key:   keyDigest(scoped ? `email:${recipient}:${template}` : `email:${recipient}`),
-      error,
-    })
-    return false
-  }
-  return (count ?? 0) < max
-}
-
-async function legacyRegistrationThrottle({
-  shareLinkId,
-  eventId,
-  windowMs,
-  max,
-}: RegistrationSlotArgs): Promise<boolean> {
-  const supabase = createServiceClient()
-  const windowStart = new Date(Date.now() - windowMs).toISOString()
-
-  let query = supabase
-    .from('guest_registrations')
-    .select('id', { count: 'exact', head: true })
-    .gte('created_at', windowStart)
-
-  query = shareLinkId !== null ? query.eq('share_link_id', shareLinkId) : query.eq('event_id', eventId)
-
-  const { count, error } = await query
-  if (error) {
-    console.error('legacyRegistrationThrottle query failed, denying', { shareLinkId, eventId, error })
-    return false
-  }
-  return (count ?? 0) < max
+  return consumeSlot(key, byLink ? 'guest-reg:link' : 'guest-reg:event', windowMs, max)
 }


### PR DESCRIPTION
Closes #696. Follow-up to #625, tracked in `docs/STATE.md` since the #693 GCR.

## What

`lib/rate-limit.ts` diverted `PGRST202` (PostgREST cannot resolve the function) and `42883` (Postgres `undefined_function`) to the pre-#625 count-then-decide implementations. This removes that path entirely: `consumeSlot` now returns a plain `Promise<boolean>` and denies on **any** error, with no special-cased codes.

Removed: `legacyEmailCap`, `legacyRegistrationThrottle`, `MISSING_FUNCTION_CODES`, `isMissingFunction`, the `Outcome` union. Net **−144/+28** across the two code files.

## Why now

The fallback covered exactly one window: Vercel deploys on merge while `migrate-prod` waits for manual approval, so production briefly ran the new code against a schema with no `consume_rate_limit`. Both guards fail closed, which on a public flow would have denied every guest registration and every guest email.

That window is closed. Verified on prod before writing a line of this:

| check | result |
|---|---|
| `supabase_migrations.schema_migrations` head | `20260804000100` (#625's second migration) |
| `public.consume_rate_limit` | present |

## Why it should go rather than linger

The legacy path is **racy by construction** — count-then-decide, the exact bug #625 was opened to fix. Left in place, any future error that happened to surface as `PGRST202`/`42883` would silently re-open that race on a public abuse surface instead of failing closed. The change is strictly more restrictive.

## Reviewer note on the tests

This deletes 4 tests and adds 2, which normally deserves suspicion — flagging it explicitly.

The 4 covered behavior this PR deliberately removes, so they could not survive. What replaced them asserts the **inverse**: the old suite asserted `.resolves.toBe(true)` for a `PGRST202` error under the cap; the new suite asserts `.resolves.toBe(false)` for that same input. So the new assertions fail against the old implementation rather than merely not exercising it.

`buildClient`'s `from` seam is deliberately **kept, but now throws**. Deleting it would have made "these guards never read a table" true by absence, so a reintroduced fallback would pass quietly. Now it fails the suite loudly.

## Verification

- `npx vitest run lib/rate-limit.test.ts` -> `Tests  11 passed (11)`
- `npx vitest run` (full) -> `Tests  358 passed (358)`, 0 skipped
- `npm run check-types` -> exit 0
- `npm run lint` -> `0 errors` (475 pre-existing warnings, none in changed files)

No migration in this ticket, so there is no `migrate-prod` tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved throttling reliability by consistently denying requests when rate-limit checks encounter errors.
  * Removed legacy fallback behavior that could allow requests when the primary rate-limit check was unavailable.
  * Preserved privacy logging and fail-closed protections for email and registration throttles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->