### PR TITLE
[2608-DEV-740] QA polish: calendar bubbles + popup, navbar radius site-wide, Trips bento link

### DIFF
--- a/app/(dashboard)/about/components/AboutContent.tsx
+++ b/app/(dashboard)/about/components/AboutContent.tsx
@@ -69,13 +69,13 @@ export default function AboutContent() {
       <HighlightedParagraph raw={t('about.body1')} highlights={P1_HIGHLIGHTS[lang]} />
 
       <div
-        className="h-px w-8 rounded-full"
+        className="h-px w-8"
         style={{ backgroundColor: 'var(--brand-crimson)', opacity: 0.4 }}
       />
       <HighlightedParagraph raw={t('about.body2')} highlights={P2_HIGHLIGHTS[lang]} />
 
       <div
-        className="h-px w-8 rounded-full"
+        className="h-px w-8"
         style={{ backgroundColor: 'var(--brand-crimson)', opacity: 0.4 }}
       />
       <HighlightedParagraph raw={t('about.body3')} highlights={[]} />

--- a/app/(dashboard)/calendar/components/AgendaView.tsx
+++ b/app/(dashboard)/calendar/components/AgendaView.tsx
@@ -75,8 +75,8 @@ export function AgendaView({
       <div className="px-4 py-4 space-y-4">
         {[...Array(4)].map((_, i) => (
           <div key={i} className="space-y-2">
-            <div className="h-6 w-32 rounded-full animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
-            <div className="h-16 rounded-xl animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.04)' }} />
+            <div className="h-6 w-32 rounded-control animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
+            <div className="h-16 rounded-container animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.04)' }} />
           </div>
         ))}
       </div>
@@ -106,7 +106,7 @@ export function AgendaView({
           >
             <div className="flex items-center gap-3 mb-2 py-2">
               <div
-                className="flex items-center gap-2 px-3 py-1 rounded-full text-xs font-semibold"
+                className="flex items-center gap-2 px-3 py-1 rounded-control text-xs font-semibold"
                 style={{
                   backgroundColor: isToday ? 'var(--crimson)' : 'rgba(0,0,0,0.06)',
                   color: isToday ? 'white' : 'var(--text-primary)',
@@ -127,7 +127,7 @@ export function AgendaView({
                     key={`${ev.id}-${dateKey}`}
                     ref={isHighlighted ? highlightRef : null}
                     onClick={() => onEventClick(ev.id)}
-                    className="w-full text-left rounded-xl border overflow-hidden hover:shadow-sm transition-shadow flex scroll-mt-20 md:scroll-mt-0"
+                    className="w-full text-left rounded-container border overflow-hidden hover:shadow-sm transition-shadow flex scroll-mt-20 md:scroll-mt-0"
                     style={{
                       backgroundColor: 'var(--bg-card)',
                       borderColor: isHighlighted ? 'var(--brand-crimson)' : 'rgba(0,0,0,0.05)',

--- a/app/(dashboard)/calendar/components/CalendarClient.tsx
+++ b/app/(dashboard)/calendar/components/CalendarClient.tsx
@@ -166,8 +166,8 @@ export default function CalendarClient({
           />
           <DialogContent
             className="fixed flex flex-col overflow-hidden p-0
-              inset-x-0 bottom-0 w-full max-h-[85vh] rounded-t-2xl
-              md:inset-x-auto md:bottom-auto md:top-1/2 md:left-1/2 md:w-[360px] md:max-h-[80vh] md:rounded-2xl md:-translate-x-1/2 md:-translate-y-1/2"
+              inset-x-0 bottom-0 w-full max-h-[85vh] rounded-t-container
+              md:inset-x-auto md:bottom-auto md:top-1/2 md:left-1/2 md:w-[360px] md:max-h-[80vh] md:rounded-container md:-translate-x-1/2 md:-translate-y-1/2"
             style={{
               backgroundColor: 'var(--bg-global)',
               boxShadow: '0 8px 40px rgba(0,0,0,0.22)',

--- a/app/(dashboard)/calendar/components/FilterControls.tsx
+++ b/app/(dashboard)/calendar/components/FilterControls.tsx
@@ -96,7 +96,7 @@ export function FilterControls({
             <button
               onClick={() => setShowN21(v => !v)}
               aria-pressed={showN21}
-              className="flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold flex-shrink-0 transition-all"
+              className="flex items-center gap-1 px-2.5 py-1 rounded-control text-xs font-semibold flex-shrink-0 transition-all"
               style={{
                 backgroundColor: showN21 ? 'var(--forest)' : 'rgba(0,0,0,0.05)',
                 color: showN21 ? 'white' : 'var(--text-secondary)',
@@ -110,7 +110,7 @@ export function FilterControls({
               <button
                 onClick={() => setShowPersonal(v => !v)}
                 aria-pressed={showPersonal}
-                className="flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold flex-shrink-0 transition-all"
+                className="flex items-center gap-1 px-2.5 py-1 rounded-control text-xs font-semibold flex-shrink-0 transition-all"
                 style={{
                   backgroundColor: showPersonal ? 'var(--sienna)' : 'rgba(0,0,0,0.05)',
                   color: showPersonal ? 'white' : 'var(--text-secondary)',
@@ -127,7 +127,7 @@ export function FilterControls({
                 key={type}
                 onClick={() => setFilterType(filterType === type ? null : type)}
                 aria-pressed={filterType === type}
-                className="px-2.5 py-1 rounded-full text-xs font-semibold flex-shrink-0 transition-all"
+                className="px-2.5 py-1 rounded-control text-xs font-semibold flex-shrink-0 transition-all"
                 style={{
                   backgroundColor: filterType === type ? 'var(--brand-teal)' : 'rgba(0,0,0,0.05)',
                   color: filterType === type ? 'white' : 'var(--text-secondary)',

--- a/app/(dashboard)/calendar/components/MonthView.tsx
+++ b/app/(dashboard)/calendar/components/MonthView.tsx
@@ -189,8 +189,8 @@ export function MonthView({
                     // the pill (w-full) touches the day-cell border. A bar cut
                     // by a week boundary stays flush at the cut, matching the
                     // squared-corner treatment in EventPill.
-                    paddingLeft: seg.continuesLeft ? 0 : 2,
-                    paddingRight: seg.continuesRight ? 0 : 2,
+                    paddingLeft: seg.continuesLeft === true ? 0 : 2,
+                    paddingRight: seg.continuesRight === true ? 0 : 2,
                   }}
                 >
                   <EventPill

--- a/app/(dashboard)/calendar/components/MonthView.tsx
+++ b/app/(dashboard)/calendar/components/MonthView.tsx
@@ -184,6 +184,13 @@ export function MonthView({
                     gridColumn: `calc(var(--col-offset) + ${seg.startCol + 1}) / span ${seg.span}`,
                     gridRow: seg.lane + 2,
                     minWidth: 0,
+                    // Day cells and event bars are grid SIBLINGS, so the cell's
+                    // p-1 never reaches the bars — inset them here instead, or
+                    // the pill (w-full) touches the day-cell border. A bar cut
+                    // by a week boundary stays flush at the cut, matching the
+                    // squared-corner treatment in EventPill.
+                    paddingLeft: seg.continuesLeft ? 0 : 2,
+                    paddingRight: seg.continuesRight ? 0 : 2,
                   }}
                 >
                   <EventPill

--- a/app/(dashboard)/calendar/components/popup/AttendSection.tsx
+++ b/app/(dashboard)/calendar/components/popup/AttendSection.tsx
@@ -51,7 +51,7 @@ export default function AttendSection({
       <div className="space-y-2.5">
       <div className="flex items-center gap-3">
         <span
-          className="flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-full"
+          className="flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-control"
           style={{ backgroundColor: 'var(--status-success-bg, rgba(129,178,154,0.18))', color: 'var(--status-success-fg, #2d6a4f)' }}
         >
           <Check size={10} />

--- a/app/(dashboard)/calendar/components/popup/EventActionsTabs.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventActionsTabs.tsx
@@ -84,7 +84,7 @@ export default function EventActionsTabs({
                     ? [slot.assigned_profile.first_name, slot.assigned_profile.last_name].filter(Boolean).join(' ') || '—'
                     : null
                   return (
-                    <div key={slot.role_label} className="rounded-lg p-2.5" style={{ backgroundColor: slotStyle.bg }}>
+                    <div key={slot.role_label} className="rounded-container p-2.5" style={{ backgroundColor: slotStyle.bg }}>
                       <div className="flex items-center justify-between gap-2">
                         <div className="flex-1 min-w-0">
                           <p className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>{slot.role_label}</p>

--- a/app/(dashboard)/calendar/components/popup/EventActionsTabs.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventActionsTabs.tsx
@@ -96,8 +96,8 @@ export default function EventActionsTabs({
                           {slot.status === 'contested' && (
                             <PendingPopover profiles={slot.pending_profiles} color={slotStyle.color} />
                           )}
-                          <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
-                            style={{ backgroundColor: 'rgba(255,255,255,0.55)', color: slotStyle.color }}>
+                          <span className="text-[10px] font-semibold px-2 py-0.5 rounded-xl"
+                            style={{ backgroundColor: 'var(--bg-card-raised)', color: slotStyle.color }}>
                             {t(`event.slot.${slot.status}` as `event.slot.${'open'|'contested'|'filled'}`)}
                           </span>
                         </div>

--- a/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
@@ -288,7 +288,7 @@ export default function EventPopupShell({
                   alt={t('cal.qrTitle')}
                   width={256}
                   height={256}
-                  className="h-auto w-full max-w-[256px] rounded-lg border"
+                  className="h-auto w-full max-w-[256px] rounded-container border"
                   style={{ borderColor: 'var(--border-default)' }}
                 />
                 <button

--- a/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
@@ -36,10 +36,12 @@ function formatAllDayRange(startIso: string, endIso: string): string {
   return `${startFmt.format(start)} – ${RANGE_FULL_FMT.format(end)}`
 }
 
+// Theme-aware token pairs, not literals — the popup is rendered in dark mode
+// too. See app/(dashboard)/calendar/components/popup/styles.ts.
 const EVENT_TYPE_STYLES: Record<string, { bg: string; color: string; label: string }> = {
-  'in-person': { bg: 'rgba(129,178,154,0.18)', color: '#2d6a4f',  label: 'In-Person' },
-  'online':    { bg: 'rgba(61,64,91,0.10)',    color: '#3d405b',  label: 'Online'    },
-  'hybrid':    { bg: 'rgba(242,204,143,0.35)', color: '#7a5c00',  label: 'Hybrid'    },
+  'in-person': { bg: 'var(--status-success-bg)', color: 'var(--status-success-fg)', label: 'In-Person' },
+  'online':    { bg: 'var(--status-info-bg)',    color: 'var(--status-info-fg)',    label: 'Online'    },
+  'hybrid':    { bg: 'var(--status-pending-bg)', color: 'var(--status-pending-fg)', label: 'Hybrid'    },
 }
 
 type Props = {
@@ -85,12 +87,12 @@ export default function EventPopupShell({
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5 flex-wrap mb-1.5">
-              <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
+              <span className="text-[10px] font-semibold px-2 py-0.5 rounded-xl"
                 style={{ backgroundColor: event?.category === 'N21' ? 'var(--brand-forest)' : 'var(--brand-sienna)', color: 'rgba(255,255,255,0.9)' }}>
                 {event?.category ?? '…'}
               </span>
               {eventTypeStyle && (
-                <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
+                <span className="text-[10px] font-semibold px-2 py-0.5 rounded-xl"
                   style={{ backgroundColor: eventTypeStyle.bg, color: eventTypeStyle.color }}>
                   {eventTypeStyle.label}
                 </span>
@@ -99,12 +101,17 @@ export default function EventPopupShell({
                 <span className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>W{event.week_number}</span>
               )}
             </div>
-            <p className="font-display text-base font-semibold leading-snug" style={{ color: 'var(--text-primary)' }}>
+            {/* A real DialogTitle, not a <p>: this Dialog previously had none,
+                which Radix warns about and which left the modal without an
+                accessible name. Promoting the title fixes the a11y gap and the
+                size in one place. DialogTitle's own `text-base` is overridden
+                by `text-lg` — Tailwind emits the larger step later. */}
+            <DialogTitle className="font-display text-lg font-semibold leading-snug" style={{ color: 'var(--text-primary)' }}>
               {isLoading ? '…' : event?.title}
-            </p>
+            </DialogTitle>
           </div>
           <button onClick={onClose}
-            className="w-6 h-6 flex items-center justify-center rounded-full hover:bg-black/5 transition-colors flex-shrink-0 mt-0.5"
+            className="w-6 h-6 flex items-center justify-center rounded-full hover:bg-[var(--bg-card-raised)] transition-colors flex-shrink-0 mt-0.5"
             style={{ color: 'var(--text-secondary)' }}>
             <X size={14} />
           </button>
@@ -119,7 +126,7 @@ export default function EventPopupShell({
         {isLoading ? (
           <div className="p-4 space-y-2">
             {[...Array(3)].map((_, i) => (
-              <div key={i} className="h-6 rounded animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
+              <div key={i} className="h-6 rounded animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
             ))}
           </div>
         ) : event ? (
@@ -266,7 +273,7 @@ export default function EventPopupShell({
                 <button
                   onClick={onQrDismiss}
                   aria-label="Close"
-                  className="w-6 h-6 flex items-center justify-center rounded-full hover:bg-black/5 transition-colors flex-shrink-0 mt-0.5"
+                  className="w-6 h-6 flex items-center justify-center rounded-full hover:bg-[var(--bg-card-raised)] transition-colors flex-shrink-0 mt-0.5"
                   style={{ color: 'var(--text-secondary)' }}
                 >
                   <X size={14} />

--- a/app/(dashboard)/calendar/components/popup/MemberActions.tsx
+++ b/app/(dashboard)/calendar/components/popup/MemberActions.tsx
@@ -41,7 +41,7 @@ export default function MemberActions({
         const mySlot = roleSlots.find(s => s.caller_request !== null)
         const myReq  = mySlot?.caller_request ?? null
         return myReq ? (
-          <div className="rounded-lg p-2.5 mb-3" style={{ backgroundColor: REQUEST_STATUS_STYLES[myReq.status].bg }}>
+          <div className="rounded-container p-2.5 mb-3" style={{ backgroundColor: REQUEST_STATUS_STYLES[myReq.status].bg }}>
             <div className="flex items-center justify-between gap-2">
               <div className="flex-1 min-w-0">
                 <p className="text-[10px] font-medium mb-0.5" style={{ color: 'var(--text-secondary)' }}>

--- a/app/(dashboard)/calendar/components/popup/MemberActions.tsx
+++ b/app/(dashboard)/calendar/components/popup/MemberActions.tsx
@@ -49,8 +49,8 @@ export default function MemberActions({
                 </p>
                 <p className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>{myReq.role_label}</p>
               </div>
-              <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
-                style={{ backgroundColor: 'rgba(255,255,255,0.6)', color: REQUEST_STATUS_STYLES[myReq.status].color }}>
+              <span className="text-[10px] font-semibold px-2 py-0.5 rounded-xl"
+                style={{ backgroundColor: 'var(--bg-card-raised)', color: REQUEST_STATUS_STYLES[myReq.status].color }}>
                 {myReq.status}
               </span>
             </div>

--- a/app/(dashboard)/calendar/components/popup/RegistrationsTab.tsx
+++ b/app/(dashboard)/calendar/components/popup/RegistrationsTab.tsx
@@ -32,7 +32,7 @@ export default function RegistrationsTab({ eventId, t }: Props) {
     return (
       <div className="px-4 py-3 space-y-2">
         {[...Array(3)].map((_, i) => (
-          <div key={i} className="h-10 rounded-lg animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
+          <div key={i} className="h-10 rounded-container animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
         ))}
       </div>
     )
@@ -72,7 +72,7 @@ export default function RegistrationsTab({ eventId, t }: Props) {
             // a registrant may ALSO appear as another row's sharer, so a bare
             // text locator is ambiguous by design of this list.
             data-testid="registration-row"
-            className="rounded-lg p-2.5"
+            className="rounded-container p-2.5"
             style={{ backgroundColor: 'var(--bg-card-raised)', border: '1px solid var(--border-default)' }}
           >
             <div className="flex items-start justify-between gap-2">
@@ -104,7 +104,7 @@ export default function RegistrationsTab({ eventId, t }: Props) {
                 )}
               </div>
               <span
-                className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
+                className="text-[10px] font-semibold px-2 py-0.5 rounded-control flex-shrink-0"
                 style={{ backgroundColor: registrationStyle.bg, color: registrationStyle.color }}
               >
                 {t(`cal.reg.status.${statusKey}` as `cal.reg.status.${StatusKey}`)}

--- a/app/(dashboard)/calendar/components/popup/RegistrationsTab.tsx
+++ b/app/(dashboard)/calendar/components/popup/RegistrationsTab.tsx
@@ -32,7 +32,7 @@ export default function RegistrationsTab({ eventId, t }: Props) {
     return (
       <div className="px-4 py-3 space-y-2">
         {[...Array(3)].map((_, i) => (
-          <div key={i} className="h-10 rounded-lg animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
+          <div key={i} className="h-10 rounded-lg animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
         ))}
       </div>
     )
@@ -73,7 +73,7 @@ export default function RegistrationsTab({ eventId, t }: Props) {
             // text locator is ambiguous by design of this list.
             data-testid="registration-row"
             className="rounded-lg p-2.5"
-            style={{ backgroundColor: 'rgba(0,0,0,0.03)', border: '1px solid rgba(0,0,0,0.05)' }}
+            style={{ backgroundColor: 'var(--bg-card-raised)', border: '1px solid var(--border-default)' }}
           >
             <div className="flex items-start justify-between gap-2">
               <div className="flex-1 min-w-0">
@@ -81,8 +81,8 @@ export default function RegistrationsTab({ eventId, t }: Props) {
                   <p data-testid="registration-name" className="text-xs font-semibold truncate" style={{ color: 'var(--text-primary)' }}>{r.registrant}</p>
                   {r.is_member && (
                     <span
-                      className="text-[9px] font-semibold px-1.5 py-0.5 rounded-full flex-shrink-0"
-                      style={{ backgroundColor: 'rgba(61,64,91,0.08)', color: '#3d405b' }}
+                      className="text-[9px] font-semibold px-1.5 py-0.5 rounded-xl flex-shrink-0"
+                      style={{ backgroundColor: 'var(--status-info-bg)', color: 'var(--status-info-fg)' }}
                     >
                       {t('cal.reg.member')}
                     </span>

--- a/app/(dashboard)/calendar/components/popup/styles.ts
+++ b/app/(dashboard)/calendar/components/popup/styles.ts
@@ -1,18 +1,29 @@
+/**
+ * Status colour maps for the calendar event popup.
+ *
+ * Every entry resolves to a `--status-*` token PAIR (bg + fg) from
+ * styles/brand-tokens.css, which is redefined under [data-theme="dark"].
+ * These were hardcoded light-mode hexes, so the popup was unreadable on dark.
+ * Never reintroduce a literal here — and never a Tailwind `dark:` class:
+ * this project toggles data-theme on <html>, so `dark:` tracks the OS setting
+ * instead. See docs/design/DESIGN-SYSTEM.md.
+ */
+
 export const SLOT_STATUS_STYLES = {
-  open:      { bg: 'rgba(0,0,0,0.05)',          color: 'var(--text-primary)'   },
-  contested: { bg: 'rgba(242,204,143,0.22)',    color: '#7a5c00'               },
-  filled:    { bg: 'rgba(129,178,154,0.22)',    color: '#2d6a4f'               },
+  open:      { bg: 'var(--status-neutral-bg)', color: 'var(--status-neutral-fg)' },
+  contested: { bg: 'var(--status-pending-bg)', color: 'var(--status-pending-fg)' },
+  filled:    { bg: 'var(--status-success-bg)', color: 'var(--status-success-fg)' },
 }
 
 export const REQUEST_STATUS_STYLES = {
-  pending:  { bg: '#f2cc8f33', color: '#7a5c00'  },
-  approved: { bg: '#81b29a33', color: '#2d6a4f'  },
-  denied:   { bg: '#bc474920', color: '#bc4749'  },
+  pending:  { bg: 'var(--status-pending-bg)', color: 'var(--status-pending-fg)' },
+  approved: { bg: 'var(--status-success-bg)', color: 'var(--status-success-fg)' },
+  denied:   { bg: 'var(--status-alert-bg)',   color: 'var(--status-alert-fg)'   },
 }
 
 export const REGISTRATION_STATUS_STYLES = {
-  attended:  { bg: 'rgba(129,178,154,0.2)',  color: '#2d6a4f' },
-  cancelled: { bg: '#bc474920',              color: '#bc4749' },
-  confirmed: { bg: 'rgba(61,64,91,0.08)',    color: '#3d405b' },
-  pending:   { bg: 'rgba(242,204,143,0.3)',  color: '#7a5c00' },
+  attended:  { bg: 'var(--status-success-bg)', color: 'var(--status-success-fg)' },
+  cancelled: { bg: 'var(--status-alert-bg)',   color: 'var(--status-alert-fg)'   },
+  confirmed: { bg: 'var(--status-info-bg)',    color: 'var(--status-info-fg)'    },
+  pending:   { bg: 'var(--status-pending-bg)', color: 'var(--status-pending-fg)' },
 }

--- a/app/(dashboard)/components/tiles/CalendarTile.tsx
+++ b/app/(dashboard)/components/tiles/CalendarTile.tsx
@@ -150,7 +150,7 @@ export default function CalendarTile({ events = [], colSpan, mobileColSpan, rowS
 
                 {/* Date badge */}
                 <div
-                  className="flex flex-col items-center flex-shrink-0 rounded-md overflow-hidden"
+                  className="flex flex-col items-center flex-shrink-0 rounded-container overflow-hidden"
                   style={{ width: 44, height: 52 }}
                 >
                   {/* Month strip */}

--- a/app/(dashboard)/components/tiles/GuidesTile.tsx
+++ b/app/(dashboard)/components/tiles/GuidesTile.tsx
@@ -45,7 +45,7 @@ export default function GuidesTile({ colSpan = 6, rowSpan, mobileColSpan }: { co
       {isLoading ? (
         <div className="space-y-3 flex-1">
           {[...Array(3)].map((_, i) => (
-            <div key={i} className="h-8 rounded-lg animate-pulse"
+            <div key={i} className="h-8 rounded-container animate-pulse"
               style={{ backgroundColor: 'var(--border-default)' }} />
           ))}
         </div>

--- a/app/(dashboard)/components/tiles/ProfileTile.tsx
+++ b/app/(dashboard)/components/tiles/ProfileTile.tsx
@@ -80,7 +80,7 @@ export default function ProfileTile({
         <div className="flex items-center justify-end">
           <div className="h-3 w-16 rounded animate-pulse" style={{ backgroundColor: 'rgba(250,248,243,0.15)' }} />
         </div>
-        <div className="h-6 w-24 rounded-lg animate-pulse" style={{ backgroundColor: 'rgba(250,248,243,0.15)' }} />
+        <div className="h-6 w-24 rounded-container animate-pulse" style={{ backgroundColor: 'rgba(250,248,243,0.15)' }} />
       </BentoCard>
     )
   }
@@ -119,7 +119,7 @@ export default function ProfileTile({
           <h2 className="font-display text-2xl font-semibold mt-3" style={{ color: 'var(--brand-parchment)' }}>
             Hey, {displayName ?? t('home.profile.there')}.
           </h2>
-          <span className="inline-block mt-2 text-xs font-semibold px-2.5 py-1 rounded-full"
+          <span className="inline-block mt-2 text-xs font-semibold px-2.5 py-1 rounded-control"
             style={{ backgroundColor: 'rgba(250,248,243,0.15)', color: 'var(--brand-parchment)' }}>
             {t('profile.unverified')}
           </span>
@@ -151,7 +151,7 @@ export default function ProfileTile({
           Hey, {displayName ?? t('home.profile.there')}.
         </h2>
         <div className="flex items-center gap-2 mt-2 flex-wrap">
-          <span className="text-xs font-semibold px-2.5 py-1 rounded-full"
+          <span className="text-xs font-semibold px-2.5 py-1 rounded-control"
             style={{ backgroundColor: roleStyle.bg, color: roleStyle.color }}>
             {t(('role.' + role) as TranslationKey)}
           </span>

--- a/app/(dashboard)/components/tiles/SocialsTile.tsx
+++ b/app/(dashboard)/components/tiles/SocialsTile.tsx
@@ -87,7 +87,7 @@ export default function SocialsTile({
     >
       {isLoading && (
         <div className="flex-1 flex flex-col justify-center gap-3 mt-3 md:mt-0">
-          <div className="h-14 rounded-lg animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
+          <div className="h-14 rounded-container animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
         </div>
       )}
 
@@ -107,7 +107,7 @@ export default function SocialsTile({
         >
           {post.thumbnail_url && (
             <div
-              className="flex-shrink-0 rounded-xl overflow-hidden self-start md:self-auto w-20 h-20 md:w-[100px] md:h-[100px] outline outline-2 outline-offset-1 outline-[rgba(0,0,0,0.08)] md:outline-0 md:shadow-[0_2px_8px_rgba(0,0,0,0.10)]"
+              className="flex-shrink-0 rounded-container overflow-hidden self-start md:self-auto w-20 h-20 md:w-[100px] md:h-[100px] outline outline-2 outline-offset-1 outline-[rgba(0,0,0,0.08)] md:outline-0 md:shadow-[0_2px_8px_rgba(0,0,0,0.10)]"
               style={{ backgroundColor: 'rgba(0,0,0,0.06)' }}
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/app/(dashboard)/components/tiles/TripHeroTile.tsx
+++ b/app/(dashboard)/components/tiles/TripHeroTile.tsx
@@ -38,14 +38,23 @@ export default function TripHeroTile({ trip }: Props) {
           }}
         />
       )}
-      <div className="absolute top-0 left-0 right-0 flex items-start justify-end px-5 pt-5 z-10">
-        <Link href="/trips" className="font-body text-[11px] font-bold tracking-widest uppercase pill-link-parchment">
+      {/* Whole-tile navigation to THIS trip. A sibling overlay, not a wrapper:
+          wrapping the tile would nest the /trips pill inside this <a>. The
+          content overlays below are pointer-events-none so clicks reach it,
+          and the /trips pill sits above it at z-20 to win the hit test. */}
+      <Link
+        href={`/trips/${trip.id}`}
+        aria-label={trip.title}
+        className="absolute inset-0 z-10"
+      />
+      <div className="absolute top-0 left-0 right-0 flex items-start justify-end px-5 pt-5 z-20 pointer-events-none">
+        <Link href="/trips" className="font-body text-[11px] font-bold tracking-widest uppercase pill-link-parchment pointer-events-auto">
           {t('home.trips.tripsLink')}
         </Link>
       </div>
-      <div className="absolute bottom-0 left-0 right-0 px-5 pb-5 z-10">
+      <div className="absolute bottom-0 left-0 right-0 px-5 pb-5 z-10 pointer-events-none">
         <span
-          className="inline-block font-body text-[9px] font-bold tracking-widest uppercase px-2.5 py-1 rounded-full mb-2"
+          className="inline-block font-body text-[9px] font-bold tracking-widest uppercase px-2.5 py-1 rounded-xl mb-2"
           style={{ backgroundColor: 'rgba(255,255,255,0.18)', color: 'var(--brand-parchment)', opacity: 0.55 }}
         >
           {t('home.trips.nextTrip')}
@@ -58,7 +67,7 @@ export default function TripHeroTile({ trip }: Props) {
         </h3>
         <div className="flex items-center gap-2 mt-1">
           <span
-            className="font-body text-[11px] font-bold px-2.5 py-1 rounded-full"
+            className="font-body text-[11px] font-bold px-2.5 py-1 rounded-xl"
             style={{ backgroundColor: 'rgba(255,255,255,0.18)', color: 'var(--brand-parchment)' }}
           >
             {trip.destination}

--- a/app/(dashboard)/los/page.tsx
+++ b/app/(dashboard)/los/page.tsx
@@ -41,7 +41,7 @@ function MemberCard({ node, isExpanded, onToggle }: {
 
   return (
     <div
-      className="rounded-xl mb-1.5 overflow-hidden"
+      className="rounded-container mb-1.5 overflow-hidden"
       style={{ border: `1px solid ${rc.border}`, opacity: rc.opacity, backgroundColor: 'var(--bg-card)' }}
     >
       <div
@@ -65,7 +65,7 @@ function MemberCard({ node, isExpanded, onToggle }: {
           </span>
         )}
         <span
-          className="text-[10px] font-bold px-2 py-0.5 rounded-full flex-shrink-0 uppercase tracking-wide"
+          className="text-[10px] font-bold px-2 py-0.5 rounded-control flex-shrink-0 uppercase tracking-wide"
           style={{ backgroundColor: rc.labelBg, color: rc.labelColor }}
         >
           {node.role ?? 'guest'}
@@ -107,7 +107,7 @@ function MemberCard({ node, isExpanded, onToggle }: {
                 {node.vital_signs.map(vs => (
                   <span
                     key={vs.definition_id}
-                    className="text-xs font-semibold px-2.5 py-1 rounded-full"
+                    className="text-xs font-semibold px-2.5 py-1 rounded-control"
                     style={{
                       backgroundColor: isVitalRecorded(vs) ? 'rgba(188,71,73,0.12)' : 'rgba(0,0,0,0.05)',
                       color: isVitalRecorded(vs) ? 'var(--brand-crimson)' : 'var(--text-secondary)',
@@ -176,7 +176,7 @@ function SimpleRow({ node, label }: { node: LOSNode; label: string }) {
           <span className="text-xs font-mono" style={{ color: 'var(--text-tertiary)' }}>{node.abo_number}</span>
         )}
         <span
-          className="text-[10px] font-bold px-2 py-0.5 rounded-full uppercase ml-auto"
+          className="text-[10px] font-bold px-2 py-0.5 rounded-control uppercase ml-auto"
           style={{ backgroundColor: rc.labelBg, color: rc.labelColor }}
         >
           {node.role ?? 'member'}
@@ -300,7 +300,7 @@ function LOSPageInner() {
         {isLoading && (
           <div className="space-y-2">
             {[...Array(8)].map((_, i) => (
-              <div key={i} className="h-10 rounded-xl animate-pulse" style={{ backgroundColor: 'var(--border-default)' }} />
+              <div key={i} className="h-10 rounded-container animate-pulse" style={{ backgroundColor: 'var(--border-default)' }} />
             ))}
           </div>
         )}

--- a/app/(dashboard)/notifications/page.tsx
+++ b/app/(dashboard)/notifications/page.tsx
@@ -151,7 +151,7 @@ export default function NotificationsPage() {
                 {/* Type pills */}
                 <button
                   onClick={() => setTypeFilter('all')}
-                  className="px-3 py-1 rounded-full text-xs font-medium transition-all"
+                  className="px-3 py-1 rounded-control text-xs font-medium transition-all"
                   style={{
                     backgroundColor: typeFilter === 'all' ? 'var(--text-primary)' : 'rgba(0,0,0,0.06)',
                     color: typeFilter === 'all' ? 'white' : 'var(--text-secondary)',
@@ -163,7 +163,7 @@ export default function NotificationsPage() {
                   <button
                     key={type}
                     onClick={() => setTypeFilter(f => f === type ? 'all' : type)}
-                    className="px-3 py-1 rounded-full text-xs font-medium transition-all"
+                    className="px-3 py-1 rounded-control text-xs font-medium transition-all"
                     style={{
                       backgroundColor: typeFilter === type
                         ? (TYPE_STYLES[type]?.bg ?? 'rgba(0,0,0,0.06)')
@@ -184,7 +184,7 @@ export default function NotificationsPage() {
           {isLoading ? (
             <div className="space-y-3">
               {[...Array(5)].map((_, i) => (
-                <div key={i} className="h-16 rounded-xl animate-pulse"
+                <div key={i} className="h-16 rounded-container animate-pulse"
                   style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
               ))}
             </div>
@@ -224,7 +224,7 @@ export default function NotificationsPage() {
                 <div
                   key={n.id}
                   onClick={() => { if (!n.is_read) markRead.mutate(n.id) }}
-                  className="rounded-xl p-4 border transition-colors cursor-pointer"
+                  className="rounded-container p-4 border transition-colors cursor-pointer"
                   style={{
                     backgroundColor: n.is_read ? 'white' : 'rgba(244,241,222,0.6)',
                     borderColor: n.is_read
@@ -235,7 +235,7 @@ export default function NotificationsPage() {
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 mb-1">
-                        <span className="text-xs font-medium px-2 py-0.5 rounded-full"
+                        <span className="text-xs font-medium px-2 py-0.5 rounded-control"
                           style={{
                             backgroundColor: (TYPE_STYLES[n.type] ?? TYPE_STYLES.event_fetched).bg,
                             color: (TYPE_STYLES[n.type] ?? TYPE_STYLES.event_fetched).color,

--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -187,7 +187,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <p className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>{t('profile.access')}</p>
             <span
-              className="text-[10px] font-bold px-2 py-0.5 rounded-xl self-start w-fit"
+              className="text-[10px] font-bold px-2 py-0.5 rounded-control self-start w-fit"
               style={{ backgroundColor: rc.bg, color: rc.font }}
             >
               {t(`profile.role.label.${role}` as Parameters<typeof t>[0])}
@@ -230,7 +230,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <p className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>{t('profile.access')}</p>
             <span
-              className="text-[10px] font-bold px-2 py-0.5 rounded-xl self-start w-fit"
+              className="text-[10px] font-bold px-2 py-0.5 rounded-control self-start w-fit"
               style={{ backgroundColor: rc.bg, color: rc.font }}
             >
               {t(`profile.role.label.${role}` as Parameters<typeof t>[0])}

--- a/app/(dashboard)/profile/components/AboInfoContent.tsx
+++ b/app/(dashboard)/profile/components/AboInfoContent.tsx
@@ -187,7 +187,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <p className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>{t('profile.access')}</p>
             <span
-              className="text-[10px] font-bold px-2 py-0.5 rounded-full self-start w-fit"
+              className="text-[10px] font-bold px-2 py-0.5 rounded-xl self-start w-fit"
               style={{ backgroundColor: rc.bg, color: rc.font }}
             >
               {t(`profile.role.label.${role}` as Parameters<typeof t>[0])}
@@ -230,7 +230,7 @@ export const AboInfoContent = memo(function AboInfoContent() {
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <p className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>{t('profile.access')}</p>
             <span
-              className="text-[10px] font-bold px-2 py-0.5 rounded-full self-start w-fit"
+              className="text-[10px] font-bold px-2 py-0.5 rounded-xl self-start w-fit"
               style={{ backgroundColor: rc.bg, color: rc.font }}
             >
               {t(`profile.role.label.${role}` as Parameters<typeof t>[0])}

--- a/app/(dashboard)/profile/components/InvitesBento.tsx
+++ b/app/(dashboard)/profile/components/InvitesBento.tsx
@@ -57,7 +57,7 @@ export function InvitesBento() {
           {[...Array(4)].map((_, i) => (
             <div
               key={i}
-              className="h-14 rounded-xl animate-pulse"
+              className="h-14 rounded-container animate-pulse"
               style={{ backgroundColor: 'var(--skeleton-base)' }}
             />
           ))}

--- a/app/(dashboard)/profile/components/InvitesSection.tsx
+++ b/app/(dashboard)/profile/components/InvitesSection.tsx
@@ -149,7 +149,7 @@ export function InvitesSection() {
     return (
       <div className="p-4 space-y-3">
         {[...Array(2)].map((_, i) => (
-          <div key={i} className="h-20 rounded-xl animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
+          <div key={i} className="h-20 rounded-container animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
         ))}
       </div>
     )
@@ -272,7 +272,7 @@ export function InvitesSection() {
             const isOpen    = !!expanded[link.id]
 
             return (
-              <div key={link.id} className="rounded-xl border overflow-hidden" style={{ borderColor: 'var(--border-default)' }}>
+              <div key={link.id} className="rounded-container border overflow-hidden" style={{ borderColor: 'var(--border-default)' }}>
                 {/* Event header */}
                 <div className="w-full flex flex-wrap items-start justify-between gap-3 px-4 py-3" style={{ backgroundColor: 'var(--bg-card)' }}>
                   <button
@@ -283,7 +283,7 @@ export function InvitesSection() {
                     <p className="text-sm font-semibold truncate" style={{ color: 'var(--text-primary)' }}>
                       {link.event.title}
                       {revoked && (
-                        <StatusBadge status="cancelled" className="ml-2 px-2 py-0.5 rounded-full text-[10px] font-semibold align-middle">
+                        <StatusBadge status="cancelled" className="ml-2 px-2 py-0.5 rounded-control text-[10px] font-semibold align-middle">
                           {t('profile.invites.revoked')}
                         </StatusBadge>
                       )}
@@ -368,7 +368,7 @@ export function InvitesSection() {
                                 <td className="px-4 py-2 font-medium" style={{ color: 'var(--text-primary)' }}>{g.name}</td>
                                 <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{g.email ?? '—'}</td>
                                 <td className="px-4 py-2">
-                                  <StatusBadge status={s} className="px-2 py-0.5 rounded-full text-[10px] font-semibold">{s}</StatusBadge>
+                                  <StatusBadge status={s} className="px-2 py-0.5 rounded-control text-[10px] font-semibold">{s}</StatusBadge>
                                 </td>
                                 <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{fmt(g.created_at)}</td>
                                 <td className="px-4 py-2" style={{ color: 'var(--text-secondary)' }}>{fmt(g.attended_at)}</td>
@@ -387,7 +387,7 @@ export function InvitesSection() {
                           <div key={g.id} className="px-4 py-3 space-y-1" style={{ borderTop: '1px solid var(--border-default)' }}>
                             <div className="flex items-center justify-between gap-2">
                               <p className="text-xs font-medium truncate" style={{ color: 'var(--text-primary)' }}>{g.name}</p>
-                              <StatusBadge status={s} className="px-2 py-0.5 rounded-full text-[10px] font-semibold shrink-0">{s}</StatusBadge>
+                              <StatusBadge status={s} className="px-2 py-0.5 rounded-control text-[10px] font-semibold shrink-0">{s}</StatusBadge>
                             </div>
                             <p className="text-[11px] truncate" style={{ color: 'var(--text-secondary)' }}>{g.email ?? '—'}</p>
                             <p className="text-[10px]" style={{ color: 'var(--text-secondary)' }}>

--- a/app/(dashboard)/profile/components/ParticipationSection.tsx
+++ b/app/(dashboard)/profile/components/ParticipationSection.tsx
@@ -51,7 +51,7 @@ export function ParticipationSection({ profileId, role }: { profileId: string; r
           </p>
           {er.note && <p className="mt-0.5 italic" style={{ color: 'var(--text-secondary)' }}>{er.note}</p>}
         </div>
-        <StatusBadge status={er.status} className="font-semibold px-2 py-0.5 rounded-full flex-shrink-0">{er.status}</StatusBadge>
+        <StatusBadge status={er.status} className="font-semibold px-2 py-0.5 rounded-control flex-shrink-0">{er.status}</StatusBadge>
       </div>
     )
   }

--- a/app/(dashboard)/profile/components/StatusBadge.tsx
+++ b/app/(dashboard)/profile/components/StatusBadge.tsx
@@ -31,7 +31,7 @@ const STATUS_TOKEN_MAP: Record<string, StatusToken> = {
   neutral:   'neutral',
 }
 
-const DEFAULT_CLASSNAME = 'inline-flex items-center rounded-xl px-2 py-0.5 text-[10px] font-semibold'
+const DEFAULT_CLASSNAME = 'inline-flex items-center rounded-control px-2 py-0.5 text-[10px] font-semibold'
 
 export function StatusBadge({
   status,

--- a/app/(dashboard)/profile/components/StatusBadge.tsx
+++ b/app/(dashboard)/profile/components/StatusBadge.tsx
@@ -31,7 +31,7 @@ const STATUS_TOKEN_MAP: Record<string, StatusToken> = {
   neutral:   'neutral',
 }
 
-const DEFAULT_CLASSNAME = 'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold'
+const DEFAULT_CLASSNAME = 'inline-flex items-center rounded-xl px-2 py-0.5 text-[10px] font-semibold'
 
 export function StatusBadge({
   status,

--- a/app/(dashboard)/profile/components/VitalsSection.tsx
+++ b/app/(dashboard)/profile/components/VitalsSection.tsx
@@ -21,14 +21,14 @@ function VitalCard({ vs }: { vs: ProfileVitalSign }) {
 
   return (
     <div
-      className="rounded-xl p-3 flex flex-col gap-1"
+      className="rounded-container p-3 flex flex-col gap-1"
       style={{
         backgroundColor: recorded ? 'color-mix(in srgb, var(--brand-crimson) 8%, transparent)' : 'var(--bg-global)',
         border: `1px solid ${recorded ? 'color-mix(in srgb, var(--brand-crimson) 20%, transparent)' : 'var(--border-default)'}`,
       }}
     >
       <span
-        className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full self-start"
+        className="text-[10px] font-semibold px-1.5 py-0.5 rounded-control self-start"
         style={{
           backgroundColor: recorded ? 'var(--status-alert-bg)' : 'var(--border-default)',
           color: recorded ? 'var(--status-alert-fg)' : 'var(--text-secondary)',

--- a/app/(dashboard)/profile/components/shared.tsx
+++ b/app/(dashboard)/profile/components/shared.tsx
@@ -48,7 +48,7 @@ export function TripRow({
   const regStatus = isCancelled ? 'cancelled' : entry.registration_status
   return (
     <div
-      className="rounded-xl p-3"
+      className="rounded-container p-3"
       style={{ backgroundColor: 'var(--bg-global)', border: '1px solid var(--border-default)', opacity: isCancelled ? 0.7 : 1 }}
     >
       <div className="flex items-start justify-between gap-2">
@@ -59,7 +59,7 @@ export function TripRow({
             {formatDate(entry.trip.start_date)} – {formatDate(entry.trip.end_date)}
           </p>
         </div>
-        <StatusBadge status={regStatus} className="text-[10px] font-semibold px-2 py-0.5 rounded-full flex-shrink-0">
+        <StatusBadge status={regStatus} className="text-[10px] font-semibold px-2 py-0.5 rounded-control flex-shrink-0">
           {isCancelled ? t('home.shared.cancelled') : entry.registration_status}
         </StatusBadge>
       </div>
@@ -147,7 +147,7 @@ export function PaymentRow({
         </span>
         <span style={{ color: 'var(--text-secondary)' }}>{formatDate(entry.transaction_date)}</span>
         {entry.payment_method != null && entry.payment_method !== '' && <span className="truncate min-w-0" style={{ color: 'var(--text-secondary)' }}>{entry.payment_method}</span>}
-        <StatusBadge status={entry.status} className="ml-auto font-semibold px-2 py-0.5 rounded-full flex-shrink-0 flex items-center gap-1">
+        <StatusBadge status={entry.status} className="ml-auto font-semibold px-2 py-0.5 rounded-control flex-shrink-0 flex items-center gap-1">
           {entry.status}
           {(hasAdminNote || linkedTripCancelled) && (
             <span title={linkedTripCancelled ? t('home.shared.tripCancelled') : (entry.admin_note ?? '')} style={{ cursor: 'help', fontSize: 10, lineHeight: 1 }}>ⓘ</span>

--- a/app/(dashboard)/profile/los-upload/LosUploadClient.tsx
+++ b/app/(dashboard)/profile/los-upload/LosUploadClient.tsx
@@ -172,7 +172,7 @@ export function LosUploadClient({ aboNumber }: { aboNumber: string | null }) {
         </p>
       </div>
 
-      <details className="rounded-xl border" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }} open={howToOpen} onToggle={handleHowToToggle}>
+      <details className="rounded-container border" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }} open={howToOpen} onToggle={handleHowToToggle}>
         <summary className="cursor-pointer px-4 py-3 text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
           {t('los.upload.howToTitle')}
         </summary>
@@ -209,7 +209,7 @@ export function LosUploadClient({ aboNumber }: { aboNumber: string | null }) {
           <AssemblySummary assembly={assembly} sourceCount={files.length} />
 
           {rootCheck && !rootCheck.ok && (
-            <div className="p-4 rounded-lg border" style={{ backgroundColor: 'rgba(188,71,73,0.06)', borderColor: 'rgba(188,71,73,0.3)' }}>
+            <div className="p-4 rounded-container border" style={{ backgroundColor: 'rgba(188,71,73,0.06)', borderColor: 'rgba(188,71,73,0.3)' }}>
               <p className="text-sm" style={{ color: '#bc4749' }}>{ROOT_ERROR[rootCheck.reason]}</p>
               {rootCheck.reason === 'mismatch' && (
                 <p className="text-xs mt-1" style={{ color: 'var(--text-secondary)' }}>
@@ -255,7 +255,7 @@ export function LosUploadClient({ aboNumber }: { aboNumber: string | null }) {
               <div key={sub.id} className="rounded-xl border px-4 py-3" style={{ backgroundColor: 'var(--bg-card)', borderColor: 'var(--border-default)' }}>
                 <div className="flex items-center gap-2 flex-wrap">
                   <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{sub.row_count} members</span>
-                  <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full" style={{ backgroundColor: s.bg, color: s.color }}>{s.label}</span>
+                  <span className="text-[10px] font-semibold px-2 py-0.5 rounded-control" style={{ backgroundColor: s.bg, color: s.color }}>{s.label}</span>
                   <span className="text-xs ml-auto" style={{ color: 'var(--text-secondary)' }}>{fmtDate(sub.created_at)}</span>
                   {sub.status === 'pending' && (
                     <button onClick={() => handleWithdraw(sub.id)} className="text-xs px-2 py-1 rounded-lg border" style={{ borderColor: 'var(--border-default)', color: 'var(--text-secondary)' }}>

--- a/app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx
+++ b/app/(dashboard)/profile/payments/PaymentsLedgerClient.tsx
@@ -321,7 +321,7 @@ export function PaymentsLedgerClient() {
                     </td>
                     <td className="px-3 py-2" style={{ color: 'var(--text-secondary)' }}>{entry.payment_method ?? ''}</td>
                     <td className="px-3 py-2">
-                      <StatusBadge status={entry.status} className="font-semibold px-2 py-0.5 rounded-full whitespace-nowrap">
+                      <StatusBadge status={entry.status} className="font-semibold px-2 py-0.5 rounded-control whitespace-nowrap">
                         {entry.status}
                       </StatusBadge>
                     </td>
@@ -394,7 +394,7 @@ function EntryCard({ entry, me, guestTag }: { entry: LedgerEntry; me: string; gu
           {formatCurrency(entry.amount, entry.currency)}
         </span>
         <span style={{ color: 'var(--text-secondary)' }}>{formatDate(entry.transaction_date)}</span>
-        <StatusBadge status={entry.status} className="ml-auto font-semibold px-2 py-0.5 rounded-full flex-shrink-0">
+        <StatusBadge status={entry.status} className="ml-auto font-semibold px-2 py-0.5 rounded-control flex-shrink-0">
           {entry.status}
         </StatusBadge>
       </div>

--- a/app/(dashboard)/profile/spouse-link/SpouseLinkClient.tsx
+++ b/app/(dashboard)/profile/spouse-link/SpouseLinkClient.tsx
@@ -216,7 +216,7 @@ function GuestView({ outboundRequest }: { outboundRequest: OutboundRequest | nul
       }}
     >
       <div
-        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold mb-3"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-control text-[10px] font-semibold mb-3"
         style={{
           backgroundColor: isPending ? '#f2cc8f33' : isDenied ? '#bc474915' : '#1a3c2e18',
           color: isPending ? '#7a5c00' : isDenied ? '#bc4749' : '#1a3c2e',

--- a/app/(dashboard)/roles/components/History.tsx
+++ b/app/(dashboard)/roles/components/History.tsx
@@ -88,7 +88,7 @@ export default function History({ data }: HistoryProps) {
                   {fullName}
                 </span>
                 <span
-                  className="text-xs font-bold px-2 py-0.5 rounded-full"
+                  className="text-xs font-bold px-2 py-0.5 rounded-control"
                   style={{
                     backgroundColor: 'rgba(var(--primary-default-rgb, 46, 125, 50), 0.1)',
                     color: 'var(--primary-default)',

--- a/app/(dashboard)/trips/[id]/components/ArchivedView.tsx
+++ b/app/(dashboard)/trips/[id]/components/ArchivedView.tsx
@@ -55,7 +55,7 @@ export function ArchivedView({
                         <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
                           {formatCurrency(p.amount)}
                         </p>
-                        <span className="text-xs px-1.5 py-0.5 rounded-full font-medium"
+                        <span className="text-xs px-1.5 py-0.5 rounded-control font-medium"
                           style={
                             p.admin_status === 'approved'
                               ? { backgroundColor: 'rgba(129,178,154,0.15)', color: '#2d6a4f' }

--- a/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
+++ b/app/(dashboard)/trips/[id]/components/AttendeeView.tsx
@@ -64,7 +64,7 @@ function WhosGoingTile({ attendees }: { attendees: TeamAttendee[] }) {
                     </p>
                   )}
                 </div>
-                <span className="text-xs font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
+                <span className="text-xs font-semibold px-2 py-0.5 rounded-control flex-shrink-0"
                   style={{ backgroundColor: colors.bg, color: colors.font }}>
                   {a.role}
                 </span>
@@ -222,7 +222,7 @@ export function AttendeeView({
                         <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
                           {formatCurrency(p.amount)}
                         </p>
-                        <span className="text-xs px-1.5 py-0.5 rounded-full font-medium"
+                        <span className="text-xs px-1.5 py-0.5 rounded-control font-medium"
                           style={
                             p.admin_status === 'approved'
                               ? { backgroundColor: 'rgba(129,178,154,0.15)', color: '#2d6a4f' }

--- a/app/(dashboard)/trips/[id]/components/LockedView.tsx
+++ b/app/(dashboard)/trips/[id]/components/LockedView.tsx
@@ -20,12 +20,12 @@ export function LockedView({ trip, profile }: { trip: Trip; profile: TripProfile
       <div className="max-w-[720px] mx-auto px-4 space-y-4">
         <BackButton />
         <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
+          <span className="text-xs font-semibold px-2 py-0.5 rounded-control"
             style={{ backgroundColor: 'var(--brand-forest)', color: 'rgba(255,255,255,0.85)' }}>
             {trip.destination}
           </span>
           {trip.trip_type && (
-            <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
+            <span className="text-xs font-semibold px-2 py-0.5 rounded-control"
               style={{ backgroundColor: 'var(--brand-teal)', color: 'rgba(255,255,255,0.85)' }}>
               {trip.trip_type}
             </span>

--- a/app/(dashboard)/trips/[id]/components/shared.tsx
+++ b/app/(dashboard)/trips/[id]/components/shared.tsx
@@ -144,14 +144,14 @@ export function TripHeroImage({
         <div className="absolute bottom-4 left-6 right-6">
           <div className="flex flex-wrap items-center gap-1.5 mb-2">
             <span
-              className="text-xs font-semibold px-2 py-0.5 rounded-full"
+              className="text-xs font-semibold px-2 py-0.5 rounded-control"
               style={{ backgroundColor: badgeBg, color: badgeColor }}
             >
               {trip.destination}
             </span>
             {trip.trip_type && (
               <span
-                className="text-xs font-semibold px-2 py-0.5 rounded-full"
+                className="text-xs font-semibold px-2 py-0.5 rounded-control"
                 style={{ backgroundColor: tealBadgeBg, color: badgeColor }}
               >
                 {trip.trip_type}
@@ -220,7 +220,7 @@ export function TripDetail({
           </div>
           {countdown === 0 && (
             <span
-              className="text-xs font-semibold px-3 py-1 rounded-full flex-shrink-0"
+              className="text-xs font-semibold px-3 py-1 rounded-control flex-shrink-0"
               style={{ backgroundColor: 'rgba(255,255,255,0.2)', color: '#fff' }}
             >
               {t('trips.todayBadge')}
@@ -280,7 +280,7 @@ export function TripDetail({
             </p>
             <div className="flex flex-wrap gap-1.5">
               {trip.inclusions.map((inc, i) => (
-                <span key={i} className="text-xs px-2 py-0.5 rounded-full"
+                <span key={i} className="text-xs px-2 py-0.5 rounded-control"
                   style={{ backgroundColor: 'rgba(129,178,154,0.15)', color: 'var(--text-primary)' }}>
                   {inc}
                 </span>

--- a/app/(dashboard)/trips/components/TripShared.tsx
+++ b/app/(dashboard)/trips/components/TripShared.tsx
@@ -89,21 +89,21 @@ export function TripBadges({ destination, tripType, completedLabel }: { destinat
     <div className="flex flex-wrap items-center gap-1.5 mb-1.5">
       {hasCompletedLabel && (
         <span
-          className="text-xs font-semibold px-2 py-0.5 rounded-full"
+          className="text-xs font-semibold px-2 py-0.5 rounded-control"
           style={{ backgroundColor: 'var(--brand-stone)', color: 'rgba(255,255,255,0.95)' }}
         >
           {completedLabel}
         </span>
       )}
       <span
-        className="text-xs font-semibold px-2 py-0.5 rounded-full"
+        className="text-xs font-semibold px-2 py-0.5 rounded-control"
         style={{ backgroundColor: 'var(--brand-forest)', color: 'rgba(255,255,255,0.85)' }}
       >
         {destination}
       </span>
       {tripType && (
         <span
-          className="text-xs font-semibold px-2 py-0.5 rounded-full"
+          className="text-xs font-semibold px-2 py-0.5 rounded-control"
           style={{ backgroundColor: 'var(--brand-teal)', color: 'rgba(255,255,255,0.85)' }}
         >
           {tripType}

--- a/app/events/[eventId]/register/components/MemberAttendPanel.tsx
+++ b/app/events/[eventId]/register/components/MemberAttendPanel.tsx
@@ -130,7 +130,7 @@ export function MemberAttendPanel({
         <div className="space-y-3">
           <div className="flex items-center gap-3 flex-wrap">
             <span
-              className="flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-full"
+              className="flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-control"
               style={{
                 backgroundColor: 'var(--status-success-bg, rgba(129,178,154,0.18))',
                 color: 'var(--status-success-fg, #2d6a4f)',

--- a/app/globals.css
+++ b/app/globals.css
@@ -32,6 +32,18 @@
   --color-brand-oyster: #f0ede6;
   --color-brand-moss: #252b23;
   --color-brand-stone: #8a8577;
+
+  /* ── Corner radius — one value site-wide (#740 A4) ──
+     Overriding v4's built-in --radius-* scale normalises ~515 existing
+     rounded-md/lg/xl/2xl usages to the navbar's 16px without editing 120
+     files. Canonical source is --radius in styles/brand-tokens.css; these are
+     literals because @theme resolves at build time and cannot read it.
+     Deliberately NOT collapsed: --radius-sm (hairline chrome) and
+     rounded-full (circular affordances) — see DESIGN-SYSTEM.md § Rounding. */
+  --radius-md: 16px;   /* was 0.375rem */
+  --radius-lg: 16px;   /* was 0.5rem   */
+  --radius-xl: 16px;   /* was 0.75rem  */
+  --radius-2xl: 16px;  /* was 1rem — already correct, pinned for clarity */
 }
 
 :root {

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,17 +33,31 @@
   --color-brand-moss: #252b23;
   --color-brand-stone: #8a8577;
 
-  /* ── Corner radius — one value site-wide (#740 A4) ──
-     Overriding v4's built-in --radius-* scale normalises ~515 existing
-     rounded-md/lg/xl/2xl usages to the navbar's 16px without editing 120
-     files. Canonical source is --radius in styles/brand-tokens.css; these are
-     literals because @theme resolves at build time and cannot read it.
-     Deliberately NOT collapsed: --radius-sm (hairline chrome) and
-     rounded-full (circular affordances) — see DESIGN-SYSTEM.md § Rounding. */
-  --radius-md: 16px;   /* was 0.375rem */
-  --radius-lg: 16px;   /* was 0.5rem   */
-  --radius-xl: 16px;   /* was 0.75rem  */
-  --radius-2xl: 16px;  /* was 1rem — already correct, pinned for clarity */
+  /* ── Corner radius — two tiers (#740 A4) ──
+     CSS clamps a corner to min(r, width/2, height/2), so any radius at or
+     above half an element's height renders as a capsule. One shared value
+     therefore cannot serve a card and a 19px badge at the same time.
+
+     NAMED utilities are the ones to write — they say which tier the element
+     belongs to, which is the thing a bare `rounded-xl` never encoded:
+       rounded-container  → surfaces  (cards, dialogs, sheets, popovers, rows)
+       rounded-control    → interactive (pills, badges, buttons, inputs, tabs)
+     Directional variants work too, e.g. rounded-t-container.
+
+     The built-in steps below are a LEGACY LANDING ZONE, not a scale: md/lg/xl
+     resolve to the control tier because that is what the overwhelming majority
+     of their existing usages are, so unmigrated code lands correctly by
+     default. Do not reach for them in new code. rounded-full stays untouched
+     and is reserved for genuinely circular affordances.
+     See docs/design/DESIGN-SYSTEM.md § Rounding. */
+  --radius-control:   4px;
+  --radius-container: 8px;
+
+  --radius-sm: 2px;                    /* hairline chrome only */
+  --radius-md: var(--radius-control);  /* legacy → control */
+  --radius-lg: var(--radius-control);  /* legacy → control */
+  --radius-xl: var(--radius-control);  /* legacy → control */
+  --radius-2xl: var(--radius-container);
 }
 
 :root {

--- a/components/admin/StatusPill.tsx
+++ b/components/admin/StatusPill.tsx
@@ -34,7 +34,7 @@ export function StatusPill({ status }: { status: string }) {
 
   return (
     <span
-      className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+      className="inline-flex items-center rounded-control px-2 py-0.5 text-xs font-medium"
       style={{
         backgroundColor: `var(--status-${token}-bg)`,
         color: `var(--status-${token}-fg)`,

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -56,7 +56,7 @@ export default function Footer() {
             {/* Tickets */}
             <a href="https://epaygo.bg/3640737494" target="_blank" rel="noopener noreferrer"
               aria-label="Tickets"
-              className="w-8 h-8 rounded-xl flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-control flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -70,7 +70,7 @@ export default function Footer() {
             {/* Mail */}
             <a href="mailto:teamenjoyvd@gmail.com"
               aria-label="Email"
-              className="w-8 h-8 rounded-xl flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-control flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -82,7 +82,7 @@ export default function Footer() {
             {/* Instagram */}
             <a href="https://www.instagram.com/teamenjoyvd/" target="_blank" rel="noopener noreferrer"
               aria-label="Instagram"
-              className="w-8 h-8 rounded-xl flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-control flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -95,7 +95,7 @@ export default function Footer() {
             {/* Facebook */}
             <a href="https://www.facebook.com/teamenjoyvd/" target="_blank" rel="noopener noreferrer"
               aria-label="Facebook"
-              className="w-8 h-8 rounded-xl flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-control flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="rgba(242,239,232,0.6)">
                 <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -56,7 +56,7 @@ export default function Footer() {
             {/* Tickets */}
             <a href="https://epaygo.bg/3640737494" target="_blank" rel="noopener noreferrer"
               aria-label="Tickets"
-              className="w-8 h-8 rounded-control flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -70,7 +70,7 @@ export default function Footer() {
             {/* Mail */}
             <a href="mailto:teamenjoyvd@gmail.com"
               aria-label="Email"
-              className="w-8 h-8 rounded-control flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -82,7 +82,7 @@ export default function Footer() {
             {/* Instagram */}
             <a href="https://www.instagram.com/teamenjoyvd/" target="_blank" rel="noopener noreferrer"
               aria-label="Instagram"
-              className="w-8 h-8 rounded-control flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -95,7 +95,7 @@ export default function Footer() {
             {/* Facebook */}
             <a href="https://www.facebook.com/teamenjoyvd/" target="_blank" rel="noopener noreferrer"
               aria-label="Facebook"
-              className="w-8 h-8 rounded-control flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="rgba(242,239,232,0.6)">
                 <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -56,7 +56,7 @@ export default function Footer() {
             {/* Tickets */}
             <a href="https://epaygo.bg/3640737494" target="_blank" rel="noopener noreferrer"
               aria-label="Tickets"
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-xl flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -70,7 +70,7 @@ export default function Footer() {
             {/* Mail */}
             <a href="mailto:teamenjoyvd@gmail.com"
               aria-label="Email"
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-xl flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -82,7 +82,7 @@ export default function Footer() {
             {/* Instagram */}
             <a href="https://www.instagram.com/teamenjoyvd/" target="_blank" rel="noopener noreferrer"
               aria-label="Instagram"
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-xl flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -95,7 +95,7 @@ export default function Footer() {
             {/* Facebook */}
             <a href="https://www.facebook.com/teamenjoyvd/" target="_blank" rel="noopener noreferrer"
               aria-label="Facebook"
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
+              className="w-8 h-8 rounded-xl flex items-center justify-center transition-colors hover:bg-white/10"
               style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="rgba(242,239,232,0.6)">
                 <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -45,7 +45,7 @@ export default function Header() {
     <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
       <header className="fixed top-4 left-0 right-0 z-50 px-4">
         <div className="max-w-[1440px] mx-auto relative z-50">
-          <div className="h-14 flex items-center px-5 rounded-2xl backdrop-blur-md backdrop-saturate-150"
+          <div className="h-14 flex items-center px-5 rounded-container backdrop-blur-md backdrop-saturate-150"
             style={{
               backgroundColor: 'rgba(var(--bg-global-rgb), 0.80)',
               border: '1px solid var(--nav-border)',
@@ -149,7 +149,7 @@ export default function Header() {
       {/* Mobile/tablet drawer — visible below lg */}
       <SheetContent
         side="top"
-        className="lg:hidden inset-x-4 top-20 max-w-[1440px] mx-auto h-auto shadow-none rounded-2xl py-2 px-3 flex flex-col gap-1"
+        className="lg:hidden inset-x-4 top-20 max-w-[1440px] mx-auto h-auto shadow-none rounded-container py-2 px-3 flex flex-col gap-1"
         style={{
           backgroundColor: 'rgba(var(--bg-global-rgb), 0.97)',
           border: '1px solid var(--nav-border)',

--- a/components/layout/NotificationPopup.tsx
+++ b/components/layout/NotificationPopup.tsx
@@ -43,7 +43,7 @@ export default function NotificationPopup({ onClose }: Props) {
         </p>
         {unreadCount > 0 && (
           <span
-            className="text-[10px] font-bold px-2 py-0.5 rounded-full"
+            className="text-[10px] font-bold px-2 py-0.5 rounded-control"
             style={{ backgroundColor: 'var(--brand-crimson)', color: 'var(--brand-parchment)' }}
           >
             {unreadCount}
@@ -56,7 +56,7 @@ export default function NotificationPopup({ onClose }: Props) {
         {isLoading ? (
           <div className="px-4 py-6 space-y-3">
             {[...Array(3)].map((_, i) => (
-              <div key={i} className="h-10 rounded-xl animate-pulse"
+              <div key={i} className="h-10 rounded-container animate-pulse"
                 style={{ backgroundColor: 'var(--border-default)' }} />
             ))}
           </div>

--- a/components/layout/UserDropdown.tsx
+++ b/components/layout/UserDropdown.tsx
@@ -100,7 +100,7 @@ export default function UserDropdown() {
                 {fullName}
               </p>
               <span
-                className="text-[10px] font-semibold px-2 py-0.5 rounded-full mt-0.5 inline-block"
+                className="text-[10px] font-semibold px-2 py-0.5 rounded-control mt-0.5 inline-block"
                 style={{ backgroundColor: roleColors.bg, color: roleColors.font }}
               >
                 {isUnverified ? 'Unverified Member' : (ROLE_LABELS[role] ?? role)}

--- a/components/los-import/AssemblySummary.tsx
+++ b/components/los-import/AssemblySummary.tsx
@@ -8,7 +8,7 @@ import { type AssemblyResult, type JunctionNode } from '@/lib/csv-import'
 export function JunctionPanel({ junctions, ownerLabel = 'in' }: { junctions: JunctionNode[]; ownerLabel?: string }) {
   if (junctions.length === 0) return null
   return (
-    <div className="p-4 rounded-xl border mt-4" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
+    <div className="p-4 rounded-container border mt-4" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
       <p className="text-xs font-semibold mb-2" style={{ color: 'var(--text-primary)' }}>
         Junction nodes ({junctions.length})
       </p>
@@ -19,7 +19,7 @@ export function JunctionPanel({ junctions, ownerLabel = 'in' }: { junctions: Jun
             style={{ backgroundColor: j.has_conflict ? 'rgba(224,122,95,0.08)' : 'rgba(129,178,154,0.08)' }}>
             <span className="font-mono font-medium" style={{ color: 'var(--text-primary)' }}>{j.abo_number}</span>
             <span style={{ color: 'var(--text-secondary)' }}>{j.name}</span>
-            <span className="ml-auto text-xs px-1.5 py-0.5 rounded-full font-semibold"
+            <span className="ml-auto text-xs px-1.5 py-0.5 rounded-control font-semibold"
               style={{
                 backgroundColor: j.has_conflict ? 'rgba(224,122,95,0.2)' : 'rgba(129,178,154,0.2)',
                 color: j.has_conflict ? '#e07a5f' : '#2d6a4f',
@@ -49,12 +49,12 @@ export function AssemblySummary({
 }) {
   return (
     <>
-      <div className="p-4 rounded-xl border" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
+      <div className="p-4 rounded-container border" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}>
         <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
           Assembly: {assembly.total_row_count} unique members from {sourceCount} {sourceLabel}{sourceCount !== 1 ? 's' : ''}
         </p>
         {assembly.disconnected_files.length > 0 && (
-          <div className="mt-2 p-3 rounded-lg" style={{ backgroundColor: 'rgba(224,122,95,0.08)' }}>
+          <div className="mt-2 p-3 rounded-container" style={{ backgroundColor: 'rgba(224,122,95,0.08)' }}>
             <p className="text-xs font-semibold" style={{ color: '#e07a5f' }}>
               ⚠ Potentially disconnected {sourceLabel}{assembly.disconnected_files.length !== 1 ? 's' : ''}: {assembly.disconnected_files.join(', ')}
             </p>

--- a/components/los-import/DropZone.tsx
+++ b/components/los-import/DropZone.tsx
@@ -22,7 +22,7 @@ export function DropZone({
   return (
     <div className="space-y-4">
       <div
-        className="border-2 border-dashed rounded-lg p-8 text-center"
+        className="border-2 border-dashed rounded-container p-8 text-center"
         style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)' }}
         onDragOver={e => e.preventDefault()}
         onDrop={onFileDrop}
@@ -49,7 +49,7 @@ export function DropZone({
           {files.map(f => (
             <div
               key={f.filename}
-              className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full border"
+              className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-control border"
               style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-card)', color: 'var(--text-primary)' }}
             >
               <span>{f.filename}</span>

--- a/components/los-import/SubtreePreview.tsx
+++ b/components/los-import/SubtreePreview.tsx
@@ -88,7 +88,7 @@ export function SubtreePreview({
   }
 
   return (
-    <div className="overflow-x-auto rounded-xl border p-3" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-subtle, var(--bg-card))' }}>
+    <div className="overflow-x-auto rounded-container border p-3" style={{ borderColor: 'var(--border-default)', backgroundColor: 'var(--bg-subtle, var(--bg-card))' }}>
       <svg width={bounds.maxX + 20} height={bounds.maxY + 20} style={{ display: 'block' }}>
         {edges.map((e, i) => (
           <path

--- a/components/payment/BeneficiaryPicker.tsx
+++ b/components/payment/BeneficiaryPicker.tsx
@@ -244,7 +244,7 @@ export function BeneficiaryPicker({
 
       {!isLoading && addingGuest && (
         <div
-          className="space-y-2 rounded-xl p-3"
+          className="space-y-2 rounded-container p-3"
           style={{ border: '1px dashed var(--border-default)' }}
         >
           <input

--- a/components/payment/PaymentForm.tsx
+++ b/components/payment/PaymentForm.tsx
@@ -355,7 +355,7 @@ export function PaymentForm(props: PaymentFormProps) {
               return (
                 <span
                   key={row.profileId}
-                  className="inline-flex items-center gap-1.5 rounded-full pl-3 pr-2 text-xs"
+                  className="inline-flex items-center gap-1.5 rounded-control pl-3 pr-2 text-xs"
                   style={{
                     minHeight: '32px',
                     border: '1px solid var(--border-default)',
@@ -393,7 +393,7 @@ export function PaymentForm(props: PaymentFormProps) {
             <button
               type="button"
               onClick={() => setPickerOpen(true)}
-              className="inline-flex items-center rounded-full px-3 text-xs font-semibold transition-opacity hover:opacity-70"
+              className="inline-flex items-center rounded-control px-3 text-xs font-semibold transition-opacity hover:opacity-70"
               style={{
                 minHeight: '32px',
                 border: '1px dashed var(--border-default)',

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -35,7 +35,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       style={{
         backgroundColor: 'var(--bg-card)',
-        borderRadius: '16px',
+        borderRadius: 'var(--radius)',
         boxShadow: 'var(--shadow-modal)',
         outline: 'none',
         ...style,

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -24,7 +24,7 @@ function DropdownMenuContent({
           width: 220,
           backgroundColor: 'var(--bg-card)',
           border: '1px solid var(--border-default)',
-          borderRadius: '16px',
+          borderRadius: 'var(--radius)',
           boxShadow: 'var(--shadow-modal)',
           overflow: 'hidden',
           outline: 'none',

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -22,7 +22,7 @@ function PopoverContent({
         style={{
           backgroundColor: 'var(--bg-global)',
           border: '1px solid var(--border-default)',
-          borderRadius: '16px',
+          borderRadius: 'var(--radius)',
           boxShadow: 'var(--shadow-modal)',
           outline: 'none',
           ...style,

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -58,7 +58,7 @@ function SelectContent({
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         className={cn(
-          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-xl border shadow-md',
+          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-container border shadow-md',
           'data-[state=open]:animate-in data-[state=closed]:animate-out',
           'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
           'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
@@ -109,7 +109,7 @@ function SelectItem({
   return (
     <SelectPrimitive.Item
       className={cn(
-        'relative flex w-full cursor-default select-none items-center rounded-lg py-2 pl-3 pr-8 text-sm outline-none',
+        'relative flex w-full cursor-default select-none items-center rounded-container py-2 pl-3 pr-8 text-sm outline-none',
         'focus:bg-black/5 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         className,
       )}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -109,7 +109,7 @@ function SelectItem({
   return (
     <SelectPrimitive.Item
       className={cn(
-        'relative flex w-full cursor-default select-none items-center rounded-container py-2 pl-3 pr-8 text-sm outline-none',
+        'relative flex w-full cursor-default select-none items-center rounded-control py-2 pl-3 pr-8 text-sm outline-none',
         'focus:bg-black/5 data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         className,
       )}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -10,7 +10,7 @@ export function Skeleton({
 }) {
   return (
     <div
-      className={cn('skeleton-shimmer rounded-md', className)}
+      className={cn('skeleton-shimmer rounded-container', className)}
       style={{ backgroundColor: 'var(--skeleton-base)', ...style }}
     />
   )

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -11,7 +11,7 @@ function Toaster({ ...props }: ToasterProps) {
           backgroundColor: 'var(--bg-card)',
           color: 'var(--text-primary)',
           border: '1px solid var(--border-default)',
-          borderRadius: '8px',
+          borderRadius: 'var(--radius)',
         },
         classNames: {
           error:

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-full font-semibold transition-all hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2 text-[var(--text-secondary)] bg-[rgba(0,0,0,0.05)] data-[state=on]:text-white data-[state=on]:bg-[var(--brand-teal)]",
+  "inline-flex items-center justify-center rounded-control font-semibold transition-all hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2 text-[var(--text-secondary)] bg-[rgba(0,0,0,0.05)] data-[state=on]:text-white data-[state=on]:bg-[var(--brand-teal)]",
   {
     variants: {
       variant: {

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -20,7 +20,7 @@ function TooltipContent({
         style={{
           backgroundColor: 'var(--bg-global)',
           border: '1px solid var(--border-default)',
-          borderRadius: '10px',
+          borderRadius: 'var(--radius)',
           boxShadow: '0 8px 32px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.06)',
           outline: 'none',
           maxWidth: '320px',

--- a/components/ui/vaul-drawer.tsx
+++ b/components/ui/vaul-drawer.tsx
@@ -56,7 +56,7 @@ export function VaulDrawer({
             zIndex: 50,
             display: 'flex',
             flexDirection: 'column',
-            borderRadius: '1rem 1rem 0 0',
+            borderRadius: 'var(--radius) var(--radius) 0 0',
             backgroundColor: 'var(--bg-global)',
             boxShadow: '0 -4px 32px rgba(0,0,0,0.18)',
             outline: 'none',

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,6 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #730 | `dev/2608-DEV-730` | env tooling only: `scripts/check-env.js`, `scripts/lib/env-files.js` (new), `scripts/lib/safe-supabase-target.js`, the four `scripts/seed-*.js` loaders, `playwright.config.ts` (comment), `.env.example`, `CLAUDE.md` — **migration: no** | 2026-08-12 |
+| #740 | `dev/2608-DEV-740` | QA polish: `app/(dashboard)/calendar/components/{MonthView.tsx,popup/*}`, `app/(dashboard)/components/tiles/TripHeroTile.tsx`, `app/(dashboard)/profile/components/{AboInfoContent,StatusBadge}.tsx`, `components/layout/Footer.tsx`, `components/ui/{tooltip,sonner,vaul-drawer}.tsx`, `styles/brand-tokens.css` (radius only), `app/globals.css` (`@theme` radius keys only), `docs/design/DESIGN-SYSTEM.md` — **migration: no** | 2026-08-13 |
+| #741 | `dev/2608-DEV-741` | Dark-mode foundation (C1 only): `styles/brand-tokens.css` (colour tokens), `app/globals.css` (`@theme inline`, `color-scheme`, `@custom-variant dark`), `docs/design/DESIGN-SYSTEM.md` — **migration: no**. ⚠️ Overlaps #740 on both CSS files; branch is **stacked on `dev/2608-DEV-740`**, PR base is that branch, not `main`. C2/C4/C5 phases are deliberately NOT in this claim. | 2026-08-13 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,31 +1,66 @@
 ## Goal
-#730 (branch `dev/2608-DEV-730`): make `npm run check:env` truthful about which Supabase project a
-command will actually reach, and define the `.env*` load order in exactly one module.
+Two stacked tickets, both open as DRAFT PRs, neither merged.
+
+- **#740** (`dev/2608-DEV-740` → PR **#744**, base `main`): QA polish — calendar bubble insets,
+  popup title + dark-mode contrast, Trips bento deep link, and a **two-tier corner radius system**.
+- **#741** (`dev/2608-DEV-741` → PR **#745**, base **`dev/2608-DEV-740`**): C1 only of the dark-mode
+  foundation — fill the token gaps and make every semantic token a Tailwind utility.
 
 ## Now
-BUILD is complete locally on `dev/2608-DEV-730`; nothing is pushed. #702 (the event-invite epic) was
-assessed and CLOSED the same session — all ten children and all six follow-ups were merged.
 
-`scripts/lib/env-files.js` is new and owns the Next.js chain (process.env, `.env.$(NODE_ENV).local`,
-`.env.local` except under test, `.env.$(NODE_ENV)`, `.env`). `check-env.js` now reports TWO Supabase
-targets — dev/seed and production-mode — because they are different projects from one working tree.
-The four `seed-*.js` scripts and `playwright.config.ts` all call the shared loader; their four
-copy-pasted loaders are gone. Target classification moved to `scripts/lib/safe-supabase-target.js`
-and matches on the parsed hostname, so `https://<dev-ref>.supabase.co.evil.example` is no longer
-reported as "DEV — safe for local writes".
+**#741 is stacked on #740.** PR #745's base is `dev/2608-DEV-740`, NOT `main`, because both branches
+edit `styles/brand-tokens.css` and `app/globals.css`. Merge #744 first; GitHub retargets #745
+automatically. **#741 has NOT yet been rebased onto the latest #740** — see Next, step 1.
+
+### #740 — what landed
+Commits `9fc24a9` (original) + the radius revision on top.
+
+A1 event-bar wrapper carries a 2px inset keyed off `packWeek`'s `continuesLeft/Right`. A2 the popup
+title is a real `DialogTitle` at `text-lg` (the Dialog had no accessible name at all). A3
+`popup/styles.ts`, `EVENT_TYPE_STYLES` and the popup's pills/rows/skeletons all resolve to
+`--status-*` pairs. A5 the Trips tile body links to `/trips/{id}` via a sibling overlay — the
+issue's `z-0` spec would NOT have worked (content overlays are `z-10` and not click-transparent), so
+content is `pointer-events-none` and the pill sits at `z-20`.
+
+**A4 was redesigned mid-session after visual review.** It originally collapsed everything to one
+16px radius. That failed because **CSS clamps corner radii**: the rendered corner is
+`min(r, width/2, height/2)`, so a 19px status badge is a capsule at 16px *and* at 12px. A single
+value cannot serve a 200px card and a 19px badge. Now:
+
+| Tier | Value | Token | Utility |
+|---|---|---|---|
+| Container | 8px | `--radius` | `rounded-container` |
+| Control | 4px | `--radius-control` | `rounded-control` |
+
+`--radius-sm` is 2px (hairline). `--radius-md/lg/xl` are pinned to the control tier and
+`--radius-2xl` to the container tier as a **legacy landing zone**, so unmigrated code lands sanely —
+that is not a scale, and new code must use the named utilities.
+
+### #741 C1 — what landed
+Commits `09b4280` + `bc60cf2` on `dev/2608-DEV-741`.
+
+`--link`, `--link-hover`, `--on-accent`, `--overlay`, `--hover-surface`, `--focus-ring` in both
+themes; `@theme inline` maps every semantic token into Tailwind's colour scale; `color-scheme` set
+for both themes; `@custom-variant dark` registered against `[data-theme="dark"]`, reversing the old
+blanket ban with the doc updated in the same commit.
 
 ## Next
-1. Ask for a push grant, then push `dev/2608-DEV-730` and open the PR as a draft (**no migration** in
-   this ticket — no prod gate, no `migrate-prod` approval needed).
-2. `/code-review low` before the first push, then mark ready for CodeRabbit and apply GCR.
-3. `npm run verify` was NOT run locally on purpose: its `next build` step runs under
-   `NODE_ENV=production`, which on this box resolves `.env.local` = PROD — exactly what the new
-   warning describes. CI builds it on the PR instead.
+1. **Rebase #741 onto #740** — `git rebase dev/2608-DEV-740` on `dev/2608-DEV-741`, then force-push.
+   Expect a conflict in `docs/STATE.md` (this file was rewritten on #740 after #741 branched) and
+   possibly in `styles/brand-tokens.css` / `app/globals.css`. Resolve by keeping BOTH: #740's radius
+   tokens and #741's colour tokens are disjoint additions to the same files.
+2. Vercel preview READY + CI green on both, then the **visual pass — the real gate**. At 390px and
+   desktop, in **both** themes: status badges and filter chips must show a flat edge;
+   cards/dialogs/navbar read at 8px; check the mobile event popup's top corners, the Footer social
+   row (now 4px squares, was circles), and the Trips hero tile (the surface most at risk at 8px).
+3. `/code-review low` on each, then mark ready for CodeRabbit and apply GCR.
+4. File the **Phase 2** issue (see Open items) for `app/admin/**`.
+5. `npm run verify` deliberately NOT run locally: its `next build` runs under `NODE_ENV=production`,
+   which on this box resolves `.env.local` = PROD. CI builds it on the PR.
 
 ## Constraints
-- Never push without an explicit grant in this conversation. Grants from earlier tickets/sessions
-  do not carry over. (No push grant in this session as of the #730 BUILD — "bring 730 to a
-  merge-able state" was not read as one.)
+- Never push without an explicit grant in this conversation. Grants from earlier tickets/sessions do
+  not carry over. (A grant WAS given this session: "PUSH TO OPEN DRAFT PR #740 and #741".)
 - Never apply migrations to a hosted Supabase project (DEV or prod) without asking first.
 - Fold `docs/CLAIMS.md` row removal + `docs/STATE.md` updates into the merging PR, never a
   standalone cleanup PR.
@@ -33,95 +68,119 @@ reported as "DEV — safe for local writes".
   Run `npm run check:env` before any command touching a hosted DB.
 
 ## Decisions
+- DECISION (#740): corner radius is **two tiers at 2:1** — containers 8px, controls 4px. Chosen so
+  that **nothing clamps anywhere** (both sit below half the height of the shortest element in their
+  tier) and so a badge reads as nested inside its card. If either changes, keep the ratio and keep
+  the control value under half the shortest badge's height.
+- DECISION (#740): the authoring API is the **named** utilities `rounded-container` /
+  `rounded-control`, not the built-in steps. A bare `rounded-xl` never encoded which KIND of element
+  it was on, which is exactly how four scales drifted into the codebase.
+- DECISION (#740): sheets and the mobile dialog follow the container tier — no exception. Footer
+  social icon buttons square up to the control tier. `--radius-sm` = 2px stays a distinct step.
+- DECISION (#740): the radius migration is **phased**. Phase 1 (this PR) covers `components/`,
+  `app/(dashboard)/`, `app/events/`. Phase 2 covers `app/admin/**`.
 - DECISION (#734): `gotoProtected` covers protected PAGE navigations only. Two spec shapes have no
   protected page to land on — API-only (`los-submission-auth`, and `admin-auth`'s `page.request`
-  cases) and PUBLIC target pages (`/events/:id/join`, `/events/:id/register`, both in
-  `PUBLIC_ROUTE_PATTERNS`). Both got `waitForServerSession()` in `e2e/auth-helpers.ts`: poll
-  `/api/profile` until it stops answering 401. Any non-401 settles it — a 404 still proves Clerk
-  resolved the user.
-- DECISION (#734): `profile-bento-auth` is converted because issue #734 lists it, but its known red
-  is #727's transient-401 eviction (fixed by PR #736) — a different bug on a different layer.
+  cases) and PUBLIC target pages (`/events/:id/join`, `/events/:id/register`). Both got
+  `waitForServerSession()` in `e2e/auth-helpers.ts`.
 
 ## Facts
-- Prod migration ledger head is `20260811000100`, verified 2026-08-12 against project
-  `ynykjpnetfwqzdnsgkkg` — #718's migration IS applied on prod. Do not re-raise it as pending.
-- `playwright.config.ts` never sets `fullyParallel`: Playwright parallelizes by FILE, so tests in
-  one spec share a worker and DB state in declaration order.
+- **CSS clamps corner radii** (CSS Backgrounds 3 §5.5): rendered corner is
+  `min(r, width/2, height/2)`. Measured element heights — status badge **19px**, Trips eyebrow
+  21.5px, filter chip 24px, Footer social button 32px, navbar 56px. This is why 12px would have
+  changed nothing for the pills.
+- `docs/design/radius-bench.html` is a standalone browser tool that renders every portal surface at
+  an adjustable radius, both themes, and reports requested vs actually-rendered radius. Open it
+  before touching either radius value. Its specimen palettes are copied from `brand-tokens.css` and
+  must be updated by hand if those tokens change.
+- Tailwind v4.2.1: a `@theme` override of a BUILT-IN scale key works, and **custom** `@theme` keys
+  generate named utilities including directional variants (`rounded-t-container`,
+  `md:rounded-container`). Verified by compiling the real `app/globals.css` through `tailwindcss`'s
+  `compile()`; that harness lived in the session scratchpad, not the repo.
+- Plain `@theme { --color-x: var(--y) }` does **NOT** freeze the light value — it emits an
+  indirection CSS still substitutes at use-time, so it is theme-aware too. `@theme inline` is
+  preferred for being the shadcn v4 convention and dropping the indirection, NOT because plain
+  `@theme` breaks. Do not repeat the "freezes the light value" claim; it was measured false.
+- Overriding a shadcn default utility by className works because Tailwind emits the larger scale step
+  later in the stylesheet (`.text-lg` after `.text-base`) — verified, not assumed.
+- Baseline on both branches: `npm test` 481 passed / 34 files, `npx tsc --noEmit` clean,
+  `npm run lint` 0 errors / 465 pre-existing warnings.
+- Prod migration ledger head is `20260811000100`, verified 2026-08-12 against `ynykjpnetfwqzdnsgkkg`.
+- `playwright.config.ts` never sets `fullyParallel`: Playwright parallelizes by FILE.
 - Authenticated e2e cannot run against `.env.local` (PROD credentials). Use the DEV override
-  (`iymwxdewcpvpjgzewtzk`). A cold dev server makes local authenticated runs untrustworthy — only a
-  warm-server run is evidence.
-- `getToken` IS exported from `@clerk/nextjs` v7.5.15 (re-export of `@clerk/shared/getToken`):
-  `node_modules/@clerk/nextjs/dist/types/index.d.ts:16`, and `require('@clerk/nextjs').getToken` is
-  a `function`. A `/code-review low` pass claimed otherwise and was wrong — do not re-litigate from
-  memory.
-- Every 401 the browser can receive from `app/api/**` is a PRE-side-effect auth guard (`proxy.ts:19`
-  plus `if (!userId) return 401` at the top of each handler, 40+ sites swept) — which is what makes
-  replaying a failed POST safe.
-- Baseline on `main` (`0b482a1`) before #730: `npm test` 33 files / 461 tests, `npx tsc --noEmit`
-  clean. After #730: 34 files / 480 tests, tsc clean, `npm run lint` 0 errors (465 pre-existing
-  warnings) — 2026-08-12.
-- This box's `.env.development.local` points at the DEAD local stack (`127.0.0.1:54321`) and
-  `.env.local` at PROD. So `npm run check:env` reports `LOCAL stack` for the dev/seed path and
-  `PROD project` for production mode. That is the #730 warning working, not a misconfiguration
-  introduced by it — but any local command needing a live DB still needs the DEV override.
+  (`iymwxdewcpvpjgzewtzk`). Only a warm-server run is evidence.
 
 ## Done
-- #702 CLOSED (epic, 2026-08-12) — assessment only, no code. All ten children (#703–#710) and all six
-  follow-ups (#713, #714, #715, #718, #726, #727) merged; body updated with the PR for each.
-- #730 BUILD — RESULT: `scripts/lib/env-files.js` (new, shared Next.js env chain) +
-  `scripts/lib/env-files.test.js` (19 tests); `check-env.js` dual-reports dev/seed vs production-mode
-  targets; `classifySupabaseTarget` moved to `scripts/lib/safe-supabase-target.js` with host matching;
-  four `seed-*.js` loaders and `playwright.config.ts` now call the shared loader. Verified:
-  `NODE_ENV=production npm run check:env` names the PROD project where it used to print
-  `LOCAL stack`; `npm test` 480 passed; tsc clean; lint 0 errors;
-  `npx playwright test --list` 73 tests in 14 files. NOT pushed.
-- #734 BUILD — RESULT: all seven specs converted to `gotoProtected`/`signInAndGoto`, plus
-  `waitForServerSession` / `signInAndWaitForSession` in `e2e/auth-helpers.ts`. tsc + eslint clean,
-  `npx playwright test --list --project=authenticated` lists 35 tests in 9 files, `/code-review low`
-  clean. PR #738, 11/11 green on `73d4412` over two consecutive `Authenticated E2E` runs.
-- MERGED: #727 as PR #736 (`01a00ee`), #733 as PR #737 (`32791a9`), #726 as PR #735 (`ff55ad2`),
-  #718 as `4ac7228` (its prod migration is applied — see Facts). #715 (#731), #714, #713, #710,
-  #709, #708, #722 merged earlier.
+- #740 BUILD — A1–A5 plus the two-tier radius revision and the Phase 1 sweep. Verified: tsc clean,
+  `npm test` 481 passed, lint 0 errors/465 warnings, real `app/globals.css` compiles to
+  `rounded-control → var(--radius-control)` and `rounded-container → var(--radius-container)`, and
+  every surviving `rounded-full` in Phase 1 scope (27 sites) audited against the circular list.
+  **NOT visually verified.** Branch `dev/2608-DEV-740`, PR #744 (draft).
+- #741 C1 BUILD — Verified: tsc clean, `npm test` 481 passed, lint unchanged, real `globals.css`
+  emits `bg-bg-card → var(--bg-card)`, `text-link → var(--link)`, `bg-bg-card/50 → color-mix(...)`,
+  `dark:shadow-lg → &:where([data-theme="dark"] *)`. **NOT visually verified.** Branch
+  `dev/2608-DEV-741`, PR #745 (draft, stacked).
+- #730 merged as PR #739; #734 as #738; #733 as #737; #726 as #735; #727 as #736; #718 as `4ac7228`.
+- #702 CLOSED (epic, 2026-08-12) — all ten children and all six follow-ups merged.
 
 ## Open items
+- **OPEN — Phase 2 of the radius migration (`app/admin/**`), not yet filed as an issue.** Audited
+  work: **61 pill-shaped `rounded-full` sites** → `rounded-control`, and **~80 containers stranded
+  on `rounded-lg`/`rounded-xl`** → `rounded-container`. High-leverage shared components to do first
+  (one edit each, many call sites): `app/admin/calendar/components/Pill.tsx:8`,
+  `app/admin/components/AdminStatusBadge.tsx:15`, `app/admin/components/RoleSelector.tsx:29`,
+  `app/admin/components/AdminTabs.tsx:65`. Two admin ambiguities deferred with it:
+  `AdminTabs.tsx:65` (count badge — near-circular at one digit) and `MembersTable.tsx:113` (24px
+  circular ABO-level token). Until this lands, admin renders at the control tier by default —
+  visible but internal-facing.
+- **OPEN (#741 C4):** `--text-tertiary` fails WCAG AA in BOTH themes — 3.15:1 light, 3.94:1 dark on
+  `--bg-card` — and is never redefined for dark at all. Not fixed in C1 because it moves light-mode
+  pixels and "light mode visually unchanged" is C1's review invariant.
+- **NOTED (#740), deliberately deferred:** `app/(dashboard)/profile/components/StatusBadge.tsx:50` is
+  `className={className ?? DEFAULT_CLASSNAME}` — a **replacement, not a merge**. Eight callers pass a
+  className and thereby silently drop `inline-flex items-center`
+  (`InvitesSection.tsx:286,371,390`, `shared.tsx:62,150`, `ParticipationSection.tsx:54`,
+  `payments/PaymentsLedgerClient.tsx:324,397`). The plan said to fix it here; I did the radius swap
+  only, because adding `inline-flex` changes `display` on eight badges for no radius reason and
+  would contaminate this PR's visual review. Fix separately with `cn()`.
+- **NOTED (#741 C1):** the 5 pre-existing `dark:` classes (`LinksGuidesTile.tsx:85,:111`,
+  `ReminderTable.tsx:68`, `RemindersTab.tsx:85,:119`) are all COLOUR classes. Registering the variant
+  makes them fire on the right signal, but under the revised rule colour belongs in tokens —
+  `LinksGuidesTile`'s pair is exactly `--hover-surface`. Convert in C2.
+- **NOTED (#740):** the calendar Dialog still has no `DialogDescription`, so Radix continues to warn
+  about a missing description even though the title is now fixed. One line, not in this ticket.
+- **NOTED:** four hand-rolled switch duplicates (`RemindersTab`, `ReminderTable`,
+  `EmailSettingsPanel`) should use `components/ui/switch.tsx`.
 - Still open from #715: five call sites silently skip on a null `contact_email`
   (`lib/abo/verifyAbo.ts:226`, both spouse-link routes,
   `app/api/admin/members/verify/[id]/route.ts:99`, `lib/server/member-registration.ts`) — a shared
   `resolveProfileEmail()` would fix all six.
 - NOTED (same-class as #715): `lib/email/send.ts:129` still reads `if (!config.enabled)`, the check
-  #715 tightened to `!== true`. `enabled` comes from JSONB through an `as EmailConfig` cast, so a row
-  holding `"true"` or `1` makes the master kill switch fail OPEN. Repo-wide sweep: exactly one
-  instance left. One-line fix, needs its own ticket.
-- RESOLVED by #730 (was NOTED from #726 GCR): `scripts/check-env.js` had no regression tests because
-  it runs side effects at require time. The resolver is now `scripts/lib/env-files.js` and
-  `scripts/lib/env-files.test.js` covers it — the repo's first `scripts/**/*.test.js`, a glob
-  `vitest.config.ts` already included. check-env's own top-level side effects are unchanged and
-  still untested directly.
+  #715 tightened to `!== true`. A row holding `"true"` or `1` makes the master kill switch fail OPEN.
 - NOTED (same-class, from #710): the case-sensitive email match fixed in the #710 RPC also exists in
   TypeScript at `lib/server/member-registration.ts` — `.eq('email', contactEmail)` in `attendEvent`'s
-  D9 adopt step. `Ivan@Example.com` is not adopted and gets a second row. Needs `citext`/`lower()`
-  or `.ilike()`.
+  D9 adopt step. Needs `citext`/`lower()` or `.ilike()`.
 - NOTED: `app/api/calendar/feed-token/route.ts:21,45,81` and
-  `app/api/profile/spouse-link/route.ts:138` still `await getBaseUrl()` unguarded. Neither commits
-  irreversible state first, so neither has #713's half-success shape. No ticket filed.
+  `app/api/profile/spouse-link/route.ts:138` still `await getBaseUrl()` unguarded.
 - NOTED: `e2e/server-watchdog-reporter.ts:57` calls `process.exit(1)`, skipping Playwright's
-  `test.afterAll` — if the dev server dies during `event-registrations-auth.spec.ts`, its cleanup
-  never runs and seeded rows are orphaned in the shared DEV project.
+  `test.afterAll` — seeded rows can be orphaned in the shared DEV project.
 - NOTED: `types/supabase.ts:2370` types five `get_event_registrations_for_viewer` returns as
   non-nullable `string` while all five are NULL in normal operation.
-- NOTED: a signed-in member blocked by a FULL event still gets `ResendLinkForm` (the guest
-  magic-link resend) at `app/events/[eventId]/register/page.tsx:179` and `:216` — wrong flow for a
-  portal identity.
+- NOTED: a signed-in member blocked by a FULL event still gets `ResendLinkForm` at
+  `app/events/[eventId]/register/page.tsx:179` and `:216` — wrong flow for a portal identity.
 - NOTED: `app/events/[eventId]/join/components/JoinActions.tsx:30-39` (`downloadIcs`) still has the
   detached-anchor + synchronous-`revokeObjectURL` pattern fixed in `AddToCalendarMenu.tsx`.
 - NOTED: `docs/ai/REF.md` §6 Edge Functions table lists `send-event-reminders` (does not exist) and
-  omits `deliver-email-notifications`; §5's `guest_registrations` row is the pre-#705 column list.
+  omits `deliver-email-notifications`.
 - FLAKE (not a spec defect): `Authenticated E2E (Clerk)` can fail wholesale at `clerk.signIn()` with
-  `[Clerk Testing] FAPI request failed after 4 attempts` — Clerk's dev FAPI transiently down. Re-run
-  the same commit; do not "fix" it in the specs.
+  `[Clerk Testing] FAPI request failed after 4 attempts`. Re-run the same commit.
 
 ## Failed attempts
 - ATTEMPT 1 [L1] (#709 GCR): adding an explicit `role="tab"` to the tab-bar buttons broke all four
   `event-registrations-auth` specs — an explicit ARIA role OVERRIDES `<button>`'s implicit role, so
   `getByRole('button', …)` matched nothing. Lesson: adding an ARIA role is a REFERENCE SWEEP trigger
   for `getByRole` locators, not just for symbol renames.
+- ATTEMPT 2 [L1] (#740 A4, first design): "one radius site-wide = the navbar's 16px". Shipped to a
+  draft PR and failed visual review — the pills still looked round. Cause: CSS radius clamping (see
+  Facts). Lesson: a radius decision cannot be reviewed as a diff; render it. That is what
+  `docs/design/radius-bench.html` is for.

--- a/docs/design/DESIGN-SYSTEM.md
+++ b/docs/design/DESIGN-SYSTEM.md
@@ -61,38 +61,79 @@ fonts have real usage in the app.
 
 ## Rounding
 
-**One radius, site-wide: 16px.** It is the navbar shell's radius (`Header.tsx`),
-and it is now canonical for every card, pill, badge, input, button and overlay
-surface. Before 2608-DEV-740 four scales coexisted (16 / 12 / 8 / 6px, plus 165
-`rounded-full`), which is why nothing looked like it belonged to one system.
+**Two tiers, held at 2:1 — containers 8px, controls 4px.**
 
-The value lives in exactly one place — `--radius` in `styles/brand-tokens.css`:
+| Tier | Value | Token | Utility | What it covers |
+|---|---|---|---|---|
+| Container | **8px** | `--radius` | `rounded-container` | Cards, tiles, dialogs, sheets, popovers, menus, list rows, panels, images, skeleton blocks, the navbar shell |
+| Control | **4px** | `--radius-control` | `rounded-control` | Pills, badges, chips, buttons, inputs, selects, tabs |
 
-| Layer | How it gets 16px |
-|---|---|
-| Tailwind utilities | `app/globals.css` `@theme` pins `--radius-md`, `--radius-lg`, `--radius-xl`, `--radius-2xl` to `16px`, so `rounded-md/lg/xl/2xl` are all the same radius. This normalises ~515 existing class usages without editing the files. |
-| `.card` and bento surfaces | `--bento-radius: var(--radius)` |
-| Inline `style` props (shadcn fork in `components/ui/`) | `borderRadius: 'var(--radius)'` |
+Both live in `styles/brand-tokens.css`. Directional variants work
+(`rounded-t-container` for the mobile bottom sheet).
 
-Because the four Tailwind steps are equal, **which one you type does not
-matter** — prefer `rounded-xl`. Never write a numeric radius (`10px`,
-`0.5rem`, `9999px`) in a component; use `var(--radius)` or a `rounded-*`
-utility.
+### Why not one value
+
+An earlier revision of this section mandated a single 16px radius. It was
+wrong, and the reason is worth keeping because it is not obvious:
+
+> **CSS clamps corner radii.** When the two radii on a side exceed that side's
+> length, *every* radius scales down by the same factor (CSS Backgrounds 3
+> §5.5). For a uniform radius the rendered corner is
+> `min(r, width/2, height/2)`.
+
+A status badge is **19px tall**. At 16px it renders at 9.5px — exactly half its
+height, which is a capsule. At 12px it is *still* a capsule. No value at or
+above ~9px changes that badge at all, so "one radius site-wide" silently meant
+"cards get 16px and every pill stays a lozenge".
+
+8px and 4px were chosen so that **nothing clamps anywhere** — every element
+renders exactly the value set — and the 2:1 gap is what makes a badge read as
+nested inside its card. If you change these, keep the ratio, and keep the
+control value below half the height of the shortest badge.
+
+### Writing it
+
+Use the **named** utilities. A bare `rounded-xl` never said which kind of thing
+it was on, which is exactly how four scales drifted into the codebase:
+
+```tsx
+<div className="rounded-container p-4">   {/* a surface     */}
+  <span className="rounded-control px-2">  {/* an interactive */}
+```
+
+Never write a numeric radius (`10px`, `0.5rem`, `9999px`) in a component.
+
+`--radius-md`, `--radius-lg` and `--radius-xl` are pinned to the **control**
+tier and `--radius-2xl` to the container tier. That is a **legacy landing zone**
+so unmigrated code lands somewhere sane — not a scale. Do not reach for
+`rounded-md/lg/xl/2xl` in new code.
 
 ### The only exceptions
 
 - **`rounded-full`** — circular affordances *only*: avatars and logos
   (`Footer.tsx`, `Header.tsx`), the calendar today-dot (`MonthView.tsx`),
-  progress tracks (`AttendeeView.tsx`), `ui/switch.tsx`, `ui/toggle.tsx`,
-  spinners, drag handles (`ui/vaul-drawer.tsx`), and dialog close buttons.
-  A status pill or badge is **not** one of these — those are `rounded-xl`.
-- **`rounded-sm`** (`--radius-sm`, 0.25rem) — deliberately left off the
-  collapse for hairline chrome. Not for cards or pills.
+  progress tracks (`AttendeeView.tsx`), `ui/switch.tsx`, spinners, the drawer
+  drag handle (`ui/vaul-drawer.tsx`), dialog close buttons, and notification
+  count dots (`BellButton.tsx`). A status pill or badge is **not** one of
+  these — those are `rounded-control`.
+- **`rounded-sm`** (`--radius-sm`, 2px) — hairline chrome only. Not cards, not pills.
 - Tiptap **rendered content** styles in `globals.css` are author content, not
   app chrome, and keep their own radii.
 
-To change the corner radius of the entire app, change `--radius` and the four
-`@theme` keys. There is no second place to look.
+### Radius Bench
+
+`docs/design/radius-bench.html` — open it in a browser. It renders every
+surface in the portal at an adjustable radius, light and dark side by side, and
+reports each specimen's measured height, the radius requested, and the radius
+actually rendered after clamping. Use it before changing either value; a
+radius decision cannot be reviewed as a diff.
+
+### Migration status
+
+`app/admin/**` has not been migrated (2608-DEV-740 Phase 1 covered
+`components/`, `app/(dashboard)/` and `app/events/`). Admin pills still use
+`rounded-full` and some admin containers still sit on `rounded-lg`/`rounded-xl`,
+so they render at the control tier. Tracked as the Phase 2 follow-up.
 
 ## Elevation Shadows
 

--- a/docs/design/DESIGN-SYSTEM.md
+++ b/docs/design/DESIGN-SYSTEM.md
@@ -59,6 +59,41 @@ utilities:
 `<body>` defaults to `font-body` (Montserrat). DM Sans was removed; the remaining
 fonts have real usage in the app.
 
+## Rounding
+
+**One radius, site-wide: 16px.** It is the navbar shell's radius (`Header.tsx`),
+and it is now canonical for every card, pill, badge, input, button and overlay
+surface. Before 2608-DEV-740 four scales coexisted (16 / 12 / 8 / 6px, plus 165
+`rounded-full`), which is why nothing looked like it belonged to one system.
+
+The value lives in exactly one place — `--radius` in `styles/brand-tokens.css`:
+
+| Layer | How it gets 16px |
+|---|---|
+| Tailwind utilities | `app/globals.css` `@theme` pins `--radius-md`, `--radius-lg`, `--radius-xl`, `--radius-2xl` to `16px`, so `rounded-md/lg/xl/2xl` are all the same radius. This normalises ~515 existing class usages without editing the files. |
+| `.card` and bento surfaces | `--bento-radius: var(--radius)` |
+| Inline `style` props (shadcn fork in `components/ui/`) | `borderRadius: 'var(--radius)'` |
+
+Because the four Tailwind steps are equal, **which one you type does not
+matter** — prefer `rounded-xl`. Never write a numeric radius (`10px`,
+`0.5rem`, `9999px`) in a component; use `var(--radius)` or a `rounded-*`
+utility.
+
+### The only exceptions
+
+- **`rounded-full`** — circular affordances *only*: avatars and logos
+  (`Footer.tsx`, `Header.tsx`), the calendar today-dot (`MonthView.tsx`),
+  progress tracks (`AttendeeView.tsx`), `ui/switch.tsx`, `ui/toggle.tsx`,
+  spinners, drag handles (`ui/vaul-drawer.tsx`), and dialog close buttons.
+  A status pill or badge is **not** one of these — those are `rounded-xl`.
+- **`rounded-sm`** (`--radius-sm`, 0.25rem) — deliberately left off the
+  collapse for hairline chrome. Not for cards or pills.
+- Tiptap **rendered content** styles in `globals.css` are author content, not
+  app chrome, and keep their own radii.
+
+To change the corner radius of the entire app, change `--radius` and the four
+`@theme` keys. There is no second place to look.
+
 ## Elevation Shadows
 
 Hierarchical shadow system for layering UI surfaces. All shadows are defined in

--- a/docs/design/radius-bench.html
+++ b/docs/design/radius-bench.html
@@ -1,0 +1,582 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Radius Bench — teamenjoyVD design system</title>
+<!--
+  Radius Bench — a standalone reference tool for the corner-radius system.
+
+  Open this file directly in a browser. No build step, no server, no
+  dependencies. It is deliberately self-contained so it keeps working when the
+  app around it changes.
+
+  WHAT IT IS FOR
+  A radius decision cannot be reviewed as a diff. This page renders every
+  surface in the portal at an adjustable radius, light and dark side by side,
+  and reports each specimen's measured height, the radius requested, and the
+  radius ACTUALLY rendered after CSS clamping. Use it before changing
+  --radius or --radius-control in styles/brand-tokens.css.
+
+  KEEPING IT HONEST
+  The specimen palettes below are copied from styles/brand-tokens.css. If those
+  tokens change, update the .app / .app[data-app="dark"] blocks here to match,
+  or this page will quietly start lying. The defaults on the two sliders should
+  track the shipped values of --radius (containers) and --radius-control.
+
+  Introduced by 2608-DEV-740. See DESIGN-SYSTEM.md § Rounding.
+-->
+<style>
+/* ── PAGE CHROME — three-state theme (bare / prefers / stamped) ── */
+:root {
+  --ground: #F7F5F0; --panel: #FFFFFF; --panel-sunk: #EFECE4;
+  --ink: #22261F; --ink-soft: #5C5950; --ink-faint: #8A8577;
+  --rule: rgba(45,51,42,.14); --rule-soft: rgba(45,51,42,.07);
+  --accent: #bc4749; --accent-soft: rgba(188,71,73,.10);
+  --warn: #a3502e; --warn-soft: rgba(224,122,95,.16);
+  --ok: #2f5138; --ok-soft: rgba(63,107,74,.14);
+  --shadow: 0 1px 2px rgba(45,51,42,.05), 0 8px 24px -10px rgba(45,51,42,.18);
+  --serif: "Iowan Old Style","Palatino Linotype",Palatino,Georgia,"Times New Roman",serif;
+  --sans: system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  --mono: ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ground:#161914; --panel:#1E221B; --panel-sunk:#14170F;
+    --ink:#F2EFE8; --ink-soft:#B5B0A8; --ink-faint:#8A8577;
+    --rule:rgba(242,239,232,.16); --rule-soft:rgba(242,239,232,.08);
+    --accent:#E08284; --accent-soft:rgba(224,130,132,.14);
+    --warn:#f0b08d; --warn-soft:rgba(232,150,120,.18);
+    --ok:#9fd6ae; --ok-soft:rgba(127,184,143,.16);
+    --shadow:0 1px 2px rgba(0,0,0,.3), 0 8px 24px -10px rgba(0,0,0,.6);
+  }
+}
+:root[data-theme="dark"] {
+  --ground:#161914; --panel:#1E221B; --panel-sunk:#14170F;
+  --ink:#F2EFE8; --ink-soft:#B5B0A8; --ink-faint:#8A8577;
+  --rule:rgba(242,239,232,.16); --rule-soft:rgba(242,239,232,.08);
+  --accent:#E08284; --accent-soft:rgba(224,130,132,.14);
+  --warn:#f0b08d; --warn-soft:rgba(232,150,120,.18);
+  --ok:#9fd6ae; --ok-soft:rgba(127,184,143,.16);
+  --shadow:0 1px 2px rgba(0,0,0,.3), 0 8px 24px -10px rgba(0,0,0,.6);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--ground); color: var(--ink);
+  font-family: var(--sans); font-size: 15px; line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+img { max-width: 100%; }
+.wrap { max-width: 1180px; margin: 0 auto; padding: 0 20px 96px; }
+
+.masthead { padding: 52px 0 26px; border-bottom: 1px solid var(--rule); }
+.eyebrow {
+  font-family: var(--mono); font-size: 11px; letter-spacing: .16em;
+  text-transform: uppercase; color: var(--ink-faint); margin: 0 0 14px;
+}
+h1 {
+  font-family: var(--serif); font-weight: 600; font-size: clamp(32px,6vw,50px);
+  line-height: 1.04; letter-spacing: -.015em; margin: 0 0 18px; text-wrap: balance;
+}
+.standfirst { font-size: 17px; line-height: 1.62; color: var(--ink-soft); max-width: 62ch; margin: 0; }
+.standfirst strong { color: var(--ink); font-weight: 600; }
+
+.axiom {
+  margin: 26px 0 0; padding: 20px 22px; background: var(--accent-soft);
+  border-left: 3px solid var(--accent); border-radius: 0 6px 6px 0; max-width: 74ch;
+}
+.axiom p { margin: 0; font-size: 14.5px; line-height: 1.65; color: var(--ink); }
+.axiom p + p { margin-top: 10px; }
+code {
+  font-family: var(--mono); font-size: .88em;
+  background: var(--rule-soft); padding: 1px 5px; border-radius: 4px;
+}
+
+.controls {
+  position: sticky; top: 0; z-index: 20;
+  background: color-mix(in oklab, var(--ground) 88%, transparent);
+  backdrop-filter: blur(12px); border-bottom: 1px solid var(--rule);
+  margin: 0 -20px; padding: 14px 20px;
+}
+.controls-inner {
+  max-width: 1140px; margin: 0 auto; display: flex; flex-wrap: wrap;
+  gap: 22px 30px; align-items: flex-end;
+}
+.ctl { display: flex; flex-direction: column; gap: 7px; min-width: 0; }
+.ctl-label {
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: .13em;
+  text-transform: uppercase; color: var(--ink-faint);
+  display: flex; align-items: baseline; gap: 8px;
+}
+.ctl-val {
+  font-family: var(--mono); font-size: 14px; color: var(--accent); font-weight: 700;
+  letter-spacing: 0; text-transform: none; font-variant-numeric: tabular-nums;
+}
+input[type="range"] { width: 190px; max-width: 46vw; accent-color: var(--accent); margin: 0; }
+.seg { display: flex; gap: 4px; flex-wrap: wrap; }
+.seg button {
+  font-family: var(--mono); font-size: 11.5px; padding: 6px 11px;
+  border: 1px solid var(--rule); background: var(--panel); color: var(--ink-soft);
+  border-radius: 5px; cursor: pointer; transition: background .13s, color .13s, border-color .13s;
+}
+.seg button:hover { border-color: var(--accent); color: var(--ink); }
+.seg button[aria-pressed="true"] { background: var(--accent); border-color: var(--accent); color: #fff; font-weight: 700; }
+:root[data-theme="dark"] .seg button[aria-pressed="true"] { color: #1A1F18; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .seg button[aria-pressed="true"] { color: #1A1F18; }
+}
+button:focus-visible, input:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+section { padding-top: 50px; }
+h2 { font-family: var(--serif); font-size: 29px; font-weight: 600; letter-spacing: -.01em; margin: 0 0 6px; }
+.tier-meta {
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--ink-faint); margin: 0 0 8px;
+}
+.tier-note { color: var(--ink-soft); max-width: 68ch; margin: 0 0 26px; font-size: 14.5px; }
+
+.specimens { display: flex; flex-direction: column; gap: 16px; }
+.spec {
+  background: var(--panel); border: 1px solid var(--rule-soft);
+  border-radius: 8px; box-shadow: var(--shadow); overflow: hidden;
+}
+.spec-head {
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px 14px;
+  padding: 13px 18px; border-bottom: 1px solid var(--rule-soft); background: var(--panel-sunk);
+}
+.spec-name { font-weight: 650; font-size: 14.5px; }
+.spec-src { font-family: var(--mono); font-size: 11px; color: var(--ink-faint); }
+.spec-metrics {
+  margin-left: auto; display: flex; gap: 7px; flex-wrap: wrap;
+  font-family: var(--mono); font-size: 11px; font-variant-numeric: tabular-nums;
+}
+.metric { padding: 3px 8px; border-radius: 4px; background: var(--rule-soft); color: var(--ink-soft); white-space: nowrap; }
+.metric b { color: var(--ink); font-weight: 700; }
+.metric.is-capsule { background: var(--warn-soft); color: var(--warn); }
+.metric.is-capsule b { color: var(--warn); }
+.metric.is-shaped { background: var(--ok-soft); color: var(--ok); }
+.metric.is-shaped b { color: var(--ok); }
+
+.stage { display: grid; grid-template-columns: 1fr 1fr; }
+.stage.solo { grid-template-columns: 1fr; }
+.stage.solo .pane[data-app="dark"] { display: none; }
+.pane {
+  padding: 30px 24px; display: flex; align-items: center; justify-content: center;
+  min-height: 128px; position: relative;
+}
+.pane + .pane { border-left: 1px solid var(--rule-soft); }
+.pane-tag {
+  position: absolute; top: 8px; left: 12px; font-family: var(--mono);
+  font-size: 9.5px; letter-spacing: .14em; text-transform: uppercase; opacity: .5;
+}
+@media (max-width: 720px) {
+  .stage { grid-template-columns: 1fr; }
+  .pane + .pane { border-left: 0; border-top: 1px solid var(--rule-soft); }
+  .spec-metrics { margin-left: 0; width: 100%; }
+}
+
+/* ── SPECIMEN PALETTES — mirrored from styles/brand-tokens.css ── */
+.app {
+  --bg-global:#FAF8F3; --bg-card:#F0EDE6; --bg-card-raised:rgba(45,51,42,.04);
+  --text-primary:#1A1F18; --text-secondary:#5C5950; --text-tertiary:#8A8577;
+  --border-default:rgba(45,51,42,.08); --nav-border:rgba(45,51,42,.08);
+  --skeleton-base:rgba(45,51,42,.07);
+  --status-success-bg:rgba(63,107,74,.12);  --status-success-fg:#2f5138;
+  --status-info-bg:rgba(62,119,133,.12);    --status-info-fg:#2c5964;
+  --status-alert-bg:rgba(188,71,73,.12);    --status-alert-fg:#96393b;
+  --status-pending-bg:rgba(224,122,95,.14); --status-pending-fg:#a3502e;
+  --status-neutral-bg:rgba(138,133,119,.15);--status-neutral-fg:#5c5950;
+  --shadow-rest:0 1px 2px rgba(45,51,42,.04), 0 2px 8px rgba(45,51,42,.04);
+  --shadow-modal:0 4px 12px rgba(26,31,24,.08), 0 24px 48px -12px rgba(26,31,24,.18);
+  --brand-crimson:#bc4749; --brand-forest:#2d332a; --brand-teal:#3E7785;
+  --brand-sienna:#e07a5f; --brand-parchment:#FAF8F3; --on-accent:#FAF8F3; --link:#356874;
+  background: var(--bg-global); color: var(--text-primary); font-family: var(--sans);
+}
+.app[data-app="dark"] {
+  --bg-global:#1A1F18; --bg-card:#252B23; --bg-card-raised:#2B3229;
+  --text-primary:#FAF8F3; --text-secondary:#B5B0A8; --text-tertiary:#8A8577;
+  --border-default:rgba(250,248,243,.10); --nav-border:rgba(250,248,243,.10);
+  --skeleton-base:rgba(250,248,243,.06);
+  --status-success-bg:rgba(127,184,143,.18); --status-success-fg:#9fd6ae;
+  --status-info-bg:rgba(94,168,184,.18);     --status-info-fg:#8fd0dd;
+  --status-alert-bg:rgba(224,110,112,.18);   --status-alert-fg:#f19a9b;
+  --status-pending-bg:rgba(232,150,120,.20); --status-pending-fg:#f0b08d;
+  --status-neutral-bg:rgba(181,176,168,.20); --status-neutral-fg:#B5B0A8;
+  --shadow-rest:0 1px 2px rgba(26,31,24,.12), 0 2px 8px rgba(26,31,24,.12);
+  --shadow-modal:0 4px 12px rgba(26,31,24,.24), 0 24px 48px -12px rgba(26,31,24,.54);
+  --link:#6FAEBE;
+}
+
+/* Component recreations. Radius comes from --rc (control) / --rk (container). */
+.badge { display:inline-flex; align-items:center; gap:5px; font-size:10px; font-weight:600; padding:2px 8px; border-radius:var(--rc); line-height:1.5; }
+.badge.tiny { font-size:9px; padding:4px 10px; letter-spacing:.12em; text-transform:uppercase; font-weight:700; }
+.chip { font-size:12px; font-weight:600; padding:4px 10px; border-radius:var(--rc); border:1px solid var(--border-default); background:var(--bg-card); color:var(--text-secondary); line-height:1.333; }
+.chip.on { background:var(--brand-crimson); border-color:var(--brand-crimson); color:var(--on-accent); }
+.btn { font-size:14px; font-weight:600; padding:9px 18px; border-radius:var(--rc); border:0; cursor:pointer; background:var(--brand-crimson); color:var(--on-accent); font-family:inherit; }
+.btn.ghost { background:transparent; border:1px solid var(--border-default); color:var(--text-primary); }
+.field { font-size:14px; padding:9px 12px; width:210px; max-width:100%; border-radius:var(--rc); border:1px solid var(--border-default); background:var(--bg-global); color:var(--text-primary); font-family:inherit; }
+.iconbtn { width:32px; height:32px; display:inline-flex; align-items:center; justify-content:center; border-radius:var(--rc); border:1px solid rgba(255,255,255,.15); background:transparent; color:rgba(242,239,232,.75); }
+.evpill { border-radius:var(--rc); background:var(--brand-teal); color:var(--brand-parchment); font-size:10px; font-weight:600; padding:2px 6px; width:150px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; line-height:1.5; }
+
+.card { border-radius:var(--rk); padding:20px; border:1px solid var(--border-default); background:var(--bg-card); box-shadow:var(--shadow-rest); width:260px; max-width:100%; }
+.card h4 { margin:0 0 4px; font-size:15px; font-weight:650; }
+.card p { margin:0; font-size:12.5px; color:var(--text-secondary); }
+.hero { border-radius:var(--rk); width:260px; max-width:100%; height:132px; padding:16px; background:linear-gradient(140deg,#6d3d34,#2d332a 78%); color:var(--brand-parchment); position:relative; overflow:hidden; display:flex; flex-direction:column; justify-content:flex-end; }
+.hero .t { font-family:var(--serif); font-size:22px; font-weight:600; line-height:1.1; }
+.dialog { border-radius:var(--rk); background:var(--bg-card); box-shadow:var(--shadow-modal); width:250px; max-width:100%; overflow:hidden; }
+.dialog .dh { padding:12px 14px; border-bottom:1px solid var(--border-default); }
+.dialog .dt { font-family:var(--serif); font-size:18px; font-weight:600; line-height:1.25; }
+.dialog .db { padding:12px 14px; font-size:12.5px; color:var(--text-secondary); }
+.sheet { border-radius:var(--rk) var(--rk) 0 0; background:var(--bg-global); width:260px; max-width:100%; padding:10px 16px 22px; box-shadow:0 -4px 32px rgba(0,0,0,.18); text-align:center; }
+.sheet .grip { width:32px; height:4px; border-radius:9999px; background:var(--text-tertiary); opacity:.5; margin:0 auto 12px; }
+.menu { border-radius:var(--rk); width:200px; background:var(--bg-card); border:1px solid var(--border-default); box-shadow:var(--shadow-modal); overflow:hidden; padding:6px; }
+.menu div { padding:7px 10px; font-size:13px; border-radius:var(--rk); }
+.menu div.sel { background:var(--bg-card-raised); }
+.tip { border-radius:var(--rk); background:var(--bg-global); border:1px solid var(--border-default); padding:8px 10px; font-size:12px; max-width:200px; box-shadow:0 8px 32px rgba(0,0,0,.12); }
+.toast { border-radius:var(--rk); background:var(--bg-card); border:1px solid var(--border-default); padding:11px 14px; width:230px; max-width:100%; }
+.toast .tt { font-size:13px; font-weight:600; }
+.toast .td { font-size:11.5px; color:var(--text-secondary); }
+.nav { border-radius:var(--rk); border:1px solid var(--nav-border); background:var(--bg-card); padding:7px 9px; display:flex; gap:4px; align-items:center; }
+.nav span { font-size:11px; font-weight:700; letter-spacing:.1em; text-transform:uppercase; padding:5px 9px; border-radius:var(--rc); color:var(--text-secondary); }
+.nav span.on { background:var(--bg-card-raised); color:var(--text-primary); }
+.row { border-radius:var(--rk); background:var(--bg-card-raised); border:1px solid var(--border-default); padding:10px 12px; width:250px; max-width:100%; display:flex; align-items:center; gap:8px; }
+.row .nm { font-size:12.5px; font-weight:600; flex:1; }
+.skel { border-radius:var(--rk); background:var(--skeleton-base); height:40px; width:250px; max-width:100%; }
+.footerbar { border-radius:var(--rk); background:var(--brand-forest); padding:14px 16px; display:flex; gap:10px; align-items:center; width:260px; max-width:100%; }
+
+.tablewrap { overflow-x: auto; border: 1px solid var(--rule); border-radius: 8px; }
+table { border-collapse: collapse; width: 100%; font-size: 13.5px; min-width: 560px; }
+th, td { text-align: left; padding: 10px 14px; border-bottom: 1px solid var(--rule-soft); }
+th { font-family: var(--mono); font-size: 10.5px; letter-spacing: .11em; text-transform: uppercase; color: var(--ink-faint); background: var(--panel-sunk); }
+tbody tr:last-child td { border-bottom: 0; }
+td.num { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.pill-ok, .pill-bad { font-family: var(--mono); font-size: 10.5px; padding: 2px 7px; border-radius: 4px; font-weight: 700; }
+.pill-ok { background: var(--ok-soft); color: var(--ok); }
+.pill-bad { background: var(--warn-soft); color: var(--warn); }
+
+.rec { margin-top: 20px; background: var(--panel); border: 1px solid var(--rule); border-radius: 10px; padding: 26px 26px 8px; box-shadow: var(--shadow); }
+.rec h3 { font-family: var(--serif); font-size: 21px; margin: 0 0 4px; font-weight: 600; }
+.rec > p { color: var(--ink-soft); margin: 0 0 20px; max-width: 66ch; font-size: 14.5px; }
+.opt { border-top: 1px solid var(--rule-soft); padding: 18px 0; }
+.opt-n { font-weight: 700; font-size: 15px; display: block; margin-bottom: 6px; }
+.opt p { margin: 0; font-size: 14px; color: var(--ink-soft); max-width: 68ch; }
+.opt p + p { margin-top: 8px; }
+.codeblock {
+  background: var(--panel-sunk); border: 1px solid var(--rule-soft); border-radius: 8px;
+  padding: 16px 18px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px;
+  line-height: 1.7; margin: 18px 0 0; color: var(--ink);
+}
+.codeblock .c { color: var(--ink-faint); }
+.codeblock .k { color: var(--accent); }
+footer { margin-top: 58px; padding-top: 22px; border-top: 1px solid var(--rule); color: var(--ink-faint); font-size: 12.5px; }
+@media (prefers-reduced-motion: reduce) { * { transition: none !important; animation: none !important; } }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead">
+  <p class="eyebrow">teamenjoyVD · design system · reference tool</p>
+  <h1>Radius Bench</h1>
+  <p class="standfirst">
+    Every surface in the portal, rendered live at whatever corner radius you dial in.
+    The sliders start at the <strong>shipped values — 8px containers, 4px controls</strong>.
+    Move them to see what a change would actually do before you make it.
+  </p>
+
+  <div class="axiom">
+    <p><strong>The fact this tool exists to make visible.</strong> CSS clamps corner
+    radii when the two radii on a side exceed that side's length
+    (CSS Backgrounds 3 §5.5): every radius scales down by the same factor. For a
+    uniform radius the rendered corner is <code>min(r, width/2, height/2)</code>.</p>
+    <p>A status badge is <strong>19px tall</strong>. At <code>16px</code> it renders at 9.5px —
+    exactly half its height, which is a capsule. At <code>12px</code> it is <em>still</em>
+    a capsule. Nothing at or above ~9px changes that badge at all. This is why a
+    single site-wide radius cannot work, and why the system has two tiers.</p>
+  </div>
+</header>
+
+<div class="controls">
+  <div class="controls-inner">
+    <div class="ctl">
+      <label class="ctl-label" for="rk">Containers <span class="ctl-val" id="rkv">8px</span></label>
+      <input type="range" id="rk" min="0" max="20" step="1" value="8">
+    </div>
+    <div class="ctl">
+      <label class="ctl-label" for="rc">Controls <span class="ctl-val" id="rcv">4px</span></label>
+      <input type="range" id="rc" min="0" max="20" step="1" value="4">
+    </div>
+    <div class="ctl">
+      <span class="ctl-label">Container presets</span>
+      <div class="seg" id="presets">
+        <button type="button" data-rk="8">8 · shipped</button>
+        <button type="button" data-rk="12">12</button>
+        <button type="button" data-rk="16">16</button>
+        <button type="button" data-rk="4">4</button>
+        <button type="button" data-rk="0">0</button>
+      </div>
+    </div>
+    <div class="ctl">
+      <span class="ctl-label">Themes</span>
+      <div class="seg" id="themes">
+        <button type="button" data-mode="both" aria-pressed="true">Both</button>
+        <button type="button" data-mode="light" aria-pressed="false">Light only</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<section>
+  <p class="tier-meta">Tier 1 · <code>rounded-control</code> · <code>--radius-control</code></p>
+  <h2>Controls</h2>
+  <p class="tier-note">
+    Badges, chips, buttons, inputs, event pills. Every specimen shows its measured
+    height and the radius actually rendered after clamping.
+  </p>
+  <div class="specimens" id="tier-controls"></div>
+</section>
+
+<section>
+  <p class="tier-meta">Tier 2 · <code>rounded-container</code> · <code>--radius</code></p>
+  <h2>Containers</h2>
+  <p class="tier-note">
+    Cards, tiles, dialogs, sheets, menus and the navbar shell. All are far taller
+    than twice any radius here, so they never clamp — a container renders exactly
+    the number you set.
+  </p>
+  <div class="specimens" id="tier-containers"></div>
+</section>
+
+<section>
+  <p class="tier-meta">Reference</p>
+  <h2>What actually renders</h2>
+  <p class="tier-note">
+    Requested versus rendered radius at the current settings. “Capsule” means the
+    corner consumed half the box — a lozenge no matter what number was asked for.
+  </p>
+  <div class="tablewrap">
+    <table>
+      <thead>
+        <tr><th>Element</th><th>Tier</th><th>Height</th><th>Requested</th><th>Rendered</th><th>Shape</th></tr>
+      </thead>
+      <tbody id="summary"></tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <p class="tier-meta">The shipped system</p>
+  <h2>Why 8 and 4</h2>
+
+  <div class="rec">
+    <h3>Two tiers, held at 2:1</h3>
+    <p>Decided in 2608-DEV-740 after the single-16px rule failed visual review.</p>
+
+    <div class="opt">
+      <span class="opt-n">One value could not work</span>
+      <p>
+        A single radius cannot serve a 200px card and a 19px badge, because the
+        badge clamps. The original rule produced 16px cards and capsule-shaped
+        pills, which is precisely what it was written to prevent.
+      </p>
+    </div>
+
+    <div class="opt">
+      <span class="opt-n">Nothing clamps at 8 / 4</span>
+      <p>
+        Both values sit below half the height of the shortest element in their
+        tier, so every surface renders the exact number set. Dial the sliders
+        above 9px and watch the control specimens flip to “capsule”.
+      </p>
+    </div>
+
+    <div class="opt">
+      <span class="opt-n">The 2:1 gap is the system</span>
+      <p>
+        A badge inside a card needs a visibly tighter corner than the card, or the
+        two tiers read as noise rather than hierarchy. If you change these values,
+        keep the ratio — and keep the control value under half the shortest badge.
+      </p>
+    </div>
+  </div>
+
+  <div class="codeblock"><span class="c">/* styles/brand-tokens.css */</span>
+<span class="k">--radius</span>:         8px;  <span class="c">/* containers → rounded-container */</span>
+<span class="k">--radius-control</span>: 4px;  <span class="c">/* controls   → rounded-control   */</span>
+
+<span class="c">/* app/globals.css @theme — legacy landing zone, not a scale */</span>
+<span class="k">--radius-sm</span>:  2px;
+<span class="k">--radius-md</span>:  var(--radius-control);
+<span class="k">--radius-lg</span>:  var(--radius-control);
+<span class="k">--radius-xl</span>:  var(--radius-control);
+<span class="k">--radius-2xl</span>: var(--radius-container);</div>
+</section>
+
+<footer>
+  Specimens mirror the token values in <code>styles/brand-tokens.css</code>; update them here if
+  those change. Heights are measured in your browser, so they reflect real layout, not estimates.
+  Type is substituted — Cormorant Garamond and Montserrat are not loaded in this standalone file,
+  so judge shape, not letterforms. See <code>DESIGN-SYSTEM.md § Rounding</code>.
+</footer>
+
+</div>
+
+<script>
+(function () {
+  'use strict';
+
+  var SPECS = [
+    ['Status badge', 'StatusBadge.tsx · text-[10px] py-0.5', 'c',
+      '<span class="badge" data-m style="background:var(--status-success-bg);color:var(--status-success-fg)">confirmed</span>' +
+      '<span class="badge" style="background:var(--status-pending-bg);color:var(--status-pending-fg);margin-left:8px">pending</span>' +
+      '<span class="badge" style="background:var(--status-alert-bg);color:var(--status-alert-fg);margin-left:8px">cancelled</span>'],
+    ['Category + type badges', 'EventPopupShell.tsx', 'c',
+      '<span class="badge" data-m style="background:var(--brand-sienna);color:var(--on-accent)">N21</span>' +
+      '<span class="badge" style="background:var(--status-success-bg);color:var(--status-success-fg);margin-left:8px">In-Person</span>'],
+    ['Trips eyebrow', 'TripHeroTile.tsx · text-[9px] py-1', 'c',
+      '<span class="badge tiny" data-m style="background:rgba(255,255,255,.18);color:#FAF8F3">Next trip</span>'],
+    ['Filter chip', 'FilterControls.tsx · text-xs py-1', 'c',
+      '<span class="chip on" data-m>N21</span><span class="chip" style="margin-left:8px">Open</span><span class="chip" style="margin-left:8px">Online</span>'],
+    ['Buttons', 'components/ui/button', 'c',
+      '<button class="btn" data-m>Attend</button><button class="btn ghost" style="margin-left:10px">Cancel</button>'],
+    ['Input field', 'components/ui/select · trigger', 'c',
+      '<input class="field" data-m value="ivan@example.com" readonly>'],
+    ['Calendar event pill', 'EventPill.tsx · compact', 'c',
+      '<div class="evpill" data-m>19:00 Team briefing</div>'],
+    ['Footer social button', 'Footer.tsx · w-8 h-8 (32px)', 'c',
+      '<div class="footerbar"><span class="iconbtn" data-m>&#9993;</span><span class="iconbtn">&#64;</span><span class="iconbtn">f</span></div>'],
+
+    ['Bento card', 'BentoCard.tsx · .card', 'k',
+      '<div class="card" data-m><h4>Your profile</h4><p>Verified ABO · Core member since 2024</p></div>'],
+    ['Trips hero tile', 'TripHeroTile.tsx', 'k',
+      '<div class="hero" data-m><span class="badge tiny" style="background:rgba(255,255,255,.18);color:#FAF8F3;align-self:flex-start;margin-bottom:6px">Next trip</span><span class="t">Amsterdam</span></div>'],
+    ['Dialog / event popup', 'components/ui/dialog', 'k',
+      '<div class="dialog" data-m><div class="dh"><span class="dt">Team briefing</span></div><div class="db">Thursday 19:00 &ndash; 20:30 · Online</div></div>'],
+    ['Bottom sheet', 'CalendarClient.tsx · rounded-t-container', 'k',
+      '<div class="sheet" data-m><div class="grip"></div><strong style="font-size:14px">Share event</strong></div>'],
+    ['Dropdown menu', 'dropdown-menu.tsx', 'k',
+      '<div class="menu" data-m><div class="sel">Profile</div><div>Payments</div><div>Sign out</div></div>'],
+    ['Tooltip', 'tooltip.tsx', 'k',
+      '<div class="tip" data-m>Only admins can edit a published event.</div>'],
+    ['Toast', 'sonner.tsx', 'k',
+      '<div class="toast" data-m><div class="tt">Link copied</div><div class="td">Anyone with it can register.</div></div>'],
+    ['Navbar shell', 'Header.tsx · h-14', 'k',
+      '<div class="nav" data-m><span class="on">Home</span><span>Calendar</span><span>Trips</span></div>'],
+    ['Registration row', 'RegistrationsTab.tsx', 'k',
+      '<div class="row" data-m><span class="nm">Ivan Petrov</span><span class="badge" style="background:var(--status-info-bg);color:var(--status-info-fg)">member</span></div>'],
+    ['Skeleton block', 'components/ui/skeleton.tsx', 'k',
+      '<div class="skel" data-m></div>']
+  ];
+
+  var els = {
+    rk: document.getElementById('rk'), rc: document.getElementById('rc'),
+    rkv: document.getElementById('rkv'), rcv: document.getElementById('rcv'),
+    tc: document.getElementById('tier-controls'), tk: document.getElementById('tier-containers'),
+    sum: document.getElementById('summary')
+  };
+
+  function build(spec) {
+    var name = spec[0], src = spec[1], tier = spec[2], html = spec[3];
+    var el = document.createElement('div');
+    el.className = 'spec';
+    el.innerHTML =
+      '<div class="spec-head"><span class="spec-name"></span><span class="spec-src"></span>' +
+      '<span class="spec-metrics"></span></div>' +
+      '<div class="stage">' +
+        '<div class="pane app" data-app="light"><span class="pane-tag">Light</span>' + html + '</div>' +
+        '<div class="pane app" data-app="dark"><span class="pane-tag">Dark</span>' + html + '</div>' +
+      '</div>';
+    el.querySelector('.spec-name').textContent = name;
+    el.querySelector('.spec-src').textContent = src;
+    el.dataset.tier = tier;
+    el.dataset.name = name;
+    return el;
+  }
+
+  SPECS.forEach(function (s) { (s[2] === 'c' ? els.tc : els.tk).appendChild(build(s)); });
+
+  function measure() {
+    var rk = Number(els.rk.value), rc = Number(els.rc.value);
+    els.sum.innerHTML = '';
+
+    Array.prototype.forEach.call(document.querySelectorAll('.spec'), function (spec) {
+      var tier = spec.dataset.tier;
+      var requested = tier === 'c' ? rc : rk;
+      var target = spec.querySelector('.pane[data-app="light"] [data-m]');
+      if (!target) return;
+      var r = target.getBoundingClientRect();
+      var h = r.height, w = r.width;
+      if (!h) return;
+
+      var rendered = Math.min(requested, h / 2, w / 2);
+      // A sheet rounds only its top corners, so half-height never binds.
+      if (spec.dataset.name === 'Bottom sheet') rendered = Math.min(requested, w / 2);
+      var capsule = requested > 0 && rendered < requested - 0.01;
+
+      var mbox = spec.querySelector('.spec-metrics');
+      mbox.innerHTML = '';
+      function chip(txt, cls) {
+        var s = document.createElement('span');
+        s.className = 'metric' + (cls ? ' ' + cls : '');
+        s.innerHTML = txt;
+        mbox.appendChild(s);
+      }
+      chip('height <b>' + h.toFixed(1) + 'px</b>');
+      chip('asked <b>' + requested + 'px</b>');
+      chip('renders <b>' + rendered.toFixed(1) + 'px</b>', capsule ? 'is-capsule' : 'is-shaped');
+      if (capsule) chip('<b>clamped to a capsule</b>', 'is-capsule');
+
+      var tr = document.createElement('tr');
+      tr.innerHTML =
+        '<td></td><td>' + (tier === 'c' ? 'Control' : 'Container') + '</td>' +
+        '<td class="num">' + h.toFixed(1) + '</td>' +
+        '<td class="num">' + requested + '</td>' +
+        '<td class="num">' + rendered.toFixed(1) + '</td>' +
+        '<td>' + (capsule ? '<span class="pill-bad">capsule</span>' : '<span class="pill-ok">shaped</span>') + '</td>';
+      tr.firstChild.textContent = spec.dataset.name;
+      els.sum.appendChild(tr);
+    });
+  }
+
+  function apply() {
+    var rk = Number(els.rk.value), rc = Number(els.rc.value);
+    document.documentElement.style.setProperty('--rk', rk + 'px');
+    document.documentElement.style.setProperty('--rc', rc + 'px');
+    els.rkv.textContent = rk + 'px';
+    els.rcv.textContent = rc + 'px';
+    Array.prototype.forEach.call(document.querySelectorAll('#presets button'), function (b) {
+      b.setAttribute('aria-pressed', String(Number(b.dataset.rk) === rk));
+    });
+    measure();
+  }
+
+  els.rk.addEventListener('input', apply);
+  els.rc.addEventListener('input', apply);
+
+  document.getElementById('presets').addEventListener('click', function (e) {
+    var b = e.target.closest('button');
+    if (!b) return;
+    els.rk.value = b.dataset.rk;
+    apply();
+  });
+
+  document.getElementById('themes').addEventListener('click', function (e) {
+    var b = e.target.closest('button');
+    if (!b) return;
+    var solo = b.dataset.mode === 'light';
+    Array.prototype.forEach.call(document.querySelectorAll('.stage'), function (s) {
+      s.classList.toggle('solo', solo);
+    });
+    Array.prototype.forEach.call(this.querySelectorAll('button'), function (x) {
+      x.setAttribute('aria-pressed', String(x === b));
+    });
+    measure();
+  });
+
+  window.addEventListener('resize', measure);
+  apply();
+})();
+</script>
+</body>
+</html>

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -40,12 +40,17 @@
   --shadow-hover: 0 2px 4px rgba(45, 51, 42, 0.05), 0 12px 24px -8px rgba(45, 51, 42, 0.10);
   --shadow-modal: 0 4px 12px rgba(26, 31, 24, 0.08), 0 24px 48px -12px rgba(26, 31, 24, 0.18);
 
-  /* ── Corner radius — ONE value site-wide ──
-     16px is the navbar shell's radius (Header.tsx), now canonical for every
-     card, pill, badge, input and button. See the Rounding section in
-     docs/design/DESIGN-SYSTEM.md for the two exceptions (rounded-full for
-     circular affordances, rounded-sm for hairline chrome). */
-  --radius: 16px;
+  /* ── Corner radius — two tiers, 2:1 ──
+     One value cannot serve both a 200px card and a 19px badge: CSS clamps a
+     corner to min(r, width/2, height/2), so ANY radius at or above half an
+     element's height renders as a capsule. A 19px status badge is a capsule at
+     16px AND at 12px — which is why "one radius site-wide" looked like it did
+     nothing to the pills.
+     Containers are 8px, controls 4px. The 2:1 gap is what makes a badge read
+     as nested inside its card. At these values nothing clamps anywhere.
+     See docs/design/DESIGN-SYSTEM.md § Rounding. */
+  --radius:         8px;   /* containers: cards, dialogs, sheets, navbar   */
+  --radius-control: 4px;   /* controls: pills, badges, buttons, inputs     */
 
   /* ── Bento tokens ── */
   --bento-gap:          12px;
@@ -221,7 +226,7 @@ html { font-size: calc(var(--font-scale) * 16px); }
 /* Light surface: crimson pill on hover */
 .pill-link-crimson {
   color: var(--text-nav);
-  border-radius: var(--radius);
+  border-radius: var(--radius-control);
   padding: 0.25rem 0.625rem;
   transition: background-color 150ms ease, color 150ms ease;
 }
@@ -233,7 +238,7 @@ html { font-size: calc(var(--font-scale) * 16px); }
 /* Dark surface: parchment pill on hover (teal/forest/crimson card bg) */
 .pill-link-parchment {
   color: var(--brand-parchment);
-  border-radius: var(--radius);
+  border-radius: var(--radius-control);
   padding: 0.25rem 0.625rem;
   transition: background-color 150ms ease, color 150ms ease;
 }
@@ -245,7 +250,7 @@ html { font-size: calc(var(--font-scale) * 16px); }
 /* Footer variant: parchment-tinted, slightly dimmer base */
 .pill-link-footer {
   color: rgba(242, 239, 232, 0.65);
-  border-radius: var(--radius);
+  border-radius: var(--radius-control);
   padding: 0.25rem 0.625rem;
   transition: background-color 150ms ease, color 150ms ease;
 }

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -40,9 +40,16 @@
   --shadow-hover: 0 2px 4px rgba(45, 51, 42, 0.05), 0 12px 24px -8px rgba(45, 51, 42, 0.10);
   --shadow-modal: 0 4px 12px rgba(26, 31, 24, 0.08), 0 24px 48px -12px rgba(26, 31, 24, 0.18);
 
+  /* ── Corner radius — ONE value site-wide ──
+     16px is the navbar shell's radius (Header.tsx), now canonical for every
+     card, pill, badge, input and button. See the Rounding section in
+     docs/design/DESIGN-SYSTEM.md for the two exceptions (rounded-full for
+     circular affordances, rounded-sm for hairline chrome). */
+  --radius: 16px;
+
   /* ── Bento tokens ── */
   --bento-gap:          12px;
-  --bento-radius:       12px;
+  --bento-radius:       var(--radius);
   --bento-border:       rgba(45, 51, 42, 0.08);
   --bento-border-hover: rgba(45, 51, 42, 0.16);
   --bento-accent-edge:  4px;
@@ -214,7 +221,7 @@ html { font-size: calc(var(--font-scale) * 16px); }
 /* Light surface: crimson pill on hover */
 .pill-link-crimson {
   color: var(--text-nav);
-  border-radius: 0.5rem;
+  border-radius: var(--radius);
   padding: 0.25rem 0.625rem;
   transition: background-color 150ms ease, color 150ms ease;
 }
@@ -226,7 +233,7 @@ html { font-size: calc(var(--font-scale) * 16px); }
 /* Dark surface: parchment pill on hover (teal/forest/crimson card bg) */
 .pill-link-parchment {
   color: var(--brand-parchment);
-  border-radius: 0.5rem;
+  border-radius: var(--radius);
   padding: 0.25rem 0.625rem;
   transition: background-color 150ms ease, color 150ms ease;
 }
@@ -238,7 +245,7 @@ html { font-size: calc(var(--font-scale) * 16px); }
 /* Footer variant: parchment-tinted, slightly dimmer base */
 .pill-link-footer {
   color: rgba(242, 239, 232, 0.65);
-  border-radius: 9999px;
+  border-radius: var(--radius);
   padding: 0.25rem 0.625rem;
   transition: background-color 150ms ease, color 150ms ease;
 }


### PR DESCRIPTION
Closes #740. No migration.

## What changed

**A1 — calendar bubbles no longer touch the day-cell border.** Day cells and event bars are grid *siblings*, so the cell's `p-1` never reached the bars. The inset goes on the bar wrapper, keyed off `packWeek`'s `continuesLeft/continuesRight`, so a multi-day bar stays flush where a week boundary cuts it.

**A2 — the popup title is a real `DialogTitle` at `text-lg`.** The Dialog previously had *no* title element, so the modal had no accessible name and Radix warned.

**A3 — the popup is legible in dark mode.** `popup/styles.ts` and `EVENT_TYPE_STYLES` were hardcoded light-mode hexes; every entry now resolves to a `--status-*` token pair, along with the pills, row surfaces and skeletons in the popup.

**A4 — a two-tier corner radius system.** See below; this was redesigned mid-review.

**A5 — the Trips bento body navigates to `/trips/{id}`** via a sibling overlay `Link`, never a wrapper, so the `/trips` pill is not nested inside another `<a>`.

## A4 was rebuilt after visual review — read this bit

The first version of this PR collapsed every radius to a single 16px value ("one radius site-wide = the navbar's"). **It failed visual review: the pills still looked round.** The reason is not obvious:

> **CSS clamps corner radii** (CSS Backgrounds 3 §5.5). The rendered corner is `min(r, width/2, height/2)`.

A status badge is **19px tall**. At 16px it renders at 9.5px — exactly half its height, i.e. a capsule. **At 12px it is still a capsule.** Nothing at or above ~9px changes that badge at all, so "one radius" silently meant "cards get 16px and every pill stays a lozenge".

### The system now

| Tier | Value | Token | Utility |
|---|---|---|---|
| Container | **8px** | `--radius` | `rounded-container` |
| Control | **4px** | `--radius-control` | `rounded-control` |

8 and 4 were chosen so **nothing clamps anywhere** — both sit below half the height of the shortest element in their tier — and the 2:1 gap is what makes a badge read as nested inside its card. `--radius-sm` is 2px for hairline chrome.

### Why named utilities instead of pinning the built-in steps

A bare `rounded-xl` never encoded *which kind of element* it was on, which is exactly how four scales drifted in. The audit: `rounded-xl` is used **296 times — ~216 controls and ~80 containers**, so no pin of that step alone can be correct. The tier now lives in the class name.

`--radius-md/lg/xl` are pinned to the control tier and `--radius-2xl` to the container tier purely as a **legacy landing zone**, which is why the ~322 controls already sitting on those steps needed no edit at all.

## Phase 1 sweep (this PR)

`components/`, `app/(dashboard)/`, `app/events/` — 47 pill-shaped `rounded-full` → `rounded-control`, ~35 stranded containers → `rounded-container`, plus the high-leverage shared components (`StatusPill`, `toggleVariants`, `NotificationPopup`, `UserDropdown`, `DropZone`, `AssemblySummary`, `PaymentForm`).

All **27** surviving `rounded-full` uses in scope were audited against the documented circular list: legend dots, today-dot, dialog close buttons, progress track/fill, avatars, logos, switch, skeleton circle, and the `BellButton` count dot.

**`app/admin/**` is Phase 2** and is explicitly flagged as unmigrated in `DESIGN-SYSTEM.md`: 61 pill sites + ~80 stranded containers. Admin renders at the control tier by default until then — visible, but internal-facing.

## New: `docs/design/radius-bench.html`

A standalone, dependency-free browser tool that renders every portal surface at an adjustable radius, light and dark side by side, and reports each specimen's measured height, the radius requested, and the radius **actually rendered after clamping**. Open the file directly; no build step.

This change is the reason it exists — a radius decision cannot be reviewed as a diff. Use it before touching either value.

## Deliberately not done here

`StatusBadge.tsx:50` is `className={className ?? DEFAULT_CLASSNAME}` — a **replacement, not a merge** — so eight callers silently drop `inline-flex items-center`. Fixing it changes `display` on eight badges for no radius reason and would contaminate this PR's visual review. Logged in `docs/STATE.md`.

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` | clean (exit 0) |
| `npm test` | 481 passed, 34 files |
| `npm run lint` | 0 errors, 465 warnings (unchanged baseline) |
| real `app/globals.css` compiled | `rounded-control` → `var(--radius-control)`, `rounded-container` → `var(--radius-container)`, `rounded-t-container` and `md:rounded-container` both emitted, `rounded-full` untouched |

**Not visually verified — that is the gate.** Check at 390px and desktop in **both** themes: badges and filter chips showing a flat edge; cards/dialogs/navbar at 8px; the mobile event popup's top corners; the Footer social row (now 4px squares, previously circles); and the Trips hero tile, the surface most at risk at 8px.

`npm run verify` was not run locally on purpose: its `next build` runs under `NODE_ENV=production`, which on this box resolves `.env.local` to PROD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trip tiles are now fully clickable while preserving existing navigation controls.
  * Calendar event bars have improved spacing from day-cell borders.
  * Event dialogs now provide clearer accessible titles.
* **Style**
  * Standardized corner rounding across calendars, trips, profiles, notifications, payments, navigation, and shared UI components.
  * Added theme-aware radius and status styling for more consistent light and dark mode presentation.
  * Updated badges, cards, popups, drawers, menus, tooltips, and loading placeholders to use shared visual tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->