### PR TITLE
[2608-DEV-704] fix: select contact_email so sharer notifications send

### DIFF
--- a/app/events/[eventId]/join/page.tsx
+++ b/app/events/[eventId]/join/page.tsx
@@ -108,14 +108,18 @@ export default async function GuestJoinPage({ params, searchParams }: Props) {
   if (new Date(reg.expires_at) < new Date()) return <InvalidState eventId={eventId} reason="expired" lang={lang} />
 
   // Stamp attendance + confirm status — idempotent, only writes when not already set
-  await supabase
+  const { data: stamped } = await supabase
     .from('guest_registrations')
     .update({ attended_at: new Date().toISOString(), status: 'confirmed' })
     .eq('id', reg.id)
     .is('attended_at', null)
+    .select('id')
 
-  // Notify sharer — fire-and-forget, must not block render
-  if (reg.share_link_id) {
+  // Notify sharer — fire-and-forget, must not block render. Gated on the
+  // update having actually stamped a row: this page is a GET, so a refresh,
+  // a revisit or a mail-client link prefetch re-renders it, and an ungated
+  // call mails the sharer once per view (2608-DEV-704).
+  if (reg.share_link_id && stamped && stamped.length > 0) {
     notifySharerOfAttendance(reg.share_link_id, reg.name)
   }
 

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #703 | `dev/2608-DEV-703` | `lib/server/calendar.ts`, `types/calendar.ts`, `app/api/calendar/feed.ics/route.ts`, `lib/server/calendar.test.ts`, `e2e/guest-invite.spec.ts` — **migration: no** | 2026-08-09 |
+| #704 | `dev/2608-DEV-704` | `lib/notifications/share-events.ts`, `lib/notifications/share-events.test.ts` (new) — **migration: no** | 2026-08-09 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -58,6 +58,13 @@ instead of discarded, and `lib/notifications/share-events.test.ts` is new (8 tes
   `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`.
 
 ## Open items
+- NOTED (not done), found while verifying #704 against DEV: **12 of 68 active `event_share_links`
+  (18%) belong to a sharer whose `profiles.contact_email` is NULL** — 7 of 24 DEV profiles have no
+  contact_email at all. Those links still silently no-op after the #704 fix, because the resolver
+  correctly guards on a null address. Deserves its own issue: either fall back to the Clerk primary
+  email or require `contact_email` before a share link can be minted. Out of #704's DoD.
+- FACT (#704, DEV probe 2026-08-09): `notification_delivery_log` contains **zero** `share_guest_%`
+  rows of any age — independent confirmation the sharer notification path has never once sent.
 - NOTED (not done): `app/(dashboard)/page.tsx:138,216` — `LocationTile` mounts twice at every
   viewport because the desktop branch is CSS-hidden rather than conditionally rendered. Cheap now
   that the tile is pure DOM, but still a duplicated subtree on every load.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,31 +1,28 @@
 ## Goal
-BUILD issue #703 (2608-DEV-703, branch `dev/2608-DEV-703`), first child of epic #702: stop shipping
-`calendar_events.meeting_url` in the role-scoped calendar list projection and the ICS feed; point
-both at the portal event page instead (epic decision D8).
+BUILD issue #704 (2608-DEV-704, branch `dev/2608-DEV-704`), sibling child of epic #702: the sharer
+notification path never sends, because `resolveShareLinkContext` selected a `profiles.email` column
+that does not exist. Unblocks #702's inviter-attribution requirement (D4).
 
 ## Now
-PR #711 (`dev/2608-DEV-703`) is open and marked ready for review (not draft). CodeRabbit's one
-review pass found 1 actionable comment (Major) + 1 nitpick; both applied in commit `10e5fe0`:
-`app/api/calendar/feed.ics/route.ts` now hashes `portalUrl` into the ETag alongside `events`/
-`calendarName`; `e2e/guest-invite.spec.ts`'s anonymous-payload test now seeds its own guest-visible
-event (with `meeting_url` set) instead of skipping when the DB has none. The ETag review thread is
-resolved. Pushed to `origin/dev/2608-DEV-703`. CI is all green and the PR is
-`mergeStateStatus: CLEAN` / `mergeable: MERGEABLE`. Not yet merged.
+PLAN and CLAIM are complete and the fix is committed locally on `dev/2608-DEV-704` (`6708d16`),
+branch pushed. `lib/notifications/share-events.ts` selects `contact_email`, the `as unknown as`
+casts are gone so the generated types now police the column names, the PostgREST error is logged
+instead of discarded, and `lib/notifications/share-events.test.ts` is new (8 tests). No PR yet.
 
 ## Next
-1. Merge PR #711.
-2. Post-merge tail (per `docs/ai/GCR.md` step 7): remove the `dev/2608-DEV-703` row from
-   `docs/CLAIMS.md`; no migrations in this PR, so the prod-migration gate is skipped; smoke-check
-   `https://www.teamenjoyvd.com`; close issue #703.
+1. Apply any `/code-review low` findings, then open PR #704 as a DRAFT (CodeRabbit skips drafts).
+2. Wait for CI green + Vercel preview READY, then do the DEV end-to-end check the DoD requires:
+   register through a share link, join, cancel; expect three `notification_delivery_log` rows
+   (`share_guest_registered` / `share_guest_attended` / `share_guest_cancelled`, `status = 'sent'`).
+3. Mark ready for review -> one CodeRabbit pass -> batch the fixes into ONE push.
 
 ## Constraints
-- Never push to `main`; `dev/2608-DEV-703` only. `git checkout -b dev/2608-DEV-703 origin/main` SET
-  origin/main as the upstream; it was unset immediately (`git branch --unset-upstream`), so
-  `git rev-parse --abbrev-ref @{u}` -> fatal and a bare `git push` cannot hit main. Re-check after
+- Never push to `main`; `dev/2608-DEV-704` only. `git checkout -b dev/2608-DEV-704 origin/main` SET
+  origin/main as the upstream — the same trap as last session. Closed here by `git push -u`, which
+  repointed it: `git rev-parse --abbrev-ref @{u}` -> `origin/dev/2608-DEV-704`. Re-check after
   every branch cut — the tracking default is the trap, not the push.
-- `git push` to `dev/2608-DEV-703` was granted in conversation on 2026-08-09 ("push to PR so it's
-  merge-ready") — used for commit `10e5fe0` and the `docs/STATE.md` prune commit. Re-ask for any
-  push after this session ends.
+- `git push` to `dev/2608-DEV-704` was granted in conversation on 2026-08-09 ("Do the needful for
+  dev/2608-DEV-704 and continue"). Re-ask for any push after this session ends.
 - Never weaken a check to make it pass.
 - Fold the `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR — NEVER a
   standalone cleanup PR.
@@ -45,6 +42,14 @@ resolved. Pushed to `origin/dev/2608-DEV-703`. CI is all green and the PR is
   failed query instead of turning a 200 into a 500.
 
 ## Facts
+- VERIFICATION for #704, commit `6708d16`: `npm run check-types` -> clean. `npx vitest run` -> 28
+  files / 370 tests passed (was 27/362 before the new file). `npm run lint` -> 0 errors, 468
+  pre-existing warnings, none in `lib/notifications/share-events*`. `/code-review low` -> no
+  findings. NOT yet verified: the DoD's DEV end-to-end send.
+- PROOF the new drift guard works (#704): temporarily restoring `email` in the select makes
+  `tsc --noEmit` fail with `SelectQueryError<"column 'email' does not exist on 'profiles'.">`.
+  The original bug was compile-visible the whole time — the `as unknown as` casts suppressed it.
+  Treat an `as unknown as` over a PostgREST result as a defect, not a convenience.
 - VERIFICATION for the #703 CodeRabbit fixes, commit `10e5fe0`: `npx tsc --noEmit` -> clean.
   `npx vitest run lib/server/calendar.test.ts` -> 14 passed. `npx eslint` on
   `app/api/calendar/feed.ics/route.ts` and `e2e/guest-invite.spec.ts` -> exit 0.
@@ -89,6 +94,9 @@ resolved. Pushed to `origin/dev/2608-DEV-703`. CI is all green and the PR is
 None currently open for #703.
 
 ## Done
+- #703 (merged as #711, 2026-08-09) — `meeting_url` scoped out of the calendar list projection and
+  the ICS feed. Its `docs/CLAIMS.md` row is pruned here. Issue #703 is still OPEN on GitHub although
+  the user reports GCR ran and completed; left alone rather than closed from this session.
 - #700 (merged as #701, 2026-08-07) — `LocationMap` size transition rebuilt on plain inline
   width/height + a CSS `transition-[width,height]` after four framer-motion approaches
   (`animate` prop, `useSpring`+`jump()`, zero-duration tween, `animate()` in an effect) all failed to

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -4,17 +4,17 @@ notification path never sends, because `resolveShareLinkContext` selected a `pro
 that does not exist. Unblocks #702's inviter-attribution requirement (D4).
 
 ## Now
-PLAN and CLAIM are complete and the fix is committed locally on `dev/2608-DEV-704` (`6708d16`),
-branch pushed. `lib/notifications/share-events.ts` selects `contact_email`, the `as unknown as`
-casts are gone so the generated types now police the column names, the PostgREST error is logged
-instead of discarded, and `lib/notifications/share-events.test.ts` is new (8 tests). No PR yet.
+PR #712 (`dev/2608-DEV-704`) is open as a DRAFT with CI green. `lib/notifications/share-events.ts`
+selects `contact_email`, the `as unknown as` casts are gone so the generated types police the
+column names, the PostgREST error is logged instead of discarded, and
+`lib/notifications/share-events.test.ts` is new (8 tests). The full DoD end-to-end has been run
+live and all three templates PASS. A second fix rides along in
+`app/events/[eventId]/join/page.tsx` — see Decisions.
 
 ## Next
-1. Apply any `/code-review low` findings, then open PR #704 as a DRAFT (CodeRabbit skips drafts).
-2. Wait for CI green + Vercel preview READY, then do the DEV end-to-end check the DoD requires:
-   register through a share link, join, cancel; expect three `notification_delivery_log` rows
-   (`share_guest_registered` / `share_guest_attended` / `share_guest_cancelled`, `status = 'sent'`).
-3. Mark ready for review -> one CodeRabbit pass -> batch the fixes into ONE push.
+1. Mark PR #712 ready for review -> one CodeRabbit pass -> batch every fix into ONE push.
+2. Remove the DEV seed fixtures (`Seed704 Sharer` profile, its share link, its registration) via
+   the cleanup script once the PR is settled.
 
 ## Constraints
 - Never push to `main`; `dev/2608-DEV-704` only. `git checkout -b dev/2608-DEV-704 origin/main` SET
@@ -33,6 +33,12 @@ instead of discarded, and `lib/notifications/share-events.test.ts` is new (8 tes
   and kills `npm run build` with `Invalid code point <n>` pointed at `app/globals.css:1:1`.
 
 ## Decisions
+- DECISION (#704): the attendance notification in `app/events/[eventId]/join/page.tsx` is now gated
+  on the `attended_at` update actually stamping a row (`.select('id')` + length check), not merely
+  on `share_link_id` being present. The join page is a GET: a refresh, a revisit, or a mail-client
+  link prefetch re-renders it, so the ungated call mailed the sharer once per view. Harmless while
+  the notifier was broken; a mail loop the moment #704 made it work. Scope was widened past the DoD
+  deliberately, with the user's approval, because #704 is what turns it into a live defect.
 - DECISION (#703): `buildEventDescription`/`toVEventInput` (`lib/server/calendar.ts`) take
   `portalUrl` as a parameter rather than calling `getBaseUrl()` internally — that call is async and
   throws, which would have dragged env mocking into the snapshot tests these functions exist to
@@ -42,6 +48,18 @@ instead of discarded, and `lib/notifications/share-events.test.ts` is new (8 tes
   failed query instead of turning a 200 into a 500.
 
 ## Facts
+- LIVE END-TO-END for #704, 2026-08-09, local dev server against hosted DEV, recipient
+  `delivered@resend.dev` (Resend test mailbox, no human): register -> join -> cancel through a
+  seeded share link produced `share_guest_registered` (12:59:50), `share_guest_attended` (13:00:31)
+  and `share_guest_cancelled` (13:01:51), all `status = 'sent'`. All three DoD templates PASS.
+  Before this fix the table held zero `share_guest_%` rows of any age.
+- EXACTLY-ONCE PROOF for the join-page gate: before the fix, 2 views of one join link produced 2
+  `share_guest_attended` rows (13:00:31 and 13:01:39). After, 3 views (goto + reload + goto)
+  produced exactly 1. Both numbers measured against the real DEV table, not mocks.
+- TEST-HARNESS TRAP worth remembering: the register form carries a `website` honeypot
+  (`lib/actions/guest-registration.ts:64-66`) that returns `{success:true}` and registers nobody
+  when non-empty. A generic `input[type=text]` Playwright selector fills it and the run looks like
+  a silent app failure. Always scope to `input[name="name"]` / `input[name="email"]`.
 - VERIFICATION for #704, commit `6708d16`: `npm run check-types` -> clean. `npx vitest run` -> 28
   files / 370 tests passed (was 27/362 before the new file). `npm run lint` -> 0 errors, 468
   pre-existing warnings, none in `lib/notifications/share-events*`. `/code-review low` -> no

--- a/lib/notifications/share-events.test.ts
+++ b/lib/notifications/share-events.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Unit coverage for the share-link sharer notifiers (issue 2608-DEV-704).
+// The bug this guards: the profiles embed selected a non-existent `email`
+// column, PostgREST rejected the query, and all three helpers silently
+// no-opped. Compile-time protection now comes from the uncast generated types
+// (`npm run check-types`); these tests cover the runtime branches — who gets
+// mailed, under which template, and every path that must send nothing.
+
+// -- Seams --------------------------------------------------------------------
+
+const mockCreateServiceClient = vi.fn()
+const sentEmails: { to: string; template: string }[] = []
+/** The raw PostgREST select string the resolver passed to supabase-js. */
+let capturedSelect = ''
+
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: () => mockCreateServiceClient(),
+}))
+vi.mock('@/lib/email/send', () => ({
+  sendTransactionalEmail: vi.fn((opts: { to: string; template: string }) => {
+    sentEmails.push({ to: opts.to, template: opts.template })
+    return Promise.resolve({ sent: true })
+  }),
+}))
+vi.mock('@/lib/email/templates/render', () => ({
+  renderEmailTemplate: () => Promise.resolve('<html></html>'),
+}))
+vi.mock('@/lib/email/templates/ShareGuestRegisteredEmail', () => ({
+  ShareGuestRegisteredEmail: () => null,
+}))
+vi.mock('@/lib/email/templates/ShareGuestAttendedEmail', () => ({
+  ShareGuestAttendedEmail: () => null,
+}))
+vi.mock('@/lib/email/templates/ShareGuestCancelledEmail', () => ({
+  ShareGuestCancelledEmail: () => null,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  sentEmails.length = 0
+  capturedSelect = ''
+})
+
+type ShareLinkRow = {
+  lang: string
+  profile: { first_name: string; last_name: string; contact_email: string | null } | null
+  event: { title: string } | null
+}
+
+const validRow: ShareLinkRow = {
+  lang: 'en',
+  profile: { first_name: 'Ivan', last_name: 'Petrov', contact_email: 'sharer@example.com' },
+  event: { title: 'Trip Kickoff' },
+}
+
+function buildClient(result: { data: ShareLinkRow | null; error?: { message: string } | null }) {
+  return {
+    from: (table: string) => {
+      if (table !== 'event_share_links') throw new Error(`unexpected table ${table}`)
+      return {
+        select: (query: string) => {
+          capturedSelect = query
+          return {
+            eq: () => ({
+              single: () => Promise.resolve({ data: result.data, error: result.error ?? null }),
+            }),
+          }
+        },
+      }
+    },
+  }
+}
+
+/** The helpers are fire-and-forget (void); let their promise chain drain. */
+const flush = () => new Promise(r => setTimeout(r, 10))
+
+// -- The column the whole issue turns on ----------------------------------------
+
+describe('share link profile embed', () => {
+  it('selects contact_email and never a bare email column', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: validRow }))
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(capturedSelect).toContain('contact_email')
+    // `profiles` has no `email` column — selecting it 400s and the notifier
+    // goes silent. \b does not match inside contact_email (underscore is \w).
+    expect(capturedSelect).not.toMatch(/\bemail\b/)
+  })
+})
+
+// -- Each helper mails the sharer under its own template ------------------------
+
+const helpers = [
+  ['notifySharerOfRegistration', 'share_guest_registered'],
+  ['notifySharerOfAttendance', 'share_guest_attended'],
+  ['notifySharerOfCancellation', 'share_guest_cancelled'],
+] as const
+
+describe.each(helpers)('%s', (helperName, template) => {
+  it(`mails the sharer's contact_email with template ${template}`, async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: validRow }))
+    const mod = await import('@/lib/notifications/share-events')
+
+    mod[helperName]('link-1', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toEqual([{ to: 'sharer@example.com', template }])
+  })
+})
+
+// -- Every path that must stay silent -------------------------------------------
+
+describe('resolver guards', () => {
+  it('sends nothing when the share link row is missing', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: null }))
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('missing-link', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toHaveLength(0)
+  })
+
+  it('sends nothing when PostgREST returns an error', async () => {
+    mockCreateServiceClient.mockReturnValue(
+      buildClient({ data: null, error: { message: 'column does not exist' } }),
+    )
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toHaveLength(0)
+  })
+
+  it('sends nothing when the sharer has no contact_email', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({
+      data: { ...validRow, profile: { first_name: 'Ivan', last_name: 'Petrov', contact_email: null } },
+    }))
+    const { notifySharerOfAttendance } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfAttendance('link-1', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toHaveLength(0)
+  })
+
+  it('sends nothing when the event is missing', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: { ...validRow, event: null } }))
+    const { notifySharerOfCancellation } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfCancellation('link-1', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toHaveLength(0)
+  })
+})

--- a/lib/notifications/share-events.ts
+++ b/lib/notifications/share-events.ts
@@ -28,25 +28,35 @@ async function resolveShareLinkContext(
 ): Promise<ShareLinkContext | null> {
   const supabase = createServiceClient()
 
-  const { data } = await supabase
+  // `contact_email` — `profiles` has no `email` column. The previous name was
+  // rejected by PostgREST, so every notification below silently no-opped
+  // (2608-DEV-704). The embeds need no FK hint: event_share_links has exactly
+  // one FK to each of profiles and calendar_events.
+  const { data, error } = await supabase
     .from('event_share_links')
     .select(`
       lang,
-      profile:profiles ( first_name, last_name, email ),
+      profile:profiles ( first_name, last_name, contact_email ),
       event:calendar_events ( title )
     `)
     .eq('id', shareLinkId)
     .single()
 
+  if (error) {
+    console.error('Failed to resolve share link context:', error.message)
+    return null
+  }
   if (!data) return null
 
-  const profile = data.profile as unknown as { first_name: string; last_name: string; email: string } | null
-  const event   = data.event   as unknown as { title: string } | null
+  // Deliberately uncast: the generated Database types check these column names
+  // at compile time, so a future rename fails `npm run check-types` instead of
+  // silently resolving to null at runtime.
+  const { profile, event } = data
 
-  if (!profile?.email || !event?.title) return null
+  if (!profile?.contact_email || !event?.title) return null
 
   return {
-    sharerEmail: profile.email,
+    sharerEmail: profile.contact_email,
     sharerName:  `${profile.first_name} ${profile.last_name}`.trim(),
     eventTitle:  event.title,
     guestName,


### PR DESCRIPTION
## Summary

Closes #704.

`resolveShareLinkContext` in `lib/notifications/share-events.ts` embedded `profile:profiles ( first_name, last_name, email )`. `profiles` has no `email` column — it has `contact_email`. PostgREST rejected the query, `data` came back null, the resolver returned null, and all three public helpers no-opped in silence:

- `notifySharerOfRegistration`
- `notifySharerOfAttendance`
- `notifySharerOfCancellation`

Every call site is fire-and-forget, so nothing surfaced to the user or the logs, and `ShareGuestRegisteredEmail` / `ShareGuestAttendedEmail` / `ShareGuestCancelledEmail` have been dead templates.

**Changes**

1. Select `contact_email`. No FK hint needed — `event_share_links` has exactly one FK to each of `profiles` and `calendar_events`.
2. Drop the `as unknown as { … email: string }` casts. This is the part that matters beyond the one-word fix: with the generated `Database` types flowing through, the bad column name is now a **compile error**. Verified by temporarily restoring it:
   ```
   error TS2339: Property 'contact_email' does not exist on type
     SelectQueryError<"column 'email' does not exist on 'profiles'.">
   ```
   The bug was compile-visible the entire time; the casts suppressed it.
3. Log the PostgREST `error` instead of discarding it, so the next failure in this resolver is not silent.
4. New `lib/notifications/share-events.test.ts` (8 tests): asserts the select string contains `contact_email` and no bare `email`, that each helper mails the sharer's `contact_email` under its own template, and that a missing row, a PostgREST error, a null `contact_email` and a missing event each send nothing.

5. **`app/events/[eventId]/join/page.tsx` — attendance is now notified exactly once.** Found while verifying the above live. The `attended_at` write was already idempotent (`.is('attended_at', null)`), but `notifySharerOfAttendance` sat *outside* that guard and fired on every render. The join page is a GET, so a refresh, a revisit, or a mail-client link prefetch mailed the sharer again each time — and this path has no `consumeEmailCap`. Harmless while the notifier was broken; a mail loop the moment change 1 made it work. The call is now gated on the update returning a stamped row.

No migration. No UI change. No call-site changes to the notifier itself.

## Checklist

- [ ] CI green and Vercel preview READY (never Done on static analysis alone)
- [x] New UI surfaces render correctly at 390px — n/a, no UI surface touched
- [x] **Migrations are expand-only** — n/a, no migration
- [x] Every new migration carries a `-- ROLLBACK:` comment — n/a, no migration
- [x] `docs/CLAIMS.md` row registered (agent workflow)

## Live verification

Run against a local dev server pointed at the hosted DEV project, with the sharer's `contact_email` set to `delivered@resend.dev` (Resend's test mailbox — accepted and logged, never reaches a person). Register → join → cancel through a seeded share link:

```
12:59:49 | guest_event_magic_link  | sent | delivered@resend.dev
12:59:50 | share_guest_registered  | sent | delivered@resend.dev   PASS
13:00:31 | share_guest_attended    | sent | delivered@resend.dev   PASS
13:01:51 | share_guest_cancelled   | sent | delivered@resend.dev   PASS
```

All three DoD templates confirmed on the real path. Before this PR, `notification_delivery_log` held **zero** `share_guest_%` rows of any age.

Exactly-once gate, measured against the same live table:

| | join-page views | `share_guest_attended` sent |
|---|---|---|
| before the fix | 2 | **2** |
| after the fix | 3 (goto + reload + goto) | **1** |

## Session State

**Status:** IN PROGRESS
**Completed:**
- [x] `lib/notifications/share-events.ts` selects `contact_email`; casts removed; error logged
- [x] `lib/notifications/share-events.test.ts` added — 8 tests
- [x] `npm run check-types` clean; `npx vitest run` 28 files / 370 tests passed; `npm run lint` 0 errors (468 pre-existing warnings, none in the touched files)
- [x] Compile-time drift guard proven by reintroducing the bad column name
- [x] `/code-review low` — no findings
- [x] `docs/CLAIMS.md` row + `docs/STATE.md` retargeted at #704
- [x] Read-only probe against the hosted DEV project (`ynykjpnetfwqzdnsgkkg`): the fixed select
      returns rows with `contact_email` populated; the old select is rejected by the live database
      with `column profiles_1.email does not exist`; `notification_delivery_log` holds **zero**
      `share_guest_%` rows of any age, confirming this path has never sent

**Findings for follow-up (not in this PR's scope)**

- 12 of 68 active share links (18%) belong to a sharer whose `contact_email` is NULL — 7 of 24 DEV
  profiles have none. Those links still no-op after this fix, correctly, because the resolver
  guards on a null address. Worth its own issue: fall back to the Clerk primary email, or require
  `contact_email` before a share link can be minted.
- `share-events.ts` sends without `consumeEmailCap`, unlike `guest-event-changes.ts`. Now that
  these emails will actually send, a widely-circulated link makes the sharer's inbox uncapped.

- [x] Live DEV end-to-end: all three templates `status = 'sent'` (see above)
- [x] Attendance notification proven exactly-once against the live delivery log

**Next:** CodeRabbit pass, then batch every finding into ONE push. Afterwards, remove the DEV seed fixtures (`Seed704 Sharer` profile, its share link, its registration).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate attendance notifications when revisiting, refreshing, or prefetching event join links.
  * Fixed share-event notifications so they use the correct contact email address.
  * Added safeguards to prevent notifications when required share, profile, or event information is unavailable.
* **Tests**
  * Added coverage for successful share notifications and cases where notification delivery should be skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->