### PR TITLE
[2608-DEV-727] Stop a transient 401 from evicting a live Clerk session

### DIFF
--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #726 | `dev/2608-DEV-726` | `app/(dashboard)/calendar/components/popup/EventPopupShell.tsx`, `app/(dashboard)/calendar/components/EventPopup.tsx` (comment only), `e2e/member-attend-auth.spec.ts` — **migration: no** | 2026-08-12 |
+| #727 | `dev/2608-DEV-727` | `lib/apiClient.ts`, `lib/apiClient.test.ts` (new) — **migration: no** | 2026-08-12 |
 

--- a/lib/apiClient.test.ts
+++ b/lib/apiClient.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+/**
+ * 2608-DEV-727 — a transient 401 during a Clerk token refresh must not evict a
+ * live session.
+ *
+ * The race cannot be forced by hand (it depends on hitting the refresh window),
+ * which is why it went undiagnosed as CI flake for so long. Here the seam is
+ * mocked instead: `getToken` decides "refresh race" vs "really signed out", and
+ * `fetch` decides whether the replay succeeds. Everything the fix promises is
+ * expressible in those two.
+ *
+ * Every test loads a FRESH copy of the module: the single-flight promise and
+ * the redirect latch are module-level state, and a leaked latch would make a
+ * later test pass for the wrong reason.
+ */
+
+const getToken = vi.fn<(options?: { skipCache?: boolean }) => Promise<string | null>>()
+vi.mock('@clerk/nextjs', () => ({
+  getToken: (options?: { skipCache?: boolean }) => getToken(options),
+}))
+
+const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>()
+
+/** Every assignment is recorded, so "redirected ONCE" is assertable, not assumed. */
+let hrefWrites: string[] = []
+const windowStub = {
+  location: {
+    get href() { return hrefWrites[hrefWrites.length - 1] ?? '' },
+    set href(value: string) { hrefWrites.push(value) },
+  },
+}
+
+function json(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * A Response body can be read once. Real `fetch` hands back a fresh one per
+ * call, so any mock standing in for repeated calls must construct per call too
+ * — `mockResolvedValue(json(...))` replays one spent instance and fails with
+ * "Body is unusable" on the second read.
+ */
+function alwaysJson(status: number, body: unknown = {}) {
+  return async () => json(status, body)
+}
+
+async function loadClient() {
+  vi.resetModules()
+  return import('./apiClient')
+}
+
+beforeEach(() => {
+  hrefWrites = []
+  getToken.mockReset()
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+  vi.stubGlobal('window', windowStub)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('apiClient 401 handling', () => {
+  it('refreshes the session and replays once, without redirecting', async () => {
+    getToken.mockResolvedValue('fresh-token')
+    fetchMock
+      .mockResolvedValueOnce(json(401, { error: 'Unauthorized' }))
+      .mockResolvedValueOnce(json(200, { id: 'p1' }))
+
+    const { apiClient } = await loadClient()
+
+    await expect(apiClient<{ id: string }>('/api/profile')).resolves.toEqual({ id: 'p1' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(getToken).toHaveBeenCalledWith({ skipCache: true })
+    expect(hrefWrites).toEqual([])
+  })
+
+  it('redirects when the replay 401s too — a fresh token did not help', async () => {
+    getToken.mockResolvedValue('fresh-token')
+    fetchMock.mockImplementation(alwaysJson(401, { error: 'Unauthorized' }))
+
+    const { apiClient, ApiError } = await loadClient()
+
+    await expect(apiClient('/api/profile')).rejects.toBeInstanceOf(ApiError)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(hrefWrites).toEqual(['/sign-in'])
+  })
+
+  it('redirects without replaying when Clerk reports no session', async () => {
+    // null is Clerk's own "not signed in" answer — the genuine expiry case.
+    getToken.mockResolvedValue(null)
+    fetchMock.mockResolvedValueOnce(json(401, { error: 'Unauthorized' }))
+
+    const { apiClient } = await loadClient()
+
+    await expect(apiClient('/api/profile')).rejects.toMatchObject({ status: 401 })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(hrefWrites).toEqual(['/sign-in'])
+  })
+
+  it('does not evict the session when the refresh itself fails', async () => {
+    // ClerkOfflineError / clerk_runtime_load_timeout: Clerk broke, which says
+    // nothing about whether the user is signed in.
+    getToken.mockRejectedValue(new Error('clerk_offline'))
+    fetchMock.mockResolvedValueOnce(json(401, { error: 'Unauthorized' }))
+
+    const { apiClient } = await loadClient()
+
+    await expect(apiClient('/api/profile')).rejects.toMatchObject({ status: 401 })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(hrefWrites).toEqual([])
+  })
+
+  it('a concurrent burst refreshes once and recovers every call', async () => {
+    // The reported shape: five endpoints 401 within 5ms right after a reload.
+    getToken.mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve('fresh-token'), 5)),
+    )
+    let call = 0
+    fetchMock.mockImplementation(async () => (++call <= 5 ? json(401) : json(200, { ok: true })))
+
+    const { apiClient } = await loadClient()
+
+    const results = await Promise.all([
+      apiClient<{ ok: boolean }>('/api/profile'),
+      apiClient<{ ok: boolean }>('/api/calendar/feed-token'),
+      apiClient<{ ok: boolean }>('/api/profile/event-roles'),
+      apiClient<{ ok: boolean }>('/api/profile/vital-signs'),
+      apiClient<{ ok: boolean }>('/api/profile/payments'),
+    ])
+
+    expect(results).toEqual(Array(5).fill({ ok: true }))
+    expect(getToken).toHaveBeenCalledTimes(1)
+    expect(hrefWrites).toEqual([])
+  })
+
+  it('a burst that is really signed out redirects exactly once', async () => {
+    getToken.mockResolvedValue(null)
+    fetchMock.mockImplementation(alwaysJson(401))
+
+    const { apiClient } = await loadClient()
+
+    const settled = await Promise.allSettled(
+      Array.from({ length: 5 }, () => apiClient('/api/profile')),
+    )
+
+    expect(settled.every(r => r.status === 'rejected')).toBe(true)
+    expect(hrefWrites).toEqual(['/sign-in'])
+  })
+})
+
+describe('apiClient non-401 behaviour is unchanged', () => {
+  it('surfaces the JSON error body on a 400', async () => {
+    fetchMock.mockResolvedValueOnce(json(400, { error: 'This event has already ended.' }))
+
+    const { apiClient } = await loadClient()
+
+    await expect(apiClient('/api/events/e1/attend', { method: 'POST', body: '{}' })).rejects
+      .toMatchObject({ status: 400, message: 'This event has already ended.' })
+    expect(getToken).not.toHaveBeenCalled()
+  })
+
+  it('sets Content-Type for a JSON body but not for FormData', async () => {
+    fetchMock.mockImplementation(alwaysJson(200, {}))
+
+    const { apiClient } = await loadClient()
+
+    await apiClient('/api/x', { method: 'POST', body: '{"a":1}' })
+    await apiClient('/api/y', { method: 'POST', body: new FormData() })
+
+    const jsonHeaders = fetchMock.mock.calls[0][1]?.headers as Headers
+    const formHeaders = fetchMock.mock.calls[1][1]?.headers as Headers
+    expect(jsonHeaders.get('Content-Type')).toBe('application/json')
+    expect(formHeaders.get('Content-Type')).toBeNull()
+  })
+})

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -4,11 +4,14 @@
  * Provides:
  * - TypeScript generics (no `any` returns)
  * - `response.ok` check (fetch does not throw on 4xx/5xx)
- * - 401 interception (redirects to sign-in)
+ * - 401 recovery (refresh the session once, replay once, redirect only on proof
+ *   of sign-out — see `recoverFrom401`)
  * - `Content-Type: application/json` header (skipped for FormData or bodyless requests)
  *
  * Client-only — do NOT import in RSC pages, route handlers, or server actions.
  */
+
+import { getToken } from '@clerk/nextjs'
 
 export class ApiError extends Error {
   constructor(public status: number, message: string) {
@@ -17,20 +20,105 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * 2608-DEV-727. A 401 is NOT proof that the session ended.
+ *
+ * `proxy.ts:13-21` answers any API request Clerk cannot resolve a `userId` for
+ * with a 401, and that includes the brief window while Clerk is refreshing the
+ * session token. A page that issues its API burst inside that window (typically
+ * right after a reload) used to be hard-navigated to /sign-in with a perfectly
+ * live session: five endpoints 401'd within 5ms and the same endpoint answered
+ * 200 seven milliseconds later.
+ *
+ * So: force one token refresh, replay once, and navigate only when the refresh
+ * says the user really is signed out, or when the replay 401s too.
+ *
+ * Both pieces of state below are module-level ON PURPOSE. The burst is
+ * concurrent, so the decision has to be shared across in-flight calls — five
+ * independent decisions means the first loser still evicts everyone.
+ */
+let refreshInFlight: Promise<string | null> | null = null
+let redirecting = false
+
+/**
+ * Single-flight: a burst of 401s triggers ONE token fetch, and every caller
+ * awaits the same promise. Rejections propagate to all awaiters by design —
+ * see the call site, where a thrown Clerk error is explicitly not treated as a
+ * sign-out.
+ */
+function refreshSession(): Promise<string | null> {
+  if (!refreshInFlight) {
+    // getToken(): @clerk/shared 4.25.2 — resolves to the session token, or null
+    // when the user is not signed in. skipCache forces the round trip that
+    // rewrites the session cookie proxy.ts reads.
+    refreshInFlight = getToken({ skipCache: true }).finally(() => {
+      refreshInFlight = null
+    })
+  }
+  return refreshInFlight
+}
+
+/** Latched: the first caller navigates, the other four in the burst do not. */
+function redirectToSignIn(): void {
+  if (redirecting) return
+  redirecting = true
+  window.location.href = '/sign-in'
+}
+
+/**
+ * Returns true when the caller should replay the request once.
+ * Throws `ApiError(401)` when it should not, having redirected if — and only
+ * if — the user is genuinely signed out.
+ */
+async function recoverFrom401(): Promise<boolean> {
+  let token: string | null
+  try {
+    token = await refreshSession()
+  } catch {
+    // Clerk itself failed: offline, or it never loaded within its timeout
+    // (both are documented ClerkRuntimeError/ClerkOfflineError cases). That is
+    // not evidence of a sign-out, so do NOT evict the session — surface the 401
+    // to the caller and let it show its own error.
+    throw new ApiError(401, 'Unauthorized')
+  }
+
+  // null is Clerk's own "not signed in" answer — the one signal that justifies
+  // throwing the user out.
+  if (token === null) {
+    redirectToSignIn()
+    throw new ApiError(401, 'Unauthorized')
+  }
+  return true
+}
+
 export async function apiClient<T>(url: string, options?: RequestInit): Promise<T> {
   const headers = new Headers(options?.headers)
   if (!headers.has('Content-Type') && options?.body && !(options.body instanceof FormData)) {
     headers.set('Content-Type', 'application/json')
   }
 
-  const response = await fetch(url, { ...options, headers })
+  const init: RequestInit = { ...options, headers }
+  let response = await fetch(url, init)
+
+  if (response.status === 401 && typeof window !== 'undefined') {
+    await recoverFrom401()
+    // Replaying is safe for every method, not just GET: every 401 reachable
+    // from the browser is a pre-side-effect auth guard (proxy.ts:19, and the
+    // `if (!userId) return 401` at the top of each app/api handler), so the
+    // rejected request wrote nothing. No call site passes a stream body, so
+    // `init` is always re-sendable.
+    response = await fetch(url, init)
+    if (response.status === 401) {
+      // A fresh token still gets a 401: this one is real.
+      redirectToSignIn()
+      throw new ApiError(401, 'Unauthorized')
+    }
+  }
 
   if (!response.ok) {
     if (response.status === 401) {
-      // Session expired — redirect to sign-in
-      if (typeof window !== 'undefined') {
-        window.location.href = '/sign-in'
-      }
+      // Reachable only without a `window` (SSR / tests): nothing to refresh and
+      // nowhere to navigate.
       throw new ApiError(401, 'Unauthorized')
     }
     const text = await response.text().catch(() => '')

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -58,7 +58,13 @@ function refreshSession(): Promise<string | null> {
   return refreshInFlight
 }
 
-/** Latched: the first caller navigates, the other four in the burst do not. */
+/**
+ * Latched: the first caller navigates, the other four in the burst do not.
+ *
+ * The latch is deliberately never reset. It is set only on the line before a
+ * full-page navigation, which discards this module along with the rest of the
+ * page; "no second navigation afterwards" is the point, not an oversight.
+ */
 function redirectToSignIn(): void {
   if (redirecting) return
   redirecting = true
@@ -107,6 +113,12 @@ export async function apiClient<T>(url: string, options?: RequestInit): Promise<
     // `if (!userId) return 401` at the top of each app/api handler), so the
     // rejected request wrote nothing. No call site passes a stream body, so
     // `init` is always re-sendable.
+    //
+    // Reusing the pre-refresh `headers` is correct here: this app authenticates
+    // by session COOKIE, which the browser attaches per request and which the
+    // refresh above has just rewritten. No call site sets an Authorization
+    // header (swept repo-wide: only Supabase edge functions do, server-side),
+    // so there is no stale token baked into `init` to resend.
     response = await fetch(url, init)
     if (response.status === 401) {
       // A fresh token still gets a 401: this one is real.


### PR DESCRIPTION
A 401 is not proof that the session ended.

`proxy.ts:13-21` answers any API request Clerk cannot resolve a `userId` for with a 401, and that
includes the brief window while Clerk is refreshing the session token. `lib/apiClient.ts` treated
every 401 as terminal and hard-navigated to `/sign-in`, so a member reloading an API-backed page at
the wrong moment was thrown out with a perfectly live session — five endpoints 401'd within 5ms and
the same endpoint answered 200 seven milliseconds later (trace in #727).

## What changed

`apiClient` now, on a 401 in the browser:

1. forces one token refresh — `getToken({ skipCache: true })` from `@clerk/nextjs`, the accessor
   documented for exactly this API-interceptor use;
2. replays the request once;
3. navigates to `/sign-in` **only** when the refresh returns `null` (Clerk's own "not signed in")
   or the replay 401s again.

The burst is concurrent, so the decision is shared rather than made five times independently: the
refresh is **single-flight** (one module-level promise) and the redirect is **latched** (one
module-level boolean). A *thrown* Clerk error — offline, load timeout — is explicitly **not**
treated as a sign-out; it surfaces the 401 to the caller instead of evicting the session.

Replaying is safe for every method: every 401 the browser can receive is a pre-side-effect auth
guard (`proxy.ts:19`, and `if (!userId) return 401` at the top of each `app/api` handler, swept
40+ sites), so the rejected request wrote nothing.

## Verification

- `lib/apiClient.test.ts` (new, 8 cases): replay-succeeds/no-redirect, replay-401s/redirect-once,
  `getToken` → `null`/redirect-without-replay, refresh-throws/no-eviction, a 5-call burst that
  refreshes once, a signed-out burst that navigates exactly once, plus the unchanged non-401
  behaviour.
- Proven red first: with the fix stashed, 5 of the 8 cases fail; restored, 8/8 pass.
- `npm test` → 33 files / 459 tests passed (baseline before this branch: 32 / 451).
- `npx tsc --noEmit` → clean. `npx eslint` on both files → clean.
- `/code-review low` run pre-push; its one blocking claim ("`@clerk/nextjs` exports no top-level
  `getToken`") was disproved at runtime — `dist/types/index.d.ts:16` re-exports it,
  `dist/esm/index.js:56,96` and `dist/cjs/index.js:66,128` carry it, and
  `require('@clerk/nextjs').getToken` is a `function`. Its two other notes are answered in comments.

Also prunes the merged `#726` row from `docs/CLAIMS.md` (folded in here rather than a standalone
cleanup PR).

## Session State
**Status:** IN PROGRESS
**Completed:**
- [x] `lib/apiClient.ts` — refresh + replay + shared redirect decision
- [x] `lib/apiClient.test.ts` — 8 cases, proven red before green
- [x] `npm test`, `tsc`, `eslint` green; `/code-review low` findings dispositioned
- [x] CI green: 11/11, `Authenticated E2E (Clerk)` 6m48s, Vercel "Deployment has completed"
**Next:** merge first of the three, then mark ready for the CodeRabbit pass.

Closes #727


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for expired sessions by refreshing authentication and retrying requests once.
  * Redirects users to sign-in when authentication cannot be restored or a retry fails.
  * Improved handling for server-side and test environments without browser navigation.

* **Bug Fixes**
  * Preserved existing behavior for non-authentication errors and request content types.
  * Prevented duplicate refresh attempts and repeated redirects during concurrent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->