### PR TITLE
[2608-DEV-714] Label the Supabase refs and fix the preview contradiction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,13 @@
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=
 
-# Supabase
+# Supabase — WHICH PROJECT GOES WHERE
+#   DEV  iymwxdewcpvpjgzewtzk — put these in .env.development.local. Safe to write to.
+#   PROD ynykjpnetfwqzdnsgkkg — live member data. Only .env.local may hold these.
+# Next.js (and scripts/check-env.js) resolve .env.development.local BEFORE .env.local,
+# so a DEV-configured .env.development.local is what protects you from a prod-configured
+# .env.local. Run `npm run check:env` to print the project the current environment
+# actually resolves to — it warns loudly on anything that is not LOCAL or DEV.
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=

--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,16 @@ CLERK_SECRET_KEY=
 # Supabase — WHICH PROJECT GOES WHERE
 #   DEV  iymwxdewcpvpjgzewtzk — put these in .env.development.local. Safe to write to.
 #   PROD ynykjpnetfwqzdnsgkkg — live member data. Only .env.local may hold these.
-# Next.js (and scripts/check-env.js) resolve .env.development.local BEFORE .env.local,
-# so a DEV-configured .env.development.local is what protects you from a prod-configured
-# .env.local. Run `npm run check:env` to print the project the current environment
-# actually resolves to — it warns loudly on anything that is not LOCAL or DEV.
+# `next dev`, the seed scripts, and scripts/check-env.js all read
+# .env.development.local BEFORE .env.local, so a DEV-configured
+# .env.development.local is what keeps a prod-configured .env.local out of local
+# development. That precedence is NOT universal: Next.js only loads
+# .env.$(NODE_ENV).local, so production-mode commands (`next build`, `next start`)
+# skip .env.development.local entirely and take .env.local's values, and an
+# exported shell/CI variable outranks every file. Run `npm run check:env` to print
+# the project the current environment resolves to — it warns loudly on anything
+# that is not LOCAL or DEV. It models the dev/seed-script order, so treat it as a
+# preflight for those commands, not as proof that a production build is safe.
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Row matched: write `TRIGGER: <event> -> <doc>`; your next tool call is Read on t
 | Supabase project — **PROD** | `ynykjpnetfwqzdnsgkkg` — live member data. Never target it from local dev, a preview, a seed script, or an e2e run. |
 | Supabase project — **DEV** | `iymwxdewcpvpjgzewtzk` — what local dev and Vercel previews use. This is the one you write to. |
 | Production URL | `https://www.teamenjoyvd.com` |
-Never ask the user to confirm these. The two refs are NOT interchangeable — `scripts/check-env.js:100-101` is authoritative, and `npm run check:env` prints which one the current environment resolves to. Run it before any command that touches hosted data.
+Never ask the user to confirm these. The two refs are NOT interchangeable — `scripts/check-env.js` (`DEV_PROJECT_REF` / `PROD_PROJECT_REF`) is authoritative, and `npm run check:env` prints which one the current environment resolves to. Run it before any command that touches hosted data.
 
 **Hard Constraints**
 Violation = immediate stop, no exceptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,10 @@ Row matched: write `TRIGGER: <event> -> <doc>`; your next tool call is Read on t
 |---|---|
 | Repo | `teamenjoyvd/tevd-portal` |
 | Branch | `main` |
-| Supabase project | `ynykjpnetfwqzdnsgkkg` |
+| Supabase project — **PROD** | `ynykjpnetfwqzdnsgkkg` — live member data. Never target it from local dev, a preview, a seed script, or an e2e run. |
+| Supabase project — **DEV** | `iymwxdewcpvpjgzewtzk` — what local dev and Vercel previews use. This is the one you write to. |
 | Production URL | `https://www.teamenjoyvd.com` |
-Never ask the user to confirm these.
+Never ask the user to confirm these. The two refs are NOT interchangeable — `scripts/check-env.js:100-101` is authoritative, and `npm run check:env` prints which one the current environment resolves to. Run it before any command that touches hosted data.
 
 **Hard Constraints**
 Violation = immediate stop, no exceptions.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm run dev                              # http://localhost:3000
 npm run check:env                        # confirms vars + which Supabase project dev targets
 ```
 
-`.env.development.local` overrides `.env.local` for local dev and should point `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY`/`SUPABASE_SERVICE_ROLE_KEY` at the hosted **DEV** Supabase project (`iymwxdewcpvpjgzewtzk`), never prod. `npm run check:env` confirms the target. Vercel preview URLs still hit the **production** Supabase project — treat preview testing as navigation-only. Details: [docs/DEV_WORKFLOW.md](docs/DEV_WORKFLOW.md).
+`.env.development.local` overrides `.env.local` for local dev and should point `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY`/`SUPABASE_SERVICE_ROLE_KEY` at the hosted **DEV** Supabase project (`iymwxdewcpvpjgzewtzk`), never prod. `npm run check:env` confirms the target. Vercel **preview** deployments also hit the DEV project (Pre-Production-scoped env vars in the Vercel dashboard, since 2026-07-16), so preview writes land in the shared DEV database — same etiquette as local dev, not navigation-only. Only the Production environment carries prod credentials. Details: [docs/DEV_WORKFLOW.md](docs/DEV_WORKFLOW.md).
 
 ## Where things live
 
@@ -42,7 +42,7 @@ npm run check:env                        # confirms vars + which Supabase projec
 
 - Never push to `main` — work lands via `dev/[YYMM]-DEV-[GH#]` branches and PRs (format: [docs/guardrails/PROJECT.md](docs/guardrails/PROJECT.md#id-format))
 - Every new UI surface must render correctly at **390px** (mobile-first)
-- Never write data to Supabase from a preview URL or local dev while they target production
+- Never write data to the **PROD** Supabase project (`ynykjpnetfwqzdnsgkkg`) from local dev, a preview, or a script — `.env.local` alone holds prod credentials, so keep `.env.development.local` pointed at DEV and run `npm run check:env` before anything that touches hosted data
 - `SUPABASE_SERVICE_ROLE_KEY` is server-only; RLS policies use Pattern-A helpers only
 
 Full list: `## Project` → Hard Constraints in [CLAUDE.md](CLAUDE.md).

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #713 | `dev/2608-DEV-713` | `lib/actions/guest-registration.ts`, `lib/actions/guest-registration.test.ts`, `lib/utils/base-url.ts`, `lib/utils/base-url.test.ts`, `.env.example` (comment only) — **migration: no** | 2026-08-11 |
+| #714 | `dev/2608-DEV-714` | `CLAUDE.md` (Constants table), `README.md`, `.env.example` (comment only), `docs/ai/BUILD.md` — **migration: no** | 2026-08-11 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,23 +1,26 @@
 ## Goal
-PLAN + BUILD issue #713 (2608-DEV-713) on branch `dev/2608-DEV-713` — guest registration
-half-succeeds and 500s when `getBaseUrl()` throws. Update epic #702. Close out #710.
+PLAN + CLAIM + BUILD issue #714 (2608-DEV-714) on branch `dev/2608-DEV-714` — docs mislabel the
+prod Supabase ref and contradict each other on what preview deployments target.
 
 ## Now
-#713 is **BUILD-complete and committed locally at `a97a7df`, not pushed**. `/code-review low` is the
+#714 is **BUILD-complete and committed locally at `da36500`, not pushed**. `/code-review low` is the
 open gate, then push + draft PR — the push needs an explicit grant in this conversation.
+
+#713 is **merged**: PR #728 (`2f82d80`). No migration, so no prod gate. Its `docs/CLAIMS.md` row was
+pruned by #714's CLAIM commit (`e20e072`), matching how `f8f3a3f` pruned #710.
 
 #710 is **fully DONE**: PR #725 merged (`17fd786`), the gated `Migrate Prod` run 31471066200
 succeeded, prod ledger head advanced to `20260811000000`, production smoke `/` 200 + `/sign-in` 200,
 issue closed. Epic #702 updated — all ten children merged, feature scope complete.
 
 ## Next
-1. Resolve any `/code-review low` findings on the #713 diff.
-2. Push `dev/2608-DEV-713` and open the PR as a DRAFT (CodeRabbit skips drafts); wait for CI green +
+1. Resolve any `/code-review low` findings on the #714 diff.
+2. Push `dev/2608-DEV-714` and open the PR as a DRAFT (CodeRabbit skips drafts); wait for CI green +
    Vercel preview READY. **Needs an explicit push grant.**
 3. Mark ready → one CodeRabbit pass → fix all findings in ONE batched push.
-4. Merge. No migration in #713, so there is no prod gate to approve afterwards — just a smoke check.
-5. The `docs/CLAIMS.md` #713 row is pruned by the NEXT ticket's CLAIM commit, matching how `f8f3a3f`
-   pruned #710 and `cdadc1d` pruned #709 — never a standalone cleanup PR.
+4. Merge. No migration in #714, so there is no prod gate to approve afterwards — just a smoke check.
+5. The `docs/CLAIMS.md` #714 row is pruned by the NEXT ticket's CLAIM commit, matching how `e20e072`
+   pruned #713 and `f8f3a3f` pruned #710 — never a standalone cleanup PR.
 
 ## Constraints
 - Never push without an explicit grant in this conversation. Grants from earlier tickets/sessions do

--- a/docs/ai/BUILD.md
+++ b/docs/ai/BUILD.md
@@ -24,6 +24,7 @@ Read the issue body. Verify `## Design Checklist` exists with all four items che
 Read only the specific `docs/ai/REF.md` sections required by the ticket (refer to the Section Map in `REF.md`).
 
 ### EXECUTE
+- **Before the first command that touches hosted data** (seed script, migration, e2e run, `supabase` CLI, dev server exercising a write path): run `npm run check:env` and confirm it reports `LOCAL stack` or `DEV project`. Anything else — including `WARNING — Supabase target is NOT the local stack or the dev project` — means you are pointed at production; stop and fix the environment first. Skipping this is what let a full guest-registration flow run against prod on 2026-08-09 (#714).
 - Code only what is required by the DoD. All changes target the feature branch only. Build and verify entirely locally against the hosted DEV Supabase project; migrations are applied and behavior-verified on the dev DB only.
 - Every new migration file carries a `-- ROLLBACK:` comment — do not push without it.
 - Before the first push: run `/code-review low` on the branch diff and fix findings locally (auth/RLS/migration changes: escalate to `/security-review` or `/code-review medium`).


### PR DESCRIPTION
`CLAUDE.md`'s Constants table listed the **production** Supabase ref `ynykjpnetfwqzdnsgkkg` under a bare `Supabase project` label, directly above `Never ask the user to confirm these.` Read in isolation — which is exactly how an agent reads it — that says prod is *the* project for this repo. On 2026-08-09 a session did read it that way and ran a full guest-registration flow against production. Separately, `README.md:29` claimed Vercel previews hit production and that preview testing is navigation-only; that has been false since 2026-07-16 and contradicted both `CLAUDE.md:52` and `docs/DEV_WORKFLOW.md:50`, discouraging the *safe* testing path.

Ground truth re-verified against the live tree before any edit: `scripts/check-env.js` (`DEV_PROJECT_REF = iymwxdewcpvpjgzewtzk`, `PROD_PROJECT_REF = ynykjpnetfwqzdnsgkkg`), corroborated by `supabase/config.toml:45-46`, `scripts/claude-hooks/dispatch.js:12`, `scripts/lib/safe-supabase-target.js:22`, and `.github/workflows/migrate-prod.yml:76`.

## Changes

| File | Change |
|---|---|
| `CLAUDE.md` | One unlabelled `Supabase project` row → two labelled rows (PROD / DEV), each stating what may target it; pointer to `check-env.js`'s constants and `npm run check:env` |
| `README.md:29` | Corrected: previews hit **DEV** via Pre-Production-scoped Vercel env vars since 2026-07-16; preview writes land in the shared DEV database |
| `README.md:45` | Non-negotiable reworded — "…while they target production" implied local dev and preview target prod; neither has since #563 / 2026-07-16 |
| `.env.example` | Supabase block names which project each env file is expected to hold, plus the `.env.development.local`-before-`.env.local` precedence that is what actually protects a dev box |
| `docs/ai/BUILD.md` | EXECUTE now requires `npm run check:env` before the first command touching hosted data |

Documentation only — no source, schema, route or env-var changes. **Migration: no.**

## Scope decisions

- **Added beyond the issue:** `README.md:45`. Same defect, same file, one paragraph down, and it is the line a reader lands on scanning "Non-negotiables".
- **Both "also worth considering" items are in.** `npm run check:env` already classified a PROD target and warned — the control existed and simply was not wired into the workflow docs. That one `BUILD.md` line is the only part of this PR that would actually have *stopped* the 2026-08-09 incident; the rest prevents the misreading that caused it.
- **Out of scope:** `scripts/setup-worktree-env.js:72` is correct as written — it fires only when `.env.development.local` is absent, i.e. when `.env.local`'s prod credentials really are the active target. `docs/archive/` carries the same unlabelled row but is explicitly historical.
- A `check-env.js:100-101` line reference was written into `CLAUDE.md` and then removed in `151b5e5` in favour of the constant names: line numbers in the auto-loaded ruleset drift on the next edit to that file, which is the same staleness class this ticket exists to fix.

## Verification

- `grep -n 'ynykjpnetfwqzdnsgkkg\|iymwxdewcpvpjgzewtzk' CLAUDE.md` → only lines 41-42, both explicitly labelled PROD / DEV.
- `npm run check:env` → exit 0, `all 6 required variables are set`, `Supabase target: LOCAL stack (127.0.0.1)`. This was the one real regression risk: `check-env.js` derives its required-variable list by parsing `.env.example`, and the new comment block does not perturb that parse.
- `/code-review low` on the branch diff → no findings.
- E2E: **none applicable** — no route, component or query changes, so neither `authenticated` nor `mobile-390` covers or needs to cover this.

Closes #714

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] PLAN — verdict READY, DoD + affected files + gotchas on the issue, Design Checklist 4/4
- [x] CLAIM — `dev/2608-DEV-714` cut from main; claim row registered and merged #713 row pruned (`e20e072`)
- [x] BUILD — 5 files edited across 2 commits (`da36500`, `151b5e5`); reference sweep dispositioned
- [x] `/code-review low` — no findings
**Next:** wait for CI green + Vercel preview READY, then mark ready for review to trigger the single CodeRabbit pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded environment configuration guidance with development and production project identifiers.
  * Documented environment-file precedence and validation behavior when running the environment check command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->