### PR TITLE
[2608-DEV-708] Recognised member on the share/register page

### DIFF
--- a/app/events/[eventId]/register/components/MemberAttendPanel.tsx
+++ b/app/events/[eventId]/register/components/MemberAttendPanel.tsx
@@ -1,0 +1,216 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Check, Video } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import AddToCalendarMenu from '@/components/AddToCalendarMenu'
+import { apiClient, ApiError } from '@/lib/apiClient'
+import { useLanguage } from '@/lib/hooks/useLanguage'
+
+/**
+ * Recognised-member panel on the public share/register page (2608-DEV-708).
+ *
+ * Replaces <RegisterForm> for a signed-in non-guest: no name/email inputs, no
+ * honeypot, no magic link — the member already has a portal identity, and the
+ * attend route resolves it server-side from the Clerk session.
+ *
+ * `isAttending` and `meetingUrl` are SERVER props, never client state: a
+ * successful call ends in router.refresh(), which re-runs the page and only
+ * then puts meeting_url in the payload. That is what keeps D3 honest — the
+ * link is never shipped to someone without an active registration.
+ *
+ * No server action here, deliberately: POST/DELETE /api/events/[id]/attend
+ * already owns this logic (identity via withProfile, 403 for role 'guest',
+ * `{ share }` -> attendEvent). A server action would be a second front door
+ * onto the same helper. The cost is useActionState's no-JS submit; the
+ * logged-out guest form keeps its server action untouched.
+ */
+
+type Props = {
+  eventId: string
+  /** Present only while an active registration exists — server-gated (D3). */
+  meetingUrl: string | null
+  eventTitle: string
+  startTime: string
+  endTime: string
+  memberName: string
+  /** Inviter's name when `?share=` resolves to a live link, else null. */
+  sharerName: string | null
+  shareToken?: string
+  isAttending: boolean
+}
+
+export function MemberAttendPanel({
+  eventId,
+  meetingUrl,
+  eventTitle,
+  startTime,
+  endTime,
+  memberName,
+  sharerName,
+  shareToken,
+  isAttending,
+}: Props) {
+  const router = useRouter()
+  const { t } = useLanguage()
+  const [isPending, setIsPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // The route reports capacity and event-ended as plain 400s; map those two to
+  // the copy this page already uses for them, and everything else — network
+  // failure, 5xx, an unrecognised message — to the generic attend error.
+  function messageFor(err: unknown): string {
+    const raw = err instanceof ApiError ? err.message : ''
+    if (raw.includes('capacity')) return t('event.register.full')
+    if (raw.includes('already ended')) return t('event.register.eventEnded')
+    return t('event.register.attendError')
+  }
+
+  async function run(request: () => Promise<unknown>) {
+    if (isPending) return
+    setIsPending(true)
+    setError(null)
+    try {
+      await request()
+      // Success renders from the refreshed server pass, not from local state.
+      router.refresh()
+    } catch (err) {
+      setError(messageFor(err))
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  const attend = () =>
+    run(() =>
+      apiClient(`/api/events/${eventId}/attend`, {
+        method: 'POST',
+        body: JSON.stringify(shareToken === undefined ? {} : { share: shareToken }),
+      }),
+    )
+
+  const cancelAttend = () =>
+    run(() => apiClient(`/api/events/${eventId}/attend`, { method: 'DELETE' }))
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+          {t('event.register.signedInAs').replace('{name}', memberName)}
+        </p>
+        {sharerName !== null && (
+          <p className="text-sm mt-0.5" style={{ color: 'var(--text-secondary)' }}>
+            {t('event.register.invitedBy').replace('{name}', sharerName)}
+          </p>
+        )}
+      </div>
+
+      {isAttending ? (
+        <div className="space-y-3">
+          <div className="flex items-center gap-3 flex-wrap">
+            <span
+              className="flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-full"
+              style={{
+                backgroundColor: 'var(--status-success-bg, rgba(129,178,154,0.18))',
+                color: 'var(--status-success-fg, #2d6a4f)',
+              }}
+            >
+              <Check size={10} />
+              {t('event.register.attendingAlready')}
+            </span>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <button
+                  disabled={isPending}
+                  className="text-xs font-medium hover:opacity-70 transition-opacity disabled:opacity-40"
+                  style={{ color: 'var(--brand-crimson, #bc4749)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+                >
+                  {t('cal.cantAttend')}
+                </button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{t('cal.cancelAttendTitle')}</AlertDialogTitle>
+                  <AlertDialogDescription>{t('cal.cancelAttendDesc')}</AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>{t('event.cancel')}</AlertDialogCancel>
+                  <AlertDialogAction onClick={cancelAttend}>{t('cal.cantAttend')}</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+
+          {meetingUrl !== null && meetingUrl !== '' && (
+            <a
+              href={meetingUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center w-full rounded-xl py-3.5 text-sm font-semibold text-white hover:opacity-80 transition-opacity"
+              style={{ backgroundColor: '#1a3c2e', minHeight: 44 }}
+            >
+              {t('event.join.joinMeeting')}
+            </a>
+          )}
+
+          {/* Mirrors AttendSection.tsx:87-102. The /join link STAMPS attendance,
+              which is not the same thing as the raw meeting_url above it — the
+              caption is what tells the two apart. Deliberately a link and not a
+              redirect on success: D4 reserves that stamp for click-through. */}
+          <div className="flex items-center gap-4 flex-wrap">
+            <a
+              href={`/events/${eventId}/join`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex flex-col"
+              style={{ color: 'var(--brand-teal, #1a3c2e)' }}
+            >
+              <span className="flex items-center gap-1.5 text-xs font-semibold hover:opacity-70 transition-opacity">
+                <Video size={12} />
+                {t('event.join.joinMeeting')}
+              </span>
+              <span className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>
+                {t('cal.joinRecordsAttendance')}
+              </span>
+            </a>
+            {startTime !== '' && endTime !== '' && (
+              <AddToCalendarMenu
+                title={eventTitle}
+                startTime={startTime}
+                endTime={endTime}
+                meetingUrl={meetingUrl}
+              />
+            )}
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={attend}
+          disabled={isPending}
+          className="w-full rounded-xl py-3.5 text-sm font-semibold text-white disabled:opacity-60 transition-opacity"
+          style={{ backgroundColor: '#1a3c2e', minHeight: 44 }}
+        >
+          {isPending ? '…' : t('event.register.attendOneTap')}
+        </button>
+      )}
+
+      {error !== null && (
+        <p className="text-sm" style={{ color: '#bc4749' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/events/[eventId]/register/components/MemberAttendPanel.tsx
+++ b/app/events/[eventId]/register/components/MemberAttendPanel.tsx
@@ -106,9 +106,14 @@ export function MemberAttendPanel({
   return (
     <div className="space-y-4">
       <div>
-        <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-          {t('event.register.signedInAs').replace('{name}', memberName)}
-        </p>
+        {/* `first_name`/`last_name` are both nullable, so page.tsx can hand us an
+            empty string. "Signed in as " with nothing after it is worse than no
+            identity line at all — the panel itself already proves recognition. */}
+        {memberName !== '' && (
+          <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            {t('event.register.signedInAs').replace('{name}', memberName)}
+          </p>
+        )}
         {sharerName !== null && (
           <p className="text-sm mt-0.5" style={{ color: 'var(--text-secondary)' }}>
             {t('event.register.invitedBy').replace('{name}', sharerName)}
@@ -199,10 +204,14 @@ export function MemberAttendPanel({
           type="button"
           onClick={attend}
           disabled={isPending}
+          aria-busy={isPending}
           className="w-full rounded-xl py-3.5 text-sm font-semibold text-white disabled:opacity-60 transition-opacity"
           style={{ backgroundColor: '#1a3c2e', minHeight: 44 }}
         >
-          {isPending ? '…' : t('event.register.attendOneTap')}
+          {/* Label kept while pending: swapping it for '…' takes the button's
+              accessible name away mid-request. disabled + disabled:opacity-60
+              already carry the visual cue, aria-busy carries it to AT. */}
+          {t('event.register.attendOneTap')}
         </button>
       )}
 

--- a/app/events/[eventId]/register/page.tsx
+++ b/app/events/[eventId]/register/page.tsx
@@ -48,7 +48,7 @@ export default async function GuestRegisterPage({ params, searchParams }: Props)
   // hint — the multi-FK `payments` trap in docs/ai/GOTCHAS.md does not apply.
   let shareLinkRevoked = false
   let sharerName: string | null = null
-  if (share) {
+  if (share !== undefined && share !== '') {
     const { data: shareLink } = await supabase
       .from('event_share_links')
       .select('revoked_at, profile:profiles(first_name, last_name)')
@@ -135,6 +135,23 @@ export default async function GuestRegisterPage({ params, searchParams }: Props)
     ? t('event.register.full', lang)
     : null
 
+  // Built once and rendered in BOTH layout blocks below: the desktop and mobile
+  // trees are separate DOM, so a second inline copy of these props would have to
+  // be kept in step by hand, and only the 390px e2e case would catch the drift.
+  const memberPanel = member === null ? null : (
+    <MemberAttendPanel
+      eventId={event.id}
+      meetingUrl={meetingUrl}
+      eventTitle={event.title}
+      startTime={event.start_time}
+      endTime={event.end_time}
+      memberName={memberName}
+      sharerName={sharerName}
+      shareToken={share}
+      isAttending={isAttending}
+    />
+  )
+
   return (
     <>
       {/* ── Desktop ────────────────────────────────────────────────────────── */}
@@ -161,18 +178,8 @@ export default async function GuestRegisterPage({ params, searchParams }: Props)
                 <p className="text-sm text-center" style={{ color: 'var(--text-secondary)' }}>{blockedMessage}</p>
                 <ResendLinkForm eventId={event.id} />
               </>
-            ) : member !== null ? (
-              <MemberAttendPanel
-                eventId={event.id}
-                meetingUrl={meetingUrl}
-                eventTitle={event.title}
-                startTime={event.start_time}
-                endTime={event.end_time}
-                memberName={memberName}
-                sharerName={sharerName}
-                shareToken={share}
-                isAttending={isAttending}
-              />
+            ) : memberPanel !== null ? (
+              memberPanel
             ) : (
               <>
                 <p className="text-sm font-semibold mb-5" style={{ color: 'var(--text-primary)' }}>
@@ -208,18 +215,8 @@ export default async function GuestRegisterPage({ params, searchParams }: Props)
               <p className="text-sm text-center" style={{ color: 'var(--text-secondary)' }}>{blockedMessage}</p>
               <ResendLinkForm eventId={event.id} />
             </>
-          ) : member !== null ? (
-            <MemberAttendPanel
-              eventId={event.id}
-              meetingUrl={meetingUrl}
-              eventTitle={event.title}
-              startTime={event.start_time}
-              endTime={event.end_time}
-              memberName={memberName}
-              sharerName={sharerName}
-              shareToken={share}
-              isAttending={isAttending}
-            />
+          ) : memberPanel !== null ? (
+            memberPanel
           ) : (
             <>
               <p className="text-sm font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>

--- a/app/events/[eventId]/register/page.tsx
+++ b/app/events/[eventId]/register/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation'
+import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { RegisterForm } from './components/RegisterForm'
+import { MemberAttendPanel } from './components/MemberAttendPanel'
 import { ResendLinkForm } from '../components/ResendLinkForm'
 import { t } from '@/lib/i18n'
 import { getLangFromCookies } from '@/lib/utils/lang-cookie'
@@ -9,6 +11,10 @@ type Props = {
   params:       Promise<{ eventId: string }>
   searchParams: Promise<{ share?: string }>
 }
+
+type SharerProfile = { first_name: string | null; last_name: string | null } | null
+
+type MemberIdentity = { id: string; first_name: string | null; last_name: string | null }
 
 export default async function GuestRegisterPage({ params, searchParams }: Props) {
   const { eventId }  = await params
@@ -37,26 +43,95 @@ export default async function GuestRegisterPage({ params, searchParams }: Props)
     eventFull = (count ?? 0) >= event.guest_capacity
   }
 
+  // `event_share_links` has exactly ONE FK to `profiles`
+  // (20260504000001_event_share_links.sql:7), so this embed needs no PostgREST
+  // hint — the multi-FK `payments` trap in docs/ai/GOTCHAS.md does not apply.
   let shareLinkRevoked = false
+  let sharerName: string | null = null
   if (share) {
     const { data: shareLink } = await supabase
       .from('event_share_links')
-      .select('revoked_at')
+      .select('revoked_at, profile:profiles(first_name, last_name)')
       .eq('token', share)
       .eq('event_id', eventId)
       .single()
     shareLinkRevoked = !!shareLink?.revoked_at
+
+    // Attribution is only shown for a live link — a revoked one credits nobody.
+    if (shareLink && !shareLink.revoked_at) {
+      // Narrow joined relation -- PostgREST returns object for to-one FK
+      const sharer = shareLink.profile as unknown as SharerProfile
+      // Convention: first_name + ' ' + last_name (lib/notifications/share-events.ts:60).
+      const name = `${sharer?.first_name ?? ''} ${sharer?.last_name ?? ''}`.trim()
+      sharerName = name === '' ? null : name
+    }
   }
+
+  // -- Member path (2608-DEV-708) ---------------------------------------------
+  // `/events/(.*)` is in PUBLIC_ROUTE_PATTERNS (lib/public-routes.ts:29), but
+  // clerkMiddleware still resolves a session on a public route — the join
+  // page's member branch relies on exactly this (join/page.tsx:165-174).
+  // Anonymous visitors get a null userId and fall through to the guest form.
+  const { userId } = await auth()
+
+  let member: MemberIdentity | null = null
+  if (userId) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('id, role, first_name, last_name')
+      .eq('clerk_id', userId)
+      .maybeSingle()
+
+    // role 'guest' has no portal identity worth using here, and the attend
+    // route would 403 them anyway (api/events/[id]/attend/route.ts:38) — they
+    // fall through to the unchanged guest form.
+    if (profile && profile.role !== 'guest') {
+      member = { id: profile.id, first_name: profile.first_name, last_name: profile.last_name }
+    }
+  }
+
+  let isAttending = false
+  let meetingUrl: string | null = null
+  if (member) {
+    const { data: registration } = await supabase
+      .from('guest_registrations')
+      .select('id')
+      .eq('event_id', eventId)
+      .eq('profile_id', member.id)
+      .is('cancelled_at', null)
+      .maybeSingle()
+    isAttending = registration != null
+
+    // D3: meeting_url is fetched ONLY behind an active registration, so it is
+    // never in this page's payload for someone who has not attended. That is
+    // also why the panel re-renders from the server after a successful attend
+    // instead of flipping client state.
+    if (isAttending) {
+      const { data: gated } = await supabase
+        .from('calendar_events')
+        .select('meeting_url')
+        .eq('id', eventId)
+        .single()
+      meetingUrl = gated?.meeting_url ?? null
+    }
+  }
+
+  const memberName = member === null
+    ? ''
+    : `${member.first_name ?? ''} ${member.last_name ?? ''}`.trim()
 
   const dateLabel = new Date(event.start_time).toLocaleDateString('en-GB', {
     weekday: 'long', day: 'numeric', month: 'long', year: 'numeric',
   })
 
+  // A member re-opening their own link is not consuming a new seat, so a full
+  // event must not block them once they already hold an active row. Ended and
+  // revoked-link still block everyone: a revoked link attributes nothing.
   const blockedMessage = eventEnded
     ? t('event.register.eventEnded', lang)
     : shareLinkRevoked
     ? t('event.register.linkNoLongerActive', lang)
-    : eventFull
+    : eventFull && !isAttending
     ? t('event.register.full', lang)
     : null
 
@@ -86,6 +161,18 @@ export default async function GuestRegisterPage({ params, searchParams }: Props)
                 <p className="text-sm text-center" style={{ color: 'var(--text-secondary)' }}>{blockedMessage}</p>
                 <ResendLinkForm eventId={event.id} />
               </>
+            ) : member !== null ? (
+              <MemberAttendPanel
+                eventId={event.id}
+                meetingUrl={meetingUrl}
+                eventTitle={event.title}
+                startTime={event.start_time}
+                endTime={event.end_time}
+                memberName={memberName}
+                sharerName={sharerName}
+                shareToken={share}
+                isAttending={isAttending}
+              />
             ) : (
               <>
                 <p className="text-sm font-semibold mb-5" style={{ color: 'var(--text-primary)' }}>
@@ -121,6 +208,18 @@ export default async function GuestRegisterPage({ params, searchParams }: Props)
               <p className="text-sm text-center" style={{ color: 'var(--text-secondary)' }}>{blockedMessage}</p>
               <ResendLinkForm eventId={event.id} />
             </>
+          ) : member !== null ? (
+            <MemberAttendPanel
+              eventId={event.id}
+              meetingUrl={meetingUrl}
+              eventTitle={event.title}
+              startTime={event.start_time}
+              endTime={event.end_time}
+              memberName={memberName}
+              sharerName={sharerName}
+              shareToken={share}
+              isAttending={isAttending}
+            />
           ) : (
             <>
               <p className="text-sm font-semibold mb-4" style={{ color: 'var(--text-primary)' }}>

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #707 | `dev/2608-DEV-707` | `lib/calendar-links.ts` + `.test.ts` (new), `components/AddToCalendarMenu.tsx` (new), `lib/email/templates/MemberEventConfirmationEmail.tsx` (new), `app/events/[eventId]/join/page.tsx`, `app/events/[eventId]/join/components/JoinActions.tsx`, `lib/server/member-registration.ts` + `.test.ts`, `app/api/events/[id]/attend/route.ts`, `app/(dashboard)/calendar/components/popup/AttendSection.tsx`, `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx`, `e2e/member-attend-auth.spec.ts` — **migration: no** | 2026-08-10 |
+| #708 | `dev/2608-DEV-708` | `app/events/[eventId]/register/page.tsx`, `app/events/[eventId]/register/components/MemberAttendPanel.tsx` (new), `lib/i18n/domains/events.ts`, `playwright.config.ts`, `e2e/member-share-register-auth.spec.ts` (new) — **migration: no** | 2026-08-10 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -4,27 +4,26 @@ D1 in epic #702: a signed-in member opening someone's `?share=` link gets one-ta
 inviter credited, never the guest name+email form.
 
 ## Now
-BUILD complete and committed as `bce3c28` (5 files, +571/-3): i18n keys, `MemberAttendPanel.tsx`,
-`register/page.tsx` wiring, `playwright.config.ts:38`, `e2e/member-share-register-auth.spec.ts`.
-Static gates all green (see Facts). `/code-review low` returned three findings, all dispositioned
-without code change — one rejected on the real prop type, one logged below as NOTED, one rejected as
-consistent with `EventPopup.tsx:76-78`. Not yet pushed.
+BUILD complete and pushed. Draft PR #720 open against `main` at `c2071dd`, ALL 11 checks green.
+Commits: `bce3c28` (feature, 5 files +571/-3), `4fa90dd` (state), `5d6e07b` (e2e locator fix),
+`c2071dd` (e2e coverage for the capacity carve-out + gated meeting link).
+Authenticated E2E genuinely executed — `Running 30 tests`, `30 passed (2.6m)`, all 5 of the new
+cases with real timings, so `skipIfUnseeded` did not silently skip. Still a DRAFT: not flipped to
+ready-for-review, because that fires the single CodeRabbit pass and is the merge decision.
 
 ## Next
-1. Push `dev/2608-DEV-708` -> draft PR (CodeRabbit skips drafts), body carries `Closes #708` and the
-   Session State block.
-2. CI green + Vercel Preview READY — confirm the Authenticated E2E job actually ran its steps rather
-   than skipping on missing secrets (green-by-skip does not count).
-3. Verify the DoD on the preview at 390px: signed-in member sees the panel and no name/email inputs;
-   logged-out visitor on the same URL still gets the guest form.
-4. Ready for review -> batch-fix CodeRabbit findings in ONE commit.
-5. After merge: GCR post-merge tail — remove the #708 row from `docs/CLAIMS.md`, smoke-check
+1. Decide whether to mark #720 ready for review (fires CodeRabbit's one pass) — needs a human call.
+2. Batch-fix any CodeRabbit findings in ONE commit; reply-and-resolve wrong ones rather than churn.
+3. After merge: GCR post-merge tail — remove the #708 row from `docs/CLAIMS.md`, smoke-check
    production, close #708. No migration, so `Migrate Prod` will auto-skip.
 
-## Not run locally
-`e2e/member-share-register-auth.spec.ts` is COLLECTED but NOT EXECUTED — the `authenticated` project
-needs local Supabase + `npm run e2e:seed-clerk`. It also needs a second named profile to act as the
-inviter; `skipIfUnseeded` covers its absence, so watch for a silent skip in CI rather than a pass.
+## Not covered by any test (#708)
+- DoD "member with `role = 'guest'` falls through to the guest form" is IMPLEMENTED
+  (`register/page.tsx`, role check) but UNVERIFIED — covering it needs a guest-role profile with a
+  live Clerk session, which the seed script does not provide.
+- The panel's cancel path (AlertDialog -> DELETE -> back to the Attend button) is implemented and
+  mirrors `AttendSection.tsx`, but no e2e case exercises it here; `member-attend-auth.spec.ts`
+  covers the same route from the calendar popup.
 
 ## Constraints
 - Never push without an explicit grant in this conversation. The grant used for `dev/2608-DEV-708`
@@ -69,6 +68,10 @@ inviter; `skipIfUnseeded` covers its absence, so watch for a silent skip in CI r
 - Production smoke 2026-08-10: `https://www.teamenjoyvd.com` 200, `/sign-in` 200.
 
 ## Done
+- #708 BUILD — RESULT: draft PR #720 at `c2071dd`, all 11 checks green, Authenticated E2E 30 passed
+  (5 new cases, none skipped). DoD verified by test: one-tap panel with no name/email inputs,
+  `share_link_id` = inviter's link, own link -> null, logged-out guest form unchanged, full event
+  does not block an active member, meeting link absent before / present after attending, 390px.
 - #708 BUILD — RESULT: `bce3c28`, 5 files, +571/-3. All six issue corrections honoured: reused the
   attend route (no `lib/actions/member-registration.ts`), one `playwright.config.ts` edit, server-
   rendered attending state, link-not-redirect to `/join`, `first_name + last_name` for the sharer.
@@ -102,4 +105,9 @@ inviter; `skipIfUnseeded` covers its absence, so watch for a silent skip in CI r
   the pre-#705 column list.
 
 ## Failed attempts
-- None this session.
+- ATTEMPT 1 [L1] (#708 e2e): the 390px case asserted the panel with
+  `getByText(/signed in as/i).first()` -> `expect(locator).toBeVisible() failed` in CI at
+  `member-share-register-auth.spec.ts:168`, twice (initial + retry #1). CAUSE: `.first()` is DOM
+  order and `page.tsx` renders the desktop block (`hidden md:flex`) before the mobile one, so at
+  390px it locked onto the CSS-hidden desktop copy. Fixed in `5d6e07b` with the `visible()` scope
+  that `member-attend-auth.spec.ts:88-93` already documents. Green on re-run.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,148 +1,87 @@
 ## Goal
-BUILD issue #707 (2608-DEV-707) — Attend: confirmation email, add-to-calendar, attendance
-tracking. The remaining half of D4 for member sign-ups, part of epic #702. CLAIM was already
-complete on session start: branch `dev/2608-DEV-707` existed with commit `34ba94a` (claim row
-registered + #706's row pruned), on top of `1c7f5bb` (#706, merged as PR #717).
+BUILD issue #708 (2608-DEV-708) — recognised member on the share/register page. Second half of
+D1 in epic #702: a signed-in member opening someone's `?share=` link gets one-tap Attend with the
+inviter credited, never the guest name+email form.
 
 ## Now
-All four issue sections are coded on `dev/2608-DEV-707`, uncommitted in the working tree:
-
-1. **Builders extracted** — `toGcalDate`/`buildGoogleCalUrl`/`buildOutlookUrl`/`buildIcsContent`
-   moved verbatim from `JoinActions.tsx:14-76` to `lib/calendar-links.ts`; `JoinActions` imports
-   them, UI untouched. `lib/calendar-links.test.ts` (10 tests) pins the exact URL params and ICS
-   line output across the move.
-2. **`components/AddToCalendarMenu.tsx`** — shadcn `DropdownMenu` over those builders, in
-   `/components` per the 2-unrelated-routes promotion rule (popup + T6 register page). Content is
-   portaled, so it carries `z-[60]` to clear the Radix Dialog's `z-50`.
-3. **Token-free member join** — `app/events/[eventId]/join/page.tsx` now branches: `token` present
-   -> the guest path, moved verbatim into an `if (token)` block; absent -> `auth()` -> profile by
-   `clerk_id` -> active member registration -> the same idempotent `attended_at` stamp and
-   `notifySharerOfAttendance` call, rendering the identical screen. Anonymous or unregistered falls
-   through to the `InvalidState reason="missing"` the URL always rendered. `CancelActions` is
-   gated on `token` (members cancel from the popup).
-4. **Confirmation email** — `lib/email/templates/MemberEventConfirmationEmail.tsx` (en/bg, same
-   `_shell` structure as `GuestEventMagicLinkEmail`), dispatched from `attendEvent` on
-   create/reactivate/adopt only, via `consumeEmailCap` -> `renderEmailTemplate` ->
-   `sendTransactionalEmail`. The popup's attending state gained the "Join meeting" CTA
-   (`/events/[id]/join`) + `AddToCalendarMenu`.
-
-**Not pushed.** No push grant in this conversation; the branch is local-only (`git ls-remote` shows
-no `dev/2608-DEV-707` on origin), so no PR exists yet and Vercel Preview / CI have not run.
-
-`/code-review low` ran twice per BUILD.md EXECUTE. The first pass silently skipped the four new
-files — they were untracked, so they carried no hunks; `git add -N` on them and a second pass
-covered them. Two findings, both addressed:
-- `member-registration.ts` — `consumeEmailCap` is consumed before render/send, so a failed send
-  still burns a slot. **Kept**: identical to the guest path's documented rule
-  (`lib/actions/guest-registration.ts:204-206`, 2608-DEV-625). Added the comment that says so.
-- `AddToCalendarMenu.tsx` — `URL.revokeObjectURL` fired synchronously after `a.click()` on a
-  detached anchor, which drops the blob before the download starts in Firefox/Safari. **Fixed**:
-  append/click/remove plus a next-tick revoke, matching `downloadQr` in `EventPopup.tsx`.
+CLAIM complete, BUILD not started. Branch `dev/2608-DEV-708` exists, cut from `main` @ `067250c`,
+with `327327c` (claim row registered + #707's row pruned) and the session-state commit on top.
+Working tree otherwise clean — no application code written yet.
 
 ## Next
-1. Fold in any `/code-review low` findings.
-2. Ask for a push grant -> push `dev/2608-DEV-707` -> open the PR as a **draft** (CodeRabbit skips
-   drafts) -> confirm CI green and Vercel Preview READY. This PR has **no migration**, so
-   `migrate-prod` will auto-skip.
-3. Verify the DoD point-by-point against the preview, including the 390px popup CTA row.
-4. Mark ready for review -> batch-fix CodeRabbit findings in ONE commit.
-5. After merge: smoke-check production, remove the #707 row from `docs/CLAIMS.md`, close #707.
+1. SHAPE/GATHER per `docs/ai/BUILD.md`; re-read `docs/ai/GOTCHAS.md` in full.
+2. Implement in this order: i18n keys -> `MemberAttendPanel.tsx` -> `register/page.tsx` wiring ->
+   `playwright.config.ts:38` -> `e2e/member-share-register-auth.spec.ts`.
+3. `npx vitest run`, `npx tsc --noEmit`, `npx eslint .`, then
+   `npx playwright test --list --project=authenticated e2e/member-share-register-auth.spec.ts`.
+4. `/code-review low` on the diff — `git add -N` any new untracked files FIRST, or they carry no
+   hunks and are silently skipped (that happened on #707).
+5. Push -> draft PR (CodeRabbit skips drafts) -> CI green + Vercel Preview READY -> verify DoD on
+   the preview at 390px -> ready for review -> batch-fix CodeRabbit findings in ONE commit.
+6. After merge: GCR post-merge tail — remove the #708 row from `docs/CLAIMS.md`, smoke-check
+   production, close #708. No migration, so `Migrate Prod` will auto-skip.
 
 ## Constraints
-- Never push without an explicit grant in this conversation; the push grant used for `e0e1cf5`/
-  `5e82ac5` on #706 does not carry over to other tickets or later sessions.
+- Never push without an explicit grant in this conversation. The grant used for `dev/2608-DEV-708`
+  ("push the branch", 2026-08-10) does not carry over to other tickets or later sessions.
 - Never apply migrations to a hosted Supabase project (DEV or prod) without asking first.
-- Fold `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR, never a standalone
-  cleanup PR.
+- Fold `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR, never a
+  standalone cleanup PR.
 - `.env.local` holds PRODUCTION Supabase credentials; `.env.development.local` holds the safe local
   stack. Run `npm run check:env` before any command touching a hosted DB.
 
 ## Decisions
-- DECISION (#707): `MemberEventConfirmationEmail` takes `googleCalUrl` and `outlookUrl` as props
-  rather than `startTime`/`endTime`. The issue's prop list (`{ name, eventTitle, eventDateLabel,
-  meetingUrl, joinUrl, lang }`) carries neither the URLs nor the raw times, and the links must be
-  built server-side from `lib/calendar-links.ts` — passing the finished URLs keeps the template a
-  pure presenter and keeps the builder as the single source of link shape.
-- DECISION (#707): `attendEvent` returns `emailed: boolean` and the route echoes it, so the popup
-  can pick `cal.attendSuccessEmailed` over `cal.attendSuccess`. The DoD requires the success copy
-  not claim an email when `contact_email` is null; the existing `cal.attendSuccess` copy is already
-  email-neutral, so only the *sent* case needed a new key.
-- DECISION (#707): the whole email dispatch is wrapped in try/catch inside `attendEvent` and returns
-  `emailed: false` on any throw. The registration is already committed when it runs, so a missing
-  `NEXT_PUBLIC_APP_URL` (the #713 failure shape, live in this code path) must not turn a successful
-  attend into a 400. This is failure-path handling for the new send, **not** a fix for #713 — that
-  ticket still owns the guest path.
-- DECISION (#707): email cap constants are duplicated as module-locals in `member-registration.ts`
-  (`MEMBER_EMAIL_DAILY_CAP = 10`, 24h window) instead of imported from
-  `lib/actions/guest-registration.ts`, which is `'use server'` and may therefore only export async
-  functions. Same *bucket* either way — `consumeEmailCap` with no `template` keys on
-  `email:${recipient}`, so members and guests share one 10/day per-recipient cap. No new scope.
-- DECISION (#707): one new i18n key beyond the six reused `event.join.*` ones —
-  `cal.joinRecordsAttendance` ("Records your attendance"), the caption under the popup's new "Join
-  meeting" CTA. `EventPopupShell:145-156` already renders the raw `meeting_url`, which does NOT
-  record attendance; the CLAIM correction requires the copy to make that difference obvious.
-- DECISION (#707): the popup CTA row's 390px coverage lives in `member-attend-auth.spec.ts` under
-  the `authenticated` project with a `test.use({ viewport: 390x844 })` block, not in `mobile-390`.
-  `mobile-390` runs in `preview-smoke.yml` with no Clerk secrets, so an authenticated popup test
-  cannot run there — same constraint that put the original attend test in `authenticated`.
+- DECISION (#708): no `lib/actions/member-registration.ts`. `app/api/events/[id]/attend/route.ts`
+  already resolves identity server-side via `withProfile`, 403s `role === 'guest'`, accepts
+  `{ share }`, and delegates to `attendEvent` — the panel `fetch`es it and calls `router.refresh()`.
+  A server action would be a second front door onto the same helper. Cost: `useActionState`'s no-JS
+  submit is lost, acceptable because `AttendSection` is already JS-driven and the logged-out guest
+  form keeps its server action untouched.
+- DECISION (#708): the attending state renders from server props after `router.refresh()`, not from
+  client state, so `meeting_url` is never in the page payload for someone without an active
+  registration (D3).
+- DECISION (#708): success does NOT redirect to `/events/[id]/join`. That page stamps `attended_at`,
+  which D4 reserves for click-through, not sign-up. Link to it instead, mirroring
+  `AttendSection.tsx:87-102` with the `cal.joinRecordsAttendance` caption.
+- DECISION (#708): sharer name is `first_name + ' ' + last_name` (convention:
+  `lib/notifications/share-events.ts:60`), not `display_names`.
 
 ## Facts
-- BASELINE before this ticket's edits: `npx vitest run` -> 31 files / 399 tests passed.
-  `npx tsc --noEmit` -> clean. `npx eslint .` -> 0 errors, 468 warnings.
-- AFTER this ticket's edits: `npx vitest run` -> 32 files / 417 tests passed (`lib/calendar-links.test.ts`
-  +10 new, `lib/server/member-registration.test.ts` 16 -> 24). `npx tsc --noEmit` -> clean.
-  `npx eslint .` -> 0 errors, 468 warnings (unchanged — the 3 warnings an earlier mock shape added
-  were removed by declaring the vi.fn mocks by signature instead of by implementation).
-  `npx playwright test --list --project=authenticated e2e/member-attend-auth.spec.ts` -> 4 tests
-  (was 1).
-- E2E is **collected, not executed** — the authenticated project needs local Supabase + a seeded
-  Clerk test member. Its real first run will be CI's `Authenticated E2E (Clerk)` job on the PR.
-- Files touched (matches the `docs/CLAIMS.md` #707 row, plus two additions noted below):
-  `lib/calendar-links.ts` + `.test.ts` (new), `components/AddToCalendarMenu.tsx` (new),
-  `lib/email/templates/MemberEventConfirmationEmail.tsx` (new),
-  `app/events/[eventId]/join/page.tsx`, `app/events/[eventId]/join/components/JoinActions.tsx`,
-  `lib/server/member-registration.ts` + `.test.ts`, `app/api/events/[id]/attend/route.ts`,
-  `app/(dashboard)/calendar/components/popup/AttendSection.tsx`,
-  `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx`,
-  `e2e/member-attend-auth.spec.ts`. **Beyond the claim row:**
-  `app/(dashboard)/calendar/components/EventPopup.tsx` (the `emailed` flag has to reach the toast)
-  and `lib/i18n/domains/calendar.ts` (`cal.joinRecordsAttendance`, `cal.attendSuccessEmailed`),
-  plus `docs/ai/REF.md` (§6 route row said "no email", now false).
-- Verified against `main` at `1c7f5bb`: `/events/(.*)` is in `PUBLIC_ROUTE_PATTERNS`
-  (`lib/public-routes.ts:29`), so the join page's `auth()` call needs no protected-route bypass;
-  the six reused `event.join.*` keys all exist (`lib/i18n/domains/events.ts:45,57-61`);
-  `components/ui/dropdown-menu.tsx` is already vendored.
-
-## Open items
-- NOTED (not done): `app/events/[eventId]/join/components/JoinActions.tsx:36-45` (`downloadIcs`)
-  still has the detached-anchor + synchronous-revoke pattern that was fixed in
-  `AddToCalendarMenu.tsx` — the same latent no-file-downloaded bug in Firefox/Safari. Left alone
-  because #707's DoD requires `JoinActions`' behaviour to be unchanged across the builder move;
-  worth folding into T6 when that page adopts `AddToCalendarMenu`.
-- FLAKE: 3/3 pass isolated. One `npx vitest run` reported `2 failed | 415 passed` at 11:07; it
-  overlapped the forked `/code-review` agent operating on this same worktree. Three subsequent
-  isolated runs were 417/417 green, as were the two after the review fixes. No test was changed in
-  response.
-- NOTED (not done): #713 (`getBaseUrl()` throws -> half-succeeded registration) is still live on the
-  guest path in `lib/actions/guest-registration.ts`. The member path added here is immune by
-  construction (try/catch, above), which narrows #713 but does not close it.
-- NOTED (not done): `docs/ai/REF.md` §6 Edge Functions table still lists `send-event-reminders`
-  (does not exist) and omits `deliver-email-notifications`; §5's `guest_registrations` row is still
-  the pre-#705 column list. Both predate this ticket; left alone to keep the diff scoped.
-- **#718** `[2608-DEV-718]` `bug` (unclaimed): capacity-check TOCTOU race, same shape in
-  `guest-registration.ts` and `member-registration.ts` — no DB-level guard on `guest_capacity`.
-  Needs one atomic DB-side check covering both call sites. Not #707's DoD.
-- Follow-ups from #706 still unclaimed: #710, #713/#714/#715.
-
-## Failed attempts
-- First typecheck of the new email mocks failed with 4× `TS2493: Tuple type '[]' of length '0' has
-  no element at index '0'` — the `(...args: unknown[]) => fn(...(args as []))` shim erased the
-  parameter types, so `.mock.calls[0][0]` had nothing to index. Replaced with signature-declared
-  mocks (`vi.fn<(payload: SendPayload) => Promise<{sent: boolean}>>()`) whose implementations are
-  set in `beforeEach`; that fixed both the type errors and the 3 unused-param lint warnings the
-  first shape introduced.
+- The T4 helper is `attendEvent` (`lib/server/member-registration.ts:150`), NOT `attendEventAsMember`
+  as issue #708 originally said. Self-attribution guard: `:181`, `shareLink.profile_id !== profileId`.
+- `playwright.config.ts` has ONE spec list, `AUTHENTICATED_SPECS` at `:38` — the three-list form the
+  issue describes no longer exists. Add `member-share-register-auth` there and nowhere else.
+- `event_share_links` has a single FK to `profiles` (`20260504000001_event_share_links.sql:7`), so
+  `profile:profiles(first_name, last_name)` needs no PostgREST hint.
+- Server-side member identity pattern to copy: `app/events/[eventId]/join/page.tsx:165-174`
+  (`auth()` -> `profiles` by `clerk_id`). Works because `/events/(.*)` is in `PUBLIC_ROUTE_PATTERNS`
+  (`lib/public-routes.ts:29`).
+- BASELINE at `067250c` (recorded during #707, files unchanged since): `npx vitest run` -> 32 files /
+  417 tests passed. `npx tsc --noEmit` -> clean. `npx eslint .` -> 0 errors, 468 warnings.
+- Production smoke 2026-08-10: `https://www.teamenjoyvd.com` 200, `/sign-in` 200.
 
 ## Done
-- #706 (merged as PR #717, 2026-08-09, `1c7f5bb`) — member one-tap Attend + meeting-link gating.
-- #705 (merged as #716, `78c67f7`) and #704 (merged as #712, `a418cab`).
-- #703 (merged as #711, 2026-08-09) — `meeting_url` scoped out of the calendar list projection and ICS feed.
+- #708 PLAN + CLAIM — RESULT: verdict READY; issue body rewritten with six corrections against
+  current `main`, Design Checklist 4/4, `## Branch dev/2608-DEV-708`; `blocked` label cleared.
+- #707 closed — RESULT: merged as PR #719 (`067250c`), no migration, `Migrate Prod` auto-skipped (8s).
+- #706 closed — RESULT: merged as PR #717 (`1c7f5bb`); migration
+  `20260809000100_2608_feat_706_member_reminder_recipient.sql` applied to prod by the gated
+  `Migrate Prod` run 2026-08-09T23:13Z (2m15s, success).
+- Epic #702 checklist updated: #703-#707 checked off; `blocked` cleared on #709 and #710, whose
+  dependencies have all merged.
+
+## Open items
+- NOTED (not done): `app/events/[eventId]/join/components/JoinActions.tsx:30-39` (`downloadIcs`)
+  still has the detached-anchor + synchronous-`revokeObjectURL` pattern fixed in
+  `AddToCalendarMenu.tsx` — same latent no-file-downloaded bug in Firefox/Safari. #707 had to leave
+  `JoinActions` behaviour unchanged; fold it in here if this page adopts `AddToCalendarMenu`.
+- **#718** `[2608-DEV-718]` `bug` (unclaimed): capacity-check TOCTOU race, same shape in
+  `guest-registration.ts` and `member-registration.ts` — no DB-level guard on `guest_capacity`.
+  Needs one atomic DB-side check covering both call sites. Not #708's DoD.
+- **#713/#714/#715** (unclaimed, from #706) and **#709/#710** (now unblocked, ready to pick).
+- NOTED (not done): `docs/ai/REF.md` §6 Edge Functions table still lists `send-event-reminders`
+  (does not exist) and omits `deliver-email-notifications`; §5's `guest_registrations` row is still
+  the pre-#705 column list.
+
+## Failed attempts
+- None this session.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -4,18 +4,15 @@ D1 in epic #702: a signed-in member opening someone's `?share=` link gets one-ta
 inviter credited, never the guest name+email form.
 
 ## Now
-BUILD complete and pushed. Draft PR #720 open against `main` at `c2071dd`, ALL 11 checks green.
-Commits: `bce3c28` (feature, 5 files +571/-3), `4fa90dd` (state), `5d6e07b` (e2e locator fix),
-`c2071dd` (e2e coverage for the capacity carve-out + gated meeting link).
-Authenticated E2E genuinely executed — `Running 30 tests`, `30 passed (2.6m)`, all 5 of the new
-cases with real timings, so `skipIfUnseeded` did not silently skip. Still a DRAFT: not flipped to
-ready-for-review, because that fires the single CodeRabbit pass and is the merge decision.
+PR #720 is ready-for-review (no longer draft) against `main`, MERGEABLE. CodeRabbit's single pass
+ran (review `4896845966`): 3 inline + 4 nitpicks. GCR applied 5 of 7 in one commit; B and E
+declined with replies and left unresolved for human follow-up. Awaiting merge.
 
 ## Next
-1. Decide whether to mark #720 ready for review (fires CodeRabbit's one pass) — needs a human call.
-2. Batch-fix any CodeRabbit findings in ONE commit; reply-and-resolve wrong ones rather than churn.
-3. After merge: GCR post-merge tail — remove the #708 row from `docs/CLAIMS.md`, smoke-check
+1. Merge #720 once the post-GCR checks are green (11/11) — the merge decision is a human call.
+2. After merge: GCR post-merge tail — remove the #708 row from `docs/CLAIMS.md`, smoke-check
    production, close #708. No migration, so `Migrate Prod` will auto-skip.
+3. Offer a ticket for the declined finding E (machine-readable attend error code) — see Open items.
 
 ## Not covered by any test (#708)
 - DoD "member with `role = 'guest'` falls through to the guest form" is IMPLEMENTED
@@ -68,6 +65,15 @@ ready-for-review, because that fires the single CodeRabbit pass and is the merge
 - Production smoke 2026-08-10: `https://www.teamenjoyvd.com` 200, `/sign-in` 200.
 
 ## Done
+- #708 GCR (PR #720) — RESULT: 5 findings applied in one commit, 2 declined. Applied: empty
+  `memberName` no longer renders a dangling "Signed in as " (`MemberAttendPanel.tsx`); the attend
+  button keeps its accessible name with `aria-busy` instead of swapping the label for '…'; the
+  duplicated 9-prop `MemberAttendPanel` call is hoisted to one `memberPanel` const used by both
+  layout blocks; `if (share)` -> `share !== undefined && share !== ''`; the e2e "Invited by"
+  assertion uses `getByText(string, { exact: false })` instead of a RegExp built from a DB name.
+  Verified: `tsc --noEmit` clean, `eslint` 0 errors, `vitest run` 32 files / 420 passed,
+  `playwright --project=authenticated member-share-register-auth` -> `5 passed (6.1m)` against
+  hosted DEV, real timings.
 - #708 BUILD — RESULT: draft PR #720 at `c2071dd`, all 11 checks green, Authenticated E2E 30 passed
   (5 new cases, none skipped). DoD verified by test: one-tap panel with no name/email inputs,
   `share_link_id` = inviter's link, own link -> null, logged-out guest form unchanged, full event
@@ -86,6 +92,19 @@ ready-for-review, because that fires the single CodeRabbit pass and is the merge
   dependencies have all merged.
 
 ## Open items
+- NOTED (not done, declined CodeRabbit finding on #720, needs its own ticket): client error copy is
+  selected by matching ENGLISH server text. `MemberAttendPanel.tsx:73-78` does
+  `raw.includes('capacity')` / `raw.includes('already ended')`, and
+  `app/(dashboard)/calendar/components/EventPopup.tsx:76-78` does the identical thing — 2 call
+  sites onto the same route. A real fix needs a machine-readable discriminator: a `code` on
+  `attendEvent`'s failure result (`lib/server/member-registration.ts`), passed through
+  `app/api/events/[id]/attend/route.ts`, and surfaced on `ApiError` (`lib/apiClient.ts:13`, which
+  today carries only `status` and `message`). Out of #708's DoD; localizing or rewording those
+  server strings silently breaks both consumers.
+- CodeRabbit's "run member-share-register-auth serially" finding (#720) was DISPROVED, not
+  deferred: `playwright.config.ts` never sets `fullyParallel`, so Playwright 1.61 parallelizes by
+  FILE. Both `describe` blocks live in one spec file, so all 5 tests already share one worker in
+  declaration order — confirmed by `Running 5 tests using 1 worker`. Do not "fix" this later.
 - NOTED (not done, found during #708): a signed-in member blocked by a FULL event still gets
   `ResendLinkForm` — the guest magic-link resend — at `app/events/[eventId]/register/page.tsx:162`
   and `:209`. Wrong flow for a portal identity, but it is the pre-existing blocked branch and

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -4,22 +4,27 @@ D1 in epic #702: a signed-in member opening someone's `?share=` link gets one-ta
 inviter credited, never the guest name+email form.
 
 ## Now
-CLAIM complete, BUILD not started. Branch `dev/2608-DEV-708` exists, cut from `main` @ `067250c`,
-with `327327c` (claim row registered + #707's row pruned) and the session-state commit on top.
-Working tree otherwise clean — no application code written yet.
+BUILD complete and committed as `bce3c28` (5 files, +571/-3): i18n keys, `MemberAttendPanel.tsx`,
+`register/page.tsx` wiring, `playwright.config.ts:38`, `e2e/member-share-register-auth.spec.ts`.
+Static gates all green (see Facts). `/code-review low` returned three findings, all dispositioned
+without code change — one rejected on the real prop type, one logged below as NOTED, one rejected as
+consistent with `EventPopup.tsx:76-78`. Not yet pushed.
 
 ## Next
-1. SHAPE/GATHER per `docs/ai/BUILD.md`; re-read `docs/ai/GOTCHAS.md` in full.
-2. Implement in this order: i18n keys -> `MemberAttendPanel.tsx` -> `register/page.tsx` wiring ->
-   `playwright.config.ts:38` -> `e2e/member-share-register-auth.spec.ts`.
-3. `npx vitest run`, `npx tsc --noEmit`, `npx eslint .`, then
-   `npx playwright test --list --project=authenticated e2e/member-share-register-auth.spec.ts`.
-4. `/code-review low` on the diff — `git add -N` any new untracked files FIRST, or they carry no
-   hunks and are silently skipped (that happened on #707).
-5. Push -> draft PR (CodeRabbit skips drafts) -> CI green + Vercel Preview READY -> verify DoD on
-   the preview at 390px -> ready for review -> batch-fix CodeRabbit findings in ONE commit.
-6. After merge: GCR post-merge tail — remove the #708 row from `docs/CLAIMS.md`, smoke-check
+1. Push `dev/2608-DEV-708` -> draft PR (CodeRabbit skips drafts), body carries `Closes #708` and the
+   Session State block.
+2. CI green + Vercel Preview READY — confirm the Authenticated E2E job actually ran its steps rather
+   than skipping on missing secrets (green-by-skip does not count).
+3. Verify the DoD on the preview at 390px: signed-in member sees the panel and no name/email inputs;
+   logged-out visitor on the same URL still gets the guest form.
+4. Ready for review -> batch-fix CodeRabbit findings in ONE commit.
+5. After merge: GCR post-merge tail — remove the #708 row from `docs/CLAIMS.md`, smoke-check
    production, close #708. No migration, so `Migrate Prod` will auto-skip.
+
+## Not run locally
+`e2e/member-share-register-auth.spec.ts` is COLLECTED but NOT EXECUTED — the `authenticated` project
+needs local Supabase + `npm run e2e:seed-clerk`. It also needs a second named profile to act as the
+inviter; `skipIfUnseeded` covers its absence, so watch for a silent skip in CI rather than a pass.
 
 ## Constraints
 - Never push without an explicit grant in this conversation. The grant used for `dev/2608-DEV-708`
@@ -56,11 +61,18 @@ Working tree otherwise clean — no application code written yet.
 - Server-side member identity pattern to copy: `app/events/[eventId]/join/page.tsx:165-174`
   (`auth()` -> `profiles` by `clerk_id`). Works because `/events/(.*)` is in `PUBLIC_ROUTE_PATTERNS`
   (`lib/public-routes.ts:29`).
-- BASELINE at `067250c` (recorded during #707, files unchanged since): `npx vitest run` -> 32 files /
-  417 tests passed. `npx tsc --noEmit` -> clean. `npx eslint .` -> 0 errors, 468 warnings.
+- BASELINE re-measured 2026-08-10 before the #708 edits: `npx vitest run` -> 32 files / **420** tests
+  passed (#707's note of 417 was stale). `npx tsc --noEmit` -> clean. `npx eslint .` -> 0 errors, 468
+  warnings. After the #708 commit: all three identical, and
+  `npx playwright test --list --project=authenticated e2e/member-share-register-auth.spec.ts` ->
+  `Total: 4 tests in 1 file`, with 0 hits under `--project=desktop --project=mobile-390`.
 - Production smoke 2026-08-10: `https://www.teamenjoyvd.com` 200, `/sign-in` 200.
 
 ## Done
+- #708 BUILD — RESULT: `bce3c28`, 5 files, +571/-3. All six issue corrections honoured: reused the
+  attend route (no `lib/actions/member-registration.ts`), one `playwright.config.ts` edit, server-
+  rendered attending state, link-not-redirect to `/join`, `first_name + last_name` for the sharer.
+  Deviation logged: 571 lines vs the ~260 estimate (2.2x), no unplanned file or kind of change.
 - #708 PLAN + CLAIM — RESULT: verdict READY; issue body rewritten with six corrections against
   current `main`, Design Checklist 4/4, `## Branch dev/2608-DEV-708`; `blocked` label cleared.
 - #707 closed — RESULT: merged as PR #719 (`067250c`), no migration, `Migrate Prod` auto-skipped (8s).
@@ -71,10 +83,16 @@ Working tree otherwise clean — no application code written yet.
   dependencies have all merged.
 
 ## Open items
+- NOTED (not done, found during #708): a signed-in member blocked by a FULL event still gets
+  `ResendLinkForm` — the guest magic-link resend — at `app/events/[eventId]/register/page.tsx:162`
+  and `:209`. Wrong flow for a portal identity, but it is the pre-existing blocked branch and
+  outside #708's DoD, which only required that a full event not block an already-active member.
 - NOTED (not done): `app/events/[eventId]/join/components/JoinActions.tsx:30-39` (`downloadIcs`)
   still has the detached-anchor + synchronous-`revokeObjectURL` pattern fixed in
   `AddToCalendarMenu.tsx` — same latent no-file-downloaded bug in Firefox/Safari. #707 had to leave
   `JoinActions` behaviour unchanged; fold it in here if this page adopts `AddToCalendarMenu`.
+  STILL OPEN after #708: the register page adopted `AddToCalendarMenu` (already carrying the fixed
+  pattern), but `JoinActions` lives on the join page and was not touched. Needs its own ticket.
 - **#718** `[2608-DEV-718]` `bug` (unclaimed): capacity-check TOCTOU race, same shape in
   `guest-registration.ts` and `member-registration.ts` — no DB-level guard on `guest_capacity`.
   Needs one atomic DB-side check covering both call sites. Not #708's DoD.

--- a/e2e/member-share-register-auth.spec.ts
+++ b/e2e/member-share-register-auth.spec.ts
@@ -165,7 +165,10 @@ function attendingBadge(page: Page): Locator {
 
 /** The panel and the guest form are mutually exclusive — assert both halves. */
 async function expectMemberPanel(page: Page) {
-  await expect(page.getByText(/signed in as/i).first()).toBeVisible({ timeout: 15_000 })
+  // visible(), not .first(): .first() is DOM order, and the desktop block is
+  // rendered before the mobile one, so at 390px .first() locks onto the
+  // CSS-hidden desktop copy and waits out the timeout.
+  await expect(visible(page, page.getByText(/signed in as/i))).toBeVisible({ timeout: 15_000 })
   await expect(page.locator('input#name')).toHaveCount(0)
   await expect(page.locator('input#email')).toHaveCount(0)
 }

--- a/e2e/member-share-register-auth.spec.ts
+++ b/e2e/member-share-register-auth.spec.ts
@@ -21,6 +21,7 @@ const TEST_RUN_ID = randomUUID().slice(0, 8)
 const EVENT_TITLE = `E2E Member Share Register ${TEST_RUN_ID}`
 const INVITER_TOKEN = `e2e-inviter-${TEST_RUN_ID}`
 const OWN_TOKEN = `e2e-own-${TEST_RUN_ID}`
+const MEETING_URL = `https://meet.example.com/e2e-share-${TEST_RUN_ID}`
 
 function svc(): SupabaseClient | null {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -76,6 +77,7 @@ test.beforeAll(async () => {
       end_time: new Date(now + 7200_000).toISOString(),
       week_number: 1,
       allow_guest_registration: true,
+      meeting_url: MEETING_URL,
     })
     .select('id')
     .single()
@@ -184,10 +186,19 @@ test.describe('recognised member on the share/register page @auth', () => {
     await expectMemberPanel(page)
     await expect(visible(page, page.getByText(new RegExp(`invited by ${inviterName}`, 'i')))).toBeVisible()
 
+    // D3: the meeting link is not in the payload of someone with no active row.
+    // toHaveCount(0) over the WHOLE page, not the visible subtree — a link
+    // hidden in the other breakpoint's block would still be a leak.
+    await expect(page.locator(`a[href="${MEETING_URL}"]`)).toHaveCount(0)
+
     await attendButton(page).click()
 
     // The attending state renders from the server after router.refresh().
     await expect(attendingBadge(page)).toBeVisible({ timeout: 15_000 })
+
+    // ...and only then does the server put meeting_url in the payload.
+    await expect(visible(page, page.locator(`a[href="${MEETING_URL}"]`))).toBeVisible()
+    await expect(visible(page, page.getByRole('button', { name: /add to calendar/i }))).toBeVisible()
 
     const row = await registrationRow()
     expect(row?.share_link_id).toBe(inviterLinkId)
@@ -210,6 +221,32 @@ test.describe('recognised member on the share/register page @auth', () => {
     const row = await registrationRow()
     expect(row?.share_link_id).toBeNull()
     expect(ownLinkId).not.toBeNull()
+  })
+
+  test('a full event does not block a member who already has an active row', async ({ page }) => {
+    skipIfUnseeded()
+    await clearRegistration()
+
+    await signInAsMember(page)
+    await page.goto(`/events/${eventId}/register?share=${INVITER_TOKEN}`)
+    await attendButton(page).click()
+    await expect(attendingBadge(page)).toBeVisible({ timeout: 15_000 })
+
+    try {
+      // Capacity 1 with exactly this member's row active -> the page's
+      // eventFull count is met. They are re-opening their own link, not
+      // consuming a new seat, so the capacity block must not appear.
+      const { error } = await sb!.from('calendar_events').update({ guest_capacity: 1 }).eq('id', eventId!)
+      if (error) throw new Error(`Failed to cap the event: ${error.message}`)
+
+      await page.reload()
+      await expect(attendingBadge(page)).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByText(/reached its guest capacity/i)).toHaveCount(0)
+    } finally {
+      // Restored even on failure — the other tests in this file share the event
+      // and would otherwise inherit a capacity that blocks them.
+      await sb!.from('calendar_events').update({ guest_capacity: null }).eq('id', eventId!)
+    }
   })
 
   test('logged-out visitor on the same URL still gets the guest form', async ({ page }) => {

--- a/e2e/member-share-register-auth.spec.ts
+++ b/e2e/member-share-register-auth.spec.ts
@@ -184,7 +184,10 @@ test.describe('recognised member on the share/register page @auth', () => {
     await page.goto(`/events/${eventId}/register?share=${INVITER_TOKEN}`)
 
     await expectMemberPanel(page)
-    await expect(visible(page, page.getByText(new RegExp(`invited by ${inviterName}`, 'i')))).toBeVisible()
+    // String, not a RegExp: inviterName comes from an arbitrary profiles row, and
+    // a metacharacter in it would change the pattern (or throw). getByText's
+    // default `exact: false` is already a case-insensitive substring match.
+    await expect(visible(page, page.getByText(`Invited by ${inviterName}`, { exact: false }))).toBeVisible()
 
     // D3: the meeting link is not in the payload of someone with no active row.
     // toHaveCount(0) over the WHOLE page, not the visible subtree — a link

--- a/e2e/member-share-register-auth.spec.ts
+++ b/e2e/member-share-register-auth.spec.ts
@@ -1,0 +1,246 @@
+import { test, expect, type Locator, type Page } from '@playwright/test'
+import { clerk } from '@clerk/testing/playwright'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { randomUUID } from 'crypto'
+
+/**
+ * D1 second half (issue 2608-DEV-708, part of epic #702): a signed-in member
+ * opening someone else's `?share=` link on /events/[id]/register gets the
+ * one-tap panel with the inviter credited — never the guest name+email form.
+ *
+ * Runs under the 'authenticated' project (see playwright.config.ts), same
+ * reason as member-attend-auth.spec.ts: mobile-390/desktop run in
+ * preview-smoke.yml against a live Vercel Preview with no Clerk secrets, so
+ * clerk.signIn() dies on bot protection there. Requires local Supabase + a
+ * seeded Clerk test-instance member (scripts/seed-clerk-test-users.js).
+ * Never target a preview/prod-DB deployment.
+ */
+
+const MEMBER_EMAIL = process.env.E2E_CLERK_MEMBER_EMAIL ?? 'e2e-member-tevd-portal@example.com'
+const TEST_RUN_ID = randomUUID().slice(0, 8)
+const EVENT_TITLE = `E2E Member Share Register ${TEST_RUN_ID}`
+const INVITER_TOKEN = `e2e-inviter-${TEST_RUN_ID}`
+const OWN_TOKEN = `e2e-own-${TEST_RUN_ID}`
+
+function svc(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (url === undefined || url === '' || key === undefined || key === '') return null
+  return createClient(url, key)
+}
+
+let sb: SupabaseClient | null = null
+let eventId: string | null = null
+let memberProfileId: string | null = null
+let inviterProfileId: string | null = null
+let inviterLinkId: string | null = null
+let ownLinkId: string | null = null
+let inviterName: string | null = null
+
+test.beforeAll(async () => {
+  sb = svc()
+  if (!sb) return
+
+  const { data: profile } = await sb
+    .from('profiles')
+    .select('id, role')
+    .eq('contact_email', MEMBER_EMAIL)
+    .maybeSingle()
+
+  // Member attend is 403 for role 'guest' — the seeded test member must
+  // already be promoted, the same precondition member-attend-auth relies on.
+  if (!profile || profile.role === 'guest') return
+  memberProfileId = profile.id
+
+  // The inviter is any OTHER profile with a name to render: the panel credits
+  // `first_name + ' ' + last_name`, so a nameless row would make the
+  // "Invited by" assertion vacuous.
+  const { data: inviter } = await sb
+    .from('profiles')
+    .select('id, first_name, last_name')
+    .neq('id', memberProfileId)
+    .not('first_name', 'is', null)
+    .limit(1)
+    .maybeSingle()
+
+  if (!inviter) return
+  inviterProfileId = inviter.id
+  inviterName = `${inviter.first_name ?? ''} ${inviter.last_name ?? ''}`.trim()
+
+  const now = Date.now()
+  const { data: event, error: insertError } = await sb
+    .from('calendar_events')
+    .insert({
+      title: EVENT_TITLE,
+      start_time: new Date(now + 3600_000).toISOString(),
+      end_time: new Date(now + 7200_000).toISOString(),
+      week_number: 1,
+      allow_guest_registration: true,
+    })
+    .select('id')
+    .single()
+
+  // Skipping is reserved for missing credentials or an unseeded member
+  // (skipIfUnseeded, below) — a DB/schema/permission failure must fail loudly.
+  if (insertError || !event) {
+    throw new Error(`Failed to seed event for member-share-register-auth: ${insertError?.message ?? 'no row returned'}`)
+  }
+  eventId = event.id
+
+  const { data: links, error: linkError } = await sb
+    .from('event_share_links')
+    .insert([
+      { profile_id: inviterProfileId, event_id: eventId, token: INVITER_TOKEN, share_method: 'clipboard' },
+      { profile_id: memberProfileId,  event_id: eventId, token: OWN_TOKEN,     share_method: 'clipboard' },
+    ])
+    .select('id, profile_id')
+
+  if (linkError || !links) {
+    throw new Error(`Failed to seed share links: ${linkError?.message ?? 'no rows returned'}`)
+  }
+  inviterLinkId = links.find((l) => l.profile_id === inviterProfileId)?.id ?? null
+  ownLinkId     = links.find((l) => l.profile_id === memberProfileId)?.id ?? null
+})
+
+test.afterAll(async () => {
+  if (!sb) return
+  if (eventId) {
+    // event_share_links and guest_registrations both cascade from the event,
+    // but the registration is deleted explicitly so a failure to remove the
+    // event never leaves this member registered on a stray row.
+    if (memberProfileId) {
+      await sb.from('guest_registrations').delete().eq('event_id', eventId).eq('profile_id', memberProfileId)
+    }
+    await sb.from('event_share_links').delete().eq('event_id', eventId)
+    await sb.from('calendar_events').delete().eq('id', eventId)
+  }
+})
+
+function skipIfUnseeded() {
+  test.skip(
+    sb === null || eventId === null || memberProfileId === null || inviterLinkId === null,
+    'no SUPABASE_SERVICE_ROLE_KEY, no member profile for E2E_CLERK_MEMBER_EMAIL, or no second named profile to act as inviter — run: npm run e2e:seed-clerk',
+  )
+}
+
+/**
+ * Hard-delete this member's row for the event. A soft cancel leaves the row in
+ * place, and `guest_registrations_event_profile_uniq` (event_id, profile_id)
+ * would then make the next test's attend an adopt-in-place of the previous
+ * one's share_link_id instead of a fresh attribution.
+ */
+async function clearRegistration() {
+  await sb!.from('guest_registrations').delete().eq('event_id', eventId!).eq('profile_id', memberProfileId!)
+}
+
+async function registrationRow() {
+  const { data } = await sb!
+    .from('guest_registrations')
+    .select('share_link_id, profile_id, status, cancelled_at')
+    .eq('event_id', eventId!)
+    .eq('profile_id', memberProfileId!)
+    .single()
+  return data
+}
+
+async function signInAsMember(page: Page) {
+  await page.goto('/')
+  await clerk.signIn({ page, emailAddress: MEMBER_EMAIL })
+}
+
+// The page renders BOTH layout blocks at once (one hidden per breakpoint via
+// CSS, not unmounted — page.tsx desktop/mobile), so every panel query matches
+// twice. Scope to the visible tree or strict mode fails the locator outright.
+function visible(page: Page, locator: Locator): Locator {
+  return locator.and(page.locator(':visible'))
+}
+
+function attendButton(page: Page): Locator {
+  return visible(page, page.getByRole('button', { name: /attend this event/i }))
+}
+
+function attendingBadge(page: Page): Locator {
+  return visible(page, page.getByText(/you're attending this event/i))
+}
+
+/** The panel and the guest form are mutually exclusive — assert both halves. */
+async function expectMemberPanel(page: Page) {
+  await expect(page.getByText(/signed in as/i).first()).toBeVisible({ timeout: 15_000 })
+  await expect(page.locator('input#name')).toHaveCount(0)
+  await expect(page.locator('input#email')).toHaveCount(0)
+}
+
+test.describe('recognised member on the share/register page @auth', () => {
+  test("member on an inviter's link attends one-tap and credits the inviter", async ({ page }) => {
+    skipIfUnseeded()
+    await clearRegistration()
+
+    await signInAsMember(page)
+    await page.goto(`/events/${eventId}/register?share=${INVITER_TOKEN}`)
+
+    await expectMemberPanel(page)
+    await expect(visible(page, page.getByText(new RegExp(`invited by ${inviterName}`, 'i')))).toBeVisible()
+
+    await attendButton(page).click()
+
+    // The attending state renders from the server after router.refresh().
+    await expect(attendingBadge(page)).toBeVisible({ timeout: 15_000 })
+
+    const row = await registrationRow()
+    expect(row?.share_link_id).toBe(inviterLinkId)
+    expect(row?.profile_id).toBe(memberProfileId)
+    expect(row?.cancelled_at).toBeNull()
+  })
+
+  test('member on their OWN link attends with share_link_id left null', async ({ page }) => {
+    skipIfUnseeded()
+    await clearRegistration()
+
+    await signInAsMember(page)
+    await page.goto(`/events/${eventId}/register?share=${OWN_TOKEN}`)
+
+    await expectMemberPanel(page)
+    await attendButton(page).click()
+    await expect(attendingBadge(page)).toBeVisible({ timeout: 15_000 })
+
+    // Self-attribution guard: lib/server/member-registration.ts:181.
+    const row = await registrationRow()
+    expect(row?.share_link_id).toBeNull()
+    expect(ownLinkId).not.toBeNull()
+  })
+
+  test('logged-out visitor on the same URL still gets the guest form', async ({ page }) => {
+    skipIfUnseeded()
+
+    await page.goto(`/events/${eventId}/register?share=${INVITER_TOKEN}`)
+
+    await expect(page.locator('input#name').first()).toBeVisible({ timeout: 15_000 })
+    await expect(page.locator('input#email').first()).toBeVisible()
+    await expect(page.getByText(/signed in as/i)).toHaveCount(0)
+  })
+})
+
+// -- 390px: the mobile block of the page renders the same panel ----------------
+
+test.describe('member share/register panel at 390px @auth', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('one-tap panel renders in the mobile layout', async ({ page }) => {
+    skipIfUnseeded()
+    await clearRegistration()
+
+    await signInAsMember(page)
+    await page.goto(`/events/${eventId}/register?share=${INVITER_TOKEN}`)
+
+    await expectMemberPanel(page)
+
+    const button = attendButton(page)
+    await expect(button).toBeVisible()
+
+    const box = await button.boundingBox()
+    expect(box, 'attend button has no layout box at 390px').not.toBeNull()
+    // 390px hard constraint: the CTA must fit the viewport and stay tappable.
+    expect(box!.width).toBeLessThanOrEqual(390)
+    expect(box!.height).toBeGreaterThanOrEqual(44)
+  })
+})

--- a/lib/i18n/domains/events.ts
+++ b/lib/i18n/domains/events.ts
@@ -66,6 +66,13 @@ export const events = {
   'event.register.linkNoLongerActive': { en: 'This share link is no longer active.',                bg: 'Тази връзка за споделяне вече не е активна.'                     },
   'event.register.full':           { en: 'This event has reached its guest capacity.',               bg: 'Това събитие достигна максималния брой гости.'                   },
 
+  // register — recognised member panel (2608-DEV-708)
+  'event.register.signedInAs':      { en: 'Signed in as {name}',        bg: 'Влезли сте като {name}'         },
+  'event.register.attendOneTap':    { en: 'Attend this event',          bg: 'Присъствам на събитието'        },
+  'event.register.invitedBy':       { en: 'Invited by {name}',          bg: 'Поканени от {name}'             },
+  'event.register.attendingAlready': { en: "You're attending this event.", bg: 'Ще присъствате на това събитие.' },
+  'event.register.attendError':     { en: 'Could not attend. Please try again.', bg: 'Записването не бе успешно. Моля, опитайте отново.' },
+
   // register/components/RegisterForm
   'event.register.checkInbox':     { en: 'Check your inbox',                                         bg: 'Проверете пощата си'                                            },
   'event.register.sentLink':       { en: "We've sent your access link. The link expires after the event ends.", bg: 'Изпратихме ви връзка за достъп. Тя изтича след края на събитието.' },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,7 @@ const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET
 // Vercel Preview with no Clerk secrets, so clerk.signIn() fails outright).
 // Named once so a new authenticated spec can't be added to one list and
 // silently omitted from the other two.
-const AUTHENTICATED_SPECS = /(admin-auth|admin-mobile-auth|los-submission-auth|profile-bento-auth|payments-on-behalf|payments-guest|member-attend-auth)\.spec\.ts/
+const AUTHENTICATED_SPECS = /(admin-auth|admin-mobile-auth|los-submission-auth|profile-bento-auth|payments-on-behalf|payments-guest|member-attend-auth|member-share-register-auth)\.spec\.ts/
 
 export default defineConfig({
   testDir: './e2e',


### PR DESCRIPTION
Second half of **D1** in epic #702: a signed-in member opening someone's `?share=` link is now recognised and gets one-tap Attend with the inviter credited, instead of retyping their own name and email into the guest form and receiving a magic link they don't need.

Closes #708

## What changed

- **`app/events/[eventId]/register/page.tsx`** — resolves the member server-side (`auth()` → `profiles` by `clerk_id`, the same pattern as `join/page.tsx:165-174`, which works because `/events/(.*)` is in `PUBLIC_ROUTE_PATTERNS`) and renders `<MemberAttendPanel>` in place of `<RegisterForm>` at **both** layout blocks. A `role = 'guest'` profile falls through to the unchanged guest form, matching the attend route's own 403.
- **`app/events/[eventId]/register/components/MemberAttendPanel.tsx`** (new, client) — "Signed in as {name}", "Invited by {sharer}" for a live link, one-tap Attend, and an attending state with the meeting link, `<AddToCalendarMenu>` and an AlertDialog cancel. No name/email inputs, no honeypot, no magic-link copy.
- **`lib/i18n/domains/events.ts`** — five new keys, en + bg.
- **`playwright.config.ts:38`** — `member-share-register-auth` added to `AUTHENTICATED_SPECS`.
- **`e2e/member-share-register-auth.spec.ts`** (new) — 4 cases under the `authenticated` project.

The logged-out path — `RegisterForm`, the honeypot, `ResendLinkForm`, the magic-link copy — is untouched.

## Decisions worth reviewing

- **No new server action.** `POST`/`DELETE /api/events/[id]/attend` already resolves identity via `withProfile`, 403s guests, accepts `{ share }` and delegates to `attendEvent`. A `lib/actions/member-registration.ts` would be a second front door onto the same helper. Cost: `useActionState`'s no-JS submit, acceptable because every other member attend surface is already JS-driven.
- **The attending state renders from server props after `router.refresh()`, never from client state.** That is what keeps D3 honest: `meeting_url` is fetched only behind an active registration, so it is never in the page payload for someone who has not attended.
- **Success links to `/events/[id]/join`, it does not redirect there.** That page stamps `attended_at`, which D4 reserves for click-through, not sign-up. Mirrors `AttendSection.tsx:87-102` with the `cal.joinRecordsAttendance` caption.
- **Capacity carve-out:** `eventFull` no longer blocks a member who already holds an active row — they are re-opening their own link, not consuming a new seat. `eventEnded` and `shareLinkRevoked` still block everyone.
- **Sharer name** is `first_name + ' ' + last_name` (`lib/notifications/share-events.ts:60`). `event_share_links` has a single FK to `profiles`, so the embed needs no PostgREST hint — the multi-FK `payments` trap does not apply.

## Verification

| check | result |
|---|---|
| `npx vitest run` | 32 files / 420 tests passed — identical to the pre-edit baseline |
| `npx tsc --noEmit` | clean |
| `npx eslint .` | 0 errors, 468 warnings — identical to baseline |
| `npx playwright test --list --project=authenticated e2e/member-share-register-auth.spec.ts` | `Total: 4 tests in 1 file` |
| `--project=desktop --project=mobile-390` | 0 hits — the spec cannot leak into the Clerk-less preview projects |
| `/code-review low` | 3 findings, all dispositioned without code change (see below) |

**CI at `c2071dd`: all 11 checks green.** The Authenticated E2E job genuinely executed rather than skipping — `Running 30 tests using 2 workers` → `30 passed (2.6m)`, with all five of the new cases reporting real timings, so `skipIfUnseeded` did not silently skip them.

DoD verified by test: one-tap panel with no name/email inputs · `share_link_id` set to the inviter's link · own link → `null` · logged-out guest form unchanged · full event does not block an already-active member · meeting link absent before attending and present after · 390px.

**Not covered by any test:** the `role = 'guest'` fallthrough is implemented but unverified — covering it needs a guest-role profile with a live Clerk session, which the seed script does not provide. The panel's cancel path is implemented and mirrors `AttendSection.tsx`; `member-attend-auth.spec.ts` exercises the same route from the calendar popup.

One CI cycle was red before this: the 390px case asserted the panel with `.first()`, which is DOM order and locked onto the CSS-hidden desktop block. Fixed in `5d6e07b` with the `visible()` scope that `member-attend-auth.spec.ts:88-93` documents.

**Review findings dispositioned:** (1) `AddToCalendarMenu` receiving a null `meetingUrl` — rejected, `AddToCalendarMenu.tsx:30` declares `string | null`. (2) A member blocked by a full event still sees `ResendLinkForm` — real but pre-existing, logged as NOTED in `docs/STATE.md`, outside this DoD. (3) Error mapping on English substrings — rejected, mirrors `EventPopup.tsx:76-78`.

**Migration:** none. `guest_registrations` already carries `profile_id` / `share_link_id` from #705, so `Migrate Prod` will auto-skip.

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] i18n keys (en + bg)
- [x] `MemberAttendPanel.tsx`
- [x] `register/page.tsx` wiring, both layout blocks
- [x] `playwright.config.ts:38`
- [x] `e2e/member-share-register-auth.spec.ts` — 5 cases
- [x] vitest / tsc / eslint green, identical to baseline
- [x] `/code-review low` dispositioned (3 findings, none needing a code change)
- [x] All 11 CI checks green at `c2071dd`; Vercel Preview READY
- [x] Authenticated E2E confirmed executed, not green-by-skip: `30 passed (2.6m)`
- [x] DoD verified by test (see Verification above)

**Next:** a human call on marking this ready for review — that fires CodeRabbit's single pass. Deliberately left as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Signed-in members can join or cancel attendance with one tap from event registration pages.
  - Members can view attendance status, inviter details, meeting links, and calendar options.
  - Share links recognize eligible members and preserve inviter attribution.
  - Guest registration remains available for visitors who are not signed in.
- **Bug Fixes**
  - Improved handling of event capacity, ended events, revoked events, and duplicate attendance requests.
- **Localization**
  - Added Bulgarian and English text for member attendance flows and related error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->