### PR TITLE
[2608-DEV-722] E2E fail-safe: abort on a dead dev server instead of failing 30 tests

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,6 +1,7 @@
 import { request } from '@playwright/test'
 import { clerkSetup } from '@clerk/testing/playwright'
 import path from 'node:path'
+import { isSafeSupabaseTarget, DEV_PROJECT_REF } from '../scripts/lib/safe-supabase-target'
 
 // Written by globalSetup, consumed as storageState in playwright.config.ts.
 export const VERCEL_BYPASS_STATE = path.join(__dirname, '.vercel-bypass-state.json')
@@ -43,7 +44,40 @@ async function vercelBypassSetup() {
  * (bad key, network, clerkSetup's own production-key guard) is rethrown —
  * that indicates a real misconfiguration, not an absent optional feature.
  */
+/**
+ * Refuse to run while a service-role key points at anything but local or the
+ * hosted DEV project (2608-DEV-722).
+ *
+ * The authenticated specs WRITE rows through the service client, and they read
+ * NEXT_PUBLIC_SUPABASE_URL from whatever the shell exports. `.env.local` holds
+ * PRODUCTION credentials, so a shell that simply forgot the DEV exports would
+ * seed events and registrations into prod. The key's presence is the precise
+ * trigger: a run that cannot write cannot cause this.
+ *
+ * Same guard the seed scripts already use, so there is one definition of
+ * "a safe write target" rather than a second copy to drift.
+ */
+function assertSafeSupabaseTarget() {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) return
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+  if (isSafeSupabaseTarget(url)) return
+  throw new Error(
+    `Refusing to run: SUPABASE_SERVICE_ROLE_KEY is set while NEXT_PUBLIC_SUPABASE_URL is "${url}", ` +
+      `which is neither a local instance nor the hosted DEV project (${DEV_PROJECT_REF}). ` +
+      'The authenticated specs write rows — this would have written them to production. ' +
+      'Export the DEV URL and key before running.',
+  )
+}
+
+// No "is the server up?" preflight here, deliberately: Playwright starts
+// config.webServer BEFORE globalSetup, so by the time this runs the server is
+// either up or the run has already died on the webServer timeout. Measured
+// 2026-08-10 — a run with no server spent 2m06s inside webServer and never
+// reached this file. The absent-server case is owned by webServer.timeout in
+// playwright.config.ts; the died-mid-run case by e2e/server-watchdog-reporter.ts.
+
 export default async function globalSetup() {
+  assertSafeSupabaseTarget()
   await vercelBypassSetup()
   try {
     await clerkSetup()

--- a/e2e/profile-bento-auth.spec.ts
+++ b/e2e/profile-bento-auth.spec.ts
@@ -76,10 +76,21 @@ test.describe('desktop bento grid — drag, collapse, layout persistence', () =>
     // Wait for the reset to actually land, rather than assuming 800ms is
     // enough. Previously this asserted on `bento_order: []` and compared
     // indexOf -1 < -1, which reported a race as a logic failure.
+    //
+    // The predicate must include the CLEARED COLLAPSE MAP (2608-DEV-723).
+    // Polling bento_order alone was satisfied by the state that existed BEFORE
+    // the click — any profile with a saved order already contains
+    // PERSONAL_DETAILS — so the poll returned instantly and the assertion below
+    // read pre-reset prefs. Whenever an earlier run had left a bento collapsed
+    // (e.g. it was interrupted), this failed with `{ payments: false }` against
+    // an expected `{}`, which reads exactly like a product regression and is
+    // not one. Both halves of "reset" must be observed before asserting either.
     await expectPersisted(
       page,
-      prefs => (prefs.bento_order ?? []).includes(BENTO_IDS.PERSONAL_DETAILS),
-      'reset layout should persist bento_order',
+      prefs =>
+        (prefs.bento_order ?? []).includes(BENTO_IDS.PERSONAL_DETAILS) &&
+        Object.keys(prefs.bento_collapsed ?? {}).length === 0,
+      'reset layout should persist bento_order and clear bento_collapsed',
     )
 
     const prefs = await getPersistedUiPrefs(page)

--- a/e2e/server-watchdog-reporter.ts
+++ b/e2e/server-watchdog-reporter.ts
@@ -1,0 +1,99 @@
+import type { Reporter, TestCase, TestResult, FullResult, FullConfig } from '@playwright/test/reporter'
+
+/**
+ * Aborts the run when the failures are the dev server's fault, not the code's
+ * (2608-DEV-722).
+ *
+ * Playwright attaches to whatever answers the port (`webServer.reuseExistingServer`)
+ * and never supervises it. When that process dies mid-run — observed twice on
+ * 2026-08-10, exit 127 — every remaining test burns its full 60s timeout and
+ * the report shows a spread of unrelated red specs that reads exactly like a
+ * code regression. Diagnosing one such run cost ~40 minutes of clean-tree
+ * bisection to establish that nothing was actually broken.
+ *
+ * So: on the FIRST failure, probe the server. If it does not answer, say so in
+ * terms nobody can misread and stop the run immediately.
+ *
+ * Exiting the process is the only way a reporter can halt a run — Playwright
+ * offers no abort hook — and it is the right trade here: every result after
+ * the server dies is noise, and a truncated HTML report costs nothing next to
+ * a misattributed failure. CI never takes this path (see `enabled`): there the
+ * server is workflow-managed, and a hard exit would hide a real failure.
+ */
+export default class ServerWatchdogReporter implements Reporter {
+  private baseURL = 'http://localhost:3000'
+  private enabled = false
+  private probing = false
+
+  onBegin(config: FullConfig): void {
+    // `use.baseURL` is per-project; every project in this repo inherits the
+    // top-level one, so the first project carrying it is authoritative.
+    const fromProject = config.projects.find(p => p.use.baseURL !== undefined)?.use.baseURL
+    if (fromProject !== undefined && fromProject !== '') this.baseURL = fromProject
+
+    // Local only. In CI the server's lifetime is the workflow's business, and
+    // killing the run on a probe failure would mask genuine test failures.
+    this.enabled = !process.env.CI
+  }
+
+  onTestEnd(_test: TestCase, result: TestResult): void {
+    if (!this.enabled || this.probing) return
+    if (result.status !== 'failed' && result.status !== 'timedOut') return
+
+    // onTestEnd is not awaited (testReporter.d.ts:228), so the probe runs
+    // detached and reports for itself.
+    this.probing = true
+    void this.probe()
+  }
+
+  private async probe(): Promise<void> {
+    if (await this.isUp()) {
+      // A real failure against a healthy server: stand down and let the run
+      // continue reporting normally. Re-arm so a later crash is still caught.
+      this.probing = false
+      return
+    }
+    this.report()
+    process.exit(1)
+  }
+
+  private async isUp(): Promise<boolean> {
+    // Any HTTP answer proves the process is alive — a 404 or a 500 is still a
+    // server. Only a transport-level failure means it is gone.
+    try {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 5_000)
+      try {
+        await fetch(this.baseURL, { signal: controller.signal })
+        return true
+      } finally {
+        clearTimeout(timer)
+      }
+    } catch {
+      return false
+    }
+  }
+
+  private report(): void {
+    const line = '='.repeat(72)
+    process.stderr.write(
+      `\n${line}\n` +
+        `  DEV SERVER DOWN — NOT A TEST FAILURE\n` +
+        `${line}\n` +
+        `  ${this.baseURL} stopped answering, so this run was aborted.\n` +
+        `  Every failure printed above is the server's absence, not your code.\n` +
+        `  Restart it and re-run before diagnosing anything:\n\n` +
+        `      npm run dev\n\n` +
+        `${line}\n\n`,
+    )
+  }
+
+  // Covers the narrow race where the server dies during the very last test and
+  // the detached probe has not resolved by then.
+  async onEnd(result: FullResult): Promise<{ status?: FullResult['status'] } | void> {
+    if (!this.enabled || result.status !== 'failed') return
+    if (await this.isUp()) return
+    this.report()
+    return { status: 'failed' }
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,7 +41,15 @@ export default defineConfig({
   testDir: './e2e',
   timeout: 60_000,
   retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  // Locally, stop after 3. Once a run starts cascading it is almost always the
+  // environment (a dead dev server, missing seed data), and grinding through
+  // the remaining specs at 60s each buys nothing but a slower, more confusing
+  // report — see e2e/server-watchdog-reporter.ts. CI keeps running everything:
+  // there, the full picture is the point. (2608-DEV-722)
+  maxFailures: process.env.CI ? 0 : 3,
+  reporter: process.env.CI
+    ? [['list'], ['html', { open: 'never' }]]
+    : [['list'], ['./e2e/server-watchdog-reporter.ts']],
   // Only the 'authenticated' project needs this; it no-ops when Clerk env
   // vars aren't configured (see e2e/global-setup.ts), so mobile-390/desktop
   // runs everywhere else (including preview-smoke.yml) are unaffected.
@@ -99,6 +107,13 @@ export default defineConfig({
         command: 'npm run dev',
         url: 'http://localhost:3000',
         reuseExistingServer: true,
-        timeout: 120_000,
+        // 300s, not 120s (2608-DEV-722). Measured 2026-08-10: with no server
+        // running, a cold Turbopack boot on this repo exceeded the 120s ceiling
+        // and the whole run died with "Timed out waiting 120000ms from
+        // config.webServer" after 2m06s — which is why starting `npm run dev`
+        // by hand had become a required, undocumented step. A warm server is
+        // still reused instantly (reuseExistingServer), so this costs nothing
+        // on the common path; it only buys a cold start the time it needs.
+        timeout: 300_000,
       },
 })


### PR DESCRIPTION
Closes #722
Closes #723

## Why

A dead dev server was indistinguishable from broken code. Playwright attaches to whatever answers port 3000 (`webServer.reuseExistingServer`) and never supervises it, so when that process died mid-run — twice on 2026-08-10, exit 127 — every remaining test burned its full 60s timeout and the report showed a spread of unrelated red specs across four files.

Diagnosing **one** such run cost ~40 minutes of stash / clean-tree bisection to establish that nothing was broken. That is the cost this PR removes.

## What

| Change | Effect |
|---|---|
| `e2e/server-watchdog-reporter.ts` | On the **first** failure, probe `baseURL`. No answer → unmissable banner, run stops. |
| `maxFailures: CI ? 0 : 3` | A local cascade stops at 3 instead of grinding all 34 specs. |
| `webServer.timeout` 120s → 300s | Cold Turbopack boot exceeded 120s, which is why `npm run dev` had silently become a required manual step. |
| `global-setup.ts` target guard | Refuses to run while `SUPABASE_SERVICE_ROLE_KEY` points anywhere but local/DEV. |
| `profile-bento-auth.spec.ts` (#723) | Reset-layout poll now waits for the condition it asserts. |

Exiting the process is the only halt available to a reporter — Playwright offers no abort hook — and it is the right trade: every result after the server dies is noise, and a truncated HTML report costs nothing next to a misattributed failure. **CI never takes this path**; there the server is workflow-managed and a hard exit would mask genuine failures.

## The prod footgun this exposed

The authenticated specs **write rows** and read `NEXT_PUBLIC_SUPABASE_URL` from whatever the shell exports. `.env.local` holds **production** credentials, so a shell that simply forgot the DEV exports would seed events and registrations into prod. The guard triggers on the service-role key's presence — precisely the runs that can write — and reuses `scripts/lib/safe-supabase-target.js` so there is one definition of "safe write target", not a second copy to drift.

## What was measured, not assumed

- **Preflight removed after measuring.** I first added an "is the server up?" check to `global-setup.ts`. It can never fire: Playwright boots `webServer` *before* `globalSetup`, and a run with no server spent **2m06s** inside `webServer` and never reached the file. That measurement is why the fix is the raised timeout instead. The dead code is gone; the reasoning is a comment.
- **Prod-target guard:** refuses instantly, before any test — `Refusing to run: SUPABASE_SERVICE_ROLE_KEY is set while NEXT_PUBLIC_SUPABASE_URL is "https://ynykjpnetfwqzdnsgkkg.supabase.co"…`
- **Watchdog:** against a dead target, 1 failed test then abort — **14.5s total**, versus the 6-minute misleading run it replaces.

## #723, re-diagnosed

The ticket said the spec should seed its own starting layout. Reading it showed something more precise: it polled for `bento_order` to contain `PERSONAL_DETAILS` after clicking Reset — a condition **already true before the click** on any profile with a saved order. The poll returned instantly and the next assertion read pre-reset prefs, so whenever an earlier run had left a bento collapsed it failed `{payments:false}` vs `{}`. The predicate now waits for the cleared collapse map too. No seeding needed.

## Verification

- `npx tsc --noEmit` → clean
- `npx eslint .` → 0 errors, 468 warnings (= `main` baseline)
- `npx vitest run` → 32 files / **420 passed**

**UNVERIFIED, to confirm before merge:** that the watchdog does *not* fire on a genuine test failure against a healthy server (the probe should find it up, stand down, and let the run continue). Run: `npx playwright test --project=authenticated` with the DEV exports and a live `npm run dev`, with any one assertion deliberately broken.

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] Watchdog reporter + `maxFailures`
- [x] `webServer.timeout` raised on measured evidence
- [x] Prod-target guard reusing `safe-supabase-target`
- [x] #723 reset-layout race fixed at the poll predicate
**Next:** confirm the no-false-positive case above, then mark ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
