### PR TITLE
[2608-DEV-700] fix: LocationMap size transition, no LIVE pill, expanded by default

### DIFF
--- a/app/(dashboard)/components/tiles/LocationTile.tsx
+++ b/app/(dashboard)/components/tiles/LocationTile.tsx
@@ -29,8 +29,6 @@ export default function LocationTile({
         className="absolute inset-0"
         location={t('home.loc.city')}
         coordinates={SOFIA_COORDS}
-        liveLabel={t('home.loc.live')}
-        expandHint={t('home.loc.expand')}
       />
     </BentoCard>
   )

--- a/components/ui/expand-map.tsx
+++ b/components/ui/expand-map.tsx
@@ -23,6 +23,17 @@
  *
  * Expanded is the default state; a click or Enter/Space collapses it.
  *
+ * REDUCED MOTION: this tile deliberately does NOT honour
+ * `prefers-reduced-motion` (product decision, 2026-08-06, #700). It used to,
+ * via `transition={reduceMotion ? instant : …}` on every animated prop — but
+ * `instant` is `{ duration: 0 }`, which keeps the state change and removes only
+ * the smoothing. The 4px hover nudge on the location name therefore teleported
+ * rather than easing, and the whole card read as a hard on/off. If this is ever
+ * reinstated, suppress the movement itself (x: 0, no scale/size change), never
+ * merely zero the duration. The repo-wide guard in app/globals.css is scoped to
+ * .skeleton-shimmer / .bento-tile / .interactive-lift, none of which this
+ * component carries, so it does not re-disable these transitions.
+ *
  * Strings are props, not translations — the component stays i18n-agnostic like
  * the rest of components/ui. Callers pass translated text.
  */
@@ -34,7 +45,6 @@ import {
   AnimatePresence,
   motion,
   useMotionValue,
-  useReducedMotion,
   useSpring,
   useTransform,
 } from 'framer-motion'
@@ -94,9 +104,6 @@ export function LocationMap({
   // The <pattern> id must be unique: the home page mounts this tile twice
   // (desktop + mobile branches of app/(dashboard)/page.tsx are both in the DOM).
   const gridId = useId()
-  const prefersReducedMotion = useReducedMotion()
-  const reduceMotion = prefersReducedMotion === true
-  const instant = { duration: 0 }
 
   const mouseX = useMotionValue(0)
   const mouseY = useMotionValue(0)
@@ -108,7 +115,6 @@ export function LocationMap({
   const springRotateY = useSpring(rotateY, { stiffness: 300, damping: 30 })
 
   const handleMouseMove = (e: React.MouseEvent) => {
-    if (prefersReducedMotion === true) return
     if (!containerRef.current) return
     const rect = containerRef.current.getBoundingClientRect()
     const centerX = rect.left + rect.width / 2
@@ -152,15 +158,14 @@ export function LocationMap({
       {/* The size is a plain inline value with a CSS transition, NOT a framer
           animation. Routed through framer it never reached the DOM: `animate`
           is not scraped into the first render, and every MotionValue variant
-          was silently defeated by the device's reduced-motion setting (framer
-          logs "Animations may not appear as expected"). A CSS transition is
-          also identical on the server and the client, and `motion-reduce`
-          honours the same preference without a second code path. */}
+          was defeated by the device's reduced-motion setting. A CSS transition
+          is also identical on the server and the client.
+          No `motion-reduce:` variant here — see the reduced-motion note in the
+          file header for why this tile animates unconditionally. */}
       <motion.div
         className={cn(
           'relative overflow-hidden rounded-2xl',
           'transition-[width,height] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)]',
-          'motion-reduce:transition-none',
         )}
         style={{
           width: isExpanded === true ? '100%' : `${COLLAPSED_WIDTH_PCT}%`,
@@ -186,10 +191,10 @@ export function LocationMap({
           {isExpanded === true && (
             <motion.div
               className="pointer-events-none absolute inset-0"
-              initial={reduceMotion ? false : { opacity: 0 }}
+              initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              transition={reduceMotion ? instant : { duration: 0.4, delay: 0.1 }}
+              transition={{ duration: 0.4, delay: 0.1 }}
             >
               <div className="absolute inset-0" style={{ backgroundColor: MOSS }} />
 
@@ -198,32 +203,32 @@ export function LocationMap({
                 <motion.line
                   x1="0%" y1="35%" x2="100%" y2="35%"
                   stroke={PARCHMENT} strokeOpacity={0.25} strokeWidth="4"
-                  initial={reduceMotion ? false : { pathLength: 0 }}
+                  initial={{ pathLength: 0 }}
                   animate={{ pathLength: 1 }}
-                  transition={reduceMotion ? instant : { duration: 0.8, delay: 0.2 }}
+                  transition={{ duration: 0.8, delay: 0.2 }}
                 />
                 <motion.line
                   x1="0%" y1="65%" x2="100%" y2="65%"
                   stroke={PARCHMENT} strokeOpacity={0.25} strokeWidth="4"
-                  initial={reduceMotion ? false : { pathLength: 0 }}
+                  initial={{ pathLength: 0 }}
                   animate={{ pathLength: 1 }}
-                  transition={reduceMotion ? instant : { duration: 0.8, delay: 0.3 }}
+                  transition={{ duration: 0.8, delay: 0.3 }}
                 />
 
                 {/* Vertical main roads */}
                 <motion.line
                   x1="30%" y1="0%" x2="30%" y2="100%"
                   stroke={PARCHMENT} strokeOpacity={0.2} strokeWidth="3"
-                  initial={reduceMotion ? false : { pathLength: 0 }}
+                  initial={{ pathLength: 0 }}
                   animate={{ pathLength: 1 }}
-                  transition={reduceMotion ? instant : { duration: 0.6, delay: 0.4 }}
+                  transition={{ duration: 0.6, delay: 0.4 }}
                 />
                 <motion.line
                   x1="70%" y1="0%" x2="70%" y2="100%"
                   stroke={PARCHMENT} strokeOpacity={0.2} strokeWidth="3"
-                  initial={reduceMotion ? false : { pathLength: 0 }}
+                  initial={{ pathLength: 0 }}
                   animate={{ pathLength: 1 }}
-                  transition={reduceMotion ? instant : { duration: 0.6, delay: 0.5 }}
+                  transition={{ duration: 0.6, delay: 0.5 }}
                 />
 
                 {/* Secondary streets */}
@@ -232,9 +237,9 @@ export function LocationMap({
                     key={`h-${y}`}
                     x1="0%" y1={`${y}%`} x2="100%" y2={`${y}%`}
                     stroke={PARCHMENT} strokeOpacity={0.1} strokeWidth="1.5"
-                    initial={reduceMotion ? false : { pathLength: 0 }}
+                    initial={{ pathLength: 0 }}
                     animate={{ pathLength: 1 }}
-                    transition={reduceMotion ? instant : { duration: 0.5, delay: 0.6 + i * 0.1 }}
+                    transition={{ duration: 0.5, delay: 0.6 + i * 0.1 }}
                   />
                 ))}
                 {V_STREETS.map((x, i) => (
@@ -242,9 +247,9 @@ export function LocationMap({
                     key={`v-${x}`}
                     x1={`${x}%`} y1="0%" x2={`${x}%`} y2="100%"
                     stroke={PARCHMENT} strokeOpacity={0.1} strokeWidth="1.5"
-                    initial={reduceMotion ? false : { pathLength: 0 }}
+                    initial={{ pathLength: 0 }}
                     animate={{ pathLength: 1 }}
-                    transition={reduceMotion ? instant : { duration: 0.5, delay: 0.7 + i * 0.1 }}
+                    transition={{ duration: 0.5, delay: 0.7 + i * 0.1 }}
                   />
                 ))}
               </svg>
@@ -262,22 +267,18 @@ export function LocationMap({
                     backgroundColor: stone(b.alpha),
                     borderColor: stone(b.alpha * 0.65),
                   }}
-                  initial={reduceMotion ? false : { opacity: 0, scale: 0.8 }}
+                  initial={{ opacity: 0, scale: 0.8 }}
                   animate={{ opacity: 1, scale: 1 }}
-                  transition={reduceMotion ? instant : { duration: 0.4, delay: b.delay }}
+                  transition={{ duration: 0.4, delay: b.delay }}
                 />
               ))}
 
               {/* Pin */}
               <motion.div
                 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
-                initial={reduceMotion ? false : { scale: 0, y: -20 }}
+                initial={{ scale: 0, y: -20 }}
                 animate={{ scale: 1, y: 0 }}
-                transition={
-                  reduceMotion
-                    ? instant
-                    : { type: 'spring', stiffness: 400, damping: 20, delay: 0.3 }
-                }
+                transition={{ type: 'spring', stiffness: 400, damping: 20, delay: 0.3 }}
               >
                 <svg
                   width="32"
@@ -308,7 +309,7 @@ export function LocationMap({
         <motion.div
           className="absolute inset-0"
           animate={{ opacity: isExpanded === true ? 0 : 0.06 }}
-          transition={reduceMotion ? instant : { duration: 0.3 }}
+          transition={{ duration: 0.3 }}
         >
           <svg width="100%" height="100%" className="absolute inset-0">
             <defs>
@@ -326,7 +327,7 @@ export function LocationMap({
           <div className="flex items-start justify-between">
             <motion.div
               animate={{ opacity: isExpanded === true ? 0 : 1 }}
-              transition={reduceMotion ? instant : { duration: 0.3 }}
+              transition={{ duration: 0.3 }}
             >
               <motion.svg
                 width="18"
@@ -343,7 +344,7 @@ export function LocationMap({
                       ? `drop-shadow(0 0 8px rgba(${ACCENT_RGB}, 0.6))`
                       : `drop-shadow(0 0 4px rgba(${ACCENT_RGB}, 0.3))`,
                 }}
-                transition={reduceMotion ? instant : { duration: 0.3 }}
+                transition={{ duration: 0.3 }}
               >
                 <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21" />
                 <line x1="9" x2="9" y1="3" y2="18" />
@@ -358,9 +359,7 @@ export function LocationMap({
               className="font-body text-sm font-semibold tracking-tight"
               style={{ color: PARCHMENT }}
               animate={{ x: isHovered === true ? 4 : 0 }}
-              transition={
-                reduceMotion ? instant : { type: 'spring', stiffness: 400, damping: 25 }
-              }
+              transition={{ type: 'spring', stiffness: 400, damping: 25 }}
             >
               {location}
             </motion.p>
@@ -373,21 +372,19 @@ export function LocationMap({
                 <motion.p
                   className="font-mono text-xs"
                   style={{ color: STONE }}
-                  initial={reduceMotion ? false : { opacity: 0, y: -10, height: 0 }}
+                  initial={{ opacity: 0, y: -10, height: 0 }}
                   animate={{ opacity: 1, y: 0, height: 'auto' }}
                   exit={{ opacity: 0, y: -10, height: 0 }}
-                  transition={reduceMotion ? instant : { duration: 0.25 }}
+                  transition={{ duration: 0.25 }}
                 >
                   {coordinates}
                 </motion.p>
               )}
             </AnimatePresence>
 
-            {/* Animated underline. initial={false} unconditionally: a
-                reduceMotion-dependent `initial` cannot survive SSR, because
-                useReducedMotion() is false on the server and true in a browser
-                that asks for reduced motion, so the two render different
-                transforms. It animates on state changes either way. */}
+            {/* Animated underline. initial={false}: the underline renders on
+                mount, so an entrance animation here is a hydration mismatch.
+                It animates on state changes either way. */}
             <motion.div
               className="h-px"
               style={{
@@ -396,7 +393,7 @@ export function LocationMap({
               }}
               initial={false}
               animate={{ scaleX: isHovered === true || isExpanded === true ? 1 : 0.3 }}
-              transition={reduceMotion ? instant : { duration: 0.4, ease: 'easeOut' }}
+              transition={{ duration: 0.4, ease: 'easeOut' }}
             />
           </div>
         </div>

--- a/components/ui/expand-map.tsx
+++ b/components/ui/expand-map.tsx
@@ -10,13 +10,18 @@
  * draws its "map" in SVG, so it has no renderer to fail.
  *
  * Two deliberate deviations from upstream:
- *   1. No width/height animation. Upstream animates 240x140 -> 360x280 in fixed
- *      pixels, which overflows the 358px content box at a 390px viewport and
- *      clips inside a fixed bento grid row. This fills its container instead and
- *      expansion is a cross-fade.
+ *   1. The size animation is a CSS transition in percentages, not a framer
+ *      animation in pixels. Upstream springs 240x140 -> 360x280 in fixed pixels;
+ *      360px overflows the 358px content box at a 390px viewport and 280px is
+ *      taller than the bento row. The card transitions between
+ *      COLLAPSED_WIDTH_PCT/COLLAPSED_HEIGHT_PCT and 100% of its tile instead, on
+ *      a back-out easing that overshoots slightly so it still reads as a spring.
+ *      The tile's footprint never changes and nothing overflows.
  *   2. Colours come from the brand tokens in styles/brand-tokens.css. Upstream
  *      targets stock shadcn base tokens (--foreground, --muted, --background),
  *      none of which this project defines.
+ *
+ * Expanded is the default state; a click or Enter/Space collapses it.
  *
  * Strings are props, not translations — the component stays i18n-agnostic like
  * the rest of components/ui. Callers pass translated text.
@@ -43,7 +48,6 @@ const MOSS = 'var(--brand-moss)'
 const ACCENT = 'var(--brand-sienna)'
 const ACCENT_RGB = '224, 122, 95'
 
-const parchment = (alpha: number) => `rgba(250, 248, 243, ${alpha})`
 const stone = (alpha: number) => `rgba(138, 133, 119, ${alpha})`
 
 // Skyline blocks: [top, left|right, width, height, fill alpha, entrance delay].
@@ -67,25 +71,25 @@ const BUILDINGS: {
 const H_STREETS = [20, 50, 80]
 const V_STREETS = [15, 45, 55, 85]
 
+// Collapsed size, as a percentage share of the tile. Percentages, not pixels, so
+// no state can overflow the tile and the card stays responsive.
+const COLLAPSED_WIDTH_PCT = 68
+const COLLAPSED_HEIGHT_PCT = 64
+
 interface LocationMapProps {
   location?: string
   coordinates?: string
-  /** Text of the status pill. */
-  liveLabel?: string
-  /** Hover affordance shown while collapsed. */
-  expandHint?: string
   className?: string
 }
 
 export function LocationMap({
   location = 'Sofia, Bulgaria',
   coordinates = '42.6977° N, 23.3219° E',
-  liveLabel = 'Live',
-  expandHint = 'Click to expand',
   className,
 }: LocationMapProps) {
   const [isHovered, setIsHovered] = useState(false)
-  const [isExpanded, setIsExpanded] = useState(false)
+  // Expanded on load; a click or Enter/Space swaps it.
+  const [isExpanded, setIsExpanded] = useState(true)
   const containerRef = useRef<HTMLDivElement>(null)
   // The <pattern> id must be unique: the home page mounts this tile twice
   // (desktop + mobile branches of app/(dashboard)/page.tsx are both in the DOM).
@@ -134,7 +138,10 @@ export function LocationMap({
       tabIndex={0}
       aria-expanded={isExpanded}
       aria-label={location}
-      className={cn('relative h-full w-full cursor-pointer select-none', className)}
+      className={cn(
+        'relative flex h-full w-full cursor-pointer items-center justify-center select-none',
+        className,
+      )}
       style={{ perspective: 1000 }}
       onMouseMove={handleMouseMove}
       onMouseEnter={() => setIsHovered(true)}
@@ -142,9 +149,22 @@ export function LocationMap({
       onClick={toggle}
       onKeyDown={handleKeyDown}
     >
+      {/* The size is a plain inline value with a CSS transition, NOT a framer
+          animation. Routed through framer it never reached the DOM: `animate`
+          is not scraped into the first render, and every MotionValue variant
+          was silently defeated by the device's reduced-motion setting (framer
+          logs "Animations may not appear as expected"). A CSS transition is
+          also identical on the server and the client, and `motion-reduce`
+          honours the same preference without a second code path. */}
       <motion.div
-        className="relative h-full w-full overflow-hidden rounded-2xl"
+        className={cn(
+          'relative overflow-hidden rounded-2xl',
+          'transition-[width,height] duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)]',
+          'motion-reduce:transition-none',
+        )}
         style={{
+          width: isExpanded === true ? '100%' : `${COLLAPSED_WIDTH_PCT}%`,
+          height: isExpanded === true ? '100%' : `${COLLAPSED_HEIGHT_PCT}%`,
           rotateX: springRotateX,
           rotateY: springRotateY,
           transformStyle: 'preserve-3d',
@@ -158,7 +178,11 @@ export function LocationMap({
           }}
         />
 
-        <AnimatePresence>
+        {/* initial={false}: expanded is the mount state, so without this the
+            entrance animation runs during hydration and React reports a
+            mismatch it refuses to patch (server opacity:0 vs client opacity:1,
+            strokeDasharray "0 1" vs "1 1"). Toggling still animates. */}
+        <AnimatePresence initial={false}>
           {isExpanded === true && (
             <motion.div
               className="pointer-events-none absolute inset-0"
@@ -326,24 +350,6 @@ export function LocationMap({
                 <line x1="15" x2="15" y1="6" y2="21" />
               </motion.svg>
             </motion.div>
-
-            {/* Status indicator */}
-            <motion.div
-              className="flex items-center gap-1.5 rounded-full px-2 py-1 backdrop-blur-sm"
-              animate={{
-                scale: isHovered === true ? 1.05 : 1,
-                backgroundColor: isHovered === true ? parchment(0.12) : parchment(0.08),
-              }}
-              transition={reduceMotion ? instant : { duration: 0.2 }}
-            >
-              <div className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: ACCENT }} />
-              <span
-                className="text-[10px] font-medium tracking-wide uppercase"
-                style={{ color: STONE }}
-              >
-                {liveLabel}
-              </span>
-            </motion.div>
           </div>
 
           {/* Bottom section */}
@@ -359,7 +365,10 @@ export function LocationMap({
               {location}
             </motion.p>
 
-            <AnimatePresence>
+            {/* initial={false} for the same reason as the map layer above: the
+                coordinates render on mount now, so an entrance animation here
+                is a hydration mismatch. */}
+            <AnimatePresence initial={false}>
               {isExpanded === true && (
                 <motion.p
                   className="font-mono text-xs"
@@ -374,33 +383,23 @@ export function LocationMap({
               )}
             </AnimatePresence>
 
-            {/* Animated underline */}
+            {/* Animated underline. initial={false} unconditionally: a
+                reduceMotion-dependent `initial` cannot survive SSR, because
+                useReducedMotion() is false on the server and true in a browser
+                that asks for reduced motion, so the two render different
+                transforms. It animates on state changes either way. */}
             <motion.div
               className="h-px"
               style={{
                 originX: 0,
                 backgroundImage: `linear-gradient(to right, rgba(${ACCENT_RGB}, 0.5), rgba(${ACCENT_RGB}, 0.3), transparent)`,
               }}
-              initial={reduceMotion ? false : { scaleX: 0 }}
+              initial={false}
               animate={{ scaleX: isHovered === true || isExpanded === true ? 1 : 0.3 }}
               transition={reduceMotion ? instant : { duration: 0.4, ease: 'easeOut' }}
             />
           </div>
         </div>
-
-        {/* Click hint — kept inside the card; the tile clips overflow */}
-        <motion.p
-          className="absolute right-4 bottom-1.5 z-10 text-[10px] whitespace-nowrap"
-          style={{ color: STONE }}
-          initial={reduceMotion ? false : { opacity: 0 }}
-          animate={{
-            opacity: isHovered === true && isExpanded === false ? 1 : 0,
-            y: isHovered === true ? 0 : 4,
-          }}
-          transition={reduceMotion ? instant : { duration: 0.2 }}
-        >
-          {expandHint}
-        </motion.p>
       </motion.div>
     </motion.div>
   )

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,6 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #698 | `dev/2608-DEV-698` | `components/ui/expand-map.tsx` · `app/(dashboard)/components/tiles/LocationTile.tsx` · `app/(dashboard)/about/components/AboutMapTile*.tsx` (deleted) · `app/globals.css` · `e2e/home-no-webgl.spec.ts` · `NEXT_PUBLIC_MAPBOX_TOKEN` sweep across `.env.example`, `ci.yml`, docs — **migration: no** | 2026-08-06 |
+
+_No in-flight claims._
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -35,7 +35,10 @@ projects, then ask the user before pushing.
   `git rev-parse --abbrev-ref @{u}` -> fatal and a bare `git push` cannot hit main. Re-check after
   every branch cut — the tracking default is the trap, not the push.
 - No `git push` unless the user asks for a push in THIS conversation, quoted beside the command.
-  NOT GRANTED for `dev/2608-DEV-700` — the 2026-08-06 grant was scoped to `dev/2608-DEV-698`.
+  GRANTED 2026-08-06 for `dev/2608-DEV-700`, verbatim: "push and open draft PR". Scope: push this
+  branch and open the PR AS A DRAFT. Does NOT cover marking it ready for review or merging — ask
+  again for both. (The earlier 2026-08-06 grant was scoped to `dev/2608-DEV-698` and did not
+  carry over.)
 - Never weaken a check to make it pass.
 - Fold the `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR — NEVER a
   standalone cleanup PR.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,49 +1,41 @@
 ## Goal
-BUILD issue #698 (2608-DEV-698, branch `dev/2608-DEV-698`): remove Mapbox GL from the app entirely
-and render the home page's Location tile with a self-contained DOM/SVG component, so no WebGL
-failure can reach the dashboard error boundary.
+BUILD issue #700 (2608-DEV-700, branch `dev/2608-DEV-700`): follow-up on the Location tile shipped
+by #698/PR #699 — give expand/collapse a real size animation, remove the "LIVE" status pill, and
+make **expanded** the state the tile loads in (a tap swaps it).
 
 ## Now
-PR #699 ready for review (not draft), GCR complete, **all CI checks green and the Vercel preview
-READY**, mergeStateStatus CLEAN. Mapbox is gone: the CDN loader, the `NEXT_PUBLIC_MAPBOX_TOKEN` env
-var, the `.mapboxgl-ctrl-*` CSS suppression, the orphaned `AboutMapTile*` pair, and the `ssr:false`
-`LocationTileLazy` wrapper. `components/ui/expand-map.tsx` (adapted from 21st.dev
-`jatin-yadav05/expand-map`) draws the card in SVG and cannot fail. `framer-motion@^12.43.0` is a new
-dependency.
-
-GCR ran against CodeRabbit's 4-comment review (`0eb1076`, `2c28bdd`):
-- Applied: reduced-motion honored for every effect in `LocationMap`, not just pointer tilt.
-- Applied: explicit `=== true`/`=== false` boolean comparisons in `expand-map.tsx` JSX conditions.
-- Applied: `e2e/home-no-webgl.spec.ts` WebGL shim rewritten as a type-preserving `Proxy`, no `any`.
-- REVERTED after CI proved it wrong: CodeRabbit suggested removing the empty catch on
-  `waitForLoadState('networkidle')` in the overflow test. Doing so broke the "390px smoke vs
-  preview" job — that check passed on `f0a9d4d` (with the catch) and failed on `0eb1076` (without
-  it): `networkidle` never fires against the real Vercel preview's background network activity,
-  unlike localhost. Restored in `2c28bdd` with a comment explaining why; that review thread is
-  left UNRESOLVED with a reply stating the reason, per GCR's skipped-comment rule.
-- 3 of 4 threads resolved via GraphQL; the 4th (above) deliberately left open for human follow-up.
+Edits applied on `dev/2608-DEV-700` (cut from `origin/main` at `dacca8b`, upstream unset):
+- `components/ui/expand-map.tsx` — the inner card's `width`/`height` are plain inline values
+  (68%/64% collapsed, 100% expanded) with a CSS `transition-[width,height] duration-500` on a
+  back-out easing that overshoots slightly; root became a centring flex container. See
+  `## Failed attempts` for why this is NOT a framer animation. `isExpanded` defaults to `true`. The
+  status pill (dot + "LIVE") and the hover hint are gone, along with the `liveLabel`/`expandHint`
+  props and the now-unused `parchment()` helper. Three `initial={false}` changes remove hydration
+  mismatches that the expanded-by-default state exposed.
+- `LocationTile.tsx` no longer passes the two removed props; `home.loc.live` / `home.loc.expand`
+  deleted from `lib/i18n/domains/home.ts`.
+- `e2e/home-no-webgl.spec.ts` third test rewritten — it clicked once and expected the coordinates to
+  APPEAR, which the inverted default turns into a collapse. It now asserts no horizontal overflow in
+  all three states (expanded on load -> collapsed -> expanded again), driving off `aria-expanded`.
 
 ## Next
-1. Merge when ready — CI green, preview READY, mergeStateStatus CLEAN, 3/4 threads resolved (see
-   `## Now`). ASK the user before merging.
-2. Post-merge: prune the `docs/CLAIMS.md` #698 row, close #698, and ask the user to delete
-   `NEXT_PUBLIC_MAPBOX_TOKEN` from the Vercel project (all scopes) — out-of-band, not a code change.
+1. ASK the user before any push or PR — no push grant exists for this branch.
+2. Decide with the user how much the reduced-motion setting matters (see `## Open items`).
 
 ## Handover — start the follow-up session with this
 ```
-GCR is done (see ## Now). Start the follow-up session by confirming with the user whether to merge
-PR #699 (branch dev/2608-DEV-698, issue #698) — CI green, preview READY, mergeStateStatus CLEAN.
+Branch dev/2608-DEV-700 (issue #700) carries the LocationMap follow-up: size spring, LIVE pill
+removed, expanded by default. Re-run lint/check-types/build and the home-no-webgl spec on both
+projects, then ask the user before pushing.
 ```
 
 ## Constraints
-- Never push to `main`; `dev/2608-DEV-698` only. `git checkout -b dev/2608-DEV-698 origin/main` SET
+- Never push to `main`; `dev/2608-DEV-700` only. `git checkout -b dev/2608-DEV-700 origin/main` SET
   origin/main as the upstream; it was unset immediately (`git branch --unset-upstream`), so
   `git rev-parse --abbrev-ref @{u}` -> fatal and a bare `git push` cannot hit main. Re-check after
   every branch cut — the tracking default is the trap, not the push.
 - No `git push` unless the user asks for a push in THIS conversation, quoted beside the command.
-  GRANTED 2026-08-06, verbatim: "Open a draft PR since change like any other must go through the
-  standard procedure." Scope: push `dev/2608-DEV-698` and open the PR AS A DRAFT. Does NOT cover
-  marking it ready for review or merging — ask again for both.
+  NOT GRANTED for `dev/2608-DEV-700` — the 2026-08-06 grant was scoped to `dev/2608-DEV-698`.
 - Never weaken a check to make it pass.
 - Fold the `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR — NEVER a
   standalone cleanup PR.
@@ -52,6 +44,40 @@ PR #699 (branch dev/2608-DEV-698, issue #698) — CI green, preview READY, merge
 - NEVER paste an absolute Windows path into a tracked file. Tailwind v4 scans every source file
   (including .md) for utility candidates; a backslash + hex digits parses as a CSS unicode escape
   and kills `npm run build` with `Invalid code point <n>` pointed at `app/globals.css:1:1`.
+
+## Failed attempts
+- ATTEMPT 1 [L1] (#700, size animation): supplied the card's size through framer-motion's `animate`
+  prop (`animate={{width: isExpanded ? '100%' : '68%', ...}}`) -> framer received the prop (React
+  fiber confirms `animate: {"width":"68%","height":"64%"}`) but emitted a DOM `style` of only
+  `{transformStyle, transform}`. `animate` is not scraped into the initially-rendered style, so the
+  element had NO width/height at all and shrank to its content: 185x103 inside a 295x220 tile, with
+  "expanded" differing from "collapsed" only by the extra coordinates line. Fixed by driving the
+  size as MotionValues in `style` instead — those framer always renders, SSR included.
+- ATTEMPT 2 [L1] (#700, size animation): `useSpring(1, SIZE_SPRING)` + `expansion.jump(target)` on
+  the reduced-motion path -> the size rendered ONE TOGGLE BEHIND the state (click to collapse ->
+  still 100%; click to expand -> 68%). `MotionValue.jump()` calls `updateAndNotify` and
+  `stopPassiveEffect()` without scheduling framer's DOM render.
+- ATTEMPT 3 [L2] (#700, size animation): kept `useSpring` but swapped its options to
+  `{type:'tween', duration:0}` under reduced motion and always called `.set()` -> the size froze at
+  100% and never moved. L2 hypothesis, read out of the installed source rather than guessed:
+  `attachFollow` (which backs `useSpring`) constructs `new JSAnimation(...)` DIRECTLY
+  (`motion-dom/dist/es/value/follow-value.mjs:70`), bypassing the zero-duration branch at
+  `motion-dom/dist/es/animation/interfaces/motion-value.mjs:64-96` that applies the final keyframe
+  via `frame.update`. A zero-duration tween through `useSpring` therefore emits no update at all.
+- ATTEMPT 4 [L3] (#700, size animation): `useMotionValue(1)` + `animate(expansion, target, ...)` in
+  an effect -> still frozen at 100%. INSTRUMENTATION (this is the L3 evidence): a MutationObserver
+  on the card's `style` attribute recorded **0 mutations** across a full toggle, and the attribute
+  kept its un-normalized SSR form (`width:100%` — framer's client writes come back spaced, as seen
+  in ATTEMPT 2). The console explains why: framer logs "You have Reduced Motion enabled on your
+  device. Animations may not appear as expected", and React reports a hydration mismatch in this
+  subtree (`style={{opacity:1}}` vs `style={{opacity:"0"}}`, `strokeDasharray "1 1"` vs `"0 1"`)
+  with "This won't be patched up".
+- RESOLUTION [L4] (#700, size animation): abandoned the framer path for the size entirely and drove
+  width/height as plain inline values with a CSS `transition-[width,height]`, which is the idiom the
+  rest of this repo already uses. No MotionValue, no reduced-motion special case (`motion-reduce:`
+  handles it), and the value is identical on server and client. `AnimatePresence initial={false}`
+  was added at the same time — with expanded as the default state the entrance animation ran during
+  hydration, which is what produced the mismatch above.
 
 ## Decisions
 - DECISION (user, 2026-08-06): drop Mapbox rather than guard it. A `mapboxgl.supported()` check plus
@@ -63,9 +89,10 @@ PR #699 (branch dev/2608-DEV-698, issue #698) — CI green, preview READY, merge
   identical. Loss of real geography accepted. The alternative offered (expanded state showing a
   Mapbox Static Images `<img>`, no WebGL) was declined.
 - DECISION (user, 2026-08-06): `framer-motion` added rather than porting the animations to CSS.
-- DECISION (2026-08-06): the component takes its strings as props (`location`, `coordinates`,
-  `liveLabel`, `expandHint`) rather than calling `t()` itself, so `components/ui/*` stays
-  i18n-agnostic like the rest of that directory. `LocationTile` supplies the translations.
+- DECISION (2026-08-06): the component takes its strings as props (`location`, `coordinates`)
+  rather than calling `t()` itself, so `components/ui/*` stays i18n-agnostic like the rest of that
+  directory. `LocationTile` supplies the translations. (`liveLabel` and `expandHint` were props too
+  until #700 removed the pill and the hint.)
 - DECISION (2026-08-06): ADR-003 marked **Superseded**, not deleted — its record stays. Its stated
   mitigation ("map tiles are non-critical UI — their failure degrades gracefully") was never true;
   nothing caught the constructor. That sentence is why the bug shipped.
@@ -74,6 +101,17 @@ PR #699 (branch dev/2608-DEV-698, issue #698) — CI green, preview READY, merge
   pixels, which overflows the 358px content box at a 390px viewport and clips inside a fixed bento
   grid row. It fills its container instead and expansion is a cross-fade. (2) All colours mapped to
   brand tokens.
+- DECISION (user, 2026-08-06, #700): deviation (1) above was REVISED, not reverted. The user
+  reported the cross-fade reads as an instant state flip and asked for the upstream motion back.
+  Upstream verbatim is still unavailable (registry needs auth) and its fixed pixel sizes still do
+  not fit, so the size spring was rebuilt in PERCENTAGES: the card springs between 68%/64% and
+  100% of its tile. The user picked this over literal upstream pixels (which would have grown the
+  desktop bento row and everything sharing it) and over a scale-only cross-fade.
+- DECISION (2026-08-06, #700): both ends of the size animation are percentages on purpose.
+  `node_modules/motion-dom/dist/es/animation/keyframes/DOMKeyframesResolver.mjs:68-87` returns early
+  when the two keyframes share a value type, but sends a px <-> % pair down the measurement path
+  (`needsMeasurement = true`), resolving the target off the element's bounding box. Same-unit
+  keyframes also cannot overflow the tile at 390px, which keeps the overflow spec honest.
 
 ## Facts
 - BUILD BASELINE, captured 2026-08-06 before any edit: `npm run check-types` -> clean.
@@ -127,6 +165,24 @@ PR #699 (branch dev/2608-DEV-698, issue #698) — CI green, preview READY, merge
   cycle.
 - `prefers-reduced-motion` gates the mouse-tilt only (via `useReducedMotion`); the entrance
   animations still run.
+- BUILD BASELINE for #700, captured before any edit on `dev/2608-DEV-700`: `npm run check-types`
+  -> clean. Note `npm install` was required first — the branch before it predated
+  `framer-motion@^12.43.0`, so `node_modules` had no copy of it.
+- VERIFICATION for #700, on `dev/2608-DEV-700` with a wiped `.next`: `npm run verify` -> exit 0
+  (lint 0 errors / 468 warnings, same count as before the change; `tsc --noEmit` clean; 27 files /
+  358 tests passed; build compiled in 93s).
+  `npx playwright test --project=mobile-390 --project=desktop e2e/home-no-webgl.spec.ts` -> 6
+  passed. `e2e/mobile-smoke.spec.ts` on both projects -> 16 passed.
+  MOTION PROOF (throwaway probe, `test.use({ reducedMotion: 'no-preference' })`, deleted after):
+  sampling the card width per animation frame across a collapse gave
+  `100, 100, 71, 69.4, 67, 66.2, 65.6, 65.2, 65, 64.9, 65, 65.3, 66.3, 67, 67.8, 68, 68...` —
+  it interpolates, overshoots past the 68% target, and settles. `transitionProperty` reads
+  `"width, height"` there and `"none"` on a reduced-motion device.
+- #700 e2e trap: the coordinates locator had to be scoped to the tile
+  (`tile.getByText(COORDS)`), not the page. Both the desktop and mobile branches of
+  `app/(dashboard)/page.tsx` are in the DOM and BOTH now render the coordinates on load, so a
+  page-level `.first()` resolves to the `display:none` branch and `toBeVisible()` fails. The role
+  locator does not have this problem — hidden subtrees are not in the accessibility tree.
 - Worktrees do NOT inherit gitignored env files. `.env.local` / `.env.development.local` had to be
   copied in from the main repo for the dev server to boot (`supabaseUrl is required` otherwise), and
   were deleted again at handover. `.env.local` points at PROD; `.env.development.local` supplies the
@@ -146,6 +202,14 @@ PR #699 (branch dev/2608-DEV-698, issue #698) — CI green, preview READY, merge
   `testMatch`) — no config change was needed.
 
 ## Open items
+- OPEN, needs a user decision (#700): **this machine has `prefers-reduced-motion: reduce` set.**
+  Confirmed twice — `matchMedia('(prefers-reduced-motion: reduce)').matches` is `true` in the user's
+  Chrome, and framer logs "You have Reduced Motion enabled on your device". That is very likely the
+  real reason the tile "had no animation" in the original report: every transition in this component
+  is gated on it, so the toggle was an instant state flip regardless of what was coded. The new size
+  transition is gated the same way (`motion-reduce:transition-none`) and was proven to animate only
+  with `reducedMotion: 'no-preference'`. Options: leave it (correct and accessible; the user sees no
+  motion until they change the OS/browser setting), or exempt the size change from the gate.
 - PR was marked ready for review before the GCR session started (CodeRabbit's 4-comment review at
   11:04 required it, since draft PRs get skipped). One review thread deliberately left unresolved —
   see `## Now`.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -19,8 +19,10 @@ Edits applied on `dev/2608-DEV-700` (cut from `origin/main` at `dacca8b`, upstre
   all three states (expanded on load -> collapsed -> expanded again), driving off `aria-expanded`.
 
 ## Next
-1. ASK the user before any push or PR — no push grant exists for this branch.
-2. Decide with the user how much the reduced-motion setting matters (see `## Open items`).
+1. CI on PR #701 has never executed — every job died in "Set up job" or timed out queued during the
+   2026-08-06 GitHub Actions major outage (`cancelled`, `steps=0`). Re-run once Actions recovers.
+   `390px smoke vs preview`, `Replay migrations` and `Security Audit` DID run and passed.
+2. PR is a DRAFT. Ask the user before marking it ready for review or merging.
 
 ## Handover — start the follow-up session with this
 ```
@@ -110,6 +112,15 @@ projects, then ask the user before pushing.
   not fit, so the size spring was rebuilt in PERCENTAGES: the card springs between 68%/64% and
   100% of its tile. The user picked this over literal upstream pixels (which would have grown the
   desktop bento row and everything sharing it) and over a scale-only cross-fade.
+- DECISION (user, 2026-08-06, #700): `components/ui/expand-map.tsx` deliberately does NOT honour
+  `prefers-reduced-motion`. Trade-off accepted knowingly, on a small decorative tile, after the
+  alternatives (honour it properly / split by motion type / user turns the OS setting off) were put
+  to the user. NOT a precedent for the rest of the repo.
+- BUG this uncovered, worth remembering repo-wide: the old pattern
+  `transition={reduceMotion ? instant : …}` with `instant = { duration: 0 }` is WRONG. It keeps the
+  state change and removes only the smoothing, so a 4px hover nudge teleports instead of easing —
+  which is what the user reported as "the text jumps on mouse over". Reduced motion must suppress
+  the MOVEMENT (x: 0, no size/scale change), never merely zero the duration.
 - DECISION (2026-08-06, #700): both ends of the size animation are percentages on purpose.
   `node_modules/motion-dom/dist/es/animation/keyframes/DOMKeyframesResolver.mjs:68-87` returns early
   when the two keyframes share a value type, but sends a px <-> % pair down the measurement path
@@ -166,8 +177,18 @@ projects, then ask the user before pushing.
   an Enter/Space handler. The e2e spec locates the tile by that role+name — deliberately NOT
   `getByText('Sofia, Bulgaria')`, which also matches the AboutTile paragraph and cost one debugging
   cycle.
-- `prefers-reduced-motion` gates the mouse-tilt only (via `useReducedMotion`); the entrance
-  animations still run.
+- `useReducedMotion` is no longer imported by `expand-map.tsx` at all (#700). The repo-wide guard in
+  `app/globals.css:100` is scoped to `.skeleton-shimmer`, `.bento-tile` and `.interactive-lift` —
+  NOT a universal `*` selector — and the Location tile carries none of those classes, so removing
+  the component-level gate was sufficient and `docs/design/DESIGN-SYSTEM.md`'s reduced-motion rule
+  did not need changing.
+- MOTION PROOF under emulated reduced motion (throwaway probe, `page.emulateMedia({ reducedMotion:
+  'reduce' })`, deleted after): size `100 -> 95.3 -> 87.1 -> 80.3 -> 75 -> 71 -> 67 -> 64.9`
+  (overshoot) `-> 67.8 -> 68`; hover nudge transform `0 -> 0.019 -> 0.72 -> 1.66 -> 2.52 -> 3.16 ->
+  4.11 -> 4.32` (spring overshoot) `-> 3.98`, i.e. 20+ distinct values where a teleport shows two.
+  NOTE for future probes: `test.use({ reducedMotion })` did NOT reach the page — use
+  `page.emulateMedia()`. And a synthetic `mouseenter` does not trigger React's hover (React derives
+  enter/leave from mouseover/mouseout) — drive it with a real `locator.hover()`.
 - BUILD BASELINE for #700, captured before any edit on `dev/2608-DEV-700`: `npm run check-types`
   -> clean. Note `npm install` was required first — the branch before it predated
   `framer-motion@^12.43.0`, so `node_modules` had no copy of it.
@@ -205,14 +226,12 @@ projects, then ask the user before pushing.
   `testMatch`) — no config change was needed.
 
 ## Open items
-- OPEN, needs a user decision (#700): **this machine has `prefers-reduced-motion: reduce` set.**
-  Confirmed twice — `matchMedia('(prefers-reduced-motion: reduce)').matches` is `true` in the user's
-  Chrome, and framer logs "You have Reduced Motion enabled on your device". That is very likely the
-  real reason the tile "had no animation" in the original report: every transition in this component
-  is gated on it, so the toggle was an instant state flip regardless of what was coded. The new size
-  transition is gated the same way (`motion-reduce:transition-none`) and was proven to animate only
-  with `reducedMotion: 'no-preference'`. Options: leave it (correct and accessible; the user sees no
-  motion until they change the OS/browser setting), or exempt the size change from the gate.
+- RESOLVED (#700, user decision 2026-08-06): the reduced-motion gate is GONE from
+  `components/ui/expand-map.tsx`. This machine has `prefers-reduced-motion: reduce` set — confirmed
+  twice (`matchMedia(...).matches === true`, plus framer logging "You have Reduced Motion enabled on
+  your device") — and that, not the code, was the real reason the tile "had no animation": all 20+
+  transitions were gated on it. Asked the user to choose between honouring it properly, splitting by
+  motion type, or animating regardless; they chose **animate regardless**. See `## Decisions`.
 - PR was marked ready for review before the GCR session started (CodeRabbit's 4-comment review at
   11:04 required it, since draft PRs get skipped). One review thread deliberately left unresolved —
   see `## Now`.

--- a/e2e/home-no-webgl.spec.ts
+++ b/e2e/home-no-webgl.spec.ts
@@ -99,14 +99,38 @@ test.describe('home page without WebGL', () => {
     const viewport = testInfo.project.use.viewport
     test.skip(viewport == null, 'needs a fixed viewport to assert against')
 
-    const scrollWidth = () =>
-      page.evaluate(() => document.scrollingElement?.scrollWidth ?? 0)
+    // The card animates its width/height over 500ms on a back-out easing. Reading
+    // scrollWidth at an arbitrary point in that window makes the assertion
+    // non-deterministic, so settle first: poll the card's box until it stops
+    // changing. Returns the widest scrollWidth seen WHILE it was moving, so the
+    // transient is covered too — the easing overshoots its target by design, and
+    // a future tweak to it must not be able to push the card past its tile
+    // unnoticed.
+    const settleAndPeak = () =>
+      page.evaluate(async () => {
+        const tileEl = [...document.querySelectorAll('[role="button"][aria-expanded]')].filter(
+          (e) => (e as HTMLElement).offsetParent !== null,
+        )[0] as HTMLElement
+        const card = tileEl.firstElementChild as HTMLElement
+        let peak = document.scrollingElement?.scrollWidth ?? 0
+        let last = -1
+        let stable = 0
+        // ~2s ceiling; the transition is 500ms.
+        for (let i = 0; i < 120 && stable < 3; i++) {
+          await new Promise((r) => requestAnimationFrame(() => r(null)))
+          peak = Math.max(peak, document.scrollingElement?.scrollWidth ?? 0)
+          const w = Math.round(card.getBoundingClientRect().width * 100)
+          stable = w === last ? stable + 1 : 0
+          last = w
+        }
+        return peak
+      })
 
     const expectNoOverflow = async (state: string) => {
-      const width = await scrollWidth()
+      const peak = await settleAndPeak()
       expect(
-        width,
-        `horizontal overflow on / with the location tile ${state}: ${width}px at ${viewport!.width}px`,
+        peak,
+        `horizontal overflow on / with the location tile ${state} (widest during + after the size transition): ${peak}px at ${viewport!.width}px`,
       ).toBeLessThanOrEqual(viewport!.width)
     }
 
@@ -127,7 +151,6 @@ test.describe('home page without WebGL', () => {
     await expect(tile).toBeVisible()
 
     // The tile ships expanded, and the coordinates line renders in that state only.
-    // Waiting on it also lets the size spring settle before each width read.
     await expect(tile).toHaveAttribute('aria-expanded', 'true')
     await expect(coords).toBeVisible()
     await expectNoOverflow('expanded on load')

--- a/e2e/home-no-webgl.spec.ts
+++ b/e2e/home-no-webgl.spec.ts
@@ -95,37 +95,51 @@ test.describe('home page without WebGL', () => {
     ).toHaveLength(0)
   })
 
-  test('expanding the tile does not overflow the viewport', async ({ page }, testInfo) => {
+  test('neither tile state overflows the viewport', async ({ page }, testInfo) => {
     const viewport = testInfo.project.use.viewport
     test.skip(viewport == null, 'needs a fixed viewport to assert against')
+
+    const scrollWidth = () =>
+      page.evaluate(() => document.scrollingElement?.scrollWidth ?? 0)
+
+    const expectNoOverflow = async (state: string) => {
+      const width = await scrollWidth()
+      expect(
+        width,
+        `horizontal overflow on / with the location tile ${state}: ${width}px at ${viewport!.width}px`,
+      ).toBeLessThanOrEqual(viewport!.width)
+    }
 
     await page.goto('/')
     // networkidle genuinely never fires on the Vercel preview (persistent background
     // network activity), unlike localhost — confirmed by CI job "390px smoke vs preview"
-    // failing here on dev/2608-DEV-698 once this catch was removed. The width assertions
-    // below are the real synchronization point; this call is best-effort only.
+    // failing here on dev/2608-DEV-698 once this catch was removed. The coordinates
+    // assertions below are the real synchronization point; this call is best-effort only.
     await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {})
 
-    const widthBefore = await page.evaluate(
-      () => document.scrollingElement?.scrollWidth ?? 0,
-    )
-    expect(
-      widthBefore,
-      `horizontal overflow on / before expanding: ${widthBefore}px at ${viewport!.width}px`,
-    ).toBeLessThanOrEqual(viewport!.width)
-
     const tile = page.getByRole('button', { name: CITY }).first()
+    // Scoped to the tile, not the page: both the desktop and mobile branches of
+    // app/(dashboard)/page.tsx are in the DOM and both now render the coordinates,
+    // so a page-level .first() would resolve to the display:none branch. The role
+    // locator above already picks the visible one — hidden subtrees are not in the
+    // accessibility tree.
+    const coords = tile.getByText(COORDS)
     await expect(tile).toBeVisible()
-    await tile.click()
-    // The coordinates line only renders in the expanded state.
-    await expect(page.getByText(COORDS).first()).toBeVisible()
 
-    const widthAfter = await page.evaluate(
-      () => document.scrollingElement?.scrollWidth ?? 0,
-    )
-    expect(
-      widthAfter,
-      `horizontal overflow on / after expanding: ${widthAfter}px at ${viewport!.width}px`,
-    ).toBeLessThanOrEqual(viewport!.width)
+    // The tile ships expanded, and the coordinates line renders in that state only.
+    // Waiting on it also lets the size spring settle before each width read.
+    await expect(tile).toHaveAttribute('aria-expanded', 'true')
+    await expect(coords).toBeVisible()
+    await expectNoOverflow('expanded on load')
+
+    await tile.click()
+    await expect(tile).toHaveAttribute('aria-expanded', 'false')
+    await expect(coords).toBeHidden()
+    await expectNoOverflow('collapsed')
+
+    await tile.click()
+    await expect(tile).toHaveAttribute('aria-expanded', 'true')
+    await expect(coords).toBeVisible()
+    await expectNoOverflow('expanded again')
   })
 })

--- a/lib/i18n/domains/home.ts
+++ b/lib/i18n/domains/home.ts
@@ -23,8 +23,6 @@ export const home = {
   'home.profile.there':      { en: 'there',                bg: 'приятел'                 },
   // LocationTile
   'home.loc.city':           { en: 'Sofia, Bulgaria',      bg: 'София, България'         },
-  'home.loc.live':           { en: 'Live',                 bg: 'На живо'                 },
-  'home.loc.expand':         { en: 'Click to expand',      bg: 'Натисни за детайли'      },
   // SocialsTile
   'home.socials.comingSoon': { en: 'Social feed coming soon.', bg: 'Социалните публикации идват скоро.' },
   'home.socials.viewPost':   { en: 'View post →',          bg: 'Виж публикацията →'      },


### PR DESCRIPTION
Follow-up to #698 / PR #699. Closes #700.

## What changed

1. **Expand/collapse had no perceptible motion.** The #699 port deliberately dropped upstream's size animation (240x140 -> 360x280 in fixed pixels) because 360px overflows the 358px content box at 390px and 280px is taller than the bento row, leaving only a cross-fade that reads as an instant state flip. The card now transitions between 68%/64% and 100% of its tile on a back-out easing that overshoots slightly, so it still reads as a spring. Percentages keep the tile's footprint fixed, so the desktop grid rows and the 390px overflow assertion are untouched.
2. **The "LIVE" status pill is gone** — dot, chip and label — along with the `liveLabel` prop, the hover hint and `expandHint`, the `home.loc.live` / `home.loc.expand` i18n keys, and the `parchment()` helper they were the only users of.
3. **`isExpanded` defaults to `true`** — the tile loads expanded and a tap collapses it.
4. **This tile no longer honours `prefers-reduced-motion`** (see below).

## The reduced-motion decision — please read before approving

Every animated prop was written `transition={reduceMotion ? instant : ...}` with `instant = { duration: 0 }`. **That keeps the state change and removes only the smoothing.** The 4px hover nudge on the location name therefore *teleported* rather than easing, and all 20+ transitions snapped, so the tile read as a hard on/off. The reporting machine has `prefers-reduced-motion: reduce` set (confirmed by `matchMedia(...).matches` and by framer's own "You have Reduced Motion enabled on your device" warning), so it was always on that path regardless of what the animations were coded to do.

Zeroing the duration is the wrong way to honour the preference in any case — the right way suppresses the *movement* (`x: 0`, no size change). The alternatives (honour it properly / split by motion type / turn the OS setting off) were put to the repo owner, who chose to **animate unconditionally on this tile**. Recorded as a deliberate trade-off in the file header and `docs/STATE.md`, and explicitly **not** a precedent for the rest of the repo.

The repo-wide guard at `app/globals.css:100` is scoped to `.skeleton-shimmer` / `.bento-tile` / `.interactive-lift` — not a universal selector — and this tile carries none of them, so `docs/design/DESIGN-SYSTEM.md`'s reduced-motion rule is unchanged.

## Why the size is a CSS transition, not a framer animation

Routed through framer it never reached the DOM: `animate` is not scraped into the initially-rendered style (the card had no width/height at all and shrank to its content, 185x103 in a 295x220 tile), and every MotionValue variant after that was defeated by the reduced-motion setting — a `MutationObserver` on the card's `style` recorded **zero mutations** across a full toggle. Full four-attempt ledger with the relevant `motion-dom` source lines is in `docs/STATE.md` under `## Failed attempts`.

## Hydration

Making expanded the mount state exposed three mismatches React refuses to patch (`opacity:0` vs `opacity:1`, `strokeDasharray "0 1"` vs `"1 1"`, `scaleX(0)` vs `none`). Both `AnimatePresence` wrappers take `initial={false}`, and the underline's `initial` no longer derives from `useReducedMotion()` — that hook is `false` on the server and `true` in a reduced-motion browser, so an `initial` built from it can never agree across hydration.

## Test change

`e2e/home-no-webgl.spec.ts`'s third test clicked once and expected the coordinates to *appear*, which the inverted default turns into a collapse. It now asserts no horizontal overflow across all three states, driving off `aria-expanded`. Its coordinates locator is scoped to the tile: both the desktop and mobile branches of `page.tsx` are in the DOM and both render coordinates on load, so a page-level `.first()` resolves to the `display:none` branch.

Also folds in the stale `#698` row removal from `docs/CLAIMS.md` (PR #699 merged), per the rule against standalone claim-cleanup PRs.

## Verification

- `npm run verify` -> exit 0 on a wiped `.next` (lint 0 errors / 468 warnings, unchanged count; `tsc --noEmit` clean; 27 files / 358 tests; build 82s)
- `e2e/home-no-webgl.spec.ts` on mobile-390 + desktop -> 6 passed
- `390px smoke vs preview` (CI, against the real Vercel preview) -> 13 passed / 5 skipped, all three home-no-webgl tests executed
- **Motion proof under EMULATED reduced motion** (`page.emulateMedia({ reducedMotion: 'reduce' })`, throwaway probe, deleted after) — this is the condition that was broken:
  - size: `100 -> 95.3 -> 87.1 -> 80.3 -> 75 -> 71 -> 67 -> 64.9 -> 67.8 -> 68` (interpolates, overshoots, settles)
  - hover nudge transform: `0 -> 0.019 -> 0.72 -> 1.66 -> 2.52 -> 3.16 -> 4.11 -> 4.32 -> 3.98` (20+ distinct values; a teleport shows two)

## CI caveat

Most CI jobs on this PR never executed — they died in "Set up job" or timed out queued during the 2026-08-06 GitHub Actions major outage (`conclusion=cancelled`, `steps=0`). `390px smoke vs preview`, `Replay migrations from scratch` and `Security Audit` did run and passed. **Do not merge until a full CI run actually completes green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Location maps now open expanded by default.
  * Collapsed maps adapt their dimensions responsively across screen sizes.
  * Map transitions and animations are smoother and more consistent.
  * Simplified map presentation removes redundant status and expansion hints.

* **Bug Fixes**
  * Improved expansion and collapse behavior during animated transitions.
  * Enhanced rendering stability when maps load.
  * Prevented horizontal overflow across map states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->