### PR TITLE
[2608-DEV-713] Guest registration half-succeeds and 500s when getBaseUrl() throws

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,4 +17,8 @@ ICAL_TOKEN_SECRET=
 # App base URL for absolute links (iCal subscription URLs, notification emails,
 # guest magic links). Required to exercise those flows locally — getBaseUrl()
 # throws rather than falling back to the request's Host header (spoofable).
+# On Vercel PREVIEW and DEVELOPMENT deployments only, getBaseUrl() falls back to
+# the platform-injected VERCEL_BRANCH_URL / VERCEL_URL (2608-DEV-713), so a
+# preview cannot break guest registration by omitting this. PRODUCTION has no
+# fallback and still throws — set it there.
 NEXT_PUBLIC_APP_URL=

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #710 | `dev/2608-DEV-710` | `supabase/migrations/20260811000000_2608_feat_710_approve_role_creates_registration.sql` (new), `lib/server/event-capacity.ts` (new), `lib/actions/guest-registration.ts`, `lib/server/member-registration.ts`, `app/events/[eventId]/register/page.tsx`, `lib/actions/guest-registration.test.ts`, `lib/server/member-registration.test.ts`, `app/api/admin/calendar/route.ts` (comment only) — **migration: yes** | 2026-08-11 |
+| #713 | `dev/2608-DEV-713` | `lib/actions/guest-registration.ts`, `lib/actions/guest-registration.test.ts`, `lib/utils/base-url.ts`, `lib/utils/base-url.test.ts`, `.env.example` (comment only) — **migration: no** | 2026-08-11 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,28 +1,23 @@
 ## Goal
-BUILD issue #710 (2608-DEV-710) on branch `dev/2608-DEV-710` — D2: approving an event role
-request auto-creates/adopts an active `guest_registrations` row for the holder; D10: capacity
-counting excludes approved role holders.
+PLAN + BUILD issue #713 (2608-DEV-713) on branch `dev/2608-DEV-713` — guest registration
+half-succeeds and 500s when `getBaseUrl()` throws. Update epic #702. Close out #710.
 
 ## Now
-#710 is **PR #725 at `a667742`, MERGE-READY**: all 11 CI checks green, Vercel preview READY,
-CodeRabbit's single finding fixed + thread resolved, PR Session State = DONE. BUILD is complete.
-Merging needs the user.
+#713 is **BUILD-complete and committed locally at `a97a7df`, not pushed**. `/code-review low` is the
+open gate, then push + draft PR — the push needs an explicit grant in this conversation.
+
+#710 is **fully DONE**: PR #725 merged (`17fd786`), the gated `Migrate Prod` run 31471066200
+succeeded, prod ledger head advanced to `20260811000000`, production smoke `/` 200 + `/sign-in` 200,
+issue closed. Epic #702 updated — all ten children merged, feature scope complete.
 
 ## Next
-1. Merge PR #725 (needs the user).
-2. IMMEDIATELY after merge, approve the gated `Migrate Prod` run (GitHub Actions -> `production`
-   environment gate) and confirm the prod ledger head advances to `20260811000000`. The route ships
-   on merge while the RPC waits for the gate, so until it is approved, approving a role request in
-   PRODUCTION silently creates no registration row.
-3. Smoke-check `https://www.teamenjoyvd.com`, tick #710 on epic #702, close the issue. "Merged" and
-   "Done" are different states — #710 closes only after the prod tail completes.
-4. The `docs/CLAIMS.md` #710 row is pruned by the NEXT ticket's CLAIM commit, matching how `cdadc1d`
-   pruned #709 — never a standalone cleanup PR.
-3. Merge, then approve the gated `Migrate Prod` run promptly and confirm the prod ledger head
-   advances to `20260811000000`. The RPC ships on merge; until the gate is approved, approving a
-   role request will NOT create a registration row in prod.
-4. Smoke-check `https://www.teamenjoyvd.com`. The `docs/CLAIMS.md` #710 row is pruned by the NEXT
-   ticket's CLAIM commit, matching how `cdadc1d` pruned #709 — never a standalone cleanup PR.
+1. Resolve any `/code-review low` findings on the #713 diff.
+2. Push `dev/2608-DEV-713` and open the PR as a DRAFT (CodeRabbit skips drafts); wait for CI green +
+   Vercel preview READY. **Needs an explicit push grant.**
+3. Mark ready → one CodeRabbit pass → fix all findings in ONE batched push.
+4. Merge. No migration in #713, so there is no prod gate to approve afterwards — just a smoke check.
+5. The `docs/CLAIMS.md` #713 row is pruned by the NEXT ticket's CLAIM commit, matching how `f8f3a3f`
+   pruned #710 and `cdadc1d` pruned #709 — never a standalone cleanup PR.
 
 ## Constraints
 - Never push without an explicit grant in this conversation. Grants from earlier tickets/sessions do
@@ -34,132 +29,104 @@ Merging needs the user.
   Run `npm run check:env` before any command touching a hosted DB.
 
 ## Decisions
-- DECISION (#710, from PLAN): capacity is counted in TypeScript across two round trips, not via
-  `.or('profile_id.is.null,profile_id.not.in.(…)')` — PostgREST cannot express `NOT IN (subquery)`,
-  and the `FakeQuery` in `lib/server/member-registration.test.ts:64-113` implements only `eq`/`is`,
-  no `or`.
-- DECISION (#710, from PLAN): the helper lives in `lib/server/event-capacity.ts`, NOT in
-  `lib/actions/guest-registration.ts` — that file is `'use server'`, so every export becomes a
-  server-action endpoint.
-- DECISION (#710, from PLAN): the RPC does adopt-then-insert (D9 shape), not a bare insert —
-  inserting on `(event_id, profile_id)` alone would leave a second row for a human who had already
-  registered as an external guest.
+- DECISION (#713, from PLAN): the issue's **option 1** (resolve before any write), not option 2
+  (degrade after). The `feed.ics` precedent at `:59-64` degrades *after* the point of no return
+  because a feed has nothing to commit; `registerGuest` does. Hoisting is strictly better: the guest
+  either registers and gets a link, or gets a clear error and is not silently half-signed-up.
+- DECISION (#713, from PLAN): the Vercel fallback is a **positive allowlist** on
+  `VERCEL_ENV === 'preview' | 'development'`, never `!== 'production'` — an unset or unknown
+  `VERCEL_ENV` must not enable it. Production keeps the throw: a `*.vercel.app` magic link in a
+  member's inbox is unbranded and phishing-shaped, and a prod misconfig should stay loud.
+- DECISION (#713, from PLAN): `VERCEL_PROJECT_PRODUCTION_URL` is **omitted**. It did not appear in
+  the Vercel docs search, and an unverified env var name is a guess.
+- DECISION (#713, from PLAN): `.env.example` keeps `NEXT_PUBLIC_APP_URL` **optional**. Promoting it
+  to required would fail `npm run check:env` on the local box for no gain once the fallback exists.
 
 ## Facts
-- BASELINE 2026-08-11 on `dev/2608-DEV-710@cdadc1d`:
-  `npx vitest run lib/actions/guest-registration.test.ts lib/server/member-registration.test.ts`
-  -> 2 files / **50 passed**. `npx tsc --noEmit` -> **1 error**, and it is STALE GENERATED OUTPUT:
-  `.next/dev/types/validator.ts(566,39)` still references
-  `app/api/admin/events/[id]/registrations/route.js`, deleted by #709. Not a source error; expect it
-  to persist until `.next` is regenerated.
-- Exactly 3 capacity counts exist against `guest_registrations`:
-  `app/events/[eventId]/register/page.tsx:40`, `lib/server/member-registration.ts:206`,
-  `lib/actions/guest-registration.ts:160`. (`e2e/guest-invite.spec.ts:134` is a test assertion, not
-  a call site.)
-- `app/api/admin/calendar/route.ts:62-68` is a row FETCH with `.not('email','is',null)`, not a
-  `count: 'exact'` capacity count — correction A confirmed against `main`.
-- `registration_status` enum = `('pending','approved','denied')` (baseline:24);
-  `guest_registration_status` = `('pending','confirmed')`.
-- `guest_registrations_event_profile_uniq` is `(event_id, profile_id) WHERE profile_id IS NOT NULL`
-  (`20260809000000:60-61`); `guest_registrations_guest_xor_member_chk` at `:53-57`.
-- `-- ROLLBACK:` convention: first line of the migration file
-  (`20260810000000_2608_feat_709_event_registrations_visibility_rpc.sql:1`).
-- Production smoke 2026-08-10: `https://www.teamenjoyvd.com` 200, `/sign-in` 200.
+- BASELINE 2026-08-11 on `dev/2608-DEV-713@f8f3a3f`:
+  `npx vitest run lib/actions/guest-registration.test.ts lib/utils/base-url.test.ts lib/server/member-registration.test.ts`
+  -> 3 files / **57 passed**. Full `npx vitest run` -> 32 files / **423 passed**. `npx eslint .` ->
+  **0 errors / 465 warnings**. `npx tsc --noEmit` -> **1 error**, STALE GENERATED OUTPUT:
+  `.next/dev/types/validator.ts(566,39)` still references the route deleted by #709. Not a source
+  error; expect it until `.next` is regenerated.
+- Vercel system env vars confirmed against the Vercel docs: `VERCEL_ENV`, `VERCEL_URL`,
+  `VERCEL_BRANCH_URL` — all bare hostnames with no scheme, available at build AND runtime.
+  `VERCEL_PROJECT_PRODUCTION_URL` was NOT confirmable and is deliberately unused.
+- The member path already carried the #713 fix: `lib/server/member-registration.ts:62-104` wraps the
+  whole confirmation send in `try/catch`, and `lib/server/member-registration.test.ts:527` is named
+  `'never fails the attend when the link builder throws (#713 shape)'`. #713 was guest-path-only.
+- `getBaseUrl` call sites, all dispositioned in the #713 reference sweep:
+  `lib/actions/guest-registration.ts` (updated), `lib/server/member-registration.ts:74`,
+  `app/api/calendar/feed.ics/route.ts:64`, `app/api/calendar/feed-token/route.ts:21,45,81`,
+  `app/api/profile/spouse-link/route.ts:138` (all unaffected — each consumes the returned string).
+- Production smoke 2026-08-11: `https://www.teamenjoyvd.com` 200, `/sign-in` 200.
 
 ## Done
-- #710 GCR (CodeRabbit on PR #725) — RESULT: 1 actionable finding, Major, VALID, and it was a defect
-  in my OWN review fix. The pre-existing `UNIQUE (event_id, email)` is CASE-SENSITIVE, so
-  `Ivan@Example.com` and `ivan@example.com` can both exist as guest rows on one event; the bare
-  `LOWER(gr.email) = LOWER(p.contact_email)` predicate matched BOTH and tried to give them the same
-  `(event_id, profile_id)` -> `guest_registrations_event_profile_uniq` violation -> the whole
-  approval RAISEs. Fixed by adopting exactly one row via a scalar subquery
-  (`ORDER BY g.created_at, g.id LIMIT 1`); further case-variants stay as orphan guest rows.
-  LESSON: the `NOT EXISTS` guard only covers a PRE-EXISTING member row, never multiple matches
-  inside the same UPDATE — a set-returning predicate under a unique index needs its own LIMIT.
-  Re-verified on hosted DEV 3/3: S4 plain adopt unchanged (same id, `created_at` preserved), S6
-  single case-mismatched row still adopted, S7 two case-variant rows -> no exception, oldest
-  adopted, 1 orphan left.
-- #710 CI on `c97e836` — RESULT: all 11 checks green. `Replay migrations from scratch` 2m27s (the
-  migration DoD item). `Authenticated E2E (Clerk)` 6m13s and it REALLY RAN, not a green-by-skip:
-  the job log shows `Running 34 tests using 2 workers` -> `34 passed (3.0m)`. `390px smoke vs
-  preview` 2m27s. Vercel preview READY. CodeRabbit correctly skipped (draft).
-- #710 Registrations-tab DoD verified on hosted DEV — RESULT: after approval,
-  `get_event_registrations_for_viewer(event, admin_viewer)` returns exactly 1 row,
-  `registrant='Tab Host'`, `is_member=t`, `email` NULL, `status=confirmed`, `profile_id` set. NOTE
-  the RPC's column is `registrant`, NOT `name` — a `rec.name` reference fails with
-  "record has no field name".
-- #710 RPC verified on hosted DEV (`iymwxdewcpvpjgzewtzk`) — RESULT: **7/7 scenarios pass**, run as
-  one rolled-up DO block with `request.jwt.claims` set to `{"role":"service_role"}` to satisfy the
-  RPC's internal guard, with all scratch rows deleted afterwards (re-checked: 0 left). S1 approval
-  creates one `confirmed`, `cancelled_at` NULL, `email` NULL row named from the profile; S1 return
-  shape still has all 7 top-level keys; S2 double approval -> 1 row, same id; S3 self-cancelled
-  holder reactivates; S4 an existing guest row is adopted in place (same id, `created_at`
-  preserved, email/token/expires_at NULL) -> exactly ONE row; S5 guest row + member row does NOT
-  raise (the NOT EXISTS guard); S6 a case-mismatched guest email IS adopted (the LOWER fix).
-  Ledger version corrected from the MCP-generated `20260810222333` to the file version
-  `20260811000000`.
-- #710 `/code-review medium` — RESULT: 5 findings, 2 in this diff and both FIXED, 3 out of scope
-  (they live in files already merged to `main` via #721/#724 — logged under Open items).
-  Fixed 1 (medium): `countAttendeesForCapacity` counted fetched rows, but
-  `supabase/config.toml:14` sets `max_rows = 1000` — which caps rows returned and never applied to
-  the `count: 'exact'` query it replaced — so an event with `guest_capacity >= 1000` would have
-  stopped enforcing capacity. Now two head:true exact counts (total, minus role holders via
-  `.in()`). Fixed 2 (low): the adopt step matched `gr.email = p.contact_email` case-sensitively;
-  `registerGuest` stores the address verbatim (`z.string().email()`, no `.toLowerCase()`), so a
-  case-mismatched signup would have produced the duplicate row the block exists to prevent. Now
-  `LOWER(...) = LOWER(...)`, proved by S6.
-- #710 BUILD (code complete) — RESULT: 7 files. New
-  `20260811000000_2608_feat_710_approve_role_creates_registration.sql` (RPC body verbatim from
-  `20260512000300` + adopt-then-insert) and new `lib/server/event-capacity.ts`
-  (`countAttendeesForCapacity`); all 3 capacity call sites routed through it; comment-only update at
-  `app/api/admin/calendar/route.ts`. Verified locally: `npx vitest run` -> 32 files / **423 passed**
-  (baseline 420 + 3 new capacity cases); `npx eslint .` -> 0 errors / 465 warnings (baseline 465);
-  `npx tsc --noEmit` -> only the pre-existing stale `.next/dev/types/validator.ts` error.
-  `grep -rn "count: 'exact'" lib app` -> no remaining count against `guest_registrations`.
-- #710 DEVIATION from the issue body: the adopt UPDATE gained a
-  `NOT EXISTS (… g2.profile_id = v_profile_id)` guard. Without it, a holder carrying BOTH a guest
-  row and a member row on the same event would collide on `guest_registrations_event_profile_uniq`
-  and the whole approval would RAISE. `attendEvent` gets this guard for free by only adopting when
-  it found no member row (`lib/server/member-registration.ts:238`).
-- #710 PLAN + CLAIM — RESULT: verdict READY; issue body carries three PLAN corrections (A: admin
-  calendar route stays out of the helper; B: RPC needs a D9-style adopt step; C: count in TS);
-  Design Checklist 4/4; `## Branch dev/2608-DEV-710`; claim row committed at `cdadc1d` with the
-  merged #709 row pruned in the same commit.
+- #713 BUILD (code complete, `a97a7df`) — RESULT: 5 files. `lib/utils/base-url.ts` gained a
+  `normalizeHost` helper + the preview/development Vercel fallback; `lib/actions/guest-registration.ts`
+  hoists the resolve above every side effect in BOTH `registerGuest` and `resendGuestLink`;
+  `.env.example` documents the fallback. Verified: `npx vitest run` -> 32 files / **433 passed**
+  (baseline 423 + 10 new); `npx eslint .` -> 0 errors / 465 warnings (baseline 465);
+  `npx tsc --noEmit` -> only the pre-existing stale `.next` error.
+- #713 PLAN + CLAIM — RESULT: verdict READY; issue body carries the DoD, affected files, and four
+  PLAN corrections (member path already fixed; option 1 over option 2; fallback excludes production;
+  `.env.example` stays optional); Design Checklist 4/4; `## Branch dev/2608-DEV-713`; claim row
+  committed at `f8f3a3f` with the merged #710 row pruned in the same commit.
+- #702 epic updated — RESULT: all ten children (#703-#710) marked merged with their PR numbers, the
+  "In flight"/"Ready to pick" sections collapsed, and a new "Follow-ups discovered during this epic"
+  section lists #713 (in flight) plus unclaimed #714, #715, #718, #726, #727. The epic's feature
+  scope is complete; the follow-ups explicitly do not block closing it.
+- #710 CLOSED — RESULT: merged as PR #725 (`17fd786`); gated `Migrate Prod` run 31471066200 approved
+  by the user and succeeded (`Applying migration 20260811000000_...` -> `Finished supabase db push`,
+  ledger head after push `20260811000000`); production smoke 200/200. The #710 GCR fix (adopt
+  exactly one guest row under a `LOWER()` match, via a scalar subquery with
+  `ORDER BY g.created_at, g.id LIMIT 1`) is live in prod. LESSON from that review: a set-returning
+  predicate under a unique index needs its own LIMIT — a `NOT EXISTS` guard only covers a
+  PRE-EXISTING row, never multiple matches inside the same UPDATE.
 - #709 closed — RESULT: merged as PR #721 (`9288601`); tiered Registrations tab live.
 - #708 closed — RESULT: merged as PR #720 (`a11b89d`).
 - #722 closed — RESULT: merged as PR #724 (`ef0c3e1`), E2E aborts on a dead dev server.
 
 ## Open items
+- NOTED (not done, out of #713's scope): `app/api/calendar/feed-token/route.ts:21,45,81` and
+  `app/api/profile/spouse-link/route.ts:138` still `await getBaseUrl()` unguarded. Neither commits
+  irreversible state first, so neither has the #713 half-success shape — they just 500 on a
+  misconfigured environment, which the Vercel fallback now prevents on previews. No ticket filed.
 - NOTED (not done, same-class defect found by `/code-review medium` on #710): the case-sensitive
   email match fixed in the #710 RPC also exists in TypeScript at
   `lib/server/member-registration.ts:239` — `.eq('email', contactEmail)` in `attendEvent`'s D9
-  adopt step. Same failure: a member who signed up as `Ivan@Example.com` is not adopted and gets a
-  second row. 2 instances of the class total; 1 fixed here (the RPC), 1 left because it is outside
-  #710's DoD. Fixing it needs either a citext/lower() index or a `.ilike()` lookup — its own ticket.
-- NOTED (not done, out of #710's scope — merged in #721): `EventPopup.tsx:156`'s
+  adopt step. A member who signed up as `Ivan@Example.com` is not adopted and gets a second row.
+  Fixing it needs either a citext/lower() index or a `.ilike()` lookup — its own ticket.
+- **#726** `[2608-DEV-726]` `bug` (unclaimed, FILED 2026-08-11 from the #710 review): `EventPopup.tsx:156`'s
   `showMeta = activeTab !== 'registrations'` now applies to EVERY role, and
   `EventPopupShell.tsx:169-214` puts `AttendSection` + the share/QR buttons inside that gate. A
   member who opens the Registrations tab loses the Attend button with no affordance explaining why.
-  Previously unreachable, since members had no tab bar at all — so this is a new regression, not a
-  carried one.
-- NOTED (not done, out of #710's scope — merged in #724): `e2e/server-watchdog-reporter.ts:57`
-  calls `process.exit(1)`, which skips Playwright's `test.afterAll`. If the dev server dies during
+  A new regression from #721, not a carried one.
+- **#727** `[2608-DEV-727]` `bug` `priority:high` (unclaimed, FILED 2026-08-11): a transient 401 while
+  Clerk refreshes the session token makes `lib/apiClient.ts:29-33` set
+  `window.location.href = '/sign-in'`, evicting a still-valid session. PROVED from the PR #725
+  Playwright traces: a 5-endpoint 401 burst at t=180726ms right after `page.reload()`, then
+  `200 GET /api/profile` 7ms later, then the `/sign-in` navigations. This — NOT leftover collapse
+  state — is what makes `e2e/profile-bento-auth.spec.ts` intermittently red (`:72` and `:154`).
+  Supersedes the earlier "order/state-dependent" note, which was a wrong diagnosis.
+- **#718** `[2608-DEV-718]` `bug` (unclaimed): capacity-check TOCTOU race, same shape in
+  `guest-registration.ts` and `member-registration.ts` — no DB-level guard on `guest_capacity`.
+  #710 moved that read-then-write shape into the helper; it does NOT close the race.
+- **#714** `[2608-DEV-714]` `chore` `priority:high` (docs mislabel the prod Supabase ref) and
+  **#715** `[2608-DEV-715]` `bug` (sharer notifications: no `contact_email` fallback, no email cap)
+  — both unclaimed, both from #706.
+- NOTED (not done, out of scope — merged in #724): `e2e/server-watchdog-reporter.ts:57` calls
+  `process.exit(1)`, which skips Playwright's `test.afterAll`. If the dev server dies during
   `e2e/event-registrations-auth.spec.ts`, its cleanup (`:164-171`) never runs and the seeded event,
   share links and registrations are orphaned in the shared DEV project.
-- NOTED (not done, out of #710's scope — merged in #721): `types/supabase.ts:2370` types the
+- NOTED (not done, out of scope — merged in #721): `types/supabase.ts:2370` types the
   `get_event_registrations_for_viewer` returns `email`, `profile_id`, `sharer_name`, `attended_at`
   and `cancelled_at` as non-nullable `string`, but all five are NULL in normal operation. The
   current caller casts to `EventRegistration` (correctly nullable); the next caller that trusts the
   generated type dereferences a null with no compiler warning.
 - NOTED (not done, found during #709): the DEV ledger has NO `20260809000100` row (#706
   `fn_schedule_guest_reminders_record`), though prod does. Function-body-only, so
-  `types/supabase.ts` is unaffected, but hosted DEV may be running the pre-#706 body. This matters
-  for #710: the D2 reminder claim depends on `COALESCE(gr.email, p.contact_email)` being live.
-- NOTED (not done, local env only): `GET /api/calendar/feed-token` 500s locally with
-  "NEXT_PUBLIC_APP_URL is not set" (`lib/utils/base-url.ts:12`). Pre-existing local env gap.
-- NOTED (not done): `e2e/profile-bento-auth.spec.ts:72` ("reset layout") fails when the shared DEV
-  member profile carries leftover collapse state from an interrupted run. Order/state-dependent,
-  not a code defect; worth its own ticket.
+  `types/supabase.ts` is unaffected, but hosted DEV may be running the pre-#706 body.
 - NOTED (not done, declined CodeRabbit finding on #720, needs its own ticket): client error copy is
   selected by matching ENGLISH server text — `MemberAttendPanel.tsx:73-78` and
   `app/(dashboard)/calendar/components/EventPopup.tsx:76-78` both do `raw.includes('capacity')`.
@@ -174,10 +141,6 @@ Merging needs the user.
 - NOTED (not done): `docs/ai/REF.md` §6 Edge Functions table still lists `send-event-reminders`
   (does not exist) and omits `deliver-email-notifications`; §5's `guest_registrations` row is still
   the pre-#705 column list.
-- **#718** `[2608-DEV-718]` `bug` (unclaimed): capacity-check TOCTOU race, same shape in
-  `guest-registration.ts` and `member-registration.ts` — no DB-level guard on `guest_capacity`.
-  #710 moves that read-then-write shape into the helper; it does NOT close the race.
-- **#713/#714/#715** (unclaimed, from #706).
 - CodeRabbit's "run member-share-register-auth serially" finding (#720) was DISPROVED, not deferred:
   `playwright.config.ts` never sets `fullyParallel`, so Playwright 1.61 parallelizes by FILE. Do not
   "fix" this later.

--- a/lib/actions/guest-registration.test.ts
+++ b/lib/actions/guest-registration.test.ts
@@ -5,7 +5,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 //    (UPDATE name/share_link_id) rather than minting a fresh token; an expired
 //    or absent one mints a new token via upsert.
 //  - base URL: the magic link is built from getBaseUrl() (NEXT_PUBLIC_APP_URL
-//    first), not the raw request host.
+//    first), not the raw request host; and since 2608-DEV-713 it is resolved
+//    before any write, so an environment that cannot produce one commits
+//    nothing rather than half-registering the guest.
 
 // -- Seams --------------------------------------------------------------------
 
@@ -115,6 +117,12 @@ beforeEach(() => {
   mockConsumeEmailCap.mockResolvedValue(true)
   mockConsumeRegistrationSlot.mockResolvedValue(true)
   process.env.NEXT_PUBLIC_APP_URL = 'https://portal.example'
+  // getBaseUrl's Vercel fallback (2608-DEV-713) resolves from the ambient
+  // environment. Cleared here so the "base URL unresolvable" tests below cannot
+  // be silently masked by VERCEL_* vars on whatever machine runs the suite.
+  delete process.env.VERCEL_ENV
+  delete process.env.VERCEL_BRANCH_URL
+  delete process.env.VERCEL_URL
 })
 
 describe('registerGuest — token reuse', () => {
@@ -217,6 +225,45 @@ describe('registerGuest — base URL', () => {
 
     expect(capturedMagicLink.startsWith('https://portal.example/events/')).toBe(true)
     expect(capturedMagicLink).not.toContain('req-host.example')
+  })
+
+  // 2608-DEV-713. The base URL is resolved BEFORE the first side effect, so an
+  // environment that cannot produce one fails clean instead of registering the
+  // guest, spending their daily email cap, and then 500ing on the link they
+  // never receive. Asserting the absence of each write is the whole point of
+  // the test — a success/failure assertion alone would still pass if the row
+  // were committed.
+  it('commits nothing when the base URL cannot be resolved', async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    const { client, updateSpy, upsertSpy } = buildClient(null)
+    mockCreateServiceClient.mockReturnValue(client)
+    const sendModule = await import('@/lib/email/send')
+    const { registerGuest } = await import('@/lib/actions/guest-registration')
+
+    const res = await registerGuest({ success: false }, form())
+
+    expect(res).toEqual({ success: false, error: 'Could not send access link. Please try again.' })
+    expect(upsertSpy).not.toHaveBeenCalled()
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(mockConsumeRegistrationSlot).not.toHaveBeenCalled()
+    expect(mockConsumeEmailCap).not.toHaveBeenCalled()
+    expect(client.rpc).not.toHaveBeenCalled()
+    expect(sendModule.sendTransactionalEmail).not.toHaveBeenCalled()
+  })
+
+  it('uses the Vercel branch URL when NEXT_PUBLIC_APP_URL is missing on a preview', async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    process.env.VERCEL_ENV = 'preview'
+    process.env.VERCEL_BRANCH_URL = 'site-git-my-branch.vercel.app'
+    const { client, upsertSpy } = buildClient(null)
+    mockCreateServiceClient.mockReturnValue(client)
+    const { registerGuest } = await import('@/lib/actions/guest-registration')
+
+    const res = await registerGuest({ success: false }, form())
+
+    expect(res.success).toBe(true)
+    expect(upsertSpy).toHaveBeenCalledTimes(1)
+    expect(capturedMagicLink.startsWith('https://site-git-my-branch.vercel.app/events/')).toBe(true)
   })
 })
 
@@ -380,6 +427,25 @@ describe('resendGuestLink — rate cap', () => {
     const res = await resendGuestLink('123e4567-e89b-12d3-a456-426614174000', 'jane@example.com')
     expect(sendModule.sendTransactionalEmail).not.toHaveBeenCalled()
     expect(res).toEqual({ success: true })
+  })
+})
+
+describe('resendGuestLink — base URL (2608-DEV-713)', () => {
+  it('spends no cap and moves no expiry when the base URL cannot be resolved', async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    const { client, updateSpy } = buildResendClient({})
+    mockCreateServiceClient.mockReturnValue(client)
+    const sendModule = await import('@/lib/email/send')
+    const { resendGuestLink } = await import('@/lib/actions/guest-registration')
+
+    const res = await resendGuestLink('123e4567-e89b-12d3-a456-426614174000', 'jane@example.com')
+
+    // Still neutral — this path must never become enumerable, not even by
+    // failing differently for a registered vs an unregistered address.
+    expect(res).toEqual({ success: true })
+    expect(mockConsumeEmailCap).not.toHaveBeenCalled()
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(sendModule.sendTransactionalEmail).not.toHaveBeenCalled()
   })
 })
 

--- a/lib/actions/guest-registration.ts
+++ b/lib/actions/guest-registration.ts
@@ -94,6 +94,22 @@ export async function registerGuest(
   if (new Date(event.end_time).getTime() < Date.now())
     return { success: false, error: 'This event has already ended.' }
 
+  // Resolve the absolute base URL BEFORE the first side effect (2608-DEV-713).
+  // getBaseUrl() throws on a misconfigured environment, and everything below
+  // this point is irreversible: the throttle slot, the upsert, the click count,
+  // the daily email cap. Resolved down at the magic-link line instead, a broken
+  // environment registered the guest, spent their cap, and then 500'd on the
+  // link they never received — a half-success invisible to guest and admin
+  // alike. Failing here returns the same "could not send" error with nothing
+  // committed, so a retry after the fix is clean.
+  let baseUrl: string
+  try {
+    baseUrl = await getBaseUrl()
+  } catch (err) {
+    console.error('registerGuest: could not resolve the app base URL', err)
+    return { success: false, error: 'Could not send access link. Please try again.' }
+  }
+
   // Resolve share token → share_link_id (null-safe). A revoked link must not
   // attribute a new registration — treat it the same as no token.
   let shareLinkId: string | null = null
@@ -211,7 +227,7 @@ export async function registerGuest(
 
   if (withinDailyCap) {
     // Build magic link from the resolved app base URL
-    const magicLink = `${await getBaseUrl()}/events/${eventId}/join?token=${token}`
+    const magicLink = `${baseUrl}/events/${eventId}/join?token=${token}`
 
     const html = await renderEmailTemplate(
       React.createElement(GuestEventMagicLinkEmail, {
@@ -278,6 +294,19 @@ export async function resendGuestLink(eventId: string, email: string): Promise<R
   if (!event || !event.allow_guest_registration) return NEUTRAL_RESULT
   if (new Date(event.end_time).getTime() < Date.now()) return NEUTRAL_RESULT
 
+  // Same rule as registerGuest (2608-DEV-713): resolve before the first side
+  // effect — the two cap consumptions and the expires_at refresh below. The
+  // neutral result is the correct failure here; this path must stay
+  // non-enumerable, and returning early on a broken environment makes it MORE
+  // uniform, not less (no cap is spent, no expiry moves, no 500 leaks).
+  let baseUrl: string
+  try {
+    baseUrl = await getBaseUrl()
+  } catch (err) {
+    console.error('resendGuestLink: could not resolve the app base URL', err)
+    return NEUTRAL_RESULT
+  }
+
   const { data: reg } = await supabase
     .from('guest_registrations')
     .select('id, name, token, lang')
@@ -322,7 +351,7 @@ export async function resendGuestLink(eventId: string, email: string): Promise<R
   // nullable. Note this interpolation would NOT fail the build if that ever
   // stopped holding — a null token stringifies to "null" in the URL rather than
   // raising — so the invariant is the only thing protecting the link.
-  const magicLink = `${await getBaseUrl()}/events/${eventId}/join?token=${reg.token}`
+  const magicLink = `${baseUrl}/events/${eventId}/join?token=${reg.token}`
 
   const html = await renderEmailTemplate(
     React.createElement(GuestEventMagicLinkEmail, {

--- a/lib/utils/base-url.test.ts
+++ b/lib/utils/base-url.test.ts
@@ -1,11 +1,23 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { getBaseUrl } from '@/lib/utils/base-url'
 
-const ORIGINAL = process.env.NEXT_PUBLIC_APP_URL
+// Every var getBaseUrl reads, snapshotted together: a test that sets only some
+// of them would otherwise inherit whatever the previous test left behind, and
+// on a real Vercel runner the VERCEL_* vars are genuinely present in the
+// ambient environment.
+const VARS = ['NEXT_PUBLIC_APP_URL', 'VERCEL_ENV', 'VERCEL_BRANCH_URL', 'VERCEL_URL'] as const
+const ORIGINAL = Object.fromEntries(VARS.map((k) => [k, process.env[k]]))
+
+beforeEach(() => {
+  for (const k of VARS) delete process.env[k]
+})
 
 afterEach(() => {
-  if (ORIGINAL === undefined) delete process.env.NEXT_PUBLIC_APP_URL
-  else process.env.NEXT_PUBLIC_APP_URL = ORIGINAL
+  for (const k of VARS) {
+    const value = ORIGINAL[k]
+    if (value === undefined) delete process.env[k]
+    else process.env[k] = value
+  }
 })
 
 describe('getBaseUrl', () => {
@@ -26,6 +38,60 @@ describe('getBaseUrl', () => {
 
   it('throws when NEXT_PUBLIC_APP_URL is slash-only', async () => {
     process.env.NEXT_PUBLIC_APP_URL = '////'
+    await expect(getBaseUrl()).rejects.toThrow('NEXT_PUBLIC_APP_URL is not set')
+  })
+})
+
+// -- Vercel fallback (2608-DEV-713) -------------------------------------------
+// A Preview deployment missing NEXT_PUBLIC_APP_URL used to throw, which took
+// the guest magic link — and the whole registration action — down with it.
+
+describe('getBaseUrl — Vercel fallback', () => {
+  it('prefers NEXT_PUBLIC_APP_URL over the platform vars', async () => {
+    process.env.NEXT_PUBLIC_APP_URL = 'https://portal.example'
+    process.env.VERCEL_ENV = 'preview'
+    process.env.VERCEL_BRANCH_URL = 'branch.vercel.app'
+    await expect(getBaseUrl()).resolves.toBe('https://portal.example')
+  })
+
+  it('falls back to VERCEL_BRANCH_URL on a preview deployment', async () => {
+    process.env.VERCEL_ENV = 'preview'
+    process.env.VERCEL_BRANCH_URL = 'site-git-my-branch.vercel.app'
+    await expect(getBaseUrl()).resolves.toBe('https://site-git-my-branch.vercel.app')
+  })
+
+  it('prefers the branch URL over the per-deployment URL', async () => {
+    // The branch URL survives the next redeploy; VERCEL_URL does not, so a
+    // magic link built from it would rot in the guest's inbox.
+    process.env.VERCEL_ENV = 'preview'
+    process.env.VERCEL_BRANCH_URL = 'site-git-my-branch.vercel.app'
+    process.env.VERCEL_URL = 'site-abc123.vercel.app'
+    await expect(getBaseUrl()).resolves.toBe('https://site-git-my-branch.vercel.app')
+  })
+
+  it('falls back to VERCEL_URL when no branch URL is present', async () => {
+    process.env.VERCEL_ENV = 'preview'
+    process.env.VERCEL_URL = 'site-abc123.vercel.app'
+    await expect(getBaseUrl()).resolves.toBe('https://site-abc123.vercel.app')
+  })
+
+  it('falls back on a development deployment too', async () => {
+    process.env.VERCEL_ENV = 'development'
+    process.env.VERCEL_URL = 'site-abc123.vercel.app'
+    await expect(getBaseUrl()).resolves.toBe('https://site-abc123.vercel.app')
+  })
+
+  it('still throws in production — a *.vercel.app link must never reach an inbox', async () => {
+    process.env.VERCEL_ENV = 'production'
+    process.env.VERCEL_BRANCH_URL = 'site-git-main.vercel.app'
+    process.env.VERCEL_URL = 'site-abc123.vercel.app'
+    await expect(getBaseUrl()).rejects.toThrow('NEXT_PUBLIC_APP_URL is not set')
+  })
+
+  it('still throws off-platform, where VERCEL_ENV is unset', async () => {
+    // The allowlist is positive on purpose: an unknown/absent VERCEL_ENV must
+    // not enable the fallback even if a stray VERCEL_URL is in the environment.
+    process.env.VERCEL_URL = 'site-abc123.vercel.app'
     await expect(getBaseUrl()).rejects.toThrow('NEXT_PUBLIC_APP_URL is not set')
   })
 })

--- a/lib/utils/base-url.ts
+++ b/lib/utils/base-url.ts
@@ -1,17 +1,44 @@
+/** Trim, strip trailing slashes, and treat a blank result as "not configured". */
+function normalizeHost(raw: string | undefined): string | null {
+  const normalized = raw?.trim().replace(/\/+$/, '')
+  if (normalized === undefined || normalized === '') return null
+  return normalized
+}
+
 /**
  * Resolve the app's public base URL, without a trailing slash.
  *
- * Requires `NEXT_PUBLIC_APP_URL` (set in every deployed environment). Throws
- * rather than falling back to the incoming request's `Host` header, which is
+ * Prefers `NEXT_PUBLIC_APP_URL` (set in every deployed environment). Never
+ * falls back to the incoming request's `Host` header, which is
  * attacker-controlled and must never be trusted for externally-visible links
  * (email `actionUrl`, ICS feed subscription URL, magic links).
+ *
+ * Vercel's `VERCEL_BRANCH_URL` / `VERCEL_URL` are a safe fallback because the
+ * platform injects them into the runtime — they are not derived from the
+ * request — so they carry none of the `Host` spoofing risk (2608-DEV-713).
+ * The fallback is scoped to non-production deployments on purpose: production
+ * has `NEXT_PUBLIC_APP_URL`, and a `*.vercel.app` magic link in a member's
+ * inbox is unbranded and phishing-shaped, so a production misconfiguration
+ * should stay loud rather than silently ship an off-domain link.
  */
 export async function getBaseUrl(): Promise<string> {
-  const normalized = process.env.NEXT_PUBLIC_APP_URL?.trim().replace(/\/+$/, '')
-  if (normalized === undefined || normalized === '') {
-    throw new Error(
-      'NEXT_PUBLIC_APP_URL is not set. Set it in .env.local to build absolute links locally.'
-    )
+  const configured = normalizeHost(process.env.NEXT_PUBLIC_APP_URL)
+  if (configured !== null) return configured
+
+  // Positive allowlist rather than `!== 'production'`: an unset or unknown
+  // VERCEL_ENV must NOT enable the fallback.
+  const vercelEnv = process.env.VERCEL_ENV
+  const isNonProductionVercelDeploy = vercelEnv === 'preview' || vercelEnv === 'development'
+  if (isNonProductionVercelDeploy) {
+    // Both are bare hostnames with no scheme. Branch URL first: it is stable
+    // across redeploys, so a magic link already sitting in an inbox still
+    // resolves after the next preview build, which the per-deployment
+    // VERCEL_URL would not guarantee.
+    const host = normalizeHost(process.env.VERCEL_BRANCH_URL) ?? normalizeHost(process.env.VERCEL_URL)
+    if (host !== null) return `https://${host}`
   }
-  return normalized
+
+  throw new Error(
+    'NEXT_PUBLIC_APP_URL is not set. Set it in .env.local to build absolute links locally.'
+  )
 }


### PR DESCRIPTION
Closes #713

A guest registering through a share link on an environment without `NEXT_PUBLIC_APP_URL` was **already registered** in the database, had **already spent** a daily email-cap slot, and then got a 500 with no magic link and no way to know any of it happened. Observed live on the `dev/2608-DEV-704` preview.

## The half-success

`registerGuest` committed everything before it could fail:

| Line (pre-fix) | What happened |
|---|---|
| `:176-182` | `guest_registrations` upsert — registration committed |
| `:187` | `increment_share_link_click` RPC — click counted |
| `:196` | `consumeEmailCap` — daily email slot spent |
| `:204` | `` `${await getBaseUrl()}/events/...` `` — **throws**, unhandled, 500 |

`getBaseUrl()` throws by design rather than trusting the spoofable `Host` header. That design is right. Awaiting it unguarded *after* irreversible writes is not. `resendGuestLink` had the same shape at `:309`.

## Fix, part 1 — resolve before any write

Both functions now resolve the base URL immediately after event validation, ahead of every side effect. `registerGuest` returns the error string it already had for a failed send (`'Could not send access link. Please try again.'`) with **nothing committed**; `resendGuestLink` returns `NEUTRAL_RESULT`, which keeps that path non-enumerable — arguably more uniform than before, since no cap is spent and no expiry moves either.

This is the issue's **option 1**, not option 2. The `feed.ics` precedent (`:59-64`, from #703) degrades *after* the point of no return because a feed has nothing to commit; `registerGuest` does. Hoisting is strictly better: the guest either registers and gets a link, or gets a clear error and is not silently half-signed-up.

## Fix, part 2 — Vercel fallback so a preview cannot hit this

`getBaseUrl()` falls back to `VERCEL_BRANCH_URL`, then `VERCEL_URL`, when `NEXT_PUBLIC_APP_URL` is unset. Both are injected by the platform rather than derived from the request, so they carry none of the `Host`-header spoofing risk the throw exists to prevent. Branch URL first: it survives the next redeploy, so a magic link already sitting in an inbox keeps resolving.

Three deliberate limits:

- **Production is excluded.** The gate is a positive allowlist on `VERCEL_ENV === 'preview' | 'development'`, never `!== 'production'`, so an unset or unknown `VERCEL_ENV` cannot enable it. Production has `NEXT_PUBLIC_APP_URL`, and a `*.vercel.app` magic link in a member's inbox is unbranded and phishing-shaped — a production misconfiguration should stay loud. Part 1 already removes the half-success there.
- **`VERCEL_PROJECT_PRODUCTION_URL` is not used.** It did not appear in a Vercel docs search; an unverified env var name is a guess.
- **`.env.example` keeps `NEXT_PUBLIC_APP_URL` optional.** Promoting it to required would fail `npm run check:env` locally for no gain once the fallback exists. The comment there now documents the fallback and that production still throws.

## Scope correction from PLAN

**The member path already had this fix and is untouched.** `lib/server/member-registration.ts:62-104` wraps the whole confirmation send in `try/catch`, and `lib/server/member-registration.test.ts:527` is named `'never fails the attend when the link builder throws (#713 shape)'`. This ticket was guest-path-only.

Reference sweep over all `getBaseUrl` call sites: `feed.ics/route.ts:64` (already in a try/catch), `feed-token/route.ts:21,45,81` and `spouse-link/route.ts:138` are unaffected — each consumes the returned string, and none commits irreversible state first, so none has the half-success shape. They just 500 on a misconfigured environment, which the fallback now prevents on previews.

## Verification

- `npx vitest run` → 32 files / **433 passed** (baseline 423 + 10 new)
- `npx eslint .` → **0 errors / 465 warnings** (baseline 465)
- `npx tsc --noEmit` → clean apart from the stale `.next/dev/types/validator.ts` artifact left by #709
- `/code-review low` → **zero findings**

New tests assert the *absence* of each write — `upsert`, `update`, `consumeRegistrationSlot`, `consumeEmailCap`, the click RPC, the send — because a pass/fail assertion alone would still pass if the row were committed. The suite also clears `VERCEL_*` in `beforeEach` so those cases cannot be masked by the ambient environment on a real runner.

No migration, so there is no gated prod run after merge.

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] PLAN — verdict READY, four corrections recorded on the issue
- [x] CLAIM — `dev/2608-DEV-713`, claim row registered, merged #710 row pruned in the same commit
- [x] BUILD — 5 files, 433 passed / 0 lint errors / typecheck clean
- [x] `/code-review low` — zero findings
**Next:** CI green + Vercel preview READY → mark ready for review → one CodeRabbit pass → merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guest registration and link resending now resolve the app URL before making changes or consuming limits.
  * Registration fails cleanly when no valid app URL is configured.
  * Resending a link remains neutral when URL configuration is unavailable, without sending emails or updating registration data.
  * Preview and development deployments can now generate links using their deployment URLs when the app URL is not configured.
  * Production deployments still require an explicitly configured app URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->