### PR TITLE
[2608-DEV-741] C1: industry-standard dark mode — semantic tokens as Tailwind utilities

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -60,6 +60,76 @@
   --radius-2xl: var(--radius-container);
 }
 
+/* ── Semantic tokens as Tailwind utilities (2608-DEV-741 C1) ──
+   Every semantic token in styles/brand-tokens.css is mapped into Tailwind's
+   colour scale here, so `bg-bg-card`, `text-text-primary`, `text-link`,
+   `hover:bg-hover-surface` and `ring-focus-ring` are ordinary utilities that
+   are theme-aware for free.
+
+   This exists to fix REACHABILITY, not capability. Using a token used to
+   require an inline style object while the wrong thing was one word
+   (`text-emerald-800`) — so the wrong thing won, 513 times. Now the correct
+   path is the shorter one.
+
+   `inline` is the shadcn/ui v4 convention: it emits the utility as
+   `var(--bg-card)` directly instead of routing through an intermediate
+   `--color-bg-card`. Opacity modifiers still work — v4 compiles
+   `bg-bg-card/50` to color-mix(in oklab, var(--bg-card) 50%, transparent).
+
+   Adding a token? Add it in BOTH :root and [data-theme="dark"] in
+   brand-tokens.css, then add its line here. */
+@theme inline {
+  /* Surfaces */
+  --color-bg-global:      var(--bg-global);
+  --color-bg-card:        var(--bg-card);
+  --color-bg-card-raised: var(--bg-card-raised);
+
+  /* Text */
+  --color-text-primary:   var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-tertiary:  var(--text-tertiary);
+  --color-text-nav:       var(--text-nav);
+
+  /* Borders */
+  --color-border-default: var(--border-default);
+  --color-border-hover:   var(--border-hover);
+  --color-nav-border:     var(--nav-border);
+
+  /* Interaction */
+  --color-link:           var(--link);
+  --color-link-hover:     var(--link-hover);
+  --color-on-accent:      var(--on-accent);
+  --color-overlay:        var(--overlay);
+  --color-hover-surface:  var(--hover-surface);
+  --color-focus-ring:     var(--focus-ring);
+  --color-skeleton-base:  var(--skeleton-base);
+
+  /* Status pairs */
+  --color-status-success-bg: var(--status-success-bg);
+  --color-status-success-fg: var(--status-success-fg);
+  --color-status-info-bg:    var(--status-info-bg);
+  --color-status-info-fg:    var(--status-info-fg);
+  --color-status-alert-bg:   var(--status-alert-bg);
+  --color-status-alert-fg:   var(--status-alert-fg);
+  --color-status-pending-bg: var(--status-pending-bg);
+  --color-status-pending-fg: var(--status-pending-fg);
+  --color-status-neutral-bg: var(--status-neutral-bg);
+  --color-status-neutral-fg: var(--status-neutral-fg);
+}
+
+/* ── The `dark:` variant, pointed at the real selector ──
+   This project sets data-theme on <html>; it does NOT use Tailwind's default
+   prefers-color-scheme dark variant. Leaving `dark:` unregistered did not
+   disable it — it wired it to the OS setting, so the five `dark:` classes
+   already in the tree fired on the wrong signal (an intermittent bug, which
+   is worse than an absent one). Registering it makes `dark:` honest.
+
+   The rule is now narrower, not looser: COLOUR goes through tokens; `dark:`
+   is only for the non-colour things a token cannot express — shadow
+   geometry, opacity, image filter, background-image gradients.
+   See docs/design/DESIGN-SYSTEM.md § Usage Rules. */
+@custom-variant dark (&:where([data-theme="dark"] *));
+
 :root {
   --forest:   #2d332a;
   --crimson:  #bc4749;

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -51,8 +51,7 @@ blanket ban with the doc updated in the same commit.
    cards/dialogs/navbar read at 8px; check the mobile event popup's top corners, the Footer social
    row (now 4px squares, was circles), and the Trips hero tile (the surface most at risk at 8px).
 2. `/code-review low` on each, then mark ready for CodeRabbit and apply GCR.
-3. File the **Phase 2** issue (see Open items) for `app/admin/**`.
-4. `npm run verify` deliberately NOT run locally: its `next build` runs under `NODE_ENV=production`,
+3. `npm run verify` deliberately NOT run locally: its `next build` runs under `NODE_ENV=production`,
    which on this box resolves `.env.local` = PROD. CI builds it on the PR.
 
 ## Constraints
@@ -121,15 +120,11 @@ blanket ban with the doc updated in the same commit.
 - #702 CLOSED (epic, 2026-08-12) — all ten children and all six follow-ups merged.
 
 ## Open items
-- **OPEN — Phase 2 of the radius migration (`app/admin/**`), not yet filed as an issue.** Audited
-  work: **61 pill-shaped `rounded-full` sites** → `rounded-control`, and **~80 containers stranded
-  on `rounded-lg`/`rounded-xl`** → `rounded-container`. High-leverage shared components to do first
-  (one edit each, many call sites): `app/admin/calendar/components/Pill.tsx:8`,
-  `app/admin/components/AdminStatusBadge.tsx:15`, `app/admin/components/RoleSelector.tsx:29`,
-  `app/admin/components/AdminTabs.tsx:65`. Two admin ambiguities deferred with it:
-  `AdminTabs.tsx:65` (count badge — near-circular at one digit) and `MembersTable.tsx:113` (24px
-  circular ABO-level token). Until this lands, admin renders at the control tier by default —
-  visible but internal-facing.
+- **FILED as #746** — Radius Phase 2 (`app/admin/**`). 61 pill-shaped `rounded-full` →
+  `rounded-control`, ~80 containers stranded on `rounded-lg`/`rounded-xl` → `rounded-container`.
+  The issue carries the shared-component shortlist and both admin ambiguities. Until it lands, admin
+  renders at the control tier by default — visible but internal-facing, and called out in
+  DESIGN-SYSTEM.md § Rounding.
 - **OPEN (#741 C4):** `--text-tertiary` fails WCAG AA in BOTH themes — 3.15:1 light, 3.94:1 dark on
   `--bg-card` — and is never redefined for dark at all. Not fixed in C1 because it moves light-mode
   pixels and "light mode visually unchanged" is C1's review invariant.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -10,7 +10,8 @@ Two stacked tickets, both open as DRAFT PRs, neither merged.
 
 **#741 is stacked on #740.** PR #745's base is `dev/2608-DEV-740`, NOT `main`, because both branches
 edit `styles/brand-tokens.css` and `app/globals.css`. Merge #744 first; GitHub retargets #745
-automatically. **#741 has NOT yet been rebased onto the latest #740** — see Next, step 1.
+automatically. #741 **has** been rebased onto the two-tier radius work; both CSS files auto-merged
+(the radius tokens and the colour tokens are disjoint additions to the same blocks).
 
 ### #740 — what landed
 Commits `9fc24a9` (original) + the radius revision on top.
@@ -45,17 +46,13 @@ for both themes; `@custom-variant dark` registered against `[data-theme="dark"]`
 blanket ban with the doc updated in the same commit.
 
 ## Next
-1. **Rebase #741 onto #740** — `git rebase dev/2608-DEV-740` on `dev/2608-DEV-741`, then force-push.
-   Expect a conflict in `docs/STATE.md` (this file was rewritten on #740 after #741 branched) and
-   possibly in `styles/brand-tokens.css` / `app/globals.css`. Resolve by keeping BOTH: #740's radius
-   tokens and #741's colour tokens are disjoint additions to the same files.
-2. Vercel preview READY + CI green on both, then the **visual pass — the real gate**. At 390px and
+1. Vercel preview READY + CI green on both, then the **visual pass — the real gate**. At 390px and
    desktop, in **both** themes: status badges and filter chips must show a flat edge;
    cards/dialogs/navbar read at 8px; check the mobile event popup's top corners, the Footer social
    row (now 4px squares, was circles), and the Trips hero tile (the surface most at risk at 8px).
-3. `/code-review low` on each, then mark ready for CodeRabbit and apply GCR.
-4. File the **Phase 2** issue (see Open items) for `app/admin/**`.
-5. `npm run verify` deliberately NOT run locally: its `next build` runs under `NODE_ENV=production`,
+2. `/code-review low` on each, then mark ready for CodeRabbit and apply GCR.
+3. File the **Phase 2** issue (see Open items) for `app/admin/**`.
+4. `npm run verify` deliberately NOT run locally: its `next build` runs under `NODE_ENV=production`,
    which on this box resolves `.env.local` = PROD. CI builds it on the PR.
 
 ## Constraints

--- a/docs/design/DESIGN-SYSTEM.md
+++ b/docs/design/DESIGN-SYSTEM.md
@@ -43,6 +43,76 @@ their dark-mode overrides live in `styles/brand-tokens.css`. The dark
 `--bg-global-rgb` **must** stay `26, 31, 24` — the header backdrop `rgba()`
 depends on it.
 
+### Tokens are Tailwind utilities
+
+`app/globals.css` maps every semantic token into Tailwind's colour scale with
+`@theme inline`, so you do **not** need an inline `style` object to use one:
+
+| Instead of | Write |
+|---|---|
+| `style={{ backgroundColor: 'var(--bg-card)' }}` | `className="bg-bg-card"` |
+| `style={{ color: 'var(--text-primary)' }}` | `className="text-text-primary"` |
+| `style={{ color: 'var(--brand-teal)' }}` on a link | `className="text-link hover:text-link-hover"` |
+| `hover:bg-black/[0.04]` | `hover:bg-hover-surface` |
+| `rgba(255,255,255,0.9)` on a crimson fill | `text-on-accent` |
+
+These are theme-aware for free. Opacity modifiers work (`bg-bg-card/50`
+compiles to `color-mix(in oklab, var(--bg-card) 50%, transparent)`).
+
+Adding a token: define it in **both** `:root` and `[data-theme="dark"]` in
+`brand-tokens.css`, add one line to the `@theme inline` block, and record its
+contrast ratio in the table below.
+
+### Interaction tokens
+
+Added in 2608-DEV-741 because there was no token for "a link", "a hover",
+"text on a crimson fill" or "the dialog scrim" — so those were typed as colour
+literals 513 times, and every one of them is wrong in dark mode.
+
+| Token | Light | Dark | For |
+|---|---|---|---|
+| `--link` / `--link-hover` | `#356874` / `#2C5964` | `#6FAEBE` / `#93CBD8` | Text links |
+| `--on-accent` | parchment | parchment | Text/icons on a crimson / forest / teal fill |
+| `--overlay` | `rgba(26,31,24,.40)` | `rgba(0,0,0,.60)` | Dialog and sheet scrims |
+| `--hover-surface` | `rgba(45,51,42,.05)` | `rgba(250,248,243,.08)` | Hover tints |
+| `--focus-ring` | crimson | `#6FAEBE` | Focus rings |
+
+`color-scheme` is set alongside them (`light` on `:root`, `dark` on
+`[data-theme="dark"]`) so native scrollbars, `<select>` popups, date pickers
+and autofill backgrounds follow the app theme.
+
+### Contrast (WCAG 2.2 AA)
+
+Measured, not estimated. AA is 4.5:1 for body text and 3:1 for large text and
+UI components. Re-measure and update this table whenever a value changes.
+
+| Pair | Light | Dark | Bar | |
+|---|---|---|---|---|
+| `--text-primary` on `--bg-card` | 14.33 | 13.66 | 4.5 | pass |
+| `--text-secondary` on `--bg-card` | 5.99 | 6.72 | 4.5 | pass |
+| `--link` on `--bg-global` | 5.85 | 6.76 | 4.5 | pass |
+| `--link` on `--bg-card` | 5.31 | 5.85 | 4.5 | pass |
+| `--link-hover` on `--bg-card` | 6.60 | 8.13 | 4.5 | pass |
+| `--on-accent` on crimson / forest / teal | 4.78 / 12.22 / 4.73 | same | 4.5 | pass |
+| `--focus-ring` on `--bg-global` / `--bg-card` | 4.78 / 4.34 | 6.76 / 5.85 | 3.0 | pass |
+| `--status-success-fg` on `--bg-card` | 7.63 | 8.77 | 4.5 | pass |
+| `--status-info-fg` on `--bg-card` | 6.60 | 8.45 | 4.5 | pass |
+| `--status-alert-fg` on `--bg-card` | 6.10 | 6.79 | 4.5 | pass |
+| `--status-pending-fg` on `--bg-card` | 4.80 | 7.80 | 4.5 | pass |
+| `--status-neutral-fg` on `--bg-card` | 5.99 | 6.72 | 4.5 | pass |
+| **`--text-tertiary` on `--bg-card`** | **3.15** | **3.94** | 4.5 | **FAIL — open** |
+
+Two notes on why `--link` is not simply `var(--brand-teal)`:
+
+- `--brand-teal` is 3.34:1 on the dark page — the AA failure this ticket was
+  filed for.
+- It is *also* 4.29:1 on the **light** card, a failure nobody had noticed.
+  `--brand-teal` stays the brand **fill** colour; `--link` is for text.
+
+`--text-tertiary` fails in both themes and is never redefined for dark at all.
+Fixing it changes light-mode pixels, so it is deliberately **not** in the C1
+foundation change — it belongs to the contrast-audit phase.
+
 ## Typography
 
 Fonts load via `next/font/google` in `app/layout.tsx`, each exposing a CSS
@@ -195,14 +265,23 @@ settings. Applied via `@media (prefers-reduced-motion: reduce)` guard in
 
 ## Usage Rules
 
-- **Never use Tailwind's `dark:` variant for theme-conditional styling.** This
-  project toggles a `data-theme="dark"|"light"` attribute on `<html>`
-  (`lib/hooks/useTheme.ts`), not `prefers-color-scheme` or a `.dark` class —
-  and no `@custom-variant dark` remaps it. `dark:*` utility classes silently
-  never fire. Use CSS custom properties with a `[data-theme="dark"] { ... }`
-  override block instead (see `styles/brand-tokens.css` for the pattern), or
-  read `data-theme` at runtime for JS-driven values (`lib/hooks/useTheme.ts`
-  exposes it; `ThemeTile.tsx` is the reference consumer).
+- **Colour goes through tokens. `dark:` is only for what a token cannot
+  express.** *(Revised in 2608-DEV-741 — this rule previously banned `dark:`
+  outright.)*
+
+  `@custom-variant dark (&:where([data-theme="dark"] *))` is now registered in
+  `app/globals.css`, so `dark:` targets the app's own `data-theme` attribute.
+  The old blanket ban was aimed at a real bug but described it wrongly: an
+  unregistered `dark:` did not "silently never fire", it fired on the **OS**
+  setting — an intermittent bug, which is worse than an absent one.
+
+  So the rule is now narrower and enforceable, not looser:
+  - **Colour** — always a semantic token. Never `dark:text-white`, never a hex.
+  - **`dark:`** — only for non-colour properties a token cannot carry: shadow
+    geometry, `opacity`, image `filter`, `background-image` gradients.
+
+  For JS-driven values, read `data-theme` at runtime (`lib/hooks/useTheme.ts`;
+  `ThemeTile.tsx` is the reference consumer).
 - **Legacy bare token names** (`--forest`, `--crimson`, `--sienna`, `--stone`,
   defined in `app/globals.css`) are a deliberate back-compat layer for older
   calendar components (`FilterControls.tsx`, `MonthView.tsx`, `AgendaView.tsx`,

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -1,6 +1,12 @@
 /* ── ISS-0027 · 2026 Bento Design System — Brand Tokens ── */
 
 :root {
+  /* Makes native UI — scrollbars, <select> popups, date pickers, autofill
+     backgrounds — follow the app theme. Without it a fully themed dark UI
+     still renders a glaring white scrollbar. Paired with [data-theme] below,
+     NOT with prefers-color-scheme: the app's theme is explicit. */
+  color-scheme: light;
+
   /* ── Palette ── */
   --brand-forest:    #2d332a;
   --brand-crimson:   #bc4749;
@@ -63,6 +69,34 @@
   /* ── Skeleton shimmer base ── */
   --skeleton-base:      rgba(45, 51, 42, 0.07);
 
+  /* ── Interaction tokens (2608-DEV-741 C1) ──
+     These exist because there was no token for "a link", "a hover", "text on
+     a crimson fill" or "the dialog scrim" — so those got typed as colour
+     literals 513 times, and every one of them is wrong in dark mode.
+     WCAG ratios for each pair are recorded in docs/design/DESIGN-SYSTEM.md. */
+
+  /* NOT var(--brand-teal): teal measures 4.29:1 on --bg-card, under the 4.5:1
+     bar for body text. This is a darkened teal at 5.31:1 on card / 5.85:1 on
+     global. --brand-teal remains the brand fill colour; --link is for text. */
+  --link:            #356874;
+  --link-hover:      #2C5964;
+
+  /* Text and icons on a crimson / forest / teal fill. Parchment clears 4.5:1
+     on all three (4.78 / 12.22 / 4.73); the rgba(255,255,255,0.9) it replaces
+     did not, because the alpha blended it toward the fill. */
+  --on-accent:       var(--brand-parchment);
+
+  /* Dialog and sheet scrims. */
+  --overlay:         rgba(26, 31, 24, 0.40);
+
+  /* The single biggest source of dark-mode invisibility: hover:bg-black/[0.02-0.05]. */
+  --hover-surface:   rgba(45, 51, 42, 0.05);
+
+  /* Must clear 3:1 against BOTH the page and card surface of its own theme.
+     Crimson does in light (4.78 / 4.34) but only 2.86 on the dark card, which
+     is exactly why this is a token and not a constant. */
+  --focus-ring:      var(--brand-crimson);
+
   /* ── Status pill tokens — semantic, theme-aware (bg tint + fg pair) ── */
   --status-success-bg:  rgba(63, 107, 74, 0.12);
   --status-success-fg:  #2f5138;
@@ -87,6 +121,8 @@
 html { font-size: calc(var(--font-scale) * 16px); }
 
 [data-theme="dark"] {
+  color-scheme: dark;
+
   --bg-global-rgb:      26, 31, 24;   /* #1A1F18 — required for rgba() header backdrop */
   --bg-global:          var(--brand-void);
   --bg-card:            var(--brand-moss);
@@ -115,6 +151,19 @@ html { font-size: calc(var(--font-scale) * 16px); }
   --status-pending-fg:  #f0b08d;
   --status-neutral-bg:  rgba(181, 176, 168, 0.20);
   --status-neutral-fg:  #B5B0A8;
+
+  /* ── Interaction tokens — dark ── */
+  /* Lightened teal: raw --brand-teal is 3.34:1 on --brand-void, a WCAG AA
+     fail. This is 6.76:1 on global, 5.85:1 on card, 5.33:1 on card-raised. */
+  --link:            #6FAEBE;
+  --link-hover:      #93CBD8;
+  --on-accent:       var(--brand-parchment);
+  /* Deeper than light: a 0.40 scrim over an already-dark page does not
+     separate the dialog from what is behind it. */
+  --overlay:         rgba(0, 0, 0, 0.60);
+  --hover-surface:   rgba(250, 248, 243, 0.08);
+  /* Crimson is only 2.86:1 on --bg-card here; the lightened teal is 5.85:1. */
+  --focus-ring:      #6FAEBE;
 }
 
 /* ── Utility classes ── */


### PR DESCRIPTION
Part of #741 — **C1 only**, per that issue's own sequencing ("C1 lands first and alone"). C2's 513-literal migration, C4's full audit and C5's CI guard are **not** here.

> ⚠️ **Stacked PR.** Base is `dev/2608-DEV-740`, not `main` — both branches edit `styles/brand-tokens.css` and `app/globals.css`. Merge #744 first; GitHub retargets this to `main` automatically.

## The diagnosis this implements

The architecture was already the standard one — semantic tokens, values swapped under `[data-theme]`, a pre-paint script, no flash. What is broken is **reachability**: using a token cost an inline `style` object while the wrong thing cost one word (`className="text-emerald-800"`). When the correct path costs more, the incorrect one wins — 513 times.

## What changed

- **a.** New interaction tokens in *both* `:root` and `[data-theme="dark"]`: `--link`, `--link-hover`, `--on-accent`, `--overlay`, `--hover-surface`, `--focus-ring`. Having **zero** tokens for "a link", "a hover", "text on a crimson fill" or "the scrim" is what produced the literals in the first place.
- **b.** `@theme inline` maps every semantic token into Tailwind's colour scale, so `bg-bg-card`, `text-text-primary`, `text-link`, `hover:bg-hover-surface` and `ring-focus-ring` are ordinary theme-aware utilities.
- **c.** `color-scheme: light|dark` — previously absent repo-wide, which is what left scrollbars and `<select>` popups rendering light inside a dark UI.
- **d.** `@custom-variant dark` registered against `[data-theme="dark"]`. This reverses the documented ban **deliberately**, and `DESIGN-SYSTEM.md` is updated in the same commit so the two never disagree.

## Spike result — correcting the issue's premise

The issue warns that plain `@theme` "resolves the variable at build time and freezes the light value". **Measured: it does not.** Plain `@theme` emits an indirection (`--color-bg-card: var(--bg-card)`) that CSS still substitutes at use-time, so both forms are theme-aware.

`@theme inline` is still the right choice — it is the shadcn v4 convention and drops a redundant indirection — but the stated justification was wrong, so it is not repeated in the docs. Opacity modifiers work under both (`bg-bg-card/50` → `color-mix(in oklab, var(--bg-card) 50%, transparent)`).

## Contrast — measured, not estimated

Every pair's ratio is now recorded in `DESIGN-SYSTEM.md`. Two findings beyond the issue:

- **`--brand-teal` fails on the *light* card too** (4.29:1), not only on dark (3.34:1). Nobody had noticed the light-mode half. So `--link` is a darkened teal (5.31 / 5.85), not `var(--brand-teal)`; teal stays the brand *fill* colour.
- **`--text-tertiary` fails AA in both themes** — 3.15:1 light, 3.94:1 dark — and is never redefined for dark at all. **Not fixed here:** it moves light-mode pixels, and "light mode visually unchanged" is this phase's review invariant. Logged for C4.
- A single focus-ring colour cannot satisfy 3:1 on both themes (crimson is 2.86:1 on the dark card) — which is precisely why it is a token.

## The 5 existing `dark:` classes

`LinksGuidesTile.tsx:85,:111`, `ReminderTable.tsx:68`, `RemindersTab.tsx:85,:119` are all colour classes. Registering the variant is what makes them correct — they fired on the **OS** setting before, an intermittent bug rather than an absent one. Converting them to tokens is C2; doing it here would shift light mode.

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` | clean (exit 0) |
| `npm test` | 481 passed, 34 files |
| `npm run lint` | 0 errors, 465 warnings (unchanged) |
| real `app/globals.css` compiled | `bg-bg-card`→`var(--bg-card)`, `text-link`→`var(--link)`, `bg-bg-card/50`→`color-mix(…)`, `dark:shadow-lg`→`&:where([data-theme="dark"] *)` |
| gotcha guard | dark `--bg-global-rgb` still `26, 31, 24` |

**Not visually verified.** The review invariant is *zero* intended light-mode change; dark mode should gain `color-scheme` on native chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved light and dark theme color handling across surfaces, text, borders, links, overlays, hover states, and focus indicators.
  * Added clearer contrast and interaction states for dark mode.
  * Updated theme switching to respond to the selected application theme rather than device preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->