### PR TITLE
[2608-DEV-726] Split the popup gate so actions survive the Registrations tab

### DIFF
--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -148,11 +148,10 @@ export default function EventPopup({
     a.remove()
   }
 
-  // Keys off the tab alone, for every role (2608-DEV-709 C6). showMeta gates
-  // more than the date/share meta — AttendSection, the share/QR buttons and
-  // the attendForLink hint all sit inside it (EventPopupShell.tsx:164-214) —
-  // so a core/member with the Registrations tab open also loses the Attend
-  // button until they switch back. Accepted: `roles` is the default tab.
+  // Keys off the tab alone, for every role (2608-DEV-709 C6). Since
+  // 2608-DEV-726 it gates the date/time/link meta and the description ONLY —
+  // AttendSection and the share/QR buttons render on both tabs, so opening
+  // Registrations no longer takes the primary action off the screen.
   const showMeta = activeTab !== 'registrations'
 
   return (

--- a/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
@@ -73,6 +73,10 @@ export default function EventPopupShell({
 }: Props) {
   const eventTypeStyle = event?.event_type ? EVENT_TYPE_STYLES[event.event_type] : null
 
+  // The action row (Attend for non-admins, plus Share/QR) is deliberately NOT
+  // tab-scoped — see the comment on the body block below. 2608-DEV-726.
+  const showActions = !!event && event.allow_guest_registration && !isGuest
+
   return (
     <>
       {/* Header */}
@@ -117,103 +121,117 @@ export default function EventPopupShell({
               <div key={i} className="h-6 rounded animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
             ))}
           </div>
-        ) : event && showMeta ? (
+        ) : event ? (
           <>
-            <div className="px-4 py-3 border-b border-black/5">
-              <div className="flex items-center gap-2 text-xs mb-1" style={{ color: 'var(--text-primary)' }}>
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
-                  stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <rect width="18" height="18" x="3" y="4" rx="2"/>
-                  <line x1="16" x2="16" y1="2" y2="6"/>
-                  <line x1="8" x2="8" y1="2" y2="6"/>
-                  <line x1="3" x2="21" y1="10" y2="10"/>
-                </svg>
-                <span className="font-medium">
-                  {event.is_all_day ? formatAllDayRange(event.start_time, event.end_time) : formatLongDate(event.start_time)}
-                </span>
+            {/* `showMeta` gates the META only (2608-DEV-726). The action row is
+                deliberately outside that gate: a member who opens the
+                Registrations tab to see who is coming must keep the Attend,
+                Share and QR controls, which #721 made reachable-then-hidden by
+                giving members the tab bar. Both halves stay inside ONE bordered
+                container so the Roles tab renders exactly as before — a sibling
+                block would add a second divider to a screen that has no bug. */}
+            {(showMeta || showActions) && (
+              <div className="px-4 py-3 border-b border-black/5">
+                {showMeta && (
+                  <>
+                    <div className="flex items-center gap-2 text-xs mb-1" style={{ color: 'var(--text-primary)' }}>
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+                        stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <rect width="18" height="18" x="3" y="4" rx="2"/>
+                        <line x1="16" x2="16" y1="2" y2="6"/>
+                        <line x1="8" x2="8" y1="2" y2="6"/>
+                        <line x1="3" x2="21" y1="10" y2="10"/>
+                      </svg>
+                      <span className="font-medium">
+                        {event.is_all_day ? formatAllDayRange(event.start_time, event.end_time) : formatLongDate(event.start_time)}
+                      </span>
+                    </div>
+                    {!event.is_all_day && (
+                      <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
+                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+                          stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <circle cx="12" cy="12" r="10"/>
+                          <polyline points="12 6 12 12 16 14"/>
+                        </svg>
+                        <span>{formatTime(event.start_time)} – {formatTime(event.end_time)}</span>
+                      </div>
+                    )}
+                    {!isGuest && event.meeting_url && (
+                      <div className="flex items-center gap-2 text-xs mt-1">
+                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+                          stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
+                          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
+                        </svg>
+                        <a href={event.meeting_url} target="_blank" rel="noopener noreferrer"
+                          className="truncate hover:underline" style={{ color: 'var(--brand-teal)' }}>
+                          {event.meeting_url}
+                        </a>
+                      </div>
+                    )}
+                    {/* Gated (D3): the API already nulled meeting_url for a non-attending
+                        non-admin caller on an event open for guest sharing — this hint
+                        is the only surface that explains why the link is missing. Also
+                        requires no active registration: an already-attending member on
+                        an event with no meeting_url configured at all must not be told
+                        to attend for a link that will never appear. Stays tab-scoped
+                        with the meta: it explains an absent meeting_url, which is meta. */}
+                    {!isGuest && !isAdmin && !event.meeting_url && event.allow_guest_registration && event.caller_registration === null && (
+                      <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>
+                        {t('cal.attendForLink')}
+                      </p>
+                    )}
+                  </>
+                )}
+                {showActions && (
+                  <div className={showMeta ? 'mt-3 space-y-3' : 'space-y-3'}>
+                    {!isAdmin && (
+                      <AttendSection
+                        isRegistered={event.caller_registration !== null}
+                        isEnded={isEventEnded}
+                        isPending={attendPending}
+                        onAttend={onAttend}
+                        onCancelAttend={onCancelAttend}
+                        t={t}
+                        eventId={event.id}
+                        title={event.title}
+                        startTime={event.start_time}
+                        endTime={event.end_time}
+                        meetingUrl={event.meeting_url}
+                      />
+                    )}
+                    <div className="flex items-center gap-4">
+                      <button
+                        onClick={onShare}
+                        disabled={shareLoading}
+                        className="flex items-center gap-1.5 text-xs font-medium hover:opacity-70 transition-opacity disabled:opacity-40"
+                        style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+                      >
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                          stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <circle cx="18" cy="5" r="3"/>
+                          <circle cx="6" cy="12" r="3"/>
+                          <circle cx="18" cy="19" r="3"/>
+                          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+                          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+                        </svg>
+                        {shareLoading ? '…' : shareCopied ? t('cal.linkCopied') : t('cal.shareEvent')}
+                      </button>
+                      <button
+                        onClick={onQrShare}
+                        disabled={qrLoading}
+                        className="flex items-center gap-1.5 text-xs font-medium hover:opacity-70 transition-opacity disabled:opacity-40"
+                        style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+                      >
+                        <QrCode size={12} />
+                        {qrLoading ? '…' : t('cal.qrShare')}
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
-              {!event.is_all_day && (
-                <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
-                    stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <circle cx="12" cy="12" r="10"/>
-                    <polyline points="12 6 12 12 16 14"/>
-                  </svg>
-                  <span>{formatTime(event.start_time)} – {formatTime(event.end_time)}</span>
-                </div>
-              )}
-              {!isGuest && event.meeting_url && (
-                <div className="flex items-center gap-2 text-xs mt-1">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
-                    stroke="var(--text-secondary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/>
-                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
-                  </svg>
-                  <a href={event.meeting_url} target="_blank" rel="noopener noreferrer"
-                    className="truncate hover:underline" style={{ color: 'var(--brand-teal)' }}>
-                    {event.meeting_url}
-                  </a>
-                </div>
-              )}
-              {/* Gated (D3): the API already nulled meeting_url for a non-attending
-                  non-admin caller on an event open for guest sharing — this hint
-                  is the only surface that explains why the link is missing. Also
-                  requires no active registration: an already-attending member on
-                  an event with no meeting_url configured at all must not be told
-                  to attend for a link that will never appear. */}
-              {!isGuest && !isAdmin && !event.meeting_url && event.allow_guest_registration && event.caller_registration === null && (
-                <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>
-                  {t('cal.attendForLink')}
-                </p>
-              )}
-              {event.allow_guest_registration && !isGuest && !isAdmin && (
-                <div className="mt-3">
-                  <AttendSection
-                    isRegistered={event.caller_registration !== null}
-                    isEnded={isEventEnded}
-                    isPending={attendPending}
-                    onAttend={onAttend}
-                    onCancelAttend={onCancelAttend}
-                    t={t}
-                    eventId={event.id}
-                    title={event.title}
-                    startTime={event.start_time}
-                    endTime={event.end_time}
-                    meetingUrl={event.meeting_url}
-                  />
-                </div>
-              )}
-              {event.allow_guest_registration && !isGuest && (
-                <div className="mt-3 flex items-center gap-4">
-                  <button
-                    onClick={onShare}
-                    disabled={shareLoading}
-                    className="flex items-center gap-1.5 text-xs font-medium hover:opacity-70 transition-opacity disabled:opacity-40"
-                    style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
-                  >
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
-                      stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <circle cx="18" cy="5" r="3"/>
-                      <circle cx="6" cy="12" r="3"/>
-                      <circle cx="18" cy="19" r="3"/>
-                      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
-                      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
-                    </svg>
-                    {shareLoading ? '…' : shareCopied ? t('cal.linkCopied') : t('cal.shareEvent')}
-                  </button>
-                  <button
-                    onClick={onQrShare}
-                    disabled={qrLoading}
-                    className="flex items-center gap-1.5 text-xs font-medium hover:opacity-70 transition-opacity disabled:opacity-40"
-                    style={{ color: 'var(--text-secondary)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
-                  >
-                    <QrCode size={12} />
-                    {qrLoading ? '…' : t('cal.qrShare')}
-                  </button>
-                </div>
-              )}
-            </div>
-            {event.description && event.description !== event.meeting_url && (
+            )}
+            {showMeta && event.description && event.description !== event.meeting_url && (
               <div className="px-4 py-3">
                 <p className="text-xs leading-relaxed" style={{ color: 'var(--text-secondary)' }}>{event.description}</p>
               </div>

--- a/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
@@ -75,7 +75,8 @@ export default function EventPopupShell({
 
   // The action row (Attend for non-admins, plus Share/QR) is deliberately NOT
   // tab-scoped — see the comment on the body block below. 2608-DEV-726.
-  const showActions = !!event && event.allow_guest_registration && !isGuest
+  const showActions =
+    event !== undefined && event.allow_guest_registration === true && isGuest === false
 
   return (
     <>

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
+| #726 | `dev/2608-DEV-726` | `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx`, `app/(dashboard)/calendar/components/EventPopup.tsx` (comment only), `e2e/member-attend-auth.spec.ts` — **migration: no** | 2026-08-12 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,85 +1,56 @@
 ## Goal
-PLAN + CLAIM + BUILD issue #718 (2608-DEV-718) on branch `dev/2608-DEV-718` — `guest_capacity` has a
-check-then-write race: nothing in the DB backs the cap, so concurrent registrations overbook it.
+PLAN + CLAIM + BUILD issue #726 (`2608-DEV-726`) on branch `dev/2608-DEV-726` — a member who opens
+the calendar popup's **Registrations** tab loses the Attend button, the share/QR buttons and the
+event meta, with nothing on screen explaining why. A regression from #721, which gave plain members
+the tab bar that makes the state reachable.
 
 ## Now
-#718 is **pushed and open as PR #732**, CI green on `0e64f9a` (11/11 checks, Vercel preview READY),
-`MERGEABLE` / `CLEAN`, not a draft. CodeRabbit's one pass left three findings — all three are now
-dispositioned (see `## Decisions`); one produced a real change to the migration, two were declined
-with evidence. GCR has not run. The fix is a `BEFORE INSERT OR UPDATE` trigger on
-`guest_registrations` — `20260811000100_2608_fix_718_guest_capacity_trigger.sql` — rather than the
-RPC the issue suggested, because #710 added a fourth writer inside `approve_event_role_request` and
-a trigger sits under all of them. Both server paths map its SQLSTATE `P0718` back onto the friendly
-"event is full" copy via `isCapacityViolation()`.
-
-Verified so far: `npx vitest run lib/actions/guest-registration.test.ts
-lib/server/member-registration.test.ts` -> 64 passed (baseline was 56). The 5 new P0718 tests were
-proven red first by breaking `CAPACITY_VIOLATION_CODE`. `npx tsc --noEmit` is clean outside `.next/`.
-
-**The race is proven closed on DEV.** `supabase db push --linked` applied `20260811000100` (and two
-already-merged migrations DEV was missing, `20260805000000` + `20260809000100`). Eight serial
-behaviour checks pass. The concurrency proof came from **two pg_cron workers** scheduled on the same
-tick, not from two client connections: the MCP serializes its calls, so a parallel-call attempt
-returned `blocked_for=5ms` and proved nothing. Under pg_cron the two workers started 0.6ms apart —
-B won the advisory lock and committed at `.123`, A blocked ~79ms on that lock, re-counted, saw B's
-committed row and raised P0718 at `.1266`. Exactly 1 active row against `guest_capacity = 1`. That
-blocking signature is the fresh-snapshot-after-lock property the whole fix depends on.
-
-Both review gates are CLOSED (2026-08-12). Pushed `0e64f9a..16cac3b` on an explicit grant; CI green
-again on `16cac3b` (11/11, `Replay migrations from scratch` 2m15s — which is what proves the edited
-PL/pgSQL is valid from an EMPTY database, not merely as an in-place `CREATE OR REPLACE`).
-`Authenticated E2E (Clerk)` came back in **6m7s vs 13m1s** on the previous run, consistent with the
-sign-in race no longer burning a retry cycle. All three CodeRabbit threads resolved; its re-review
-added nothing.
-
-**DEV was re-applied by hand** and matches the file. `db push` could not do it — the version was
-already in the DEV ledger, so it skips — the new body went in as `CREATE OR REPLACE FUNCTION` via
-the Supabase MCP against `iymwxdewcpvpjgzewtzk`, trigger untouched (`has_new_guard=true`,
-`trigger_count=1`). **Reusable technique:** a probe that must leave no trace can run its whole
-fixture set inside one `DO $$ … $$` block and end with `RAISE EXCEPTION` carrying the results in the
-message — the raise rolls every fixture back, and the MCP surfaces the message as the error string.
-Verified 0 probe events / 0 probe registrations afterwards.
-
-**Open gate: merge + prod.** #718 ships a migration, so merging arms the gated `migrate-prod` run.
-
-#715 is **merged**: PR #731 (`ddaa2e5`), no migration, no prod gate. #714 merged (`c6ba2f2`).
-#713 merged (`2f82d80`). #710 fully DONE — prod ledger head `20260811000000`.
+PLAN and CLAIM are complete; BUILD is code-complete and committed locally, **not pushed**.
+- Issue #726 body now carries the PLAN, a file-path-level DoD, Affected Files, Gotchas, Migration &
+  Test Impact, `## Design Checklist` (4/4) and `## Branch dev/2608-DEV-726`.
+- `2d301e9` — claim row in `docs/CLAIMS.md` (migration: no). `caf0fc0` — the fix.
+- The fix: `EventPopupShell.tsx`'s outer branch became `event ? … : null`; `showMeta` now gates only
+  the date/time/`meeting_url`/`attendForLink` meta and the description. A new local
+  `showActions = !!event && event.allow_guest_registration && !isGuest` gates the action row, which
+  renders on BOTH tabs inside the SAME `px-4 py-3 border-b` container as the meta — so the Roles tab
+  is pixel-identical (a sibling block would have added a second divider). `!isAdmin` still gates
+  `AttendSection` alone. Spacing preserved: the group carries `space-y-3`, plus `mt-3` only when the
+  meta above it is shown.
+- `e2e/member-attend-auth.spec.ts` gained a 390px `@auth` test asserting Attend + Share stay visible
+  after clicking the Registrations tab, that the `attendForLink` hint is correctly GONE (proving the
+  gate was split, not deleted), and no 390px horizontal overflow. A `clearMemberRegistration()`
+  helper was extracted from `seedMemberRegistration()`, which now calls it.
+Verified: `npx tsc --noEmit` -> **clean, zero errors** (the long-standing stale
+`.next/dev/types/validator.ts:566` error is gone — `.next` has since been regenerated);
+`npx eslint` on the three changed files -> **0 errors / 1 warning**, identical to the baseline taken
+before the edits (`EventPopup.tsx:61` unused `request_id`, pre-existing).
+No unit test can cover this: `vitest.config.ts` includes only `lib|app/**/*.test.ts` +
+`scripts/**/*.test.js` under `environment: 'node'`, and the repo has no `*.test.tsx` at all.
+Component verification is e2e-only.
+Verified 2026-08-12, run LOCALLY against hosted DEV (`iymwxdewcpvpjgzewtzk`), not just CI:
+`npx playwright test --project=authenticated e2e/member-attend-auth.spec.ts` -> **5 passed (34.6s)**.
+The regression test was proven RED first — reverting only `EventPopupShell.tsx` to `2d301e9` and
+re-running it fails on `getByRole('dialog').getByRole('button', { name: /^attend$/i })`,
+"element(s) not found", which is the reported symptom exactly; restored from a byte-identical copy
+(`git status` clean afterwards) and re-run -> **1 passed**.
+`/code-review low` on the branch diff -> **zero findings**.
 
 ## Next
-1. DONE — applied to DEV.
-2. DONE — all eight serial checks plus the pg_cron concurrency proof pass; every fixture rolled back
-   or deleted, DEV left clean (0 probe events, 0 probe registrations, 0 leftover cron jobs).
-   **Reusable technique:** when two truly concurrent transactions are needed against a hosted DB and
-   no DB password is at hand, schedule two `cron.schedule(...)` jobs on the same tick and read the
-   outcome out of `cron.job_run_details` — the MCP cannot do it, it serializes its calls.
-3. DONE — no e2e impact. Every fixture creator omits `guest_capacity` (NULL = unlimited). The one
-   spec that caps an event, `e2e/member-share-register-auth.spec.ts:229-253`, writes no registration
-   while capped (it only reloads a read-only page), and `calendar_events` updates do not fire the
-   trigger.
-4. DONE — reviewed, pushed, PR #732 opened and marked ready; CI green, preview READY.
-5. DONE — CodeRabbit's single pass returned three findings; all three answered on the thread and
-   fixed-or-declined in one batch (2026-08-12).
-6. DONE — pushed `16cac3b`; CI green 11/11 including `Replay migrations from scratch`.
-7. DONE — DEV re-applied by hand and behaviour-probed (edit-active ALLOWED, adopt-active ALLOWED,
-   new-seat-on-full REFUSED P0718), DEV left clean.
-8. DONE — all three CodeRabbit threads resolved; one correction posted where its verifier read the
-   pre-push revision and reported the fix missing.
-9. **Merge** -> GCR. The claim row is already pruned in this PR's own commits, so GCR is
-   issue-close (#718) + branch cleanup only.
-10. After merge: approve the gated `migrate-prod` run — **#718 ships a migration**, unlike the last
-   four tickets. Prod ledger head should move `20260811000000` -> `20260811000100`. Then smoke
-   `https://www.teamenjoyvd.com`.
-11. Follow-ups filed and unclaimed: **#733** (machine-readable failure code, retires the English
-   error-text matching) and **#734** (seven e2e specs still carrying the sign-in race).
-7. Still open from #715: five call sites silently skip on a null `contact_email`
-   (`lib/abo/verifyAbo.ts:226`, both spouse-link routes, `app/api/admin/members/verify/[id]/route.ts:99`,
-   `lib/server/member-registration.ts`) — a shared `resolveProfileEmail()` would fix all six.
-
-## Open items
-- `.next/dev/types/validator.ts:566` references `app/api/admin/events/[id]/registrations/route.js`,
-  a route that no longer exists, so `npx tsc --noEmit` exits non-zero on a clean tree. Proven
-  pre-existing by stashing (2026-08-11). Stale build artifact, not a source defect; out of #718's
-  scope.
+1. ~~`/code-review low` on the branch diff~~ — DONE, zero findings.
+2. **BLOCKED ON THE USER:** ask for a push grant, push `dev/2608-DEV-726`, open the PR **as a
+   draft** with `Closes #726`. Nothing else on this ticket can proceed without it.
+3. CI green + Vercel preview READY. Then eyeball the preview at 390px on both tabs — the DoD's
+   "no visual change on the Roles tab" claim is the one item no automated check covers.
+4. Mark ready -> one CodeRabbit pass -> fix findings in ONE batched push.
+5. Merge -> GCR: prune the `#726` claim row (fold into this PR's own commits, per Constraints),
+   close #726. **No migration**, so no prod gate for this ticket.
+6. **STILL OPEN FROM #718:** PR #732 merged as `4ac7228` and it SHIPPED A MIGRATION, so the gated
+   `migrate-prod` run is armed and unapproved. Prod ledger head must move
+   `20260811000000` -> `20260811000100`, then smoke `https://www.teamenjoyvd.com`. Until that runs,
+   prod has the app code that raises `P0718` but NOT the trigger that produces it — harmless (the
+   app-level check still guards) but the race is only closed on DEV.
+7. Follow-ups filed and unclaimed: **#727** (401 eviction during Clerk token refresh, `priority:high`),
+   **#733** (machine-readable capacity failure code), **#734** (seven e2e specs with the sign-in race).
 
 ## Constraints
 - Never push without an explicit grant in this conversation. Grants from earlier tickets/sessions do
@@ -91,230 +62,104 @@ Verified 0 probe events / 0 probe registrations afterwards.
   Run `npm run check:env` before any command touching a hosted DB.
 
 ## Decisions
-- DECISION (#718, from PLAN): a **trigger, not the RPC the issue proposed**. #718 was filed before
-  #710, which added a fourth writer of active registrations inside `approve_event_role_request`
-  (`20260811000000:99-142`) — an RPC would have to absorb the guest token-reuse decision, the member
-  adopt-or-insert branch, and re-entry from another PL/pgSQL function. A trigger sits under all of
-  them plus the e2e/seed direct inserts, and cannot be defeated by forgetting to call it, which is
-  what the issue actually asked for.
-- DECISION (#718, from BUILD): the app-level `countAttendeesForCapacity()` checks **stay**. They are
-  the fast path that produces the localized "event is full" copy; the trigger is the backstop for
-  the window they cannot cover. Cost accepted: the "who occupies a seat" rule (approved role holders
-  exempt) now exists in two places and must be changed in both — flagged in `docs/ai/GOTCHAS.md`.
-- DECISION (#718, from BUILD): custom SQLSTATE **`P0718`**, not a 23xxx integrity code.
-  `guest_registrations` carries real CHECK and UNIQUE constraints, so matching a shared class would
-  report an unrelated violation to a guest as "event is full".
-- DECISION (#718, from BUILD): the trigger function is `SECURITY DEFINER` with **no internal
-  `auth.role()` guard**, departing from the `docs/ai/GOTCHAS.md` "Trusted RPC" rule. That rule
-  guards directly-callable functions; Postgres refuses to invoke a `trigger`-returning function
-  outside a trigger context, so there is no caller to authorize. DEFINER is used only so the count
-  is computed over every row rather than an RLS-filtered view, which could under-count. EXECUTE is
-  deliberately not revoked — trigger-function privileges are checked at CREATE TRIGGER time, and
-  revoking would risk the write paths for no gain.
-- DECISION (#718, from REVIEW): CodeRabbit's 🟠 "enforce capacity when an active row changes
-  exemption status" is **unreachable today but was fixed anyway**. The overbooking it describes
-  needs an UPDATE moving `profile_id` off an approved role holder on an already-active row; every
-  writer that sets `profile_id` requires the pre-image to be NULL
-  (`member-registration.ts:255` `.is('profile_id', null)`, `20260811000000:112`
-  `g.profile_id IS NULL`), and `registerGuest`'s upsert never names the column — NULL -> non-NULL
-  only moves a row toward exempt, which under-counts and cannot overbook. Accepted anyway because
-  the trigger's whole premise is surviving a writer nobody has written yet: the early return now
-  also requires `OLD.profile_id IS NOT DISTINCT FROM NEW.profile_id`. Safe for the adopt paths that
-  do fall through — `gr.id <> NEW.id` excludes the row's own already-counted seat, so adopting the
-  last guest on an exactly-full event still passes.
-- DECISION (#718, from REVIEW): CodeRabbit's 🟠 "localize the member capacity error" is **DECLINED —
-  the proposed fix is a regression.** `CAPACITY_ERROR` is not new (`git diff origin/main` shows the
-  same English string at `:218` before this PR); it is a server->client protocol matched by
-  `MemberAttendPanel.tsx:75` and `EventPopup.tsx:79` via `raw.includes('capacity')`. Returning
-  Bulgarian when `lang === 'bg'` makes BOTH matchers miss and fall through to the generic attend
-  error — strictly worse for the Bulgarian user the finding is about. The same finding was declined
-  on #720 for the same reason; the real fix is the machine-readable `code` already logged under
-  Open items, now filed as **#733** `[2608-DEV-733]`.
-- DECISION (#718, from REVIEW): CodeRabbit's 🟡 test-fidelity finding was **correct and taken**.
-  `member-registration.test.ts`'s ADOPT P0718 test seeded `cancelled_at: null`, and the trigger
-  returns at `:79` for an active same-event pre-image, so it asserted on a rejection the database
-  cannot produce. Now seeds a cancelled row — the one adoption shape that genuinely re-seats a
-  registrant, since the adopt lookup does not filter on `cancelled_at`
-  (`member-registration.ts:250-256`).
-- DECISION (#715, from PLAN): sharer notifications are **notifications, not transactional mail** —
-  they now dispatch through `sendNotificationEmail`, so `email_config.enabled` and the per-template
-  toggle both apply. The sharer did not request each message. Consequence accepted: flipping the
-  master switch off silences sharer mail too. Guest magic links stay transactional.
-- DECISION (#715, from PLAN): fallback order is `contact_email` → **Clerk primary email**, not the
-  issue's option 2 (require `contact_email` before minting a share link). `contact_email` is a
-  preference and may be deliberately blank; Clerk's primary is the verified backstop. Profiles with
-  no `clerk_id` (admin-created spouse/co-owner rows) keep the silent skip — no address exists.
-- DECISION (#715, from PLAN): the cap bucket is **template-scoped**, unlike
-  `guest-event-changes.ts`'s recipient-wide bucket — a registration burst through a viral link must
-  not consume the budget that would otherwise deliver the cancellation notice. 10 per 24h.
-- DECISION (#715, from BUILD): **no migration.** Keys absent from
-  `notification_config.email_settings.notification_types` already pass the gate
-  (`lib/email/send.ts:131` compares `=== false`), so the three admin toggles need no seed row — the
-  panel writes the key on first toggle.
-- DECISION (#713, from PLAN): the issue's **option 1** (resolve before any write), not option 2
-  (degrade after). The `feed.ics` precedent at `:59-64` degrades *after* the point of no return
-  because a feed has nothing to commit; `registerGuest` does. Hoisting is strictly better: the guest
-  either registers and gets a link, or gets a clear error and is not silently half-signed-up.
-- DECISION (#713, from PLAN): the Vercel fallback is a **positive allowlist** on
-  `VERCEL_ENV === 'preview' | 'development'`, never `!== 'production'` — an unset or unknown
-  `VERCEL_ENV` must not enable it. Production keeps the throw: a `*.vercel.app` magic link in a
-  member's inbox is unbranded and phishing-shaped, and a prod misconfig should stay loud.
-- DECISION (#713, from PLAN): `VERCEL_PROJECT_PRODUCTION_URL` is **omitted**. It did not appear in
-  the Vercel docs search, and an unverified env var name is a guess.
-- DECISION (#713, from PLAN): `.env.example` keeps `NEXT_PUBLIC_APP_URL` **optional**. Promoting it
-  to required would fail `npm run check:env` on the local box for no gain once the fallback exists.
+- DECISION (#726, from PLAN): take the issue's **first** suggested fix (un-scope the actions), not
+  the "compact footer on the Registrations tab" variant — the footer duplicates the action row's
+  render conditions in two places and drifts the moment either changes.
+- DECISION (#726, from PLAN): depart from the suggestion's *structure*. The actions stay inside the
+  existing bordered container and it is the META CONTENT that becomes conditional, rather than
+  lifting the actions into a sibling block. A sibling block adds a second `border-b` hairline to the
+  Roles tab, which has no bug. The container is skipped entirely when neither half has anything to
+  render, so an event with `allow_guest_registration = false` shows no empty 24px strip.
+- DECISION (#726, from PLAN): the `cal.attendForLink` hint STAYS tab-scoped with the meta, even
+  though the issue lists it among the things that disappear. It exists solely to explain an absent
+  `meeting_url` (`EventPopupShell.tsx` D3 comment), and `meeting_url` is meta.
+- DECISION (#726): `showMeta` keeps its name — the change makes the name accurate for the first
+  time. One consumer, one prop, unchanged signature, so no REFERENCE SWEEP is triggered.
 
 ## Facts
-- BASELINE 2026-08-11 on `dev/2608-DEV-713@f8f3a3f`:
-  `npx vitest run lib/actions/guest-registration.test.ts lib/utils/base-url.test.ts lib/server/member-registration.test.ts`
-  -> 3 files / **57 passed**. Full `npx vitest run` -> 32 files / **423 passed**. `npx eslint .` ->
-  **0 errors / 465 warnings**. `npx tsc --noEmit` -> **1 error**, STALE GENERATED OUTPUT:
-  `.next/dev/types/validator.ts(566,39)` still references the route deleted by #709. Not a source
-  error; expect it until `.next` is regenerated.
-- Vercel system env vars confirmed against the Vercel docs: `VERCEL_ENV`, `VERCEL_URL`,
-  `VERCEL_BRANCH_URL` — all bare hostnames with no scheme, available at build AND runtime.
-  `VERCEL_PROJECT_PRODUCTION_URL` was NOT confirmable and is deliberately unused.
-- The member path already carried the #713 fix: `lib/server/member-registration.ts:62-104` wraps the
-  whole confirmation send in `try/catch`, and `lib/server/member-registration.test.ts:527` is named
-  `'never fails the attend when the link builder throws (#713 shape)'`. #713 was guest-path-only.
-- `getBaseUrl` call sites, all dispositioned in the #713 reference sweep:
-  `lib/actions/guest-registration.ts` (updated), `lib/server/member-registration.ts:74`,
-  `app/api/calendar/feed.ics/route.ts:64`, `app/api/calendar/feed-token/route.ts:21,45,81`,
-  `app/api/profile/spouse-link/route.ts:138` (all unaffected — each consumes the returned string).
+- `EventPopupShell` has exactly ONE consumer (`EventPopup.tsx:9`); `AttendSection` has exactly one
+  (`EventPopupShell.tsx:18`). There is no shared "popup action row" helper.
+- `EventActionsTabs.tsx:52-56` sets an explicit `role="tab"`, which OVERRIDES `<button>`'s implicit
+  role — `getByRole('button')` matches nothing there. Same trap as ATTEMPT 1 below.
+- `playwright.config.ts` never sets `fullyParallel`, so Playwright 1.61 parallelizes by FILE: tests
+  inside one spec run in declaration order in one worker, and DB state carries between them.
+- Authenticated e2e cannot run against `.env.local` — it holds PROD credentials. Use the DEV
+  override (`iymwxdewcpvpjgzewtzk`) documented in the no-local-Docker memory.
 - Production smoke 2026-08-11: `https://www.teamenjoyvd.com` 200, `/sign-in` 200.
 
 ## Done
-- #715 PLAN + CLAIM + BUILD (code complete, `6a3b29f` + the review fix) — RESULT: 6 files.
-  `lib/notifications/share-events.ts` gained `resolveSharerEmail` (contact_email → Clerk primary,
-  Clerk failure caught) and `sendShareNotification` (admin gates, then a template-scoped 10/24h
-  `consumeEmailCap`, then `sendNotificationEmail`); `EmailSettingsPanel.tsx` + `i18n/domains/admin/
-  content.ts` expose the three toggles; `lib/email/send.ts` JSDoc lists the new caller. `/code-review
-  low` found one real defect — the cap was spent BEFORE the gates, so a disabled template burned the
-  sharer's daily budget; fixed by re-checking `getEmailConfig()` ahead of `consumeEmailCap`, covered
-  by two new tests. Verified: `npx vitest run` -> 32 files / **443 passed** (baseline 441 on this
-  branch's parent + 2); `npx tsc --noEmit` -> only the pre-existing stale `.next` error;
-  `npx eslint` on the changed files -> clean.
-- #714 CLOSED — RESULT: merged as PR #729 (`c6ba2f2`), no migration, no prod gate.
-- #713 BUILD (code complete, `a97a7df`) — RESULT: 5 files. `lib/utils/base-url.ts` gained a
-  `normalizeHost` helper + the preview/development Vercel fallback; `lib/actions/guest-registration.ts`
-  hoists the resolve above every side effect in BOTH `registerGuest` and `resendGuestLink`;
-  `.env.example` documents the fallback. Verified: `npx vitest run` -> 32 files / **433 passed**
-  (baseline 423 + 10 new); `npx eslint .` -> 0 errors / 465 warnings (baseline 465);
-  `npx tsc --noEmit` -> only the pre-existing stale `.next` error.
-- #713 PLAN + CLAIM — RESULT: verdict READY; issue body carries the DoD, affected files, and four
-  PLAN corrections (member path already fixed; option 1 over option 2; fallback excludes production;
-  `.env.example` stays optional); Design Checklist 4/4; `## Branch dev/2608-DEV-713`; claim row
-  committed at `f8f3a3f` with the merged #710 row pruned in the same commit.
-- #702 epic updated — RESULT: all ten children (#703-#710) marked merged with their PR numbers, the
-  "In flight"/"Ready to pick" sections collapsed, and a new "Follow-ups discovered during this epic"
-  section lists #713 (in flight) plus unclaimed #714, #715, #718, #726, #727. The epic's feature
-  scope is complete; the follow-ups explicitly do not block closing it.
-- #710 CLOSED — RESULT: merged as PR #725 (`17fd786`); gated `Migrate Prod` run 31471066200 approved
-  by the user and succeeded (`Applying migration 20260811000000_...` -> `Finished supabase db push`,
-  ledger head after push `20260811000000`); production smoke 200/200. The #710 GCR fix (adopt
-  exactly one guest row under a `LOWER()` match, via a scalar subquery with
-  `ORDER BY g.created_at, g.id LIMIT 1`) is live in prod. LESSON from that review: a set-returning
-  predicate under a unique index needs its own LIMIT — a `NOT EXISTS` guard only covers a
-  PRE-EXISTING row, never multiple matches inside the same UPDATE.
-- #709 closed — RESULT: merged as PR #721 (`9288601`); tiered Registrations tab live.
-- #708 closed — RESULT: merged as PR #720 (`a11b89d`).
-- #722 closed — RESULT: merged as PR #724 (`ef0c3e1`), E2E aborts on a dead dev server.
+- #726 PLAN + CLAIM — RESULT: verdict READY; issue body carries the DoD, affected files, gotchas and
+  the structural correction to the issue's own suggestion; Design Checklist 4/4;
+  `## Branch dev/2608-DEV-726`; claim row committed at `2d301e9` against an EMPTY claims table (no
+  overlap: zero in-flight rows, zero open PRs at claim time).
+- #726 BUILD (code complete, `caf0fc0`) — RESULT: 3 files, +117/-100 (most of it reindentation).
+  Verified as recorded under `## Now`: tsc clean, eslint at baseline, `/code-review low` zero
+  findings, and the authenticated e2e spec 5/5 green locally against DEV with the new test proven
+  red-then-green. Remaining gate is the PR itself (Vercel preview READY + CI green), which needs a
+  push grant — see `## Next` item 2.
+- #718 MERGED — RESULT: PR #732 -> `4ac7228`. `guest_capacity` is now DB-enforced by
+  `trg_enforce_event_guest_capacity` (SQLSTATE `P0718`) on DEV; the race was proven closed there
+  with two pg_cron workers on the same tick (B took the advisory lock and committed, A blocked
+  ~79ms, re-counted and raised). **Prod migration gate still unapproved — see `## Next` item 6.**
+- #715 merged (PR #731, `ddaa2e5`). #714 merged (`c6ba2f2`). #713 merged (`2f82d80`).
+  #710 fully DONE incl. prod, ledger head `20260811000000`. #709 (PR #721), #708 (PR #720),
+  #722 (PR #724) merged.
 
 ## Open items
-- NOTED (not done, same-class defect, out of #715's scope): `lib/email/send.ts:129` still reads
-  `if (!config.enabled) return` — the exact check #715 tightened to `!== true` at
-  `share-events.ts:135`. `enabled` is typed `boolean` but comes from a JSONB column through an
-  `as EmailConfig` cast (`send.ts:35`), so a malformed row holding `"true"` or `1` makes the master
-  kill switch fail OPEN there. Repo-wide sweep found exactly one remaining instance (the two
-  `EmailSettingsPanel.tsx` hits are display-only toggles). One-line fix, needs its own ticket.
-- FLAKE (2026-08-11, PR #731, not a spec defect): the `Authenticated E2E (Clerk)` job failed with 21
-  tests red across `payments-guest`, `payments-on-behalf`, `profile-bento-auth` and the 390px share
-  specs — every one at `clerk.signIn()`, with 5x `[Clerk Testing] FAPI request failed after 4
-  attempts` against `loved-mole-75.clerk.accounts.dev`. No assertion ever ran. The run took 18m25s
-  because 60s timeout x retry x ~10 tests, vs a 6m baseline. Re-run of the SAME commit passed in
-  5m50s. Clerk's dev FAPI was transiently down; do not "fix" this in the specs.
-- FIXED (2026-08-12, in PR #732) — a DIFFERENT flake from the one above, and a real spec defect:
-  `payments-on-behalf.spec.ts:169` went red on run 31532749854 with 30s of "element(s) not found"
-  for a button that only exists on `/profile`. Cause: `clerk.signIn()` resolves on
-  `waitForFunction(() => window.Clerk?.user !== null)` (@clerk/testing 2.2.7) — an in-memory CLIENT
-  signal — while `proxy.ts:14-21` authorises `/profile` SERVER-side from the session cookie and
-  answers `NextResponse.redirect('/sign-in')` when it cannot resolve a userId. A `goto` on the next
-  line can be decided against a cookie the browser has not finished writing, and the test then fails
-  naming the missing element rather than the redirect that actually happened. Fixed by
-  `e2e/auth-helpers.ts` (`gotoProtected` re-navigates until the path sticks — a retry loop, not
-  `expect.poll`, because a cold Turbopack compile can make a SUCCESSFUL goto take ~80s and a poll
-  deadline would abort it). Both payments specs adopted it; they were byte-identical and carried the
-  identical bug.
-- NOTED (not done, out of #718's scope, FILED as **#734** `[2608-DEV-734]`): seven other e2e specs still do
-  `clerk.signIn()` followed by a navigation without waiting for the server to honour the session —
-  `profile-bento-auth.spec.ts:34-35` (`/profile`, the same shape as the two fixed specs),
-  `member-attend-auth.spec.ts:127,179,227`, `event-registrations-auth.spec.ts:232,250,268,287`,
-  `admin-auth.spec.ts:24`, `admin-mobile-auth.spec.ts:57`, `member-share-register-auth.spec.ts:150`,
-  `los-submission-auth.spec.ts:41`. Deliberately NOT converted inside #718 — an unrelated
-  cross-cutting e2e change does not belong in a capacity-trigger PR, and `profile-bento-auth` in
-  particular has its own diagnosed cause in #727 (401 eviction after `page.reload()`) that this
-  helper would mask rather than fix.
-- CI (2026-08-12, in PR #732): the authenticated-E2E artifact upload was gated on `failure()`, but
-  `retries: 1` means a flaky spec passes on attempt 2 and the JOB goes green — throwing away the
-  trace for the one run with something to explain, which is exactly what happened to the flake
-  above. Now `!cancelled()` with `if-no-files-found: ignore`.
+- FLAKE (not a spec defect, found 2026-08-12): `member-attend-auth.spec.ts:136` can fail on the
+  FIRST local run against a cold dev server — `openEventPopup` waits only for the dialog to be
+  visible, so the assertion's 5s default timeout can expire while the popup still shows its `…`
+  loading placeholder (the failure's DOM snapshot was literally `dialog: text: …`). Warm, it is
+  `3/3 pass isolated` and the whole file is 5/5. Warm the server (`curl localhost:3000/`) before
+  running, or hoist the wait into `openEventPopup`. Not touched here — out of #726's scope.
+- NOTED (not done, tooling): `scripts/check-env.js:73-77` resolves `.env.development.local` then
+  `.env.local` then `process.env` — files BEAT exported vars, the reverse of the runtime precedence
+  in `playwright.config.ts:10-20` and `@next/env`. So `npm run check:env` printed
+  "Supabase target: LOCAL stack (127.0.0.1)" during a session whose exported vars correctly pointed
+  the dev server and Playwright at DEV. The CLAUDE.md instruction to trust it before touching hosted
+  data is therefore wrong for the exported-override workflow. Needs its own ticket.
+- Still open from #715: five call sites silently skip on a null `contact_email`
+  (`lib/abo/verifyAbo.ts:226`, both spouse-link routes,
+  `app/api/admin/members/verify/[id]/route.ts:99`, `lib/server/member-registration.ts`) — a shared
+  `resolveProfileEmail()` would fix all six.
+- NOTED (not done, same-class as #715): `lib/email/send.ts:129` still reads `if (!config.enabled)`,
+  the exact check #715 tightened to `!== true`. `enabled` comes from JSONB through an
+  `as EmailConfig` cast, so a row holding `"true"` or `1` makes the master kill switch fail OPEN.
+  Repo-wide sweep: exactly one remaining instance. One-line fix, needs its own ticket.
 - NOTED (not done, out of #713's scope): `app/api/calendar/feed-token/route.ts:21,45,81` and
   `app/api/profile/spouse-link/route.ts:138` still `await getBaseUrl()` unguarded. Neither commits
-  irreversible state first, so neither has the #713 half-success shape — they just 500 on a
-  misconfigured environment, which the Vercel fallback now prevents on previews. No ticket filed.
-- NOTED (not done, same-class defect found by `/code-review medium` on #710): the case-sensitive
-  email match fixed in the #710 RPC also exists in TypeScript at
-  `lib/server/member-registration.ts:239` — `.eq('email', contactEmail)` in `attendEvent`'s D9
-  adopt step. A member who signed up as `Ivan@Example.com` is not adopted and gets a second row.
-  Fixing it needs either a citext/lower() index or a `.ilike()` lookup — its own ticket.
-- **#726** `[2608-DEV-726]` `bug` (unclaimed, FILED 2026-08-11 from the #710 review): `EventPopup.tsx:156`'s
-  `showMeta = activeTab !== 'registrations'` now applies to EVERY role, and
-  `EventPopupShell.tsx:169-214` puts `AttendSection` + the share/QR buttons inside that gate. A
-  member who opens the Registrations tab loses the Attend button with no affordance explaining why.
-  A new regression from #721, not a carried one.
-- **#727** `[2608-DEV-727]` `bug` `priority:high` (unclaimed, FILED 2026-08-11): a transient 401 while
-  Clerk refreshes the session token makes `lib/apiClient.ts:29-33` set
-  `window.location.href = '/sign-in'`, evicting a still-valid session. PROVED from the PR #725
-  Playwright traces: a 5-endpoint 401 burst at t=180726ms right after `page.reload()`, then
-  `200 GET /api/profile` 7ms later, then the `/sign-in` navigations. This — NOT leftover collapse
-  state — is what makes `e2e/profile-bento-auth.spec.ts` intermittently red (`:72` and `:154`).
-  Supersedes the earlier "order/state-dependent" note, which was a wrong diagnosis.
-- **#718** `[2608-DEV-718]` `bug` (unclaimed): capacity-check TOCTOU race, same shape in
-  `guest-registration.ts` and `member-registration.ts` — no DB-level guard on `guest_capacity`.
-  #710 moved that read-then-write shape into the helper; it does NOT close the race.
-- **#714** `[2608-DEV-714]` `chore` `priority:high` (docs mislabel the prod Supabase ref) and
-  **#715** `[2608-DEV-715]` `bug` (sharer notifications: no `contact_email` fallback, no email cap)
-  — both unclaimed, both from #706.
-- NOTED (not done, out of scope — merged in #724): `e2e/server-watchdog-reporter.ts:57` calls
-  `process.exit(1)`, which skips Playwright's `test.afterAll`. If the dev server dies during
-  `e2e/event-registrations-auth.spec.ts`, its cleanup (`:164-171`) never runs and the seeded event,
-  share links and registrations are orphaned in the shared DEV project.
-- NOTED (not done, out of scope — merged in #721): `types/supabase.ts:2370` types the
-  `get_event_registrations_for_viewer` returns `email`, `profile_id`, `sharer_name`, `attended_at`
-  and `cancelled_at` as non-nullable `string`, but all five are NULL in normal operation. The
-  current caller casts to `EventRegistration` (correctly nullable); the next caller that trusts the
-  generated type dereferences a null with no compiler warning.
-- NOTED (not done, found during #709): the DEV ledger has NO `20260809000100` row (#706
-  `fn_schedule_guest_reminders_record`), though prod does. Function-body-only, so
-  `types/supabase.ts` is unaffected, but hosted DEV may be running the pre-#706 body.
-- NOTED (FILED 2026-08-12 as **#733** `[2608-DEV-733]`; declined CodeRabbit finding on #720 AND
-  again on #732): client error copy is
-  selected by matching ENGLISH server text — `MemberAttendPanel.tsx:73-78` and
-  `app/(dashboard)/calendar/components/EventPopup.tsx:76-78` both do `raw.includes('capacity')`.
-  A real fix needs a machine-readable `code` on `attendEvent`'s failure result, through
-  `app/api/events/[id]/attend/route.ts`, surfaced on `ApiError` (`lib/apiClient.ts:13`).
-- NOTED (not done, found during #708): a signed-in member blocked by a FULL event still gets
-  `ResendLinkForm` — the guest magic-link resend — at `app/events/[eventId]/register/page.tsx:179`
-  and `:216`. Wrong flow for a portal identity; pre-existing blocked branch.
-- NOTED (not done): `app/events/[eventId]/join/components/JoinActions.tsx:30-39` (`downloadIcs`)
-  still has the detached-anchor + synchronous-`revokeObjectURL` pattern fixed in
-  `AddToCalendarMenu.tsx` — same latent no-file-downloaded bug in Firefox/Safari. Needs its own ticket.
-- NOTED (not done): `docs/ai/REF.md` §6 Edge Functions table still lists `send-event-reminders`
-  (does not exist) and omits `deliver-email-notifications`; §5's `guest_registrations` row is still
-  the pre-#705 column list.
-- CodeRabbit's "run member-share-register-auth serially" finding (#720) was DISPROVED, not deferred:
-  `playwright.config.ts` never sets `fullyParallel`, so Playwright 1.61 parallelizes by FILE. Do not
-  "fix" this later.
+  irreversible state first, so neither has the #713 half-success shape. No ticket filed.
+- NOTED (same-class, found on #710): the case-sensitive email match fixed in the #710 RPC also
+  exists in TypeScript at `lib/server/member-registration.ts:239` — `.eq('email', contactEmail)` in
+  `attendEvent`'s D9 adopt step. `Ivan@Example.com` is not adopted and gets a second row. Needs a
+  citext/lower() index or `.ilike()` — its own ticket.
+- NOTED (merged in #724): `e2e/server-watchdog-reporter.ts:57` calls `process.exit(1)`, skipping
+  Playwright's `test.afterAll`. If the dev server dies during `event-registrations-auth.spec.ts`,
+  its cleanup (`:164-171`) never runs and seeded rows are orphaned in the shared DEV project.
+- NOTED (merged in #721): `types/supabase.ts:2370` types five
+  `get_event_registrations_for_viewer` returns (`email`, `profile_id`, `sharer_name`,
+  `attended_at`, `cancelled_at`) as non-nullable `string`, but all five are NULL in normal
+  operation. The current caller casts correctly; the next one that trusts the generated type
+  dereferences a null with no compiler warning.
+- NOTED (found during #708): a signed-in member blocked by a FULL event still gets `ResendLinkForm`
+  — the guest magic-link resend — at `app/events/[eventId]/register/page.tsx:179` and `:216`.
+  Wrong flow for a portal identity; pre-existing blocked branch.
+- NOTED: `app/events/[eventId]/join/components/JoinActions.tsx:30-39` (`downloadIcs`) still has the
+  detached-anchor + synchronous-`revokeObjectURL` pattern fixed in `AddToCalendarMenu.tsx` — same
+  latent no-file-downloaded bug in Firefox/Safari. Needs its own ticket.
+- NOTED: `docs/ai/REF.md` §6 Edge Functions table still lists `send-event-reminders` (does not
+  exist) and omits `deliver-email-notifications`; §5's `guest_registrations` row is still the
+  pre-#705 column list.
+- FLAKE (not a spec defect): `Authenticated E2E (Clerk)` can fail wholesale at `clerk.signIn()` with
+  `[Clerk Testing] FAPI request failed after 4 attempts` against `loved-mole-75.clerk.accounts.dev`
+  — no assertion ever runs and the job takes ~3x baseline. Clerk's dev FAPI being transiently down.
+  Re-run the same commit; do not "fix" it in the specs.
+- CodeRabbit's "run member-share-register-auth serially" finding (#720) was DISPROVED, not deferred
+  — see the `fullyParallel` fact above. Do not "fix" this later.
+- CodeRabbit's "localize the member capacity error" was DECLINED TWICE (#720, #732): the client
+  selects copy by matching ENGLISH server text (`MemberAttendPanel.tsx:73-78`,
+  `EventPopup.tsx:76-78`, both `raw.includes('capacity')`), so returning Bulgarian makes BOTH
+  matchers miss. The real fix is #733's machine-readable `code`.
 
 ## Failed attempts
 - ATTEMPT 1 [L1] (#709 GCR): adding an explicit `role="tab"` to the tab-bar buttons broke all 4

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -9,6 +9,19 @@ PLAN, CLAIM and BUILD are complete. **PR #735 is open as a DRAFT**, `MERGEABLE`,
 checks green on `17bc5a7` — including `Authenticated E2E (Clerk)` in 6m5s (a real run, not the
 old vacuous skip) and `390px smoke vs preview` in 2m32s; Vercel reports "Deployment has
 completed". Branch pushed 2026-08-12 under an explicit grant.
+GCR run against PR #735 (2026-08-12): CodeRabbit posted 3 inline comments even though its CHECK
+reported "Review skipped: draft pull request" — never trust the check status, always fetch
+`pulls/N/comments`. 2 applied in full, 1 applied in part:
+- `EventPopupShell.tsx:78` explicit comparisons in `showActions` (Major) — APPLIED. Dropped
+  CodeRabbit's `event !== null`: the prop type is `EventDetail | undefined` and the value comes
+  from `useQuery`, whose `data` is never null.
+- `member-attend-auth.spec.ts` `clearMemberRegistration` now throws on the delete error (Minor) —
+  APPLIED, matching `seedMemberRegistration`.
+- `check-env.js` empty-value contract (Major) — APPLIED the resolver half: DEFINED wins at each
+  level, empty included, mirroring `@next/env` and `scripts/*`'s `loadEnvFile` (both assign only
+  when `=== undefined`). SKIPPED the "add regression cases" half: no `scripts/*.test.js` harness
+  exists and `check-env.js` runs side effects at require time incl. `process.exit`, so testing it
+  needs the resolver extracted into a module — a refactor, not a review fix. Needs its own ticket.
 Remaining before merge: the human 390px eyeball on BOTH tabs (the "no visual change on the Roles
 tab" claim is the one item no check covers), then mark ready -> one CodeRabbit pass (it skipped
 while the PR is a draft) -> fix findings in ONE batched push.
@@ -167,6 +180,17 @@ re-running it fails on `getByRole('dialog').getByRole('button', { name: /^attend
   selects copy by matching ENGLISH server text (`MemberAttendPanel.tsx:73-78`,
   `EventPopup.tsx:76-78`, both `raw.includes('capacity')`), so returning Bulgarian makes BOTH
   matchers miss. The real fix is #733's machine-readable `code`.
+
+## Facts (added 2026-08-12, GCR #735)
+- Killing a background task wrapper does NOT necessarily kill `next dev` — the node process can
+  survive holding the port, and losing its stdout pipe makes every write throw
+  `write EPIPE` as an uncaughtException, which kills Next's render WORKERS. The server then still
+  answers `/` from cache (a naive curl health check says 200) while every route needing a worker
+  500s with "Jest worker encountered 2 child process exceptions". Start it with stdout redirected
+  to a log file, and health-check a real route, not `/`.
+- Local authenticated e2e is NOT trustworthy on a cold server: a full run right after start gave
+  3 failures that all passed once warm. Only a warm-server run is evidence. A/B against a stash
+  proved this: stashed passed, restored ALSO passed, so the first A/B reading was itself noise.
 
 ## Failed attempts
 - ATTEMPT 1 [L1] (#709 GCR): adding an explicit `role="tab"` to the tab-bar buttons broke all 4

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -5,7 +5,13 @@ event meta, with nothing on screen explaining why. A regression from #721, which
 the tab bar that makes the state reachable.
 
 ## Now
-PLAN and CLAIM are complete; BUILD is code-complete and committed locally, **not pushed**.
+PLAN, CLAIM and BUILD are complete. **PR #735 is open as a DRAFT**, `MERGEABLE`, with all 11
+checks green on `17bc5a7` — including `Authenticated E2E (Clerk)` in 6m5s (a real run, not the
+old vacuous skip) and `390px smoke vs preview` in 2m32s; Vercel reports "Deployment has
+completed". Branch pushed 2026-08-12 under an explicit grant.
+Remaining before merge: the human 390px eyeball on BOTH tabs (the "no visual change on the Roles
+tab" claim is the one item no check covers), then mark ready -> one CodeRabbit pass (it skipped
+while the PR is a draft) -> fix findings in ONE batched push.
 - Issue #726 body now carries the PLAN, a file-path-level DoD, Affected Files, Gotchas, Migration &
   Test Impact, `## Design Checklist` (4/4) and `## Branch dev/2608-DEV-726`.
 - `2d301e9` — claim row in `docs/CLAIMS.md` (migration: no). `caf0fc0` — the fix.
@@ -37,10 +43,10 @@ re-running it fails on `getByRole('dialog').getByRole('button', { name: /^attend
 
 ## Next
 1. ~~`/code-review low` on the branch diff~~ — DONE, zero findings.
-2. **BLOCKED ON THE USER:** ask for a push grant, push `dev/2608-DEV-726`, open the PR **as a
-   draft** with `Closes #726`. Nothing else on this ticket can proceed without it.
-3. CI green + Vercel preview READY. Then eyeball the preview at 390px on both tabs — the DoD's
-   "no visual change on the Roles tab" claim is the one item no automated check covers.
+2. ~~push + open the draft PR~~ — DONE, PR #735.
+3. ~~CI green + Vercel preview READY~~ — DONE, 11/11 on `17bc5a7`. Still to do: eyeball the
+   preview at 390px on both tabs — the DoD's "no visual change on the Roles tab" claim is the one
+   item no automated check covers, and it needs a signed-in member so it cannot be automated here.
 4. Mark ready -> one CodeRabbit pass -> fix findings in ONE batched push.
 5. Merge -> GCR: prune the `#726` claim row (fold into this PR's own commits, per Constraints),
    close #726. **No migration**, so no prod gate for this ticket.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -88,6 +88,19 @@ re-running it fails on `getByRole('dialog').getByRole('button', { name: /^attend
 - Production smoke 2026-08-11: `https://www.teamenjoyvd.com` 200, `/sign-in` 200.
 
 ## Done
+- Two findings from the #726 verification pass, FIXED on this branch at the user's explicit
+  instruction (they are not #726 defects — flagged as scope-mixing when asked):
+  1. `e2e/member-attend-auth.spec.ts` `openEventPopup` now waits for the dialog to contain the real
+     event title, not merely to be visible. The dialog turns visible while `EventPopupShell` still
+     renders its `…` loading placeholders, so on a cold dev server a caller's 5s default expect
+     timeout could land on the loading state (observed: snapshot `dialog: text: …`). Uses the same
+     15s budget as the existing `eventButton` wait. NOT re-reproduced cold — a restart keeps
+     Turbopack's persistent cache — so the fix is targeted at the observed state, not a repro.
+  2. `scripts/check-env.js` `resolveValue` now resolves `process.env` BEFORE the two env files,
+     matching `@next/env` (which only fills a key absent from the initial `process.env` snapshot)
+     and `playwright.config.ts:10-20`. Empty is unset at every level; the file pair keeps Next's
+     relative order. Verified both branches: no exports -> `LOCAL stack (127.0.0.1)`; with the DEV
+     vars exported -> `DEV project (iymwxdewcpvpjgzewtzk) — safe for local writes`.
 - #726 PLAN + CLAIM — RESULT: verdict READY; issue body carries the DoD, affected files, gotchas and
   the structural correction to the issue's own suggestion; Design Checklist 4/4;
   `## Branch dev/2608-DEV-726`; claim row committed at `2d301e9` against an EMPTY claims table (no
@@ -106,18 +119,6 @@ re-running it fails on `getByRole('dialog').getByRole('button', { name: /^attend
   #722 (PR #724) merged.
 
 ## Open items
-- FLAKE (not a spec defect, found 2026-08-12): `member-attend-auth.spec.ts:136` can fail on the
-  FIRST local run against a cold dev server — `openEventPopup` waits only for the dialog to be
-  visible, so the assertion's 5s default timeout can expire while the popup still shows its `…`
-  loading placeholder (the failure's DOM snapshot was literally `dialog: text: …`). Warm, it is
-  `3/3 pass isolated` and the whole file is 5/5. Warm the server (`curl localhost:3000/`) before
-  running, or hoist the wait into `openEventPopup`. Not touched here — out of #726's scope.
-- NOTED (not done, tooling): `scripts/check-env.js:73-77` resolves `.env.development.local` then
-  `.env.local` then `process.env` — files BEAT exported vars, the reverse of the runtime precedence
-  in `playwright.config.ts:10-20` and `@next/env`. So `npm run check:env` printed
-  "Supabase target: LOCAL stack (127.0.0.1)" during a session whose exported vars correctly pointed
-  the dev server and Playwright at DEV. The CLAUDE.md instruction to trust it before touching hosted
-  data is therefore wrong for the exported-override workflow. Needs its own ticket.
 - Still open from #715: five call sites silently skip on a null `contact_email`
   (`lib/abo/verifyAbo.ts:226`, both spouse-link routes,
   `app/api/admin/members/verify/[id]/route.ts:99`, `lib/server/member-registration.ts`) — a shared

--- a/e2e/member-attend-auth.spec.ts
+++ b/e2e/member-attend-auth.spec.ts
@@ -98,8 +98,12 @@ function visible(page: Page, locator: Locator): Locator {
  * makes a bare insert fail once an earlier test in this file has registered
  * this member — a soft cancel leaves the row in place.
  */
-async function seedMemberRegistration() {
+async function clearMemberRegistration() {
   await sb!.from('guest_registrations').delete().eq('event_id', eventId!).eq('profile_id', memberProfileId!)
+}
+
+async function seedMemberRegistration() {
+  await clearMemberRegistration()
   const { error } = await sb!
     .from('guest_registrations')
     .insert({
@@ -210,6 +214,50 @@ test.describe('member token-free join @auth', () => {
 
     await page.goto(`/events/${eventId}/join`)
     await expect(page.getByText(/this link is invalid/i).first()).toBeVisible({ timeout: 15_000 })
+  })
+})
+
+// -- 2608-DEV-726: the action row is not tab-scoped ----------------------------
+
+test.describe('popup actions survive the Registrations tab @auth', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('Attend and Share stay visible while the Registrations tab is open', async ({ page }) => {
+    skipIfUnseeded()
+
+    // The regression is about a member who has NOT attended yet: they open the
+    // roster to see who is coming, and then cannot get back to the button.
+    await clearMemberRegistration()
+
+    await page.goto('/')
+    await clerk.signIn({ page, emailAddress: MEMBER_EMAIL })
+    await openEventPopup(page)
+
+    const dialog = page.getByRole('dialog')
+    const attend = dialog.getByRole('button', { name: /^attend$/i })
+    const share = dialog.getByRole('button', { name: /share event/i })
+    await expect(attend).toBeVisible({ timeout: 15_000 })
+    await expect(share).toBeVisible()
+
+    // role="tab", not "button": EventActionsTabs sets an explicit role="tab" on
+    // these, which overrides <button>'s implicit one, so getByRole('button')
+    // matches nothing.
+    await dialog.getByRole('tab', { name: /registrations/i }).click()
+    await expect(dialog.getByRole('tabpanel')).toBeVisible()
+
+    // Before 2608-DEV-726 both vanished with the meta block, leaving the tab
+    // with no way to attend and no affordance explaining why.
+    await expect(attend).toBeVisible()
+    await expect(share).toBeVisible()
+
+    // The meta itself IS still tab-scoped — this asserts the gate was split,
+    // not simply deleted.
+    await expect(dialog.getByText(/attend to see the meeting link/i)).toHaveCount(0)
+
+    // html { overflow-x: hidden } clips visually without shrinking scrollWidth,
+    // so this still detects a real 390px overflow from the extra row.
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth)
+    expect(overflow).toBeLessThanOrEqual(0)
   })
 })
 

--- a/e2e/member-attend-auth.spec.ts
+++ b/e2e/member-attend-auth.spec.ts
@@ -120,7 +120,15 @@ async function openEventPopup(page: Page) {
   const eventButton = visible(page, page.locator('[role="row"] button', { hasText: EVENT_TITLE })).first()
   await expect(eventButton, `seeded event "${EVENT_TITLE}" not visible on the current month view`).toBeVisible({ timeout: 15_000 })
   await eventButton.click()
-  await expect(page.getByRole('dialog')).toBeVisible()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  // The dialog turns visible BEFORE the event detail resolves: EventPopupShell
+  // renders '…' placeholders for the category and title while isLoading. On a
+  // cold dev server that fetch can outlast a caller's 5s default expect
+  // timeout, so a caller asserting on popup CONTENT races the loading state
+  // (observed 2026-08-12: the failure snapshot was literally `dialog: text: …`).
+  // Waiting for the real title here fixes it once for every caller.
+  await expect(dialog).toContainText(EVENT_TITLE, { timeout: 15_000 })
 }
 
 test.describe('member one-tap attend @auth', () => {

--- a/e2e/member-attend-auth.spec.ts
+++ b/e2e/member-attend-auth.spec.ts
@@ -99,7 +99,15 @@ function visible(page: Page, locator: Locator): Locator {
  * this member — a soft cancel leaves the row in place.
  */
 async function clearMemberRegistration() {
-  await sb!.from('guest_registrations').delete().eq('event_id', eventId!).eq('profile_id', memberProfileId!)
+  const { error } = await sb!
+    .from('guest_registrations')
+    .delete()
+    .eq('event_id', eventId!)
+    .eq('profile_id', memberProfileId!)
+  // Fail loudly, like the insert below: a silent cleanup failure leaves the
+  // member registered, and the caller then fails much later on a missing
+  // Attend button — a symptom that looks nothing like its cause.
+  if (error) throw new Error(`Failed to clear member registration: ${error.message}`)
 }
 
 async function seedMemberRegistration() {

--- a/scripts/check-env.js
+++ b/scripts/check-env.js
@@ -11,6 +11,11 @@
  * pair keeps Next.js's relative order. Empty values count as missing. Prints
  * missing names only, never values.
  *
+ * Resolution contract: the FIRST source that DEFINES the key wins, even if its
+ * value is empty; only a wholly undefined key falls through to the next source.
+ * This mirrors @next/env and scripts/*'s loadEnvFile, both of which assign only
+ * when the key is `=== undefined`. An empty winner is then reported missing.
+ *
  * Vars listed below a `# --- optional ---` line in .env.example only warn.
  *
  * Also classifies NEXT_PUBLIC_SUPABASE_URL as LOCAL / DEV / anything else
@@ -80,10 +85,17 @@ function resolveValue(name) {
   // invisible: with the DEV project exported, this printed "LOCAL stack
   // (127.0.0.1)" from a stale .env.development.local while the dev server and
   // Playwright were correctly on DEV. Empty counts as unset at every level.
+  // DEFINED wins at each level, even when the value is empty — do not "skip
+  // the empty one and try the next source". Both @next/env and the seed
+  // scripts' loadEnvFile assign only when the key is `=== undefined`, so an
+  // exported KEY= (empty) shadows every file and the app really does receive
+  // ''. Falling through to the next source here would let check:env certify a
+  // value nobody will get, which is the one thing this script exists to
+  // prevent. An empty result reaches isMissing() and is reported missing.
   const exported = process.env[name]
-  if (exported !== undefined && exported !== '') return exported
-  if (devLocalVars[name] !== undefined && devLocalVars[name].value !== '') return devLocalVars[name].value
-  if (localVars[name] !== undefined && localVars[name].value !== '') return localVars[name].value
+  if (exported !== undefined) return exported
+  if (devLocalVars[name] !== undefined) return devLocalVars[name].value
+  if (localVars[name] !== undefined) return localVars[name].value
   return undefined
 }
 

--- a/scripts/check-env.js
+++ b/scripts/check-env.js
@@ -5,10 +5,11 @@
  * reading env files directly (plain `node` does not auto-load env files —
  * the PR #544 version checked process.env only and always failed).
  *
- * Sources, in order: .env.development.local values (if present, mirrors
- * Next.js precedence), then .env.local values, then process.env (CI/exported
- * shells). Empty values count as missing. Prints missing names only, never
- * values.
+ * Sources, in order: process.env (CI / an exported shell override), then
+ * .env.development.local, then .env.local — process.env outranks both because
+ * that is what @next/env and playwright.config.ts do at runtime, and the file
+ * pair keeps Next.js's relative order. Empty values count as missing. Prints
+ * missing names only, never values.
  *
  * Vars listed below a `# --- optional ---` line in .env.example only warn.
  *
@@ -71,9 +72,19 @@ const devLocalPath = path.join(root, '.env.development.local')
 const devLocalVars = fs.existsSync(devLocalPath) ? parseEnvFile(devLocalPath) : {}
 
 function resolveValue(name) {
+  // process.env FIRST — this MUST match how the app and the tests resolve env,
+  // or the script certifies a target nobody is actually using. @next/env only
+  // takes a file value when the key is absent from the initial process.env
+  // snapshot, and playwright.config.ts does the same ("if (process.env[m[1]]
+  // === undefined)"). Resolving files first made an exported override
+  // invisible: with the DEV project exported, this printed "LOCAL stack
+  // (127.0.0.1)" from a stale .env.development.local while the dev server and
+  // Playwright were correctly on DEV. Empty counts as unset at every level.
+  const exported = process.env[name]
+  if (exported !== undefined && exported !== '') return exported
   if (devLocalVars[name] !== undefined && devLocalVars[name].value !== '') return devLocalVars[name].value
   if (localVars[name] !== undefined && localVars[name].value !== '') return localVars[name].value
-  return process.env[name]
+  return undefined
 }
 
 function isMissing(name) {


### PR DESCRIPTION
Closes #726

## The bug

A member who opened the calendar popup's **Registrations** tab lost the Attend button, the
share/QR buttons and the event meta, with nothing on screen explaining why. A regression from
#721, which gave plain members the tab bar that makes the state reachable.

## The fix

`EventPopupShell.tsx`'s outer branch became `event ? … : null`. `showMeta` now gates only the
date/time/`meeting_url`/`attendForLink` meta and the description. A new local
`showActions = !!event && event.allow_guest_registration && !isGuest` gates the action row, which
renders on **both** tabs inside the **same** `px-4 py-3 border-b` container as the meta — so the
Roles tab is pixel-identical. A sibling block would have added a second divider to a screen that
has no bug. `!isAdmin` still gates `AttendSection` alone.

Two deliberate departures from the issue's own suggestion:

- The issue's second variant (a compact footer on the Registrations tab) was rejected: it
  duplicates the action row's render conditions in two places and drifts the moment either changes.
- The `cal.attendForLink` hint **stays** tab-scoped with the meta, even though the issue lists it
  among the things that disappear. It exists solely to explain an absent `meeting_url`, and
  `meeting_url` is meta.

The container is skipped entirely when neither half has anything to render, so an event with
`allow_guest_registration = false` shows no empty strip.

## Verification

Run locally against the hosted **DEV** project (`iymwxdewcpvpjgzewtzk`), not just CI:

- `npx playwright test --project=authenticated e2e/member-attend-auth.spec.ts` -> **5 passed**
- The new regression test was proven **red first**: reverting only `EventPopupShell.tsx` to the
  pre-fix commit fails it on `getByRole('dialog').getByRole('button', { name: /^attend$/i })`,
  "element(s) not found" — the reported symptom exactly. Restored byte-identical, re-run green.
- `npx tsc --noEmit` -> clean. `npx eslint` -> 0 errors.
- `/code-review low` on the branch diff -> zero findings.

No unit test can cover this: `vitest.config.ts` includes only `lib|app/**/*.test.ts` and
`scripts/**/*.test.js` under `environment: 'node'`, and the repo has no `*.test.tsx` at all.

**No migration.** No prod gate for this ticket.

## Also in this PR (scope note)

Two findings surfaced by the verification pass, unrelated to #726, folded in on request rather
than spun out. Reviewers may want to read `17bc5a7` on its own:

1. `openEventPopup` returned as soon as the dialog was visible — which happens while the popup
   still renders its `…` loading placeholders — so a caller asserting on popup content could race
   the loading state on a cold dev server. It now waits for the real event title.
2. `scripts/check-env.js` resolved env **files** ahead of `process.env`, inverting what
   `@next/env` and `playwright.config.ts` actually do. An exported override was invisible to it:
   with the DEV project exported it still reported the stale local stack, so the one command
   CLAUDE.md says to trust before touching hosted data could name the wrong target.

## Reviewer check the automation cannot do

Eyeball the preview at 390px on **both** tabs. "No visual change on the Roles tab" is the one
claim no automated check covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Event actions such as Attend, Share, and QR access now remain available while switching between event tabs.
  - Date, time, link metadata, description, and meeting-link guidance are shown only on the relevant tab.
  - Improved mobile event popup behavior to prevent horizontal overflow.
  - Fixed event loading and registration state handling for more reliable attendance interactions.

- **Chores**
  - Clarified environment configuration precedence and handling of empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->