### PR TITLE
[2608-DEV-715] Sharer notifications: Clerk email fallback, daily cap, admin gates

### DIFF
--- a/app/admin/settings/components/EmailSettingsPanel.tsx
+++ b/app/admin/settings/components/EmailSettingsPanel.tsx
@@ -17,6 +17,12 @@ const TEMPLATES = [
   { id: 'doc_expiry' },
   { id: 'abo_verification_result' },
   { id: 'trip_registration_status' },
+  // Share-link sharer notifications (2608-DEV-715). Absent keys already pass
+  // the gate in lib/email/send.ts (it compares === false), so these need no
+  // seed row — the first toggle writes the key.
+  { id: 'share_guest_registered' },
+  { id: 'share_guest_attended' },
+  { id: 'share_guest_cancelled' },
 ]
 
 export function EmailSettingsPanel({ initialConfig }: { initialConfig: EmailConfig }) {

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #714 | `dev/2608-DEV-714` | `CLAUDE.md` (Constants table), `README.md`, `.env.example` (comment only), `docs/ai/BUILD.md` — **migration: no** | 2026-08-11 |
+| #715 | `dev/2608-DEV-715` | `lib/notifications/share-events.ts`, `lib/notifications/share-events.test.ts`, `app/admin/settings/components/EmailSettingsPanel.tsx`, `lib/i18n/domains/admin/content.ts` — **migration: no** | 2026-08-11 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,26 +1,30 @@
 ## Goal
-PLAN + CLAIM + BUILD issue #714 (2608-DEV-714) on branch `dev/2608-DEV-714` — docs mislabel the
-prod Supabase ref and contradict each other on what preview deployments target.
+PLAN + CLAIM + BUILD issue #715 (2608-DEV-715) on branch `dev/2608-DEV-715` — sharer share-link
+notifications skip every sharer with no `contact_email`, and are capped by nothing.
 
 ## Now
-#714 is **BUILD-complete and committed locally at `da36500`, not pushed**. `/code-review low` is the
-open gate, then push + draft PR — the push needs an explicit grant in this conversation.
+#715 is **BUILD-complete and committed locally at `6a3b29f`, not pushed** (CLAIM row at `b455e27`,
+branch rebased onto `c6ba2f2`). `/code-review low` is the open gate, then push + draft PR — the push
+needs an explicit grant in this conversation.
 
-#713 is **merged**: PR #728 (`2f82d80`). No migration, so no prod gate. Its `docs/CLAIMS.md` row was
-pruned by #714's CLAIM commit (`e20e072`), matching how `f8f3a3f` pruned #710.
+#714 is **merged**: PR #729 (`c6ba2f2`). No migration, so no prod gate. Its `docs/CLAIMS.md` row was
+pruned by #715's CLAIM commit (`b455e27`), matching how `e20e072` pruned #713.
 
-#710 is **fully DONE**: PR #725 merged (`17fd786`), the gated `Migrate Prod` run 31471066200
-succeeded, prod ledger head advanced to `20260811000000`, production smoke `/` 200 + `/sign-in` 200,
-issue closed. Epic #702 updated — all ten children merged, feature scope complete.
+#713 is **merged**: PR #728 (`2f82d80`). #710 is **fully DONE**: PR #725 merged (`17fd786`), gated
+`Migrate Prod` run 31471066200 succeeded, prod ledger head `20260811000000`, production smoke 200/200.
+Epic #702 updated — all ten children merged, feature scope complete.
 
 ## Next
-1. Resolve any `/code-review low` findings on the #714 diff.
-2. Push `dev/2608-DEV-714` and open the PR as a DRAFT (CodeRabbit skips drafts); wait for CI green +
+1. Resolve any `/code-review low` findings on the #715 diff.
+2. Push `dev/2608-DEV-715` and open the PR as a DRAFT (CodeRabbit skips drafts); wait for CI green +
    Vercel preview READY. **Needs an explicit push grant.**
 3. Mark ready → one CodeRabbit pass → fix all findings in ONE batched push.
-4. Merge. No migration in #714, so there is no prod gate to approve afterwards — just a smoke check.
-5. The `docs/CLAIMS.md` #714 row is pruned by the NEXT ticket's CLAIM commit, matching how `e20e072`
-   pruned #713 and `f8f3a3f` pruned #710 — never a standalone cleanup PR.
+4. Merge. No migration in #715, so there is no prod gate to approve afterwards — just a smoke check.
+5. The `docs/CLAIMS.md` #715 row is pruned by the NEXT ticket's CLAIM commit, matching how `b455e27`
+   pruned #714 and `e20e072` pruned #713 — never a standalone cleanup PR.
+6. File the deferred follow-up: five other call sites silently skip on a null `contact_email`
+   (`lib/abo/verifyAbo.ts:226`, both spouse-link routes, `app/api/admin/members/verify/[id]/route.ts:99`,
+   `lib/server/member-registration.ts`) — a shared `resolveProfileEmail()` would fix all six.
 
 ## Constraints
 - Never push without an explicit grant in this conversation. Grants from earlier tickets/sessions do
@@ -32,6 +36,21 @@ issue closed. Epic #702 updated — all ten children merged, feature scope compl
   Run `npm run check:env` before any command touching a hosted DB.
 
 ## Decisions
+- DECISION (#715, from PLAN): sharer notifications are **notifications, not transactional mail** —
+  they now dispatch through `sendNotificationEmail`, so `email_config.enabled` and the per-template
+  toggle both apply. The sharer did not request each message. Consequence accepted: flipping the
+  master switch off silences sharer mail too. Guest magic links stay transactional.
+- DECISION (#715, from PLAN): fallback order is `contact_email` → **Clerk primary email**, not the
+  issue's option 2 (require `contact_email` before minting a share link). `contact_email` is a
+  preference and may be deliberately blank; Clerk's primary is the verified backstop. Profiles with
+  no `clerk_id` (admin-created spouse/co-owner rows) keep the silent skip — no address exists.
+- DECISION (#715, from PLAN): the cap bucket is **template-scoped**, unlike
+  `guest-event-changes.ts`'s recipient-wide bucket — a registration burst through a viral link must
+  not consume the budget that would otherwise deliver the cancellation notice. 10 per 24h.
+- DECISION (#715, from BUILD): **no migration.** Keys absent from
+  `notification_config.email_settings.notification_types` already pass the gate
+  (`lib/email/send.ts:131` compares `=== false`), so the three admin toggles need no seed row — the
+  panel writes the key on first toggle.
 - DECISION (#713, from PLAN): the issue's **option 1** (resolve before any write), not option 2
   (degrade after). The `feed.ics` precedent at `:59-64` degrades *after* the point of no return
   because a feed has nothing to commit; `registerGuest` does. Hoisting is strictly better: the guest
@@ -65,6 +84,17 @@ issue closed. Epic #702 updated — all ten children merged, feature scope compl
 - Production smoke 2026-08-11: `https://www.teamenjoyvd.com` 200, `/sign-in` 200.
 
 ## Done
+- #715 PLAN + CLAIM + BUILD (code complete, `6a3b29f` + the review fix) — RESULT: 6 files.
+  `lib/notifications/share-events.ts` gained `resolveSharerEmail` (contact_email → Clerk primary,
+  Clerk failure caught) and `sendShareNotification` (admin gates, then a template-scoped 10/24h
+  `consumeEmailCap`, then `sendNotificationEmail`); `EmailSettingsPanel.tsx` + `i18n/domains/admin/
+  content.ts` expose the three toggles; `lib/email/send.ts` JSDoc lists the new caller. `/code-review
+  low` found one real defect — the cap was spent BEFORE the gates, so a disabled template burned the
+  sharer's daily budget; fixed by re-checking `getEmailConfig()` ahead of `consumeEmailCap`, covered
+  by two new tests. Verified: `npx vitest run` -> 32 files / **443 passed** (baseline 441 on this
+  branch's parent + 2); `npx tsc --noEmit` -> only the pre-existing stale `.next` error;
+  `npx eslint` on the changed files -> clean.
+- #714 CLOSED — RESULT: merged as PR #729 (`c6ba2f2`), no migration, no prod gate.
 - #713 BUILD (code complete, `a97a7df`) — RESULT: 5 files. `lib/utils/base-url.ts` gained a
   `normalizeHost` helper + the preview/development Vercel fallback; `lib/actions/guest-registration.ts`
   hoists the resolve above every side effect in BOTH `registerGuest` and `resendGuestLink`;

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -3,9 +3,10 @@ PLAN + CLAIM + BUILD issue #715 (2608-DEV-715) on branch `dev/2608-DEV-715` — 
 notifications skip every sharer with no `contact_email`, and are capped by nothing.
 
 ## Now
-#715 is **BUILD-complete and committed locally at `6a3b29f`, not pushed** (CLAIM row at `b455e27`,
-branch rebased onto `c6ba2f2`). `/code-review low` is the open gate, then push + draft PR — the push
-needs an explicit grant in this conversation.
+#715 is **pushed and open as DRAFT PR #731** (head `4dd255a`, CLAIM row at `b455e27`, branch rebased
+onto `c6ba2f2`). `/code-review low` is done — its one finding (cap spent before the admin gates) is
+fixed at `4dd255a`. Open gate: CI green + Vercel preview READY, then mark ready for one CodeRabbit
+pass.
 
 #714 is **merged**: PR #729 (`c6ba2f2`). No migration, so no prod gate. Its `docs/CLAIMS.md` row was
 pruned by #715's CLAIM commit (`b455e27`), matching how `e20e072` pruned #713.
@@ -16,8 +17,7 @@ Epic #702 updated — all ten children merged, feature scope complete.
 
 ## Next
 1. Resolve any `/code-review low` findings on the #715 diff.
-2. Push `dev/2608-DEV-715` and open the PR as a DRAFT (CodeRabbit skips drafts); wait for CI green +
-   Vercel preview READY. **Needs an explicit push grant.**
+2. DONE — pushed, draft PR #731 open. Wait for CI green + Vercel preview READY.
 3. Mark ready → one CodeRabbit pass → fix all findings in ONE batched push.
 4. Merge. No migration in #715, so there is no prod gate to approve afterwards — just a smoke check.
 5. The `docs/CLAIMS.md` #715 row is pruned by the NEXT ticket's CLAIM commit, matching how `b455e27`

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -3,10 +3,10 @@ PLAN + CLAIM + BUILD issue #715 (2608-DEV-715) on branch `dev/2608-DEV-715` — 
 notifications skip every sharer with no `contact_email`, and are capped by nothing.
 
 ## Now
-#715 is **pushed and open as DRAFT PR #731** (head `4dd255a`, CLAIM row at `b455e27`, branch rebased
-onto `c6ba2f2`). `/code-review low` is done — its one finding (cap spent before the admin gates) is
-fixed at `4dd255a`. Open gate: CI green + Vercel preview READY, then mark ready for one CodeRabbit
-pass.
+#715 is **open as PR #731, ready for review, all 11 checks green** (CLAIM row at `b455e27`, branch
+rebased onto `c6ba2f2`). `/code-review low` fixed the cap-before-gates defect at `4dd255a`. The one
+CodeRabbit pass is done: 2 comments, 1 applied (truthiness -> explicit comparisons), 1 rejected as a
+phantom (claimed duplicate declarations that do not exist in the file). Open gate: merge.
 
 #714 is **merged**: PR #729 (`c6ba2f2`). No migration, so no prod gate. Its `docs/CLAIMS.md` row was
 pruned by #715's CLAIM commit (`b455e27`), matching how `e20e072` pruned #713.
@@ -121,6 +121,18 @@ Epic #702 updated — all ten children merged, feature scope complete.
 - #722 closed — RESULT: merged as PR #724 (`ef0c3e1`), E2E aborts on a dead dev server.
 
 ## Open items
+- NOTED (not done, same-class defect, out of #715's scope): `lib/email/send.ts:129` still reads
+  `if (!config.enabled) return` — the exact check #715 tightened to `!== true` at
+  `share-events.ts:135`. `enabled` is typed `boolean` but comes from a JSONB column through an
+  `as EmailConfig` cast (`send.ts:35`), so a malformed row holding `"true"` or `1` makes the master
+  kill switch fail OPEN there. Repo-wide sweep found exactly one remaining instance (the two
+  `EmailSettingsPanel.tsx` hits are display-only toggles). One-line fix, needs its own ticket.
+- FLAKE (2026-08-11, PR #731, not a spec defect): the `Authenticated E2E (Clerk)` job failed with 21
+  tests red across `payments-guest`, `payments-on-behalf`, `profile-bento-auth` and the 390px share
+  specs — every one at `clerk.signIn()`, with 5x `[Clerk Testing] FAPI request failed after 4
+  attempts` against `loved-mole-75.clerk.accounts.dev`. No assertion ever ran. The run took 18m25s
+  because 60s timeout x retry x ~10 tests, vs a 6m baseline. Re-run of the SAME commit passed in
+  5m50s. Clerk's dev FAPI was transiently down; do not "fix" this in the specs.
 - NOTED (not done, out of #713's scope): `app/api/calendar/feed-token/route.ts:21,45,81` and
   `app/api/profile/spouse-link/route.ts:138` still `await getBaseUrl()` unguarded. Neither commits
   irreversible state first, so neither has the #713 half-success shape — they just 500 on a

--- a/lib/email/send.ts
+++ b/lib/email/send.ts
@@ -120,6 +120,7 @@ async function _dispatch(
  * - `app/api/admin/members/verify/[id]/route.ts`
  * - `app/api/admin/event-role-requests/[id]/route.ts`
  * - `app/api/profile/payments/route.ts`
+ * - `lib/notifications/share-events.ts` (static import, via `sendShareNotification`)
  */
 export async function sendNotificationEmail(payload: SendEmailPayload): Promise<void> {
   const config = await getEmailConfig()

--- a/lib/i18n/domains/admin/content.ts
+++ b/lib/i18n/domains/admin/content.ts
@@ -34,6 +34,9 @@ export const adminContent = {
   'admin.settings.emailPanel.template.doc_expiry': { en: 'Document Expiry Warnings', bg: 'Предупреждения за изтичащи документи' },
   'admin.settings.emailPanel.template.abo_verification_result': { en: 'ABO Verification Results', bg: 'Резултати от СБА верификация' },
   'admin.settings.emailPanel.template.trip_registration_status': { en: 'Trip Registration Updates', bg: 'Обновяване на регистрация за пътуване' },
+  'admin.settings.emailPanel.template.share_guest_registered': { en: 'Share Link: Guest Registered', bg: 'Връзка за споделяне: регистриран гост' },
+  'admin.settings.emailPanel.template.share_guest_attended': { en: 'Share Link: Guest Joined', bg: 'Връзка за споделяне: гостът се присъедини' },
+  'admin.settings.emailPanel.template.share_guest_cancelled': { en: 'Share Link: Guest Cancelled', bg: 'Връзка за споделяне: гостът се отказа' },
 
   // -- Content: page --
   'admin.content.page.heading': { en: 'Content', bg: 'Съдържание' },

--- a/lib/notifications/share-events.test.ts
+++ b/lib/notifications/share-events.test.ts
@@ -17,6 +17,7 @@ let capturedSelect = ''
 const capCalls: { recipient: string; template?: string; max: number }[] = []
 const mockConsumeEmailCap = vi.fn(() => Promise.resolve(true))
 const mockGetUser = vi.fn()
+const mockGetEmailConfig = vi.fn()
 
 vi.mock('@/lib/supabase/service', () => ({
   createServiceClient: () => mockCreateServiceClient(),
@@ -25,6 +26,7 @@ vi.mock('@/lib/supabase/service', () => ({
 // master switch and per-template toggle must apply, so the helpers dispatch
 // through sendNotificationEmail.
 vi.mock('@/lib/email/send', () => ({
+  getEmailConfig: () => mockGetEmailConfig(),
   sendNotificationEmail: vi.fn((opts: { to: string; template: string }) => {
     sentEmails.push({ to: opts.to, template: opts.template })
     return Promise.resolve()
@@ -62,6 +64,9 @@ beforeEach(() => {
   mockConsumeEmailCap.mockImplementation(() => Promise.resolve(true))
   mockGetUser.mockImplementation(() =>
     Promise.resolve({ primaryEmailAddress: { emailAddress: 'clerk@example.com' } }),
+  )
+  mockGetEmailConfig.mockImplementation(() =>
+    Promise.resolve({ enabled: true, notification_types: {}, alert_recipient: '' }),
   )
 })
 
@@ -292,6 +297,41 @@ describe('daily email cap', () => {
 
     expect(capCalls).toHaveLength(1)
     expect(sentEmails).toHaveLength(0)
+  })
+
+  it('does not spend a slot when the master switch is off', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: validRow }))
+    mockGetEmailConfig.mockImplementation(() =>
+      Promise.resolve({ enabled: false, notification_types: {}, alert_recipient: '' }),
+    )
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toHaveLength(0)
+    expect(capCalls).toHaveLength(0)
+  })
+
+  it('does not spend a slot when the template toggle is off', async () => {
+    // Gating AFTER the cap would let a suppressed template burn the sharer's
+    // whole daily budget on mail that was never sent; re-enabling the toggle
+    // would then deliver nothing until the window rolled.
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: validRow }))
+    mockGetEmailConfig.mockImplementation(() =>
+      Promise.resolve({
+        enabled: true,
+        notification_types: { share_guest_registered: false },
+        alert_recipient: '',
+      }),
+    )
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toHaveLength(0)
+    expect(capCalls).toHaveLength(0)
   })
 
   it('scopes the bucket per template, so a registration burst cannot starve the cancellation notice', async () => {

--- a/lib/notifications/share-events.test.ts
+++ b/lib/notifications/share-events.test.ts
@@ -13,15 +13,31 @@ const mockCreateServiceClient = vi.fn()
 const sentEmails: { to: string; template: string }[] = []
 /** The raw PostgREST select string the resolver passed to supabase-js. */
 let capturedSelect = ''
+/** Every consumeEmailCap call, in order — proves the bucket is template-scoped. */
+const capCalls: { recipient: string; template?: string; max: number }[] = []
+const mockConsumeEmailCap = vi.fn(() => Promise.resolve(true))
+const mockGetUser = vi.fn()
 
 vi.mock('@/lib/supabase/service', () => ({
   createServiceClient: () => mockCreateServiceClient(),
 }))
+// These are notifications, not transactional mail (2608-DEV-715): the admin
+// master switch and per-template toggle must apply, so the helpers dispatch
+// through sendNotificationEmail.
 vi.mock('@/lib/email/send', () => ({
-  sendTransactionalEmail: vi.fn((opts: { to: string; template: string }) => {
+  sendNotificationEmail: vi.fn((opts: { to: string; template: string }) => {
     sentEmails.push({ to: opts.to, template: opts.template })
-    return Promise.resolve({ sent: true })
+    return Promise.resolve()
   }),
+}))
+vi.mock('@/lib/rate-limit', () => ({
+  consumeEmailCap: (args: { recipient: string; template?: string; max: number }) => {
+    capCalls.push({ recipient: args.recipient, template: args.template, max: args.max })
+    return mockConsumeEmailCap()
+  },
+}))
+vi.mock('@clerk/nextjs/server', () => ({
+  clerkClient: () => Promise.resolve({ users: { getUser: (id: string) => mockGetUser(id) } }),
 }))
 vi.mock('@/lib/email/templates/render', () => ({
   renderEmailTemplate: () => Promise.resolve('<html></html>'),
@@ -39,18 +55,35 @@ vi.mock('@/lib/email/templates/ShareGuestCancelledEmail', () => ({
 beforeEach(() => {
   vi.clearAllMocks()
   sentEmails.length = 0
+  capCalls.length = 0
   capturedSelect = ''
+  // clearAllMocks wipes calls, not implementations — restate both defaults so
+  // one test's override cannot leak into the next.
+  mockConsumeEmailCap.mockImplementation(() => Promise.resolve(true))
+  mockGetUser.mockImplementation(() =>
+    Promise.resolve({ primaryEmailAddress: { emailAddress: 'clerk@example.com' } }),
+  )
 })
 
 type ShareLinkRow = {
   lang: string
-  profile: { first_name: string; last_name: string; contact_email: string | null } | null
+  profile: {
+    first_name: string
+    last_name: string
+    contact_email: string | null
+    clerk_id: string | null
+  } | null
   event: { title: string } | null
 }
 
 const validRow: ShareLinkRow = {
   lang: 'en',
-  profile: { first_name: 'Ivan', last_name: 'Petrov', contact_email: 'sharer@example.com' },
+  profile: {
+    first_name: 'Ivan',
+    last_name: 'Petrov',
+    contact_email: 'sharer@example.com',
+    clerk_id: 'user_ivan',
+  },
   event: { title: 'Trip Kickoff' },
 }
 
@@ -137,9 +170,12 @@ describe('resolver guards', () => {
     expect(sentEmails).toHaveLength(0)
   })
 
-  it('sends nothing when the sharer has no contact_email', async () => {
+  it('sends nothing when the sharer has neither contact_email nor clerk_id', async () => {
     mockCreateServiceClient.mockReturnValue(buildClient({
-      data: { ...validRow, profile: { first_name: 'Ivan', last_name: 'Petrov', contact_email: null } },
+      data: {
+        ...validRow,
+        profile: { first_name: 'Ivan', last_name: 'Petrov', contact_email: null, clerk_id: null },
+      },
     }))
     const { notifySharerOfAttendance } = await import('@/lib/notifications/share-events')
 
@@ -147,6 +183,7 @@ describe('resolver guards', () => {
     await flush()
 
     expect(sentEmails).toHaveLength(0)
+    expect(mockGetUser).not.toHaveBeenCalled()
   })
 
   it('sends nothing when the event is missing', async () => {
@@ -157,5 +194,119 @@ describe('resolver guards', () => {
     await flush()
 
     expect(sentEmails).toHaveLength(0)
+  })
+})
+
+// -- Clerk fallback (2608-DEV-715) ----------------------------------------------
+// 12 of 68 active share links belonged to a sharer with a NULL contact_email on
+// 2026-08-09 — every one of them a silent non-delivery before this fallback.
+
+describe('sharer email resolution', () => {
+  const noContactEmail: ShareLinkRow = {
+    ...validRow,
+    profile: { first_name: 'Ivan', last_name: 'Petrov', contact_email: null, clerk_id: 'user_ivan' },
+  }
+
+  it('falls back to the Clerk primary email when contact_email is null', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: noContactEmail }))
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(mockGetUser).toHaveBeenCalledWith('user_ivan')
+    expect(sentEmails).toEqual([{ to: 'clerk@example.com', template: 'share_guest_registered' }])
+  })
+
+  it('prefers contact_email over Clerk and never calls Clerk when it is set', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: validRow }))
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toEqual([{ to: 'sharer@example.com', template: 'share_guest_registered' }])
+    expect(mockGetUser).not.toHaveBeenCalled()
+  })
+
+  it('treats a blank contact_email as absent and still falls back', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({
+      data: {
+        ...validRow,
+        profile: { first_name: 'Ivan', last_name: 'Petrov', contact_email: '   ', clerk_id: 'user_ivan' },
+      },
+    }))
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toEqual([{ to: 'clerk@example.com', template: 'share_guest_registered' }])
+  })
+
+  it('sends nothing when the Clerk lookup throws — an outage must not escape', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: noContactEmail }))
+    mockGetUser.mockImplementation(() => Promise.reject(new Error('clerk down')))
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toHaveLength(0)
+  })
+
+  it('sends nothing when the Clerk user has no primary email', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: noContactEmail }))
+    mockGetUser.mockImplementation(() => Promise.resolve({ primaryEmailAddress: null }))
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(sentEmails).toHaveLength(0)
+  })
+
+  it('selects clerk_id alongside contact_email', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: validRow }))
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(capturedSelect).toContain('clerk_id')
+  })
+})
+
+// -- Daily cap (2608-DEV-715) ---------------------------------------------------
+// A widely-circulated share link had no upper bound on the mail it could
+// generate for its owner: the helpers bypassed both the cap and the admin gates.
+
+describe('daily email cap', () => {
+  it('sends nothing when the cap is spent', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: validRow }))
+    mockConsumeEmailCap.mockImplementation(() => Promise.resolve(false))
+    const { notifySharerOfRegistration } = await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+
+    expect(capCalls).toHaveLength(1)
+    expect(sentEmails).toHaveLength(0)
+  })
+
+  it('scopes the bucket per template, so a registration burst cannot starve the cancellation notice', async () => {
+    mockCreateServiceClient.mockReturnValue(buildClient({ data: validRow }))
+    const { notifySharerOfRegistration, notifySharerOfCancellation } =
+      await import('@/lib/notifications/share-events')
+
+    notifySharerOfRegistration('link-1', 'Jane Guest')
+    await flush()
+    notifySharerOfCancellation('link-1', 'Jane Guest')
+    await flush()
+
+    expect(capCalls).toEqual([
+      { recipient: 'sharer@example.com', template: 'share_guest_registered', max: 10 },
+      { recipient: 'sharer@example.com', template: 'share_guest_cancelled', max: 10 },
+    ])
   })
 })

--- a/lib/notifications/share-events.ts
+++ b/lib/notifications/share-events.ts
@@ -5,7 +5,7 @@
 import * as React from 'react'
 import { clerkClient } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
-import { sendNotificationEmail, type SendEmailPayload } from '@/lib/email/send'
+import { getEmailConfig, sendNotificationEmail, type SendEmailPayload } from '@/lib/email/send'
 import { consumeEmailCap } from '@/lib/rate-limit'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { ShareGuestRegisteredEmail } from '@/lib/email/templates/ShareGuestRegisteredEmail'
@@ -119,6 +119,17 @@ async function resolveShareLinkContext(
  * magic links stay on `sendTransactionalEmail` — there the email IS the feature.
  */
 async function sendShareNotification(payload: SendEmailPayload): Promise<void> {
+  // The admin gates are re-checked HERE, ahead of the cap, even though
+  // sendNotificationEmail checks them again: consumeEmailCap SPENDS a slot on
+  // every allowed call, so gating afterwards would let a disabled template burn
+  // the sharer's whole daily budget on mail that was never sent — re-enabling
+  // the toggle would then deliver nothing until the window rolled. The config
+  // read is a 60s-cached single row (lib/email/send.ts), so the double check is
+  // effectively free.
+  const config = await getEmailConfig()
+  if (!config.enabled) return
+  if (config.notification_types[payload.template] === false) return
+
   const withinDailyCap = await consumeEmailCap({
     recipient: payload.to,
     template:  payload.template,

--- a/lib/notifications/share-events.ts
+++ b/lib/notifications/share-events.ts
@@ -98,7 +98,9 @@ async function resolveShareLinkContext(
   // silently resolving to null at runtime.
   const { profile, event } = data
 
-  if (!profile || !event?.title) return null
+  // Explicit absence checks, not truthiness: `title` is a string, and `''` must
+  // read as "no title to name in the subject line" deliberately, not by accident.
+  if (profile == null || event?.title == null || event.title === '') return null
 
   const sharerEmail = await resolveSharerEmail(profile)
   if (sharerEmail === null) return null
@@ -127,7 +129,10 @@ async function sendShareNotification(payload: SendEmailPayload): Promise<void> {
   // read is a 60s-cached single row (lib/email/send.ts), so the double check is
   // effectively free.
   const config = await getEmailConfig()
-  if (!config.enabled) return
+  // `!== true`, not `!`: `enabled` is typed boolean but arrives from a JSONB
+  // column via an `as EmailConfig` cast (lib/email/send.ts:35), so a malformed
+  // row could hold `"true"` or `1`. A master kill switch fails closed.
+  if (config.enabled !== true) return
   if (config.notification_types[payload.template] === false) return
 
   const withinDailyCap = await consumeEmailCap({

--- a/lib/notifications/share-events.ts
+++ b/lib/notifications/share-events.ts
@@ -3,12 +3,22 @@
 // Always call without await — a failing email must never block the user.
 
 import * as React from 'react'
+import { clerkClient } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
-import { sendTransactionalEmail } from '@/lib/email/send'
+import { sendNotificationEmail, type SendEmailPayload } from '@/lib/email/send'
+import { consumeEmailCap } from '@/lib/rate-limit'
 import { renderEmailTemplate } from '@/lib/email/templates/render'
 import { ShareGuestRegisteredEmail } from '@/lib/email/templates/ShareGuestRegisteredEmail'
 import { ShareGuestAttendedEmail } from '@/lib/email/templates/ShareGuestAttendedEmail'
 import { ShareGuestCancelledEmail } from '@/lib/email/templates/ShareGuestCancelledEmail'
+
+// ── Caps ─────────────────────────────────────────────────────────────────
+// Same shape as MEMBER_EMAIL_DAILY_CAP / GUEST_EMAIL_DAILY_CAP, but keyed per
+// TEMPLATE rather than per recipient (2608-DEV-715): a widely-circulated link
+// can produce a burst of registrations, and that burst must not consume the
+// budget that would otherwise deliver the sharer's *cancellation* notice.
+const SHARE_EMAIL_DAILY_CAP = 10
+const SHARE_EMAIL_DAILY_WINDOW_MS = 24 * 60 * 60 * 1000
 
 // ── Internal resolver ────────────────────────────────────────────────────
 
@@ -20,6 +30,41 @@ type ShareLinkContext = {
   eventTitle:   string
   guestName:    string
   lang:         Lang
+}
+
+/**
+ * The address to notify a sharer at, or null when there is none.
+ *
+ * `contact_email` is the member's stated preference and wins outright. It is
+ * nullable and unset for a sizeable share of real profiles (12 of 68 active
+ * share links on 2026-08-09), which used to mean silent non-delivery — hence
+ * the fallback to the Clerk primary address, which every authenticating member
+ * necessarily has and which Clerk has verified. Profiles with no `clerk_id`
+ * (admin-created spouse/co-owner rows) still resolve to null: there is no
+ * address to reach them at.
+ */
+async function resolveSharerEmail(profile: {
+  contact_email: string | null
+  clerk_id:      string | null
+}): Promise<string | null> {
+  // Explicit empty-string check: a blank contact_email is not an address, but
+  // it must not shadow the Clerk fallback either.
+  const preferred = profile.contact_email?.trim()
+  if (preferred != null && preferred !== '') return preferred
+
+  const clerkId = profile.clerk_id?.trim()
+  if (clerkId == null || clerkId === '') return null
+
+  try {
+    const clerk = await clerkClient()
+    const user = await clerk.users.getUser(clerkId)
+    return user.primaryEmailAddress?.emailAddress ?? null
+  } catch (err) {
+    // A Clerk outage must not throw inside a fire-and-forget path — the caller
+    // treats null as "nothing to send", which is the correct degradation.
+    console.error('Failed to resolve sharer email from Clerk:', err)
+    return null
+  }
 }
 
 async function resolveShareLinkContext(
@@ -36,7 +81,7 @@ async function resolveShareLinkContext(
     .from('event_share_links')
     .select(`
       lang,
-      profile:profiles ( first_name, last_name, contact_email ),
+      profile:profiles ( first_name, last_name, contact_email, clerk_id ),
       event:calendar_events ( title )
     `)
     .eq('id', shareLinkId)
@@ -53,15 +98,36 @@ async function resolveShareLinkContext(
   // silently resolving to null at runtime.
   const { profile, event } = data
 
-  if (!profile?.contact_email || !event?.title) return null
+  if (!profile || !event?.title) return null
+
+  const sharerEmail = await resolveSharerEmail(profile)
+  if (sharerEmail === null) return null
 
   return {
-    sharerEmail: profile.contact_email,
+    sharerEmail,
     sharerName:  `${profile.first_name} ${profile.last_name}`.trim(),
     eventTitle:  event.title,
     guestName,
     lang:        data.lang === 'bg' ? 'bg' : 'en',
   }
+}
+
+/**
+ * Cap, then send. These are notifications, not transactional mail: the sharer
+ * did not request each individual message, so both the `email_config.enabled`
+ * master switch and the per-template admin toggle apply (2608-DEV-715). Guest
+ * magic links stay on `sendTransactionalEmail` — there the email IS the feature.
+ */
+async function sendShareNotification(payload: SendEmailPayload): Promise<void> {
+  const withinDailyCap = await consumeEmailCap({
+    recipient: payload.to,
+    template:  payload.template,
+    windowMs:  SHARE_EMAIL_DAILY_WINDOW_MS,
+    max:       SHARE_EMAIL_DAILY_CAP,
+  })
+  if (!withinDailyCap) return
+
+  await sendNotificationEmail(payload)
 }
 
 // ── Public API ────────────────────────────────────────────────────────────
@@ -82,7 +148,7 @@ export function notifySharerOfRegistration(shareLinkId: string, guestName: strin
       const subject = ctx.lang === 'bg'
         ? `${ctx.guestName} се регистрира за ${ctx.eventTitle}`
         : `${ctx.guestName} registered for ${ctx.eventTitle}`
-      await sendTransactionalEmail({
+      await sendShareNotification({
         to:       ctx.sharerEmail,
         subject,
         html,
@@ -109,7 +175,7 @@ export function notifySharerOfAttendance(shareLinkId: string, guestName: string)
       const subject = ctx.lang === 'bg'
         ? `${ctx.guestName} се присъедини към ${ctx.eventTitle}`
         : `${ctx.guestName} joined ${ctx.eventTitle}`
-      await sendTransactionalEmail({
+      await sendShareNotification({
         to:       ctx.sharerEmail,
         subject,
         html,
@@ -136,7 +202,7 @@ export function notifySharerOfCancellation(shareLinkId: string, guestName: strin
       const subject = ctx.lang === 'bg'
         ? `${ctx.guestName} се отказа от ${ctx.eventTitle}`
         : `${ctx.guestName} cancelled for ${ctx.eventTitle}`
-      await sendTransactionalEmail({
+      await sendShareNotification({
         to:       ctx.sharerEmail,
         subject,
         html,


### PR DESCRIPTION
Closes #715.

Sharer share-link notifications skipped every sharer whose `profiles.contact_email` was null (12 of 68 active links in prod, measured 2026-08-09), and were capped by nothing — no daily budget, no admin brake.

## What changed

**`lib/notifications/share-events.ts`**
- `resolveSharerEmail()` — `contact_email` → Clerk primary email. The `profiles` embed now selects `clerk_id`; a Clerk lookup failure is caught and degrades to the previous silent skip. Profiles with no `clerk_id` (admin-created spouse/co-owner rows) still skip — no address exists.
- `sendShareNotification()` — dispatches through `sendNotificationEmail` instead of `sendTransactionalEmail`, so the `email_config.enabled` master switch and the per-template toggle both apply. Order is: admin gates → `consumeEmailCap` → send, so a disabled template never burns the sharer's daily budget.
- The cap bucket is **template-scoped** (10 per 24h per template), not recipient-wide like `guest-event-changes.ts`: a registration burst through a viral link must not eat the budget that would otherwise deliver the cancellation notice.

**`EmailSettingsPanel.tsx` + `lib/i18n/domains/admin/content.ts`** — expose the three `share_guest_*` toggles in the admin panel.

**`lib/email/send.ts`** — JSDoc lists the new caller.

## Decisions

- These are **notifications, not transactional mail** — the sharer did not request each message. Consequence accepted: flipping the master switch off silences sharer mail too. Guest magic links stay transactional and are untouched.
- Issue option 2 (require `contact_email` before minting a share link) declined — `contact_email` is a preference and may be deliberately blank.
- **No migration.** Keys absent from `notification_config.email_settings.notification_types` already pass the gate (`lib/email/send.ts:131` compares `=== false`), so the three toggles need no seed row; the panel writes the key on first toggle.

## Verification

- `npx vitest run` -> 32 files / **443 passed** (branch parent baseline 441, +2 new cap-ordering tests)
- `npx tsc --noEmit` -> only the pre-existing stale `.next/dev/types/validator.ts` error from #709
- `npx eslint` on the changed files -> clean

## Follow-up (not in this PR)

Five other call sites silently skip on a null `contact_email` — `lib/abo/verifyAbo.ts:226`, both spouse-link routes, `app/api/admin/members/verify/[id]/route.ts:99`, `lib/server/member-registration.ts`. A shared `resolveProfileEmail()` would fix all six; needs its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable email notifications for share-link guest registration, attendance, and cancellation events.
  * Notifications can use the sharer’s contact email or verified account email when available.
  * Added English and Bulgarian labels and descriptions in email settings.

* **Bug Fixes**
  * Improved notification reliability when contact details are missing or unavailable.
  * Added safeguards to prevent excessive duplicate notifications through daily, template-specific limits.
  * Notifications now respect administrator enablement settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->