### PR TITLE
fix: scope meeting_url out of the calendar list and ICS payloads

### DIFF
--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -82,7 +82,8 @@ export async function GET(req: Request) {
   // would change the ETag on every request even when the underlying data hasn't,
   // permanently defeating If-None-Match. Computed before building/serializing the
   // calendar so a conditional-GET hit short-circuits that work entirely.
-  const etag = `W/"${createHash('sha1').update(JSON.stringify(events ?? []) + calendarName).digest('hex')}"`
+  const etagInput = JSON.stringify({ events: events ?? [], calendarName, portalUrl })
+  const etag = `W/"${createHash('sha1').update(etagInput).digest('hex')}"`
 
   if (matchesIfNoneMatch(req.headers.get('if-none-match'), etag)) {
     return new Response(null, {

--- a/app/api/calendar/feed.ics/route.ts
+++ b/app/api/calendar/feed.ics/route.ts
@@ -3,6 +3,7 @@ import { createServiceClient } from '@/lib/supabase/service'
 import ical from 'ical-generator'
 import { listEventsForRole, toVEventInput } from '@/lib/server/calendar'
 import { verifyIcalToken, IcalTokenConfigError } from '@/lib/server/icalToken'
+import { getBaseUrl } from '@/lib/utils/base-url'
 
 const FEED_WINDOW_PAST_DAYS = 90
 const FEED_WINDOW_FUTURE_DAYS = 365
@@ -54,13 +55,19 @@ export async function GET(req: Request) {
   // Falls back to an empty feed on a query error rather than surfacing a 500,
   // matching the prior inline query's behavior (errors were not checked there either).
   let events: Awaited<ReturnType<typeof listEventsForRole>> = []
+  // Absolute portal link for each VEVENT's url/Details line (2608-DEV-703).
+  // getBaseUrl() throws on a missing NEXT_PUBLIC_APP_URL, so it is resolved
+  // INSIDE this try: a misconfigured env must degrade to the same empty feed
+  // as a failed query, not turn a 200 into a 500.
+  let portalUrl = ''
   try {
+    portalUrl = await getBaseUrl()
     const now = Date.now()
     const from = new Date(now - FEED_WINDOW_PAST_DAYS * 86400000).toISOString()
     const to = new Date(now + FEED_WINDOW_FUTURE_DAYS * 86400000).toISOString()
     events = await listEventsForRole({ role: profile.role, from, to, limit: FEED_LIMIT })
   } catch (err) {
-    console.error('feed.ics: listEventsForRole failed', err)
+    console.error('feed.ics: could not build the event list', err)
   }
 
   // Use member's custom display name if set; fall back to default.
@@ -95,7 +102,7 @@ export async function GET(req: Request) {
   })
 
   for (const event of events ?? []) {
-    calendar.createEvent(toVEventInput(event))
+    calendar.createEvent(toVEventInput(event, portalUrl))
   }
 
   return new Response(calendar.toString(), {

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,6 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-
-_No in-flight claims._
+| #703 | `dev/2608-DEV-703` | `lib/server/calendar.ts`, `types/calendar.ts`, `app/api/calendar/feed.ics/route.ts`, `lib/server/calendar.test.ts`, `e2e/guest-invite.spec.ts` — **migration: no** | 2026-08-09 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -4,45 +4,28 @@ BUILD issue #703 (2608-DEV-703, branch `dev/2608-DEV-703`), first child of epic 
 both at the portal event page instead (epic decision D8).
 
 ## Now
-All edits applied and verified on `dev/2608-DEV-703` (cut from `origin/main` at `435c58f`, upstream
-unset). NOT pushed — no push authorization in this conversation.
-- `lib/server/calendar.ts` — `meeting_url` dropped from `LIST_COLUMNS`. New module-local
-  `portalEventUrl(portalUrl, eventId)` builds `<portal>/calendar?event=<encoded id>`.
-  `buildEventDescription(event, portalUrl)` and `toVEventInput(event, portalUrl)` both gained a
-  second parameter and lost `meeting_url` from their param types; the VEVENT `url` and the
-  plain-text `Meeting link:` line are now the portal pointer (`Details: …`).
-- `types/calendar.ts` — `'meeting_url'` removed from the `CalendarListEvent` pick.
-- `app/api/calendar/feed.ics/route.ts` — resolves `await getBaseUrl()` INSIDE the existing try that
-  already degrades to an empty feed, so a missing `NEXT_PUBLIC_APP_URL` cannot turn a 200 into a 500.
-- `lib/server/calendar.test.ts` — 6 snapshots updated, +4 tests (URL-encoding, stale `meeting_url`
-  on the row ignored, VEVENT `url` is the portal, and a `listEventsForRole` projection guard that
-  asserts the full `select()` column list).
-- `e2e/guest-invite.spec.ts` — new non-serial describe asserting the anonymous `/api/calendar`
-  payload carries no `meeting_url`, skipping loudly rather than passing vacuously on an empty list.
-- `docs/ai/REF.md` — the two calendar rows in the routes table no longer claim the ICS `URL` is the
-  meeting link.
+PR #711 (`dev/2608-DEV-703`) is open and marked ready for review (not draft). CodeRabbit's one
+review pass found 1 actionable comment (Major) + 1 nitpick; both applied in commit `10e5fe0`:
+`app/api/calendar/feed.ics/route.ts` now hashes `portalUrl` into the ETag alongside `events`/
+`calendarName`; `e2e/guest-invite.spec.ts`'s anonymous-payload test now seeds its own guest-visible
+event (with `meeting_url` set) instead of skipping when the DB has none. The ETag review thread is
+resolved. Pushed to `origin/dev/2608-DEV-703`. CI is all green and the PR is
+`mergeStateStatus: CLEAN` / `mergeable: MERGEABLE`. Not yet merged.
 
 ## Next
-1. Address any `/code-review low` findings locally.
-2. Ask the user before pushing `dev/2608-DEV-703` and opening the draft PR.
-3. PR body must carry `Closes #703`; announce the ICS downgrade (phone-calendar users lose one-tap
-   join on every event, gated or not — issue #703 "Announce the ICS change").
-
-## Handover — start the follow-up session with this
-```
-Branch dev/2608-DEV-703 (issue #703, child of epic #702) removes meeting_url from the calendar list
-projection and the ICS feed. npm run verify is green (362 tests). Nothing is pushed. Ask the user
-before pushing / opening the PR.
-```
+1. Merge PR #711.
+2. Post-merge tail (per `docs/ai/GCR.md` step 7): remove the `dev/2608-DEV-703` row from
+   `docs/CLAIMS.md`; no migrations in this PR, so the prod-migration gate is skipped; smoke-check
+   `https://www.teamenjoyvd.com`; close issue #703.
 
 ## Constraints
 - Never push to `main`; `dev/2608-DEV-703` only. `git checkout -b dev/2608-DEV-703 origin/main` SET
   origin/main as the upstream; it was unset immediately (`git branch --unset-upstream`), so
   `git rev-parse --abbrev-ref @{u}` -> fatal and a bare `git push` cannot hit main. Re-check after
   every branch cut — the tracking default is the trap, not the push.
-- No `git push` unless the user asks for a push in THIS conversation, quoted beside the command.
-  NOT GRANTED for `dev/2608-DEV-703` as of 2026-08-09. (The 2026-08-06 grants were scoped to
-  `dev/2608-DEV-698` and `dev/2608-DEV-700` and did not carry over.)
+- `git push` to `dev/2608-DEV-703` was granted in conversation on 2026-08-09 ("push to PR so it's
+  merge-ready") — used for commit `10e5fe0` and the `docs/STATE.md` prune commit. Re-ask for any
+  push after this session ends.
 - Never weaken a check to make it pass.
 - Fold the `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR — NEVER a
   standalone cleanup PR.
@@ -52,200 +35,33 @@ before pushing / opening the PR.
   (including .md) for utility candidates; a backslash + hex digits parses as a CSS unicode escape
   and kills `npm run build` with `Invalid code point <n>` pointed at `app/globals.css:1:1`.
 
-## Failed attempts
-- ATTEMPT 1 [L1] (#700, size animation): supplied the card's size through framer-motion's `animate`
-  prop (`animate={{width: isExpanded ? '100%' : '68%', ...}}`) -> framer received the prop (React
-  fiber confirms `animate: {"width":"68%","height":"64%"}`) but emitted a DOM `style` of only
-  `{transformStyle, transform}`. `animate` is not scraped into the initially-rendered style, so the
-  element had NO width/height at all and shrank to its content: 185x103 inside a 295x220 tile, with
-  "expanded" differing from "collapsed" only by the extra coordinates line. Fixed by driving the
-  size as MotionValues in `style` instead — those framer always renders, SSR included.
-- ATTEMPT 2 [L1] (#700, size animation): `useSpring(1, SIZE_SPRING)` + `expansion.jump(target)` on
-  the reduced-motion path -> the size rendered ONE TOGGLE BEHIND the state (click to collapse ->
-  still 100%; click to expand -> 68%). `MotionValue.jump()` calls `updateAndNotify` and
-  `stopPassiveEffect()` without scheduling framer's DOM render.
-- ATTEMPT 3 [L2] (#700, size animation): kept `useSpring` but swapped its options to
-  `{type:'tween', duration:0}` under reduced motion and always called `.set()` -> the size froze at
-  100% and never moved. L2 hypothesis, read out of the installed source rather than guessed:
-  `attachFollow` (which backs `useSpring`) constructs `new JSAnimation(...)` DIRECTLY
-  (`motion-dom/dist/es/value/follow-value.mjs:70`), bypassing the zero-duration branch at
-  `motion-dom/dist/es/animation/interfaces/motion-value.mjs:64-96` that applies the final keyframe
-  via `frame.update`. A zero-duration tween through `useSpring` therefore emits no update at all.
-- ATTEMPT 4 [L3] (#700, size animation): `useMotionValue(1)` + `animate(expansion, target, ...)` in
-  an effect -> still frozen at 100%. INSTRUMENTATION (this is the L3 evidence): a MutationObserver
-  on the card's `style` attribute recorded **0 mutations** across a full toggle, and the attribute
-  kept its un-normalized SSR form (`width:100%` — framer's client writes come back spaced, as seen
-  in ATTEMPT 2). The console explains why: framer logs "You have Reduced Motion enabled on your
-  device. Animations may not appear as expected", and React reports a hydration mismatch in this
-  subtree (`style={{opacity:1}}` vs `style={{opacity:"0"}}`, `strokeDasharray "1 1"` vs `"0 1"`)
-  with "This won't be patched up".
-- RESOLUTION [L4] (#700, size animation): abandoned the framer path for the size entirely and drove
-  width/height as plain inline values with a CSS `transition-[width,height]`, which is the idiom the
-  rest of this repo already uses. No MotionValue, no reduced-motion special case (`motion-reduce:`
-  handles it), and the value is identical on server and client. `AnimatePresence initial={false}`
-  was added at the same time — with expanded as the default state the entrance animation ran during
-  hydration, which is what produced the mismatch above.
-
 ## Decisions
-- DECISION (user, 2026-08-06): drop Mapbox rather than guard it. A `mapboxgl.supported()` check plus
-  try/catch would have fixed the crash in ~15 lines, but the tile is decorative (non-interactive,
-  fixed zoom 12, attribution hidden) and the machinery — WebGL renderer, CDN script, public API
-  token — is disproportionate. Removing it deletes the failure mode instead of catching it.
-- DECISION (user, 2026-08-06): the replacement is decorative. `LocationMap` renders SVG "streets" at
-  fixed percentages and six absolutely-positioned "buildings"; Sofia and San Francisco look
-  identical. Loss of real geography accepted. The alternative offered (expanded state showing a
-  Mapbox Static Images `<img>`, no WebGL) was declined.
-- DECISION (user, 2026-08-06): `framer-motion` added rather than porting the animations to CSS.
-- DECISION (2026-08-06): the component takes its strings as props (`location`, `coordinates`)
-  rather than calling `t()` itself, so `components/ui/*` stays i18n-agnostic like the rest of that
-  directory. `LocationTile` supplies the translations. (`liveLabel` and `expandHint` were props too
-  until #700 removed the pill and the hint.)
-- DECISION (2026-08-06): ADR-003 marked **Superseded**, not deleted — its record stays. Its stated
-  mitigation ("map tiles are non-critical UI — their failure degrades gracefully") was never true;
-  nothing caught the constructor. That sentence is why the bug shipped.
-- DECISION (2026-08-06): two deliberate deviations from the upstream component, both documented in
-  the file header. (1) No width/height animation: upstream animates 240x140 -> 360x280 in fixed
-  pixels, which overflows the 358px content box at a 390px viewport and clips inside a fixed bento
-  grid row. It fills its container instead and expansion is a cross-fade. (2) All colours mapped to
-  brand tokens.
-- DECISION (user, 2026-08-06, #700): deviation (1) above was REVISED, not reverted. The user
-  reported the cross-fade reads as an instant state flip and asked for the upstream motion back.
-  Upstream verbatim is still unavailable (registry needs auth) and its fixed pixel sizes still do
-  not fit, so the size spring was rebuilt in PERCENTAGES: the card springs between 68%/64% and
-  100% of its tile. The user picked this over literal upstream pixels (which would have grown the
-  desktop bento row and everything sharing it) and over a scale-only cross-fade.
-- DECISION (user, 2026-08-06, #700): `components/ui/expand-map.tsx` deliberately does NOT honour
-  `prefers-reduced-motion`. Trade-off accepted knowingly, on a small decorative tile, after the
-  alternatives (honour it properly / split by motion type / user turns the OS setting off) were put
-  to the user. NOT a precedent for the rest of the repo.
-- BUG this uncovered, worth remembering repo-wide: the old pattern
-  `transition={reduceMotion ? instant : …}` with `instant = { duration: 0 }` is WRONG. It keeps the
-  state change and removes only the smoothing, so a 4px hover nudge teleports instead of easing —
-  which is what the user reported as "the text jumps on mouse over". Reduced motion must suppress
-  the MOVEMENT (x: 0, no size/scale change), never merely zero the duration.
-- DECISION (2026-08-06, #700): both ends of the size animation are percentages on purpose.
-  `node_modules/motion-dom/dist/es/animation/keyframes/DOMKeyframesResolver.mjs:68-87` returns early
-  when the two keyframes share a value type, but sends a px <-> % pair down the measurement path
-  (`needsMeasurement = true`), resolving the target off the element's bounding box. Same-unit
-  keyframes also cannot overflow the tile at 390px, which keeps the overflow spec honest.
+- DECISION (#703): `buildEventDescription`/`toVEventInput` (`lib/server/calendar.ts`) take
+  `portalUrl` as a parameter rather than calling `getBaseUrl()` internally — that call is async and
+  throws, which would have dragged env mocking into the snapshot tests these functions exist to
+  keep clean.
+- DECISION (#703): `feed.ics` (`app/api/calendar/feed.ics/route.ts`) resolves `getBaseUrl()` inside
+  the existing try/catch, so a missing `NEXT_PUBLIC_APP_URL` degrades to the same empty feed as a
+  failed query instead of turning a 200 into a 500.
 
 ## Facts
-- BUILD BASELINE, captured 2026-08-06 before any edit: `npm run check-types` -> clean.
-- VERIFICATION, after the fix, all on `dev/2608-DEV-698`:
-  `npm run check-types` -> clean. `npx eslint` on the changed files -> zero output.
-  `npm run lint` -> 0 errors, 463 warnings (all pre-existing). `npm test` -> 27 files / 358 tests
-  passed. `npm run build` -> success.
-  `npx playwright test --project=mobile-390 --project=desktop e2e/home-no-webgl.spec.ts` -> 6 passed.
-  `e2e/mobile-smoke.spec.ts` on both projects -> 16 passed.
-- RED PROOF, 2026-08-06 — the guard was proven to fail before the fix by pointing it at live
-  production, which still runs the old code: `BASE_URL=https://www.teamenjoyvd.com npx playwright
-  test --project=mobile-390 e2e/home-no-webgl.spec.ts` -> 3 failed. No git stashing was involved.
-- THE DIAGNOSIS THAT CHANGED MID-TASK, and the reason the spec has two tests: a COLD LOAD DOES NOT
-  CRASH. On first paint the Mapbox throw happens inside the CDN `script.onload` handler, escapes
-  uncaught, and the tile just stays blank — Playwright's page snapshot of production confirms the
-  tile container and its "Sofia, Bulgaria" pill still render. The reported error screen needs a
-  RE-MOUNT: `window.mapboxgl` already set, so the effect takes its
-  `if ((window as any).mapboxgl) initMap()` branch and throws synchronously inside the `useEffect`,
-  which React unwinds to `app/(dashboard)/error.tsx`. Reproduced by hand on
-  `https://www.teamenjoyvd.com` with `HTMLCanvasElement.prototype.getContext` patched to return null
-  for webgl, then `/` -> `/about` -> `/`. A guard that only covers the cold load passes against the
-  broken code — the first draft of the spec did exactly that.
-- LAYOUT TRAP, found and fixed during visual verification: `h-full` on the component root did NOT
-  fill the tile. `BentoCard` sets `min-height: 200`, not `height`, and a percentage height does not
-  resolve against an auto-height parent — the tile rendered ~100px tall. `LocationTile` now passes
-  `className="absolute inset-0"`, which is what the old Mapbox container did (`LocationTile.tsx:144`
-  before this change).
-- The `<pattern id>` in the grid overlay uses `useId()`. The home page mounts this tile TWICE at
-  every viewport — `app/(dashboard)/page.tsx:138` (desktop, inside a CSS-only `hidden md:block`,
-  which does not unmount) and `:216` (mobile) — so a literal id would duplicate in the DOM.
-- The 21st.dev registry endpoint (`https://21st.dev/r/jatin-yadav05/expand-map`) returns
-  `{"error":"Authentication required"}`, so `npx shadcn@latest add <that URL>` cannot fetch it. The
-  source was pasted in by the user. The component's compiled source is also readable without auth
-  from `cdn.21st.dev/jatin-yadav05/expand-map/default/bundle.*.html`, which is how its behaviour was
-  confirmed before any code was written.
-- Retheme mapping (upstream -> this repo), since the upstream targets stock shadcn base tokens and
-  grep confirms this project defines NONE of `--foreground`, `--background`, `--muted`,
-  `--muted-foreground`, `--border`: `bg-background`/`fill-background` -> `--brand-moss`;
-  `bg-muted` -> `--brand-moss`; `stroke-foreground/*` -> `--brand-parchment` + explicit
-  `strokeOpacity`; `bg-muted-foreground/*` -> `rgba(138,133,119,a)`; `text-foreground` ->
-  `--brand-parchment`; `text-muted-foreground` -> `--brand-stone`; `bg-foreground/5` and the inline
-  `hsl(var(--foreground) / 0.05)` -> `rgba(250,248,243,0.08)` (the `hsl(var(…))` form is invalid
-  here and resolves transparent); emerald `#34D399` -> `--brand-sienna`. Dark mode then works for
-  free via `[data-theme="dark"]` in `styles/brand-tokens.css:77`. This follows the existing
-  `docs/ai/GOTCHAS.md` rule "shadcn CSS vars: edit vended source in components/ui/ to use project
-  tokens, not shadcn defaults".
-- Accessibility added over upstream: the root was a bare `<div>` with `onClick`, unreachable by
-  keyboard. It is now `role="button" tabIndex={0}` with `aria-expanded`, `aria-label={location}` and
-  an Enter/Space handler. The e2e spec locates the tile by that role+name — deliberately NOT
-  `getByText('Sofia, Bulgaria')`, which also matches the AboutTile paragraph and cost one debugging
-  cycle.
-- `useReducedMotion` is no longer imported by `expand-map.tsx` at all (#700). The repo-wide guard in
-  `app/globals.css:100` is scoped to `.skeleton-shimmer`, `.bento-tile` and `.interactive-lift` —
-  NOT a universal `*` selector — and the Location tile carries none of those classes, so removing
-  the component-level gate was sufficient and `docs/design/DESIGN-SYSTEM.md`'s reduced-motion rule
-  did not need changing.
-- MOTION PROOF under emulated reduced motion (throwaway probe, `page.emulateMedia({ reducedMotion:
-  'reduce' })`, deleted after): size `100 -> 95.3 -> 87.1 -> 80.3 -> 75 -> 71 -> 67 -> 64.9`
-  (overshoot) `-> 67.8 -> 68`; hover nudge transform `0 -> 0.019 -> 0.72 -> 1.66 -> 2.52 -> 3.16 ->
-  4.11 -> 4.32` (spring overshoot) `-> 3.98`, i.e. 20+ distinct values where a teleport shows two.
-  NOTE for future probes: `test.use({ reducedMotion })` did NOT reach the page — use
-  `page.emulateMedia()`. And a synthetic `mouseenter` does not trigger React's hover (React derives
-  enter/leave from mouseover/mouseout) — drive it with a real `locator.hover()`.
-- BUILD BASELINE for #700, captured before any edit on `dev/2608-DEV-700`: `npm run check-types`
-  -> clean. Note `npm install` was required first — the branch before it predated
-  `framer-motion@^12.43.0`, so `node_modules` had no copy of it.
-- VERIFICATION for #700, on `dev/2608-DEV-700` with a wiped `.next`: `npm run verify` -> exit 0
-  (lint 0 errors / 468 warnings, same count as before the change; `tsc --noEmit` clean; 27 files /
-  358 tests passed; build compiled in 93s).
-  `npx playwright test --project=mobile-390 --project=desktop e2e/home-no-webgl.spec.ts` -> 6
-  passed. `e2e/mobile-smoke.spec.ts` on both projects -> 16 passed.
-  MOTION PROOF (throwaway probe, `test.use({ reducedMotion: 'no-preference' })`, deleted after):
-  sampling the card width per animation frame across a collapse gave
-  `100, 100, 71, 69.4, 67, 66.2, 65.6, 65.2, 65, 64.9, 65, 65.3, 66.3, 67, 67.8, 68, 68...` —
-  it interpolates, overshoots past the 68% target, and settles. `transitionProperty` reads
-  `"width, height"` there and `"none"` on a reduced-motion device.
-- #700 e2e trap: the coordinates locator had to be scoped to the tile
-  (`tile.getByText(COORDS)`), not the page. Both the desktop and mobile branches of
-  `app/(dashboard)/page.tsx` are in the DOM and BOTH now render the coordinates on load, so a
-  page-level `.first()` resolves to the `display:none` branch and `toBeVisible()` fails. The role
-  locator does not have this problem — hidden subtrees are not in the accessibility tree.
-- Worktrees do NOT inherit gitignored env files. `.env.local` / `.env.development.local` had to be
-  copied in from the main repo for the dev server to boot (`supabaseUrl is required` otherwise), and
-  were deleted again at handover. `.env.local` points at PROD; `.env.development.local` supplies the
-  DEV Supabase and wins under Next's precedence.
-- CI ON PR #699, all green: Lint, Type Check, Test, Build, Security Audit, Replay migrations,
-  Vercel (deployment completed). `390px smoke vs preview` ran the mobile-390 project against the
-  REAL preview and the new spec passed there — `home-no-webgl.spec.ts` lines 48 / 75 / 101 all ✓,
-  13 passed in 1.6m. `Authenticated E2E (Clerk)` GENUINELY RAN this time (`Running 21 tests using
-  2 workers` -> `20 passed (2.2m)`), so this was NOT the vacuous 6-second green tracked as #679 —
-  still worth re-confirming on the next run rather than trusting the tick.
-- Running the spec against the preview from a dev machine FAILS with "landed off the app origin" —
-  that is the guard working, not a defect. Vercel deployment protection redirects to vercel.com
-  without `VERCEL_AUTOMATION_BYPASS_SECRET`, which only CI has. Verify preview behaviour by reading
-  the `390px smoke vs preview` job log, not by running it locally.
-- E2E coverage lives in `e2e/home-no-webgl.spec.ts`. It is collected by the `mobile-390` and
-  `desktop` projects (both use `testIgnore`) and excluded from `authenticated` (which uses
-  `testMatch`) — no config change was needed.
+- VERIFICATION for the #703 CodeRabbit fixes, commit `10e5fe0`: `npx tsc --noEmit` -> clean.
+  `npx vitest run lib/server/calendar.test.ts` -> 14 passed. `npx eslint` on
+  `app/api/calendar/feed.ics/route.ts` and `e2e/guest-invite.spec.ts` -> exit 0.
+- CI on PR #711, all green: Type Check, Replay migrations from scratch, 390px smoke vs preview,
+  Lint, Test, Build, Security Audit, Authenticated E2E (Clerk), Vercel Preview Comments.
+  `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`.
 
 ## Open items
-- RESOLVED (#700, user decision 2026-08-06): the reduced-motion gate is GONE from
-  `components/ui/expand-map.tsx`. This machine has `prefers-reduced-motion: reduce` set — confirmed
-  twice (`matchMedia(...).matches === true`, plus framer logging "You have Reduced Motion enabled on
-  your device") — and that, not the code, was the real reason the tile "had no animation": all 20+
-  transitions were gated on it. Asked the user to choose between honouring it properly, splitting by
-  motion type, or animating regardless; they chose **animate regardless**. See `## Decisions`.
-- PR was marked ready for review before the GCR session started (CodeRabbit's 4-comment review at
-  11:04 required it, since draft PRs get skipped). One review thread deliberately left unresolved —
-  see `## Now`.
 - NOTED (not done): `app/(dashboard)/page.tsx:138,216` — `LocationTile` mounts twice at every
   viewport because the desktop branch is CSS-hidden rather than conditionally rendered. Cheap now
   that the tile is pure DOM, but still a duplicated subtree on every load.
 - NOTED (not done): no `app/global-error.tsx` exists, so a throw in the root layout has no boundary
-  at all — the same class of single-point-of-failure as this bug.
+  at all — the same class of single-point-of-failure as the #700 Mapbox bug.
 - NOTED (not done): `docs/perf/BASELINE.md` numbers predate the removal of the ~900KB Mapbox CDN
   script and need a re-measure. The row was updated to say so.
-- OUT OF BAND, user-owned, after merge: delete `NEXT_PUBLIC_MAPBOX_TOKEN` from the Vercel project
-  (all scopes).
+- OUT OF BAND, user-owned, after #700's merge: delete `NEXT_PUBLIC_MAPBOX_TOKEN` from the Vercel
+  project (all scopes).
 - CARRIED: the CI check `Authenticated E2E (Clerk)` has historically gone green in seconds WITHOUT
   running the specs (tracked as #679). Never treat a green tick as proof; confirm 0 skipped.
 - CARRIED FROM #677, NEVER VERIFIED: admin guest link/unlink has no automated coverage and has never
@@ -269,7 +85,16 @@ before pushing / opening the PR.
   `toBeVisible()` at 36.3s then passed on retry — a cold-server timing profile, same shape as the L8
   flake logged during #688.
 
+## Failed attempts
+None currently open for #703.
+
 ## Done
+- #700 (merged as #701, 2026-08-07) — `LocationMap` size transition rebuilt on plain inline
+  width/height + a CSS `transition-[width,height]` after four framer-motion approaches
+  (`animate` prop, `useSpring`+`jump()`, zero-duration tween, `animate()` in an effect) all failed to
+  update the DOM under `prefers-reduced-motion`; no LIVE pill, expanded by default.
+  `npm run verify` green (27 files / 358 tests); CI on PR #699 confirmed green including
+  `Authenticated E2E (Clerk)` genuinely running (21 tests, not the #679 vacuous-green).
 - #696 (merged as #697, `dab0677`) — the transitional `PGRST202`/`42883` fallback removed from
   `lib/rate-limit.ts`; every RPC error now fails closed. Its `docs/CLAIMS.md` row is pruned here.
 - #694 (merged as #695, `7234846`) — `price_checker` DB role dropped from DEV. STILL OUTSTANDING,

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,46 +1,48 @@
 ## Goal
-BUILD issue #700 (2608-DEV-700, branch `dev/2608-DEV-700`): follow-up on the Location tile shipped
-by #698/PR #699 — give expand/collapse a real size animation, remove the "LIVE" status pill, and
-make **expanded** the state the tile loads in (a tap swaps it).
+BUILD issue #703 (2608-DEV-703, branch `dev/2608-DEV-703`), first child of epic #702: stop shipping
+`calendar_events.meeting_url` in the role-scoped calendar list projection and the ICS feed; point
+both at the portal event page instead (epic decision D8).
 
 ## Now
-Edits applied on `dev/2608-DEV-700` (cut from `origin/main` at `dacca8b`, upstream unset):
-- `components/ui/expand-map.tsx` — the inner card's `width`/`height` are plain inline values
-  (68%/64% collapsed, 100% expanded) with a CSS `transition-[width,height] duration-500` on a
-  back-out easing that overshoots slightly; root became a centring flex container. See
-  `## Failed attempts` for why this is NOT a framer animation. `isExpanded` defaults to `true`. The
-  status pill (dot + "LIVE") and the hover hint are gone, along with the `liveLabel`/`expandHint`
-  props and the now-unused `parchment()` helper. Three `initial={false}` changes remove hydration
-  mismatches that the expanded-by-default state exposed.
-- `LocationTile.tsx` no longer passes the two removed props; `home.loc.live` / `home.loc.expand`
-  deleted from `lib/i18n/domains/home.ts`.
-- `e2e/home-no-webgl.spec.ts` third test rewritten — it clicked once and expected the coordinates to
-  APPEAR, which the inverted default turns into a collapse. It now asserts no horizontal overflow in
-  all three states (expanded on load -> collapsed -> expanded again), driving off `aria-expanded`.
+All edits applied and verified on `dev/2608-DEV-703` (cut from `origin/main` at `435c58f`, upstream
+unset). NOT pushed — no push authorization in this conversation.
+- `lib/server/calendar.ts` — `meeting_url` dropped from `LIST_COLUMNS`. New module-local
+  `portalEventUrl(portalUrl, eventId)` builds `<portal>/calendar?event=<encoded id>`.
+  `buildEventDescription(event, portalUrl)` and `toVEventInput(event, portalUrl)` both gained a
+  second parameter and lost `meeting_url` from their param types; the VEVENT `url` and the
+  plain-text `Meeting link:` line are now the portal pointer (`Details: …`).
+- `types/calendar.ts` — `'meeting_url'` removed from the `CalendarListEvent` pick.
+- `app/api/calendar/feed.ics/route.ts` — resolves `await getBaseUrl()` INSIDE the existing try that
+  already degrades to an empty feed, so a missing `NEXT_PUBLIC_APP_URL` cannot turn a 200 into a 500.
+- `lib/server/calendar.test.ts` — 6 snapshots updated, +4 tests (URL-encoding, stale `meeting_url`
+  on the row ignored, VEVENT `url` is the portal, and a `listEventsForRole` projection guard that
+  asserts the full `select()` column list).
+- `e2e/guest-invite.spec.ts` — new non-serial describe asserting the anonymous `/api/calendar`
+  payload carries no `meeting_url`, skipping loudly rather than passing vacuously on an empty list.
+- `docs/ai/REF.md` — the two calendar rows in the routes table no longer claim the ICS `URL` is the
+  meeting link.
 
 ## Next
-1. CI on PR #701 has never executed — every job died in "Set up job" or timed out queued during the
-   2026-08-06 GitHub Actions major outage (`cancelled`, `steps=0`). Re-run once Actions recovers.
-   `390px smoke vs preview`, `Replay migrations` and `Security Audit` DID run and passed.
-2. PR is a DRAFT. Ask the user before marking it ready for review or merging.
+1. Address any `/code-review low` findings locally.
+2. Ask the user before pushing `dev/2608-DEV-703` and opening the draft PR.
+3. PR body must carry `Closes #703`; announce the ICS downgrade (phone-calendar users lose one-tap
+   join on every event, gated or not — issue #703 "Announce the ICS change").
 
 ## Handover — start the follow-up session with this
 ```
-Branch dev/2608-DEV-700 (issue #700) carries the LocationMap follow-up: size spring, LIVE pill
-removed, expanded by default. Re-run lint/check-types/build and the home-no-webgl spec on both
-projects, then ask the user before pushing.
+Branch dev/2608-DEV-703 (issue #703, child of epic #702) removes meeting_url from the calendar list
+projection and the ICS feed. npm run verify is green (362 tests). Nothing is pushed. Ask the user
+before pushing / opening the PR.
 ```
 
 ## Constraints
-- Never push to `main`; `dev/2608-DEV-700` only. `git checkout -b dev/2608-DEV-700 origin/main` SET
+- Never push to `main`; `dev/2608-DEV-703` only. `git checkout -b dev/2608-DEV-703 origin/main` SET
   origin/main as the upstream; it was unset immediately (`git branch --unset-upstream`), so
   `git rev-parse --abbrev-ref @{u}` -> fatal and a bare `git push` cannot hit main. Re-check after
   every branch cut — the tracking default is the trap, not the push.
 - No `git push` unless the user asks for a push in THIS conversation, quoted beside the command.
-  GRANTED 2026-08-06 for `dev/2608-DEV-700`, verbatim: "push and open draft PR". Scope: push this
-  branch and open the PR AS A DRAFT. Does NOT cover marking it ready for review or merging — ask
-  again for both. (The earlier 2026-08-06 grant was scoped to `dev/2608-DEV-698` and did not
-  carry over.)
+  NOT GRANTED for `dev/2608-DEV-703` as of 2026-08-09. (The 2026-08-06 grants were scoped to
+  `dev/2608-DEV-698` and `dev/2608-DEV-700` and did not carry over.)
 - Never weaken a check to make it pass.
 - Fold the `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR — NEVER a
   standalone cleanup PR.

--- a/docs/ai/REF.md
+++ b/docs/ai/REF.md
@@ -443,8 +443,8 @@ Normalised UNION ALL over `profiles_audit` + `role_change_audit`. Columns: `prof
 | `/api/trips` | GET, POST | GET: role-filtered list (unauthenticated → guest). POST: admin-only create |
 | `/api/trips/[id]/messages` | GET | Read-only trip bulletin (admin-authored; no author shown to members) |
 | `/api/trips/[id]/payments` | GET | |
-| `/api/calendar` | GET | Role-filtered; no `?month` → agenda from today |
-| `/api/calendar/feed.ics` | GET | iCal feed; `?token=` JWT auth; emits LOCATION + URL + CATEGORIES |
+| `/api/calendar` | GET | Role-filtered; no `?month` → agenda from today. Never returns `meeting_url` (2608-DEV-703 / D8) — the gated detail endpoint `/api/events/[id]` serves it |
+| `/api/calendar/feed.ics` | GET | iCal feed; `?token=` JWT auth; emits LOCATION + URL + CATEGORIES. `URL` is the portal event page (`/calendar?event=<id>`), never `meeting_url` (2608-DEV-703 / D8) |
 | `/api/calendar/feed-token` | GET, POST | Issue/regenerate iCal subscription token |
 | `/api/guides` | GET | Published, access_roles respected |
 | `/api/links` | GET | Active links, role-filtered |

--- a/e2e/guest-invite.spec.ts
+++ b/e2e/guest-invite.spec.ts
@@ -221,28 +221,55 @@ test.describe('390px viewport', () => {
 // 2608-DEV-703 / epic #702 D8. /api/calendar is on the public allowlist
 // (lib/public-routes.ts) and resolves sessionless callers to role 'guest', so
 // this is exactly the payload an anonymous visitor receives. Runs outside the
-// serial chain above and needs neither the fixture nor service credentials.
+// serial chain above and needs neither the fixture nor service credentials —
+// but when SUPABASE_SERVICE_ROLE_KEY IS present, it seeds its own guest-visible
+// event so the meeting_url assertion below is never vacuous.
 test.describe('anonymous /api/calendar payload', () => {
   test.describe.configure({ mode: 'default' })
 
   test('never carries meeting_url', async ({ request }) => {
-    const res = await request.get('/api/calendar')
-    expect(res.ok(), `GET /api/calendar returned ${res.status()}`).toBe(true)
+    const client = svc()
+    let seededEventId: string | null = null
 
-    const events = (await res.json()) as Array<Record<string, unknown>>
-    expect(Array.isArray(events)).toBe(true)
+    if (client) {
+      const now = Date.now()
+      const { data: seeded } = await client
+        .from('calendar_events')
+        .insert({
+          title: `e2e-anon-payload-${TEST_RUN_ID}`,
+          // access_roles defaults to all roles (incl. guest) — no override needed.
+          start_time: new Date(now + 3600000).toISOString(),
+          end_time: new Date(now + 7200000).toISOString(),
+          week_number: 1,
+          meeting_url: 'https://example.com/should-not-leak',
+        })
+        .select('id')
+        .single()
+      seededEventId = seeded?.id ?? null
+    }
 
-    // An empty list would pass the key assertion vacuously — make that visible
-    // as a skip rather than a green tick on a DB with no guest-visible events.
-    test.skip(
-      events.length === 0,
-      'no guest-visible calendar events in this DB — the meeting_url assertion would pass vacuously',
-    )
+    try {
+      const res = await request.get('/api/calendar')
+      expect(res.ok(), `GET /api/calendar returned ${res.status()}`).toBe(true)
 
-    const leaking = events.filter(e => 'meeting_url' in e)
-    expect(
-      leaking,
-      `meeting_url present on ${leaking.length}/${events.length} events in the anonymous payload`,
-    ).toEqual([])
+      const events = (await res.json()) as Array<Record<string, unknown>>
+      expect(Array.isArray(events)).toBe(true)
+
+      // Only reachable without a seeded event when SUPABASE_SERVICE_ROLE_KEY is
+      // absent (e.g. the preview-smoke CI job) — make that visible as a skip
+      // rather than a green tick on a DB with no guest-visible events.
+      test.skip(
+        seededEventId === null && events.length === 0,
+        'no SUPABASE_SERVICE_ROLE_KEY to seed a guest-visible event, and none exist in this DB',
+      )
+
+      const leaking = events.filter(e => 'meeting_url' in e)
+      expect(
+        leaking,
+        `meeting_url present on ${leaking.length}/${events.length} events in the anonymous payload`,
+      ).toEqual([])
+    } finally {
+      if (seededEventId) await client!.from('calendar_events').delete().eq('id', seededEventId)
+    }
   })
 })

--- a/e2e/guest-invite.spec.ts
+++ b/e2e/guest-invite.spec.ts
@@ -215,3 +215,34 @@ test.describe('390px viewport', () => {
     ).toBeLessThanOrEqual(390)
   })
 })
+
+// -- anonymous list payload carries no meeting link ---------------------------
+
+// 2608-DEV-703 / epic #702 D8. /api/calendar is on the public allowlist
+// (lib/public-routes.ts) and resolves sessionless callers to role 'guest', so
+// this is exactly the payload an anonymous visitor receives. Runs outside the
+// serial chain above and needs neither the fixture nor service credentials.
+test.describe('anonymous /api/calendar payload', () => {
+  test.describe.configure({ mode: 'default' })
+
+  test('never carries meeting_url', async ({ request }) => {
+    const res = await request.get('/api/calendar')
+    expect(res.ok(), `GET /api/calendar returned ${res.status()}`).toBe(true)
+
+    const events = (await res.json()) as Array<Record<string, unknown>>
+    expect(Array.isArray(events)).toBe(true)
+
+    // An empty list would pass the key assertion vacuously — make that visible
+    // as a skip rather than a green tick on a DB with no guest-visible events.
+    test.skip(
+      events.length === 0,
+      'no guest-visible calendar events in this DB — the meeting_url assertion would pass vacuously',
+    )
+
+    const leaking = events.filter(e => 'meeting_url' in e)
+    expect(
+      leaking,
+      `meeting_url present on ${leaking.length}/${events.length} events in the anonymous payload`,
+    ).toEqual([])
+  })
+})

--- a/lib/server/calendar.test.ts
+++ b/lib/server/calendar.test.ts
@@ -7,35 +7,41 @@ vi.mock('@/lib/supabase/service', () => ({
 
 import { buildEventDescription, toVEventInput, listEventsForRole } from '@/lib/server/calendar'
 
+const PORTAL = 'https://portal.example'
+
 describe('buildEventDescription', () => {
-  it('returns undefined when no description or detail fields are set', () => {
+  it('returns just the portal pointer when no description or detail fields are set', () => {
     expect(
-      buildEventDescription({ description: null, location: null, meeting_url: null, category: null }),
-    ).toMatchInlineSnapshot(`undefined`)
+      buildEventDescription({ id: 'ev-1', description: null, location: null, category: null }, PORTAL),
+    ).toMatchInlineSnapshot(`"Details: https://portal.example/calendar?event=ev-1"`)
   })
 
-  it('returns just the base description when no detail fields are set', () => {
+  it('returns the base description plus the portal pointer when no other detail fields are set', () => {
     expect(
       buildEventDescription({
+        id: 'ev-1',
         description: 'Monthly N21 meetup',
         location: null,
-        meeting_url: null,
         category: null,
-      }),
-    ).toMatchInlineSnapshot(`"Monthly N21 meetup"`)
+      }, PORTAL),
+    ).toMatchInlineSnapshot(`
+      "Monthly N21 meetup
+
+      Details: https://portal.example/calendar?event=ev-1"
+    `)
   })
 
   it('returns just the detail lines when there is no base description', () => {
     expect(
       buildEventDescription({
+        id: 'ev-1',
         description: null,
         location: 'Sofia HQ',
-        meeting_url: 'https://meet.example.com/abc',
         category: 'N21',
-      }),
+      }, PORTAL),
     ).toMatchInlineSnapshot(`
       "Location: Sofia HQ
-      Meeting link: https://meet.example.com/abc
+      Details: https://portal.example/calendar?event=ev-1
       Category: N21"
     `)
   })
@@ -43,16 +49,16 @@ describe('buildEventDescription', () => {
   it('joins the base description and detail lines with a blank line (Phase 1c format)', () => {
     expect(
       buildEventDescription({
+        id: 'ev-1',
         description: 'Monthly N21 meetup',
         location: 'Sofia HQ',
-        meeting_url: 'https://meet.example.com/abc',
         category: 'N21',
-      }),
+      }, PORTAL),
     ).toMatchInlineSnapshot(`
       "Monthly N21 meetup
 
       Location: Sofia HQ
-      Meeting link: https://meet.example.com/abc
+      Details: https://portal.example/calendar?event=ev-1
       Category: N21"
     `)
   })
@@ -60,27 +66,58 @@ describe('buildEventDescription', () => {
   it('omits a detail line whose field is an empty string', () => {
     expect(
       buildEventDescription({
+        id: 'ev-1',
         description: 'Monthly N21 meetup',
         location: '',
-        meeting_url: 'https://meet.example.com/abc',
         category: null,
-      }),
+      }, PORTAL),
     ).toMatchInlineSnapshot(`
       "Monthly N21 meetup
 
-      Meeting link: https://meet.example.com/abc"
+      Details: https://portal.example/calendar?event=ev-1"
     `)
   })
 
   it('omits the category line when category is an empty string', () => {
     expect(
       buildEventDescription({
+        id: 'ev-1',
         description: 'Monthly N21 meetup',
         location: null,
-        meeting_url: null,
         category: '',
-      }),
-    ).toMatchInlineSnapshot(`"Monthly N21 meetup"`)
+      }, PORTAL),
+    ).toMatchInlineSnapshot(`
+      "Monthly N21 meetup
+
+      Details: https://portal.example/calendar?event=ev-1"
+    `)
+  })
+
+  // Google event ids are opaque and have historically contained characters that
+  // are not URL-safe; the pointer must survive them rather than silently
+  // truncating the query string.
+  it('URL-encodes the event id in the portal pointer', () => {
+    expect(
+      buildEventDescription({ id: 'a b&c=d', description: null, location: null, category: null }, PORTAL),
+    ).toMatchInlineSnapshot(`"Details: https://portal.example/calendar?event=a%20b%26c%3Dd"`)
+  })
+
+  // 2608-DEV-703 / epic #702 D8: the meeting link must never reach the ICS
+  // payload. A subscribed client refreshes every 15 minutes for a year, which
+  // would bypass the meeting-link gate passively.
+  it('ignores a stale meeting_url still present on the incoming row', () => {
+    // Passed as a variable, not a literal, so TS structural typing lets the
+    // extra property through — this is what a caller left un-migrated would do.
+    const legacyRow = {
+      id: 'ev-1',
+      description: null,
+      location: null,
+      category: null,
+      meeting_url: 'https://meet.example.com/abc',
+    }
+    const out = buildEventDescription(legacyRow, PORTAL)
+    expect(out).not.toContain('meet.example.com')
+    expect(out).toBe('Details: https://portal.example/calendar?event=ev-1')
   })
 })
 
@@ -91,12 +128,11 @@ describe('toVEventInput', () => {
       title: 'WES event',
       description: null,
       location: null,
-      meeting_url: null,
       category: null,
       is_all_day: true,
       start_time: '2026-10-22T22:00:00Z',
       end_time: '2026-10-24T22:00:00Z',
-    })
+    }, PORTAL)
     // ical-generator serializes allDay dates via UTC getters (no calendar
     // timezone set) — assert the UTC date directly, matching what actually
     // lands in DTSTART;VALUE=DATE / DTEND;VALUE=DATE.
@@ -114,12 +150,11 @@ describe('toVEventInput', () => {
         title: 'WES event',
         description: null,
         location: null,
-        meeting_url: null,
         category: null,
         is_all_day: true,
         start_time: '2026-10-22T22:00:00Z',
         end_time: '2026-10-24T22:00:00Z',
-      }),
+      }, PORTAL),
     )
     const output = calendar.toString()
     expect(output).toContain('DTSTART;VALUE=DATE:20261023')
@@ -132,14 +167,30 @@ describe('toVEventInput', () => {
       title: 'Meeting',
       description: null,
       location: null,
-      meeting_url: null,
       category: null,
       is_all_day: false,
       start_time: '2026-06-15T10:00:00Z',
       end_time: '2026-06-15T11:00:00Z',
-    })
+    }, PORTAL)
     expect((input.start as Date).toISOString()).toBe('2026-06-15T10:00:00.000Z')
     expect(input.allDay).toBe(false)
+  })
+
+  // 2608-DEV-703 / epic #702 D8. Before this change `url` carried
+  // meeting_url, so one feed subscription handed out every meeting link for a
+  // 365-day window, refreshed every 15 minutes — passively defeating the gate.
+  it('sets the VEVENT url to the portal event page, not the meeting link', () => {
+    const input = toVEventInput({
+      id: 'timed-1',
+      title: 'Meeting',
+      description: null,
+      location: null,
+      category: null,
+      is_all_day: false,
+      start_time: '2026-06-15T10:00:00Z',
+      end_time: '2026-06-15T11:00:00Z',
+    }, PORTAL)
+    expect(input.url).toBe('https://portal.example/calendar?event=timed-1')
   })
 })
 
@@ -168,5 +219,50 @@ describe('listEventsForRole overlap semantics', () => {
     expect(result).toEqual([overlappingEvent])
     expect(lt).toHaveBeenCalledWith('start_time', '2026-11-01T00:00:00Z')
     expect(gte).toHaveBeenCalledWith('end_time', '2026-10-01T00:00:00Z')
+  })
+})
+
+// 2608-DEV-703 / epic #702 D8. /api/calendar is on the public allowlist and
+// resolves sessionless callers to role 'guest', so every column named here
+// reaches anonymous visitors. The overlap test above asserts nothing about the
+// column string — its mock is `select: () => chain`, which swallows the
+// argument entirely — so without this the projection could regain meeting_url
+// with every test still green.
+describe('listEventsForRole projection', () => {
+  it('never selects meeting_url', async () => {
+    const select = vi.fn()
+    const chain: Record<string, unknown> = {}
+    Object.assign(chain, {
+      contains: vi.fn().mockReturnValue(chain),
+      order: vi.fn().mockReturnValue(chain),
+      gte: vi.fn().mockReturnValue(chain),
+      lt: vi.fn().mockReturnValue(chain),
+      limit: vi.fn().mockReturnValue(chain),
+      then: (resolve: (v: unknown) => void) => resolve({ data: [], error: null }),
+    })
+    select.mockReturnValue(chain)
+
+    mockCreateServiceClient.mockReturnValue({ from: () => ({ select }) })
+
+    await listEventsForRole({ role: 'guest' })
+
+    expect(select).toHaveBeenCalledTimes(1)
+    const columns = select.mock.calls[0][0] as string
+    expect(columns).not.toContain('meeting_url')
+    // Guard the whole projection, not just the one column: a future addition
+    // lands here as a failure to be reviewed rather than shipping silently.
+    expect(columns.split(',').map(c => c.trim())).toEqual([
+      'id',
+      'title',
+      'description',
+      'start_time',
+      'end_time',
+      'category',
+      'event_type',
+      'week_number',
+      'access_roles',
+      'is_all_day',
+      'location',
+    ])
   })
 })

--- a/lib/server/calendar.ts
+++ b/lib/server/calendar.ts
@@ -7,27 +7,43 @@ import type { CalendarListEvent } from '@/types/calendar'
 import { icsAllDayRange } from '@/lib/calendar-dates'
 import type { ICalEventData } from 'ical-generator'
 
+// meeting_url is deliberately absent (2608-DEV-703, epic #702 decision D8).
+// /api/calendar is on the public allowlist and resolves sessionless callers to
+// role 'guest', so anything selected here reaches anonymous visitors. The link
+// is served only by the gated detail endpoint, app/api/events/[id]/route.ts.
 const LIST_COLUMNS =
-  'id, title, description, start_time, end_time, category, event_type, week_number, access_roles, is_all_day, location, meeting_url'
+  'id, title, description, start_time, end_time, category, event_type, week_number, access_roles, is_all_day, location'
+
+/** Deep link to a single event in the portal calendar (app/(dashboard)/calendar/page.tsx reads ?event=). */
+function portalEventUrl(portalUrl: string, eventId: string): string {
+  return `${portalUrl}/calendar?event=${encodeURIComponent(eventId)}`
+}
 
 /**
  * Composes the ICS VEVENT description: the event's own description plus
- * human-readable Location/Meeting link/Category lines. Google Calendar
+ * human-readable Location/Details/Category lines. Google Calendar
  * (Android) and iOS Calendar don't surface the structured LOCATION/URL/
  * CATEGORIES properties in their event view, so this appends the same info
  * as plain text — kept alongside the structured properties for clients that
  * do read them. Extracted from feed.ics/route.ts so the composed format can
  * be snapshot-tested without mocking auth/DB (Phase 1c format, #597).
+ *
+ * `portalUrl` is passed in rather than resolved here: getBaseUrl() is async and
+ * throws on a missing NEXT_PUBLIC_APP_URL, which would make this function async
+ * and drag auth/env mocking into its snapshot tests. The caller owns that.
  */
-export function buildEventDescription(event: {
-  description: string | null
-  location: string | null
-  meeting_url: string | null
-  category: string | null
-}): string | undefined {
+export function buildEventDescription(
+  event: {
+    id: string
+    description: string | null
+    location: string | null
+    category: string | null
+  },
+  portalUrl: string,
+): string | undefined {
   const detailLines = [
     event.location != null && event.location !== '' ? `Location: ${event.location}` : undefined,
-    event.meeting_url != null && event.meeting_url !== '' ? `Meeting link: ${event.meeting_url}` : undefined,
+    `Details: ${portalEventUrl(portalUrl, event.id)}`,
     event.category != null && event.category !== '' ? `Category: ${event.category}` : undefined,
   ].filter((line): line is string => line !== undefined)
   const baseDescription = event.description != null && event.description !== '' ? event.description : undefined
@@ -46,18 +62,20 @@ export function buildEventDescription(event: {
  * per RFC 5545 §3.8.2.2); timed events pass start_time/end_time straight
  * through — they're already +00 UTC strings from Supabase.
  */
-export function toVEventInput(event: {
-  id: string
-  title: string
-  description: string | null
-  location: string | null
-  meeting_url: string | null
-  category: string | null
-  is_all_day: boolean
-  start_time: string
-  end_time: string
-}): ICalEventData {
-  const description = buildEventDescription(event)
+export function toVEventInput(
+  event: {
+    id: string
+    title: string
+    description: string | null
+    location: string | null
+    category: string | null
+    is_all_day: boolean
+    start_time: string
+    end_time: string
+  },
+  portalUrl: string,
+): ICalEventData {
+  const description = buildEventDescription(event, portalUrl)
   const { start, end } = event.is_all_day
     ? icsAllDayRange(event.start_time, event.end_time)
     : { start: new Date(event.start_time), end: new Date(event.end_time) }
@@ -70,7 +88,9 @@ export function toVEventInput(event: {
     start,
     end,
     location: event.location != null && event.location !== '' ? event.location : undefined,
-    url: event.meeting_url != null && event.meeting_url !== '' ? event.meeting_url : undefined,
+    // Points at the portal, never the meeting link (D8) — a single feed
+    // subscription would otherwise hand out every link for a year.
+    url: portalEventUrl(portalUrl, event.id),
     categories: event.category != null ? [{ name: event.category }] : undefined,
   }
 }

--- a/types/calendar.ts
+++ b/types/calendar.ts
@@ -18,7 +18,6 @@ export type CalendarListEvent = Pick<
   | 'access_roles'
   | 'is_all_day'
   | 'location'
-  | 'meeting_url'
 >
 
 /** Full row shape for single-event detail consumers. */


### PR DESCRIPTION
## Summary
- Scope `meeting_url` out of the calendar list endpoint and ICS feed payloads
- Register CLAIMS row for the meeting_url scoping work
- Add e2e coverage for guest invite behavior

## Test plan
- [ ] `lib/server/calendar.test.ts` passes
- [ ] `e2e/guest-invite.spec.ts` passes
- [ ] Manually verify calendar list and ICS export no longer expose meeting_url where they shouldn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar feed links now direct users to portal event pages.
  * Event descriptions include portal links for easier access.
  * Calendar feed URLs update automatically when the portal address changes.

* **Bug Fixes**
  * Calendar feeds no longer expose outdated meeting links.
  * Configuration or event-loading issues now return an empty feed instead of a server error.

* **Tests**
  * Added coverage confirming guest calendar responses exclude meeting URLs and event links are correctly encoded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->