### PR TITLE
[2608-DEV-749] Cancel / revoke calendar role participation + 1h sign-up cutoff

### DIFF
--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { apiClient, ApiError } from '@/lib/apiClient'
+import { isRoleWindowClosed } from '@/lib/events/role-cutoff'
 import QRCode from 'qrcode'
 import { toast } from 'sonner'
 import EventPopupShell from './popup/EventPopupShell'
@@ -42,9 +43,10 @@ export default function EventPopup({
   const actionsRole: 'admin' | 'core' | 'member' | null =
     userRole === 'guest' || userRole === null ? null : userRole
 
-  // Role requests close 15 minutes before start. Admins always see full UI.
-  const isClosed = !isAdmin && !!event &&
-    Date.now() >= new Date(event.start_time).getTime() - 15 * 60 * 1000
+  // Role sign-ups close ROLE_CUTOFF_MS before start (60 min since
+  // 2608-DEV-749, was 15). Admins always see the full UI. The window itself
+  // lives in lib/events/role-cutoff.ts, shared with the route that enforces it.
+  const isClosed = !isAdmin && !!event && isRoleWindowClosed(event.start_time)
 
   const isEventEnded = !!event && Date.now() >= new Date(event.end_time).getTime()
 
@@ -55,12 +57,36 @@ export default function EventPopup({
         body: JSON.stringify({ role_label }),
       }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['event', eventId] }),
+    onError: (err: unknown) => {
+      const code = err instanceof ApiError ? err.code : undefined
+      const key = code === 'role_window_closed' ? 'cal.roleWindowClosed'
+        : code === 'slot_filled' ? 'cal.roleSlotFilled'
+        : code === 'already_requested' ? 'cal.roleAlreadyRequested'
+        : 'cal.requestRoleError'
+      toast.error(t(key))
+      // slot_filled / state_changed mean this client is looking at a stale
+      // board — refetch so the member sees what actually happened.
+      qc.invalidateQueries({ queryKey: ['event', eventId] })
+    },
   })
 
+  // Takes no argument: the route identifies the row from the session + event id,
+  // and the old `request_id` parameter was accepted and never sent.
   const cancelMutation = useMutation({
-    mutationFn: (request_id: string) =>
+    mutationFn: () =>
       apiClient(`/api/events/${eventId}/request-role`, { method: 'DELETE' }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['event', eventId] }),
+    onSuccess: () => {
+      toast.success(t('cal.cancelRoleSuccess'))
+      qc.invalidateQueries({ queryKey: ['event', eventId] })
+    },
+    // Same code-keyed branching as attendMutation — never match on err.message.
+    onError: (err: unknown) => {
+      const code = err instanceof ApiError ? err.code : undefined
+      const key = code === 'role_window_closed' ? 'cal.roleWindowClosed'
+        : code === 'nothing_to_cancel' ? 'cal.cancelRoleGone'
+        : 'cal.cancelRoleError'
+      toast.error(t(key))
+    },
   })
 
   const attendMutation = useMutation({

--- a/app/(dashboard)/calendar/components/EventPopup.tsx
+++ b/app/(dashboard)/calendar/components/EventPopup.tsx
@@ -62,6 +62,7 @@ export default function EventPopup({
       const key = code === 'role_window_closed' ? 'cal.roleWindowClosed'
         : code === 'slot_filled' ? 'cal.roleSlotFilled'
         : code === 'already_requested' ? 'cal.roleAlreadyRequested'
+        : code === 'state_changed' ? 'cal.roleStateChanged'
         : 'cal.requestRoleError'
       toast.error(t(key))
       // slot_filled / state_changed mean this client is looking at a stale
@@ -86,6 +87,12 @@ export default function EventPopup({
         : code === 'nothing_to_cancel' ? 'cal.cancelRoleGone'
         : 'cal.cancelRoleError'
       toast.error(t(key))
+      // nothing_to_cancel means the server has no active row while this client
+      // still shows one (an admin revoked it, or a second tab withdrew first) —
+      // refetch, or the popup keeps offering a withdraw that can never succeed.
+      if (code === 'nothing_to_cancel') {
+        qc.invalidateQueries({ queryKey: ['event', eventId] })
+      }
     },
   })
 

--- a/app/(dashboard)/calendar/components/popup/EventActionsTabs.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventActionsTabs.tsx
@@ -20,7 +20,9 @@ type Props = {
   canRequestRole: boolean
   profileNameMissing: boolean
   requestMutation: UseMutationResult<unknown, unknown, string>
-  cancelMutation: UseMutationResult<unknown, unknown, string>
+  // void, not string: the DELETE route resolves the row from the session and the
+  // event id, so the old `request_id` argument was accepted and never sent.
+  cancelMutation: UseMutationResult<unknown, unknown, void>
   t: (key: TranslationKey) => string
 }
 

--- a/app/(dashboard)/calendar/components/popup/MemberActions.tsx
+++ b/app/(dashboard)/calendar/components/popup/MemberActions.tsx
@@ -42,7 +42,12 @@ export default function MemberActions({
   // case of an event days away.
   const startTime = event?.start_time ?? ''
   const minutesLeft = startTime !== '' ? minutesUntilRoleCutoff(startTime) : Number.POSITIVE_INFINITY
-  const inCountdown = !isClosed && minutesLeft > 0 && minutesLeft <= CUTOFF_MINUTES
+  // Derived here, not just taken from the prop: the prop is computed once in
+  // EventPopup, and the tick below re-renders THIS component only. Without the
+  // local `minutesLeft <= 0` the popup would sit on the generic hint at the
+  // exact moment the window closed, with the buttons still live.
+  const closed = isClosed || minutesLeft <= 0
+  const inCountdown = !closed && minutesLeft <= CUTOFF_MINUTES
   useMinuteTick(inCountdown)
 
   if (isLoading || !event) return null
@@ -60,7 +65,7 @@ export default function MemberActions({
   )
   const showNameGate = canRequestRole && profileNameMissing && !hasActiveRequest
 
-  const cutoffLine = isClosed
+  const cutoffLine = closed
     ? t('event.cutoff.closed')
     : inCountdown
       ? t('event.cutoff.countdown').replace('{{minutes}}', String(minutesLeft))
@@ -70,7 +75,7 @@ export default function MemberActions({
     <div className="px-4 py-3 border-b border-black/5">
       <p className="text-[10px] font-semibold tracking-widest uppercase mb-1 flex items-center gap-1" style={{ color: 'var(--text-secondary)' }}>
         {t('event.roles')}
-        {isClosed && <Lock size={10} />}
+        {closed && <Lock size={10} />}
       </p>
 
       {/* Cutoff copy: the window was silent before this ticket — a closed slot
@@ -124,8 +129,8 @@ export default function MemberActions({
 
             const isPendingMine  = isActive && myReq.status === 'pending'
             const isApprovedMine = isActive && myReq.status === 'approved'
-            const disabledCancel  = isMutating || isClosed
-            const disabledRequest = isMutating || isFilled || hasActiveRequest || isClosed
+            const disabledCancel  = isMutating || closed
+            const disabledRequest = isMutating || isFilled || hasActiveRequest || closed
 
             const occupantName = isFilled && slot.assigned_profile
               ? [slot.assigned_profile.first_name, slot.assigned_profile.last_name].filter(Boolean).join(' ') || null
@@ -140,10 +145,11 @@ export default function MemberActions({
             const buttonBody = (
               <>
                 {slot.role_label}
-                {isPendingMine  && <X size={10} className="opacity-60" />}
-                {isApprovedMine && <X size={10} className="opacity-60" />}
+                {/* Both of the caller's own live states now offer a way out —
+                    the approved case used to render an inert <Check/>. */}
+                {(isPendingMine || isApprovedMine) && <X size={10} className="opacity-60" />}
                 {isFilled && !isActive && <Check size={10} className="opacity-40" />}
-                {isClosed && !isActive && <Lock size={10} className="opacity-40" />}
+                {closed && !isActive && <Lock size={10} className="opacity-40" />}
               </>
             )
 
@@ -177,7 +183,7 @@ export default function MemberActions({
                   ) : (
                     <button
                       onClick={() => {
-                        if (isClosed) return
+                        if (closed) return
                         if (isPendingMine) cancelMutation.mutate()
                         else if (!hasActiveRequest && !isFilled) requestMutation.mutate(slot.role_label)
                       }}

--- a/app/(dashboard)/calendar/components/popup/MemberActions.tsx
+++ b/app/(dashboard)/calendar/components/popup/MemberActions.tsx
@@ -3,10 +3,25 @@
 import { UseMutationResult } from '@tanstack/react-query'
 import { X, Check, Lock } from 'lucide-react'
 import Link from 'next/link'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
 import type { TranslationKey } from '@/lib/i18n'
+import { ROLE_CUTOFF_MS, minutesUntilRoleCutoff } from '@/lib/events/role-cutoff'
+import { useMinuteTick } from '@/lib/hooks/useMinuteTick'
 import { PendingPopover } from './PendingPopover'
 import { SLOT_STATUS_STYLES, REQUEST_STATUS_STYLES } from './styles'
 import type { EventDetail, RoleSlot } from './types'
+
+const CUTOFF_MINUTES = ROLE_CUTOFF_MS / 60_000
 
 type Props = {
   event: EventDetail
@@ -15,25 +30,53 @@ type Props = {
   isClosed: boolean
   profileNameMissing: boolean
   requestMutation: UseMutationResult<unknown, unknown, string>
-  cancelMutation: UseMutationResult<unknown, unknown, string>
+  cancelMutation: UseMutationResult<unknown, unknown, void>
   t: (key: TranslationKey) => string
 }
 
 export default function MemberActions({
   event, isLoading, canRequestRole, isClosed, profileNameMissing, requestMutation, cancelMutation, t,
 }: Props) {
+  // Hooks run before the early return — a countdown that only ticks while the
+  // popup is open AND inside the final hour, so no interval runs for the common
+  // case of an event days away.
+  const startTime = event?.start_time ?? ''
+  const minutesLeft = startTime !== '' ? minutesUntilRoleCutoff(startTime) : Number.POSITIVE_INFINITY
+  const inCountdown = !isClosed && minutesLeft > 0 && minutesLeft <= CUTOFF_MINUTES
+  useMinuteTick(inCountdown)
+
   if (isLoading || !event) return null
 
   const roleSlots = event.role_slots ?? []
   const isMutating = requestMutation.isPending || cancelMutation.isPending
-  const hasAnyRequest = roleSlots.some(s => s.caller_request !== null)
-  const showNameGate = canRequestRole && profileNameMissing && !hasAnyRequest
+
+  // Only a PENDING or APPROVED request occupies the member (2608-DEV-749).
+  // A denied row no longer blocks them — that is what lets a member the admin
+  // passed over claim a slot that has since reopened. /api/events/[id] never
+  // sends a cancelled row as caller_request at all.
+  const hasActiveRequest = roleSlots.some(
+    s => s.caller_request !== null
+      && (s.caller_request.status === 'pending' || s.caller_request.status === 'approved'),
+  )
+  const showNameGate = canRequestRole && profileNameMissing && !hasActiveRequest
+
+  const cutoffLine = isClosed
+    ? t('event.cutoff.closed')
+    : inCountdown
+      ? t('event.cutoff.countdown').replace('{{minutes}}', String(minutesLeft))
+      : t('event.cutoff.hint')
 
   return (
     <div className="px-4 py-3 border-b border-black/5">
-      <p className="text-[10px] font-semibold tracking-widest uppercase mb-3 flex items-center gap-1" style={{ color: 'var(--text-secondary)' }}>
+      <p className="text-[10px] font-semibold tracking-widest uppercase mb-1 flex items-center gap-1" style={{ color: 'var(--text-secondary)' }}>
         {t('event.roles')}
         {isClosed && <Lock size={10} />}
+      </p>
+
+      {/* Cutoff copy: the window was silent before this ticket — a closed slot
+          rendered as a bare lock icon with no explanation. */}
+      <p className="text-[10px] mb-3" style={{ color: 'var(--text-secondary)' }}>
+        {cutoffLine}
       </p>
 
       {/* Existing request read-only badge (shown above buttons) */}
@@ -76,40 +119,75 @@ export default function MemberActions({
             const myReq     = slot.caller_request
             const isActive  = myReq !== null
             const isFilled  = slot.status === 'filled'
-            const activeStyle = isActive ? REQUEST_STATUS_STYLES[myReq!.status] : null
+            const activeStyle = isActive ? REQUEST_STATUS_STYLES[myReq.status] : null
             const slotStyle   = isFilled ? SLOT_STATUS_STYLES.filled : SLOT_STATUS_STYLES[slot.status]
 
-            const isCancel        = isActive && myReq!.status === 'pending'
+            const isPendingMine  = isActive && myReq.status === 'pending'
+            const isApprovedMine = isActive && myReq.status === 'approved'
             const disabledCancel  = isMutating || isClosed
-            const disabledRequest = isMutating || isFilled || hasAnyRequest || isClosed
+            const disabledRequest = isMutating || isFilled || hasActiveRequest || isClosed
 
             const occupantName = isFilled && slot.assigned_profile
               ? [slot.assigned_profile.first_name, slot.assigned_profile.last_name].filter(Boolean).join(' ') || null
               : null
 
+            const buttonClass = 'flex-1 flex items-center justify-center gap-1 py-2 rounded-xl text-[11px] font-bold tracking-wider uppercase transition-all disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-95 active:scale-[0.97]'
+            const buttonStyle = {
+              backgroundColor: activeStyle ? activeStyle.bg : slotStyle.bg,
+              color: activeStyle ? activeStyle.color : slotStyle.color,
+              border: activeStyle ? `1px solid ${activeStyle.color}33` : '1px solid transparent',
+            }
+            const buttonBody = (
+              <>
+                {slot.role_label}
+                {isPendingMine  && <X size={10} className="opacity-60" />}
+                {isApprovedMine && <X size={10} className="opacity-60" />}
+                {isFilled && !isActive && <Check size={10} className="opacity-40" />}
+                {isClosed && !isActive && <Lock size={10} className="opacity-40" />}
+              </>
+            )
+
             return (
               <div key={slot.role_label} className="flex-1 flex flex-col gap-0.5 min-w-0">
                 <div className="flex items-center gap-1">
-                  <button
-                    onClick={() => {
-                      if (isClosed) return
-                      if (isCancel) cancelMutation.mutate(myReq!.id)
-                      else if (!hasAnyRequest && !isFilled) requestMutation.mutate(slot.role_label)
-                    }}
-                    disabled={isCancel ? disabledCancel : disabledRequest}
-                    className="flex-1 flex items-center justify-center gap-1 py-2 rounded-xl text-[11px] font-bold tracking-wider uppercase transition-all disabled:opacity-40 disabled:cursor-not-allowed hover:brightness-95 active:scale-[0.97]"
-                    style={{
-                      backgroundColor: activeStyle ? activeStyle.bg : slotStyle.bg,
-                      color: activeStyle ? activeStyle.color : slotStyle.color,
-                      border: activeStyle ? `1px solid ${activeStyle.color}33` : '1px solid transparent',
-                    }}
-                  >
-                    {slot.role_label}
-                    {isActive && myReq!.status === 'pending' && <X size={10} className="opacity-60" />}
-                    {isActive && myReq!.status === 'approved' && <Check size={10} />}
-                    {isFilled && !isActive && <Check size={10} className="opacity-40" />}
-                    {isClosed && !isActive && <Lock size={10} className="opacity-40" />}
-                  </button>
+                  {isApprovedMine ? (
+                    // Giving up a role you already hold is destructive and
+                    // reopens the slot for everyone, so it goes behind a
+                    // confirm. Pending-cancel stays a direct click — nothing is
+                    // lost by re-requesting.
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <button disabled={disabledCancel} className={buttonClass} style={buttonStyle}>
+                          {buttonBody}
+                        </button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>{t('event.withdrawRoleTitle')}</AlertDialogTitle>
+                          <AlertDialogDescription>{t('event.withdrawRoleDesc')}</AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>{t('event.cancel')}</AlertDialogCancel>
+                          <AlertDialogAction onClick={() => cancelMutation.mutate()}>
+                            {t('event.withdrawRoleConfirm')}
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  ) : (
+                    <button
+                      onClick={() => {
+                        if (isClosed) return
+                        if (isPendingMine) cancelMutation.mutate()
+                        else if (!hasActiveRequest && !isFilled) requestMutation.mutate(slot.role_label)
+                      }}
+                      disabled={isPendingMine ? disabledCancel : disabledRequest}
+                      className={buttonClass}
+                      style={buttonStyle}
+                    >
+                      {buttonBody}
+                    </button>
+                  )}
                   {slot.status === 'contested' && slot.pending_profiles.length > 0 && (
                     <PendingPopover profiles={slot.pending_profiles} color={slotStyle.color} />
                   )}

--- a/app/(dashboard)/calendar/components/popup/styles.ts
+++ b/app/(dashboard)/calendar/components/popup/styles.ts
@@ -19,6 +19,9 @@ export const REQUEST_STATUS_STYLES = {
   pending:  { bg: 'var(--status-pending-bg)', color: 'var(--status-pending-fg)' },
   approved: { bg: 'var(--status-success-bg)', color: 'var(--status-success-fg)' },
   denied:   { bg: 'var(--status-alert-bg)',   color: 'var(--status-alert-fg)'   },
+  // 2608-DEV-749 — a withdrawn/revoked role is neutral, not an alert: nothing
+  // went wrong, the slot simply reopened.
+  cancelled: { bg: 'var(--status-neutral-bg)', color: 'var(--status-neutral-fg)' },
 }
 
 export const REGISTRATION_STATUS_STYLES = {

--- a/app/(dashboard)/calendar/components/popup/types.ts
+++ b/app/(dashboard)/calendar/components/popup/types.ts
@@ -1,7 +1,10 @@
 export type CallerRequest = {
   id: string
   role_label: string
-  status: 'pending' | 'approved' | 'denied'
+  // 'cancelled' (2608-DEV-749) is in the union because the type mirrors the
+  // registration_status enum, but /api/events/[id] deliberately never sends a
+  // cancelled row as caller_request — see that route's callerReq filter.
+  status: 'pending' | 'approved' | 'denied' | 'cancelled'
 }
 
 export type PendingProfile = {

--- a/app/admin/approval-hub/components/EventRolesTab.tsx
+++ b/app/admin/approval-hub/components/EventRolesTab.tsx
@@ -17,6 +17,7 @@ import { toast } from '@/lib/toast'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatDate, formatTime } from '@/lib/format'
 import { fetchJson } from '@/lib/utils/fetchJson'
+import type { TranslationKey } from '@/lib/i18n'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -49,6 +50,16 @@ const STATUS_BADGE: Record<string, string> = {
   // 2608-DEV-749 — neutral grey: a revoked role is an administrative change,
   // not a rejection. Same shape as the entries above it.
   cancelled: 'bg-black/5 text-[var(--text-secondary)] border border-black/10',
+}
+
+// The badge used to render the raw enum value, so an admin on Bulgarian read
+// "cancelled". Keyed on the same union as RoleRequest['status'], so adding a
+// status to that type fails the build here until a label exists for it.
+const STATUS_LABEL: Record<RoleRequest['status'], TranslationKey> = {
+  pending:   'admin.approval.events.status.pending',
+  approved:  'admin.approval.events.status.approved',
+  denied:    'admin.approval.events.status.denied',
+  cancelled: 'admin.approval.events.status.cancelled',
 }
 
 const SLOT_BADGE: Record<string, string> = {
@@ -279,7 +290,7 @@ export function EventRolesTab() {
               </div>
               <div className="flex items-center gap-2 flex-shrink-0">
                 <span className={`text-xs px-2.5 py-1 rounded-full font-medium ${STATUS_BADGE[r.status]}`}>
-                  {r.status}
+                  {t(STATUS_LABEL[r.status])}
                 </span>
                 {/* 2608-DEV-749: an approved role was read-only here, so nobody
                     could undo it. Behind a confirm — it emails the member and

--- a/app/admin/approval-hub/components/EventRolesTab.tsx
+++ b/app/admin/approval-hub/components/EventRolesTab.tsx
@@ -2,6 +2,17 @@
 
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
 import { toast } from '@/lib/toast'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatDate, formatTime } from '@/lib/format'
@@ -14,7 +25,7 @@ type CalendarEvent = { id: string; title: string; start_time: string }
 type RoleRequest = {
   id: string
   role_label: string
-  status: 'pending' | 'approved' | 'denied'
+  status: 'pending' | 'approved' | 'denied' | 'cancelled'
   note: string | null
   created_at: string
   event_id: string
@@ -35,6 +46,9 @@ const STATUS_BADGE: Record<string, string> = {
   pending:  'bg-[#f2cc8f]/30 text-[#7a5c00] border border-[#f2cc8f]',
   approved: 'bg-[#81b29a]/20 text-[#2d6a4f] border border-[#81b29a]/50',
   denied:   'bg-[#bc4749]/10 text-[#bc4749] border border-[#bc4749]/30',
+  // 2608-DEV-749 — neutral grey: a revoked role is an administrative change,
+  // not a rejection. Same shape as the entries above it.
+  cancelled: 'bg-black/5 text-[var(--text-secondary)] border border-black/10',
 }
 
 const SLOT_BADGE: Record<string, string> = {
@@ -97,7 +111,7 @@ export function EventRolesTab() {
   )
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, status }: { id: string; status: 'approved' | 'denied' }) =>
+    mutationFn: ({ id, status }: { id: string; status: 'approved' | 'denied' | 'cancelled' }) =>
       fetchJson(`/api/admin/event-role-requests/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -263,9 +277,39 @@ export function EventRolesTab() {
                   {eventMeta(r)}
                 </p>
               </div>
-              <span className={`text-xs px-2.5 py-1 rounded-full font-medium flex-shrink-0 ${STATUS_BADGE[r.status]}`}>
-                {r.status}
-              </span>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <span className={`text-xs px-2.5 py-1 rounded-full font-medium ${STATUS_BADGE[r.status]}`}>
+                  {r.status}
+                </span>
+                {/* 2608-DEV-749: an approved role was read-only here, so nobody
+                    could undo it. Behind a confirm — it emails the member and
+                    reopens the slot. */}
+                {r.status === 'approved' && (
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <button
+                        disabled={updateMutation.isPending}
+                        className="text-xs font-medium hover:opacity-70 transition-opacity disabled:opacity-40"
+                        style={{ color: 'var(--brand-crimson)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+                      >
+                        {t('admin.approval.events.btn.revoke')}
+                      </button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>{t('admin.approval.events.revokeTitle')}</AlertDialogTitle>
+                        <AlertDialogDescription>{t('admin.approval.events.revokeDesc')}</AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>{t('event.cancel')}</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => updateMutation.mutate({ id: r.id, status: 'cancelled' })}>
+                          {t('admin.approval.events.btn.revoke')}
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
+              </div>
             </div>
           )
         })}

--- a/app/admin/members/[id]/components/memberDetailFormat.ts
+++ b/app/admin/members/[id]/components/memberDetailFormat.ts
@@ -10,6 +10,9 @@ export const STATUS_PILL: Record<string, string> = {
   pending:   'bg-[#f2cc8f33] text-[#7a5c00]',
   approved:  'bg-[#81b29a33] text-[#2d6a4f]',
   denied:    'bg-[#bc474920] text-[#bc4749]',
+  // 2608-DEV-749 — registration_status gained 'cancelled'; without a line here
+  // the `?? ''` fallback at the three call sites renders an unstyled pill.
+  cancelled: 'bg-black/5 text-[var(--text-secondary)]',
   completed: 'bg-[#81b29a33] text-[#2d6a4f]',
   failed:    'bg-[#bc474920] text-[#bc4749]',
 }

--- a/app/api/admin/event-role-requests/[id]/route.ts
+++ b/app/api/admin/event-role-requests/[id]/route.ts
@@ -8,9 +8,15 @@ type RoleEmailPayload = {
   eventTitle: string
   eventDate: string
   roleLabel: string
-  status: 'approved' | 'denied'
+  status: 'approved' | 'denied' | 'cancelled'
   requestId: string
   profileId: string
+}
+
+const EMAIL_SUBJECT: Record<RoleEmailPayload['status'], string> = {
+  approved:  'Event Role Request Approved ✓',
+  denied:    'Event Role Request Declined',
+  cancelled: 'Event Role Participation Cancelled',
 }
 
 async function sendRoleEmail(payload: RoleEmailPayload): Promise<void> {
@@ -30,7 +36,7 @@ async function sendRoleEmail(payload: RoleEmailPayload): Promise<void> {
 
   await sendNotificationEmail({
     to: payload.contactEmail,
-    subject: payload.status === 'approved' ? 'Event Role Request Approved ✓' : 'Event Role Request Declined',
+    subject: EMAIL_SUBJECT[payload.status],
     html,
     template: 'event_role_request_result',
     meta: { request_id: payload.requestId, profile_id: payload.profileId },
@@ -50,7 +56,9 @@ export async function PATCH(
   if (ctx.guard) return ctx.guard
 
   const { status } = await req.json()
-  if (!['approved', 'denied'].includes(status)) {
+  // 'cancelled' (2608-DEV-749) is the admin revoke: it takes an APPROVED role
+  // away and reopens the slot. 'denied' still means "never granted".
+  if (!['approved', 'denied', 'cancelled'].includes(status)) {
     return Response.json({ error: 'Invalid status' }, { status: 400 })
   }
 
@@ -88,15 +96,38 @@ export async function PATCH(
     return Response.json(result)
   }
 
-  // Deny path — direct update, no slot write needed
-  const { data, error } = await supabase
+  // Deny / revoke path — direct update, no slot write needed. Cancelling stamps
+  // the audit columns with the acting admin; denying leaves them alone.
+  //
+  // The `.in('status', ...)` on the revoke is a precondition re-checked at write
+  // time: only an APPROVED role can be revoked, and reading-then-writing would
+  // let a concurrent change slip through between the two statements.
+  const patch = status === 'cancelled'
+    ? {
+        status: 'cancelled' as const,
+        cancelled_at: new Date().toISOString(),
+        cancelled_by: ctx.profile.id,
+      }
+    : { status: 'denied' as const }
+
+  const query = supabase
     .from('event_role_requests')
-    .update({ status: 'denied' })
+    .update(patch)
     .eq('id', id)
+
+  if (status === 'cancelled') query.in('status', ['approved'])
+
+  const { data, error } = await query
     .select('id, role_label, profile_id, profile:profiles!profile_id(first_name, contact_email), event:calendar_events!event_id(title, start_time)')
-    .single()
+    .maybeSingle()
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
+  if (!data) {
+    return Response.json(
+      { error: 'This request is no longer in a state that can be changed', code: 'state_changed' },
+      { status: 409 },
+    )
+  }
 
   const profileData = data.profile as { first_name: string | null; contact_email: string | null }
   const eventData = data.event as { title: string; start_time: string }
@@ -111,7 +142,7 @@ export async function PATCH(
         ? new Date(eventData.start_time).toLocaleDateString()
         : 'TBD',
       roleLabel: data.role_label,
-      status: 'denied',
+      status: status === 'cancelled' ? 'cancelled' : 'denied',
       requestId: data.id,
       profileId: data.profile_id,
     }).catch(console.error)

--- a/app/api/events/[id]/request-role/route.test.ts
+++ b/app/api/events/[id]/request-role/route.test.ts
@@ -1,0 +1,339 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * 2608-DEV-749. Nothing covered this route before — the `event_role_requests`
+ * references in lib/server/member-registration.test.ts and
+ * lib/actions/guest-registration.test.ts are capacity fixtures only.
+ *
+ * Same fake-Supabase shape as app/api/admin/members/[id]/route.test.ts, with one
+ * addition it did not need: this route issues SEVERAL distinct queries against
+ * ONE table, and two of them carry a `.in('status', ...)` PRECONDITION that is
+ * the whole defence against a read-then-write race. So the fake queues results
+ * per table in call order and records every chained call, letting the tests
+ * assert that the precondition was actually sent — not just that the happy path
+ * returned 200.
+ */
+
+type QueryResult = { data: unknown; error: { message: string } | null }
+type ChainCall = { table: string; method: string; args: unknown[] }
+
+const OK = (data: unknown): QueryResult => ({ data, error: null })
+
+function makeDb(queues: Record<string, QueryResult[]>) {
+  const calls: ChainCall[] = []
+
+  function chainable(table: string): Record<string, unknown> {
+    const obj: Record<string, unknown> = {}
+    const record = (method: string) => (...args: unknown[]) => {
+      calls.push({ table, method, args })
+      return obj
+    }
+    for (const m of ['select', 'eq', 'in', 'order', 'update', 'insert', 'limit', 'is']) {
+      obj[m] = record(m)
+    }
+    const next = (): QueryResult => {
+      const q = queues[table]
+      if (!q || q.length === 0) throw new Error(`fake supabase: no queued result for "${table}"`)
+      return q.shift() as QueryResult
+    }
+    obj.maybeSingle = () => Promise.resolve(next())
+    obj.single = () => Promise.resolve(next())
+    obj.then = (resolve: (v: QueryResult) => void, reject: (e: unknown) => void) =>
+      Promise.resolve(next()).then(resolve, reject)
+    return obj
+  }
+
+  const client = { from: (table: string) => chainable(table) } as unknown as SupabaseClient
+  return { client, calls }
+}
+
+/** Every `.in(...)` sent against event_role_requests, flattened for assertions. */
+function statusPreconditions(calls: ChainCall[]): unknown[][] {
+  return calls
+    .filter(c => c.table === 'event_role_requests' && c.method === 'in')
+    .map(c => c.args)
+}
+
+const mockAuth = vi.fn()
+const mockCreateServiceClient = vi.fn()
+
+vi.mock('@clerk/nextjs/server', () => ({ auth: () => mockAuth() }))
+vi.mock('@/lib/supabase/service', () => ({
+  createServiceClient: () => mockCreateServiceClient(),
+}))
+
+const EVENT_ID = 'evt_1'
+const params = Promise.resolve({ id: EVENT_ID })
+
+/** Far enough out that the 60-minute window is comfortably open. */
+const OPEN_EVENT = OK({ start_time: new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString() })
+/** Inside the 60-minute window — sign-ups and withdrawals are closed. */
+const CLOSED_EVENT = OK({ start_time: new Date(Date.now() + 20 * 60 * 1000).toISOString() })
+
+const MEMBER = OK({ id: 'p_member', role: 'member' })
+const ADMIN  = OK({ id: 'p_admin',  role: 'admin' })
+
+function postReq(body: unknown): Request {
+  return new Request(`http://localhost/api/events/${EVENT_ID}/request-role`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+function deleteReq(): Request {
+  return new Request(`http://localhost/api/events/${EVENT_ID}/request-role`, { method: 'DELETE' })
+}
+
+beforeEach(() => {
+  mockAuth.mockReset()
+  mockCreateServiceClient.mockReset()
+})
+
+describe('DELETE /api/events/[id]/request-role — member self-withdraw', () => {
+  it('cancels an APPROVED request (the whole point of 749) and stamps the actor', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client, calls } = makeDb({
+      profiles: [MEMBER],
+      calendar_events: [OPEN_EVENT],
+      event_role_requests: [OK({ id: 'req_1', status: 'cancelled' })],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { DELETE } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await DELETE(deleteReq(), { params })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ cancelled: true, id: 'req_1' })
+
+    const update = calls.find(c => c.table === 'event_role_requests' && c.method === 'update')
+    expect(update?.args[0]).toMatchObject({ status: 'cancelled', cancelled_by: 'p_member' })
+    expect((update?.args[0] as { cancelled_at: string }).cancelled_at).toEqual(expect.any(String))
+
+    // The precondition is re-asserted at write time — no read-then-write.
+    expect(statusPreconditions(calls)).toEqual([['status', ['pending', 'approved']]])
+  })
+
+  it('returns 404 with a code when nothing is cancellable — not the old fake 200', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client } = makeDb({
+      profiles: [MEMBER],
+      calendar_events: [OPEN_EVENT],
+      event_role_requests: [OK(null)],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { DELETE } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await DELETE(deleteReq(), { params })
+
+    expect(res.status).toBe(404)
+    expect((await res.json()).code).toBe('nothing_to_cancel')
+  })
+
+  it('enforces the cutoff on withdrawal too — it was client-only before', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client, calls } = makeDb({
+      profiles: [MEMBER],
+      calendar_events: [CLOSED_EVENT],
+      event_role_requests: [],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { DELETE } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await DELETE(deleteReq(), { params })
+
+    expect(res.status).toBe(403)
+    expect((await res.json()).code).toBe('role_window_closed')
+    // Nothing was written.
+    expect(calls.some(c => c.table === 'event_role_requests')).toBe(false)
+  })
+
+  it('an admin bypasses the cutoff and never even loads the event', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_admin' })
+    const { client, calls } = makeDb({
+      profiles: [ADMIN],
+      calendar_events: [],
+      event_role_requests: [OK({ id: 'req_1', status: 'cancelled' })],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { DELETE } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await DELETE(deleteReq(), { params })
+
+    expect(res.status).toBe(200)
+    expect(calls.some(c => c.table === 'calendar_events')).toBe(false)
+  })
+})
+
+describe('POST /api/events/[id]/request-role — request and revive', () => {
+  it('revives a CANCELLED row instead of 23505-ing, clearing the cancel stamp', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client, calls } = makeDb({
+      profiles: [MEMBER],
+      calendar_events: [OPEN_EVENT],
+      event_role_requests: [
+        OK(null),                                     // slot-filled guard: nobody holds it
+        OK({ id: 'req_1', status: 'cancelled' }),     // caller's existing row
+        OK({ id: 'req_1', status: 'pending' }),       // the revive UPDATE
+      ],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { POST } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await POST(postReq({ role_label: 'HOST' }), { params })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 'req_1', status: 'pending' })
+
+    const update = calls.find(c => c.table === 'event_role_requests' && c.method === 'update')
+    expect(update?.args[0]).toEqual({
+      status: 'pending',
+      role_label: 'HOST',
+      note: null,
+      cancelled_at: null,
+      cancelled_by: null,
+    })
+    expect(statusPreconditions(calls)).toEqual([['status', ['denied', 'cancelled']]])
+    // Never an INSERT — UNIQUE (event_id, profile_id) allows exactly one row.
+    expect(calls.some(c => c.table === 'event_role_requests' && c.method === 'insert')).toBe(false)
+  })
+
+  it('revives a DENIED row — a passed-over member can claim a reopened slot', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client } = makeDb({
+      profiles: [MEMBER],
+      calendar_events: [OPEN_EVENT],
+      event_role_requests: [
+        OK(null),
+        OK({ id: 'req_2', status: 'denied' }),
+        OK({ id: 'req_2', status: 'pending' }),
+      ],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { POST } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await POST(postReq({ role_label: 'SPEAKER' }), { params })
+    expect(res.status).toBe(200)
+  })
+
+  it('409s when the caller already holds an APPROVED row — never downgrades it', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client, calls } = makeDb({
+      profiles: [MEMBER],
+      calendar_events: [OPEN_EVENT],
+      event_role_requests: [
+        OK(null),
+        OK({ id: 'req_3', status: 'approved' }),
+      ],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { POST } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await POST(postReq({ role_label: 'HOST' }), { params })
+
+    expect(res.status).toBe(409)
+    expect((await res.json()).code).toBe('already_requested')
+    expect(calls.some(c => c.table === 'event_role_requests' && c.method === 'update')).toBe(false)
+  })
+
+  it('409s when the revive precondition matches zero rows — the race case', async () => {
+    // An admin approved this member's denied row between our read and our write.
+    // The `.in('status', ['denied','cancelled'])` filter makes the UPDATE match
+    // nothing, and we must NOT retry: retrying would clobber 'approved'.
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client, calls } = makeDb({
+      profiles: [MEMBER],
+      calendar_events: [OPEN_EVENT],
+      event_role_requests: [
+        OK(null),
+        OK({ id: 'req_4', status: 'denied' }),
+        OK(null),                                     // UPDATE matched zero rows
+      ],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { POST } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await POST(postReq({ role_label: 'HOST' }), { params })
+
+    expect(res.status).toBe(409)
+    expect((await res.json()).code).toBe('state_changed')
+    expect(calls.filter(c => c.table === 'event_role_requests' && c.method === 'update')).toHaveLength(1)
+  })
+
+  it('inserts a fresh row when the caller has never requested here', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client, calls } = makeDb({
+      profiles: [MEMBER],
+      calendar_events: [OPEN_EVENT],
+      event_role_requests: [
+        OK(null),
+        OK(null),
+        OK({ id: 'req_5', status: 'pending' }),
+      ],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { POST } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await POST(postReq({ role_label: 'HOST' }), { params })
+
+    expect(res.status).toBe(201)
+    const insert = calls.find(c => c.table === 'event_role_requests' && c.method === 'insert')
+    expect(insert?.args[0]).toEqual({
+      event_id: EVENT_ID, profile_id: 'p_member', role_label: 'HOST', note: null,
+    })
+  })
+
+  it('409s with slot_filled when someone else already holds the role', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client } = makeDb({
+      profiles: [MEMBER],
+      calendar_events: [OPEN_EVENT],
+      event_role_requests: [OK({ status: 'approved' })],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { POST } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await POST(postReq({ role_label: 'HOST' }), { params })
+
+    expect(res.status).toBe(409)
+    expect((await res.json()).code).toBe('slot_filled')
+  })
+
+  it('403s past the cutoff with a code the popup can toast on', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_member' })
+    const { client } = makeDb({
+      profiles: [MEMBER],
+      calendar_events: [CLOSED_EVENT],
+      event_role_requests: [],
+    })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { POST } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await POST(postReq({ role_label: 'HOST' }), { params })
+
+    expect(res.status).toBe(403)
+    expect((await res.json()).code).toBe('role_window_closed')
+  })
+
+  it('401s when unauthenticated and touches no table', async () => {
+    mockAuth.mockResolvedValue({ userId: null })
+    const { client, calls } = makeDb({})
+    mockCreateServiceClient.mockReturnValue(client)
+    const { POST } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await POST(postReq({ role_label: 'HOST' }), { params })
+    expect(res.status).toBe(401)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('403s a guest before any role work happens', async () => {
+    mockAuth.mockResolvedValue({ userId: 'clerk_guest' })
+    const { client, calls } = makeDb({ profiles: [OK({ id: 'p_guest', role: 'guest' })] })
+    mockCreateServiceClient.mockReturnValue(client)
+    const { POST } = await import('@/app/api/events/[id]/request-role/route')
+
+    const res = await POST(postReq({ role_label: 'HOST' }), { params })
+    expect(res.status).toBe(403)
+    expect(calls.some(c => c.table === 'event_role_requests')).toBe(false)
+  })
+})

--- a/app/api/events/[id]/request-role/route.ts
+++ b/app/api/events/[id]/request-role/route.ts
@@ -1,6 +1,50 @@
 import { auth } from '@clerk/nextjs/server'
 import { createServiceClient } from '@/lib/supabase/service'
 import { getCallerProfile } from '@/lib/supabase/guards'
+import { isRoleWindowClosed } from '@/lib/events/role-cutoff'
+
+/**
+ * Machine-readable failure discriminants (2608-DEV-749), mirroring the
+ * AttendFailureCode pattern from /api/events/[id]/attend that the popup already
+ * reads via `ApiError.code`. The client switches on these, never on `error`,
+ * which is English developer copy.
+ */
+export type RoleRequestFailureCode =
+  | 'role_window_closed'   // past the cutoff, and the caller is not an admin
+  | 'already_requested'    // caller already holds a pending/approved row here
+  | 'slot_filled'          // somebody else already holds this role
+  | 'state_changed'        // the row moved under us between read and write
+  | 'nothing_to_cancel'    // no pending/approved row of the caller's to cancel
+
+type SupabaseLike = ReturnType<typeof createServiceClient>
+
+/**
+ * Shared gate for POST and DELETE: admins act at any time, everyone else is
+ * bound by the 60-minute window. Returns a Response to send, or null to carry
+ * on.
+ */
+async function guardRoleWindow(
+  supabase: SupabaseLike,
+  eventId: string,
+  role: string,
+): Promise<Response | null> {
+  if (role === 'admin') return null
+
+  const { data: event } = await supabase
+    .from('calendar_events')
+    .select('start_time')
+    .eq('id', eventId)
+    .single()
+
+  if (!event) return Response.json({ error: 'Event not found' }, { status: 404 })
+  if (isRoleWindowClosed(event.start_time)) {
+    return Response.json(
+      { error: 'Role sign-ups are closed for this event', code: 'role_window_closed' },
+      { status: 403 },
+    )
+  }
+  return null
+}
 
 export async function POST(
   req: Request,
@@ -19,19 +63,8 @@ export async function POST(
     return Response.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  // Enforce 15-minute cutoff before event start. Admins bypass this gate.
-  if (profile.role !== 'admin') {
-    const { data: event } = await supabase
-      .from('calendar_events')
-      .select('start_time')
-      .eq('id', event_id)
-      .single()
-    if (!event) return Response.json({ error: 'Event not found' }, { status: 404 })
-    const cutoff = new Date(event.start_time).getTime() - 15 * 60 * 1000
-    if (Date.now() >= cutoff) {
-      return Response.json({ error: 'Role requests closed' }, { status: 403 })
-    }
-  }
+  const closed = await guardRoleWindow(supabase, event_id, profile.role)
+  if (closed) return closed
 
   const { role_label, note } = await req.json()
   if (!role_label) return Response.json({ error: 'role_label required' }, { status: 400 })
@@ -46,7 +79,64 @@ export async function POST(
     .maybeSingle()
 
   if (slotError) return Response.json({ error: slotError.message }, { status: 500 })
-  if (slotRequests) return Response.json({ error: 'This role is already filled' }, { status: 409 })
+  if (slotRequests) {
+    return Response.json(
+      { error: 'This role is already filled', code: 'slot_filled' },
+      { status: 409 },
+    )
+  }
+
+  // UNIQUE (event_id, profile_id) means one row per member per event, so a
+  // member re-requesting after a cancel or a deny has to UPDATE that row rather
+  // than insert a second one. Explicit branches, deliberately not a blanket
+  // upsert: an upsert would knock an already-approved row back to 'pending'.
+  const { data: existing, error: existingError } = await supabase
+    .from('event_role_requests')
+    .select('id, status')
+    .eq('event_id', event_id)
+    .eq('profile_id', profile.id)
+    .maybeSingle()
+
+  if (existingError) return Response.json({ error: existingError.message }, { status: 500 })
+
+  if (existing) {
+    if (existing.status === 'pending' || existing.status === 'approved') {
+      return Response.json(
+        { error: 'You already have a request for this event', code: 'already_requested' },
+        { status: 409 },
+      )
+    }
+
+    // Revive a denied/cancelled row. The `.in('status', ...)` is a PRECONDITION
+    // re-checked at write time, not decoration: `.eq('id', ...)` alone is a
+    // read-then-write race that loses data — a member reviving their denied row
+    // while an admin approves it would clobber 'approved' back to 'pending',
+    // and idx_event_role_requests_one_approved_per_slot would not catch it
+    // (it only guards approved-vs-approved).
+    const { data: revived, error: reviveError } = await supabase
+      .from('event_role_requests')
+      .update({
+        status: 'pending',
+        role_label,
+        note: note ?? null,
+        cancelled_at: null,
+        cancelled_by: null,
+      })
+      .eq('id', existing.id)
+      .in('status', ['denied', 'cancelled'])
+      .select()
+      .maybeSingle()
+
+    if (reviveError) return Response.json({ error: reviveError.message }, { status: 500 })
+    if (!revived) {
+      // Zero rows means the state moved under us. Never retry silently.
+      return Response.json(
+        { error: 'This request changed while you were acting on it', code: 'state_changed' },
+        { status: 409 },
+      )
+    }
+    return Response.json(revived, { status: 200 })
+  }
 
   const { data, error } = await supabase
     .from('event_role_requests')
@@ -55,9 +145,12 @@ export async function POST(
     .single()
 
   if (error) {
-    // Unique constraint — already requested
+    // Unique constraint — a concurrent request beat us to the insert.
     if (error.code === '23505') {
-      return Response.json({ error: 'You already have a request for this event' }, { status: 409 })
+      return Response.json(
+        { error: 'You already have a request for this event', code: 'already_requested' },
+        { status: 409 },
+      )
     }
     return Response.json({ error: error.message }, { status: 500 })
   }
@@ -65,6 +158,15 @@ export async function POST(
   return Response.json(data, { status: 201 })
 }
 
+/**
+ * Member self-withdraw — for pending AND approved rows since 2608-DEV-749.
+ *
+ * The hard DELETE is gone: cancelling is a soft status move, which is what makes
+ * the audit trail and the revive branch above coherent. It is also what stopped
+ * this route lying — it used to answer `{cancelled: true}` 200 even when its
+ * `.eq('status','pending')` filter matched zero rows, so an approved holder saw
+ * a success toast and nothing changed.
+ */
 export async function DELETE(
   _req: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -77,13 +179,33 @@ export async function DELETE(
   const profile = await getCallerProfile(userId, supabase)
   if (!profile) return Response.json({ error: 'Profile not found' }, { status: 404 })
 
-  const { error } = await supabase
+  // The cutoff binds withdrawals too — it was client-only before (`disabledCancel`),
+  // so a crafted request could free a slot minutes before the event started.
+  const closed = await guardRoleWindow(supabase, event_id, profile.role)
+  if (closed) return closed
+
+  // One conditional UPDATE, no read-then-write: the `.in('status', ...)` is the
+  // precondition, evaluated at write time. Uniform for pending and approved.
+  const { data, error } = await supabase
     .from('event_role_requests')
-    .delete()
+    .update({
+      status: 'cancelled',
+      cancelled_at: new Date().toISOString(),
+      cancelled_by: profile.id,
+    })
     .eq('event_id', event_id)
     .eq('profile_id', profile.id)
-    .eq('status', 'pending') // Can only cancel pending requests
+    .in('status', ['pending', 'approved'])
+    .select('id, status')
+    .maybeSingle()
 
   if (error) return Response.json({ error: error.message }, { status: 500 })
-  return Response.json({ cancelled: true })
+  if (!data) {
+    return Response.json(
+      { error: 'No active role request to cancel', code: 'nothing_to_cancel' },
+      { status: 404 },
+    )
+  }
+
+  return Response.json({ cancelled: true, id: data.id })
 }

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -65,7 +65,12 @@ export async function GET(
     const slotRequests = requestsByRole[slot.role_label] ?? []
     const approvedReq = slotRequests.find(r => r.status === 'approved')
     const pendingReqs = slotRequests.filter(r => r.status === 'pending')
-    const callerReq = slotRequests.find(r => r.profile_id === callerProfile.id) ?? null
+    // A cancelled row is history, not "your request" (2608-DEV-749) — surfacing
+    // it would keep rendering the withdrawn slot as the caller's and block them
+    // from claiming another. `denied` still surfaces, exactly as before.
+    const callerReq = slotRequests.find(
+      r => r.profile_id === callerProfile.id && r.status !== 'cancelled',
+    ) ?? null
 
     let status: 'open' | 'contested' | 'filled'
     if (approvedReq) {

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,4 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
+| #749 | `dev/2608-DEV-749` | `supabase/migrations/` (**migration: yes** — enum + columns + trigger fn), `app/api/events/[id]/request-role/route.ts`, `app/api/events/[id]/route.ts`, `app/api/admin/event-role-requests/[id]/route.ts`, `app/(dashboard)/calendar/components/popup/**`, `app/admin/approval-hub/components/EventRolesTab.tsx`, `app/admin/members/[id]/components/memberDetailFormat.ts`, `lib/events/role-cutoff.ts` (new), `lib/hooks/useMinuteTick.ts` (new), `lib/email/templates/EventRoleRequestEmail.tsx`, `lib/i18n/domains/{events,calendar}.ts` | 2026-08-16 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,12 +1,33 @@
 ## Goal
-**#743** (`dev/2608-DEV-743`, cut from `main` @ `0a29718`): redesign the Socials bento as a
-full-bleed image hero, a sibling to the Trips tile it sits beside. No migration.
+**#749** (`dev/2608-DEV-749`, cut from `main` @ `915a7e8`): make an approved calendar role
+revocable — member self-withdraw and admin revoke, as a soft `cancelled` status — and move the
+sign-up cutoff 15 min → 60 min with the deadline actually surfaced. **Migration: yes (two files).**
 
 ## Now
 
-**PR #748 is ready to merge.** The CLAIMS row is already removed in this PR (never a standalone
-cleanup PR). After merge, the only remaining GCR work is closing #743 and deleting the DEV seed
-rows + storage objects listed below.
+BUILD complete and locally verified; next action is the draft PR.
+
+**Migrations are already applied to DEV `iymwxdewcpvpjgzewtzk`** (user approved this session).
+The Supabase MCP recorded HHMMSS-style ledger versions (`20260816203117` / `...203152`); both rows
+were **rewritten in place** to `20260816000000` / `20260816000100` so the ledger matches the repo
+filenames. Verified on DEV: `enum_range(registration_status)` = approved/cancelled/denied/pending,
+both `cancelled_*` columns present, both functions recompiled with the new bodies.
+
+`types/supabase.ts` was **NOT** taken wholesale from the MCP generator — it emits `public` only and
+would have deleted the `graphql_public` and `storage` schemas (485 lines). The four generator-
+produced deltas were spliced into the committed file instead (22 insertions, 2 modified lines).
+
+**The issue body was wrong on one point.** It said to copy `notify_role_request_status_change()`
+from `baseline.sql:785`. That is not the live definition — `20260705000800:261` retargeted the
+insert from `public.notifications` to `public.member_notifications`. Copying the baseline body would
+have silently reverted that. The migration copies the 20260705000800 version.
+
+**The issue's "must be checked at BUILD" question is answered: no duplicate reminders.**
+`fn_schedule_guest_reminders_record` (`20260705000800:53-75`) upserts
+`ON CONFLICT (registration_id, type) DO UPDATE`, and re-approval reuses the same
+`guest_registrations.id`. Nothing to fix.
+
+### #743 — what landed (merged as PR #748)
 
 `app/(dashboard)/components/tiles/SocialsTile.test.tsx` is the **repo's first component test suite**
 — 13 cases over the six seeded data shapes. Infra: `jsdom` + `@testing-library/react` (+ the
@@ -14,23 +35,6 @@ rows + storage objects listed below.
 include globs. Default environment stays `node`; component files opt into jsdom with a
 `// @vitest-environment jsdom` docblock. `tsconfig.json` already sets `jsx: react-jsx`, so esbuild
 transforms `.tsx` with no React plugin.
-
-Earlier state (kept for the record): head `d0b6921`, all checks green (including
-`390px smoke vs preview` and `Authenticated E2E (Clerk)`). CodeRabbit's one finding — truthiness on
-`post.caption` — is fixed and its thread is resolved. Its **re-review after that push was rate
-limited**, so the ready-state pass covers `9bc7010`, not `d0b6921`; the delta is a one-line
-absence check.
-
-Remaining: merge, then GCR (prune the CLAIMS row, close #743). **Delete the DEV seed rows** —
-`social_posts` holds **6 seeded variants** (`post_url` all match `%dev-seed-743-variant-%`), plus
-three objects in the DEV `social-thumbnails` bucket (`dev-seed-743.jpg`, `-pale.png`, `-alt.png`).
-They cover long/short/empty/no-thumbnail/unknown-platform cases; the API shows the lowest
-`sort_order`, so `update social_posts set sort_order = case when post_url like '%variant-N%' then 0
-else 10 end;` switches which one renders. DEV `social_posts` was empty before this ticket, so
-deleting every row is the correct cleanup.
-
-#740 (PR #744) and #741 (PR #745) both **merged** on 2026-08-13; their CLAIMS.md rows were stale and
-are pruned in this branch's CLAIM commit rather than in a standalone cleanup PR.
 
 ### #740 — what landed (merged)
 Commits `9fc24a9` (original) + the radius revision on top.
@@ -65,10 +69,14 @@ for both themes; `@custom-variant dark` registered against `[data-theme="dark"]`
 blanket ban with the doc updated in the same commit.
 
 ## Next
-1. Merge #748, then GCR: remove the CLAIMS row, close #743, and delete the DEV seed row + storage
-   object.
+1. Push `dev/2608-DEV-749`, open the PR as a DRAFT, wait for CI green + Vercel preview READY, then
+   mark it ready for review (one CodeRabbit pass).
 2. `npm run verify` deliberately NOT run locally: its `next build` runs under `NODE_ENV=production`,
    which on this box resolves `.env.local` = PROD. CI builds it on the PR.
+3. **DEV cleanup pending from #743** (carried, not done in this ticket): `social_posts` holds 6
+   seeded variants (`post_url like '%dev-seed-743-variant-%'`) plus three objects in the DEV
+   `social-thumbnails` bucket (`dev-seed-743.jpg`, `-pale.png`, `-alt.png`). DEV `social_posts` was
+   empty before that ticket, so deleting every row is correct. #743 also still needs closing.
 
 ## Constraints
 - Never push without an explicit grant in this conversation. Grants from earlier tickets/sessions do
@@ -136,6 +144,12 @@ blanket ban with the doc updated in the same commit.
   (`iymwxdewcpvpjgzewtzk`). Only a warm-server run is evidence.
 
 ## Done
+- #749 CLAIM + BUILD. Verified: `npx tsc --noEmit` clean; `npm test` **507 passed / 36 files**
+  (baseline 494/35 — the 13 new cases are `app/api/events/[id]/request-role/route.test.ts`, the
+  route's first coverage ever); `npx eslint` on all 15 changed files → 0 findings; DEV DB probe
+  confirms the enum value, both columns and both recompiled functions. **NOT visually verified and
+  the new e2e spec has NOT been run** — `e2e/member-role-cancel-auth.spec.ts` needs a warm dev
+  server against DEV plus the seeded Clerk member.
 - #743 CLAIM + BUILD (`5d1e57a`, `5e67671` + the review fix). **Visually verified locally, unlike
   #740/#741**: dev server against hosted DEV, a seeded `social_posts` row with a 241-char Bulgarian
   caption, Playwright at 390×844 and 1440×900 in **both** themes. Measured — page `scrollWidth`
@@ -165,6 +179,16 @@ blanket ban with the doc updated in the same commit.
 - #702 CLOSED (epic, 2026-08-12) — all ten children and all six follow-ups merged.
 
 ## Open items
+- **NOTED (#749), pre-existing, deliberately not fixed:** `fn_schedule_guest_reminders_record`'s
+  `ON CONFLICT ... DO UPDATE SET status = 'pending', attempts = 0` has no `WHERE`, so re-confirming
+  a registration resets an **already-sent** reminder back to pending. Reachable today via
+  attend → cancel → attend, so #749 does not open the door — but it is real.
+- **NOTED (#749), accepted side effect:** `lib/server/event-capacity.ts:41-45` excludes approved
+  role holders from the guest headcount. After a cancel the person keeps their registration and
+  starts counting, so an at-capacity event can end up one over. Derived count, tolerable.
+- **NOTED (#749), pre-existing, out of scope:** `event_role_requests.event_id` has no
+  `ON DELETE CASCADE` (`baseline.sql:158`), unlike `event_role_slots` — deleting a calendar event
+  that has role requests still fails on the FK.
 - **FILED as #746** — Radius Phase 2 (`app/admin/**`). 61 pill-shaped `rounded-full` →
   `rounded-control`, ~80 containers stranded on `rounded-lg`/`rounded-xl` → `rounded-container`.
   The issue carries the shared-component shortlist and both admin ambiguities. Until it lands, admin

--- a/e2e/member-role-cancel-auth.spec.ts
+++ b/e2e/member-role-cancel-auth.spec.ts
@@ -27,6 +27,9 @@ const TEST_RUN_ID = randomUUID().slice(0, 8)
 const EVENT_TITLE = `E2E Role Cancel ${TEST_RUN_ID}`
 const ROLE_LABEL = 'HOST'
 
+// The write target is guarded once, globally: e2e/global-setup.ts calls
+// assertSafeSupabaseTarget(), which throws before any spec loads unless the URL
+// is localhost or the hosted DEV project. No per-spec copy of that check.
 function svc(): SupabaseClient | null {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY
@@ -40,7 +43,7 @@ let memberProfileId: string | null = null
 
 test.beforeAll(async () => {
   sb = svc()
-  if (!sb) return
+  if (sb === null) return
 
   const { data: profile } = await sb
     .from('profiles')
@@ -49,7 +52,7 @@ test.beforeAll(async () => {
     .maybeSingle()
 
   // Guests are 403 on this route — the seeded member must already be promoted.
-  if (!profile || profile.role === 'guest') return
+  if (profile === null || profile.role === 'guest') return
   memberProfileId = profile.id
 
   const now = Date.now()
@@ -71,14 +74,14 @@ test.beforeAll(async () => {
     .select('id')
     .single()
 
-  if (insertError || !event) {
+  if (insertError !== null || event === null) {
     throw new Error(`Failed to seed event for member-role-cancel-auth: ${insertError?.message ?? 'no row returned'}`)
   }
   eventId = event.id
 })
 
 test.afterAll(async () => {
-  if (!sb || !eventId) return
+  if (sb === null || eventId === null) return
   // event_role_requests.event_id has no ON DELETE CASCADE (baseline.sql:158),
   // unlike event_role_slots — so the requests must go first or the event delete
   // fails on the FK. Approval also leaves a guest_registrations row behind

--- a/e2e/member-role-cancel-auth.spec.ts
+++ b/e2e/member-role-cancel-auth.spec.ts
@@ -1,0 +1,201 @@
+import { test, expect, type Locator, type Page } from '@playwright/test'
+import { clerk } from '@clerk/testing/playwright'
+import { gotoProtected } from './auth-helpers'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { randomUUID } from 'crypto'
+
+/**
+ * 2608-DEV-749 — a member can give up a role they already hold, and the slot
+ * reopens. Before this ticket the withdraw path did not exist: the DELETE route
+ * filtered `status = 'pending'` and still answered 200, so an approved holder
+ * saw a success toast and stayed in the slot forever.
+ *
+ * The approval step goes through the real `approve_event_role_request` RPC via
+ * the service client rather than the admin UI — this spec is about the WITHDRAW
+ * path, and driving the approval hub would double its runtime and its flake
+ * surface for no extra coverage.
+ *
+ * Runs under the 'authenticated' project (playwright.config.ts) for the same
+ * reason as member-attend-auth.spec.ts: preview-smoke has no Clerk secrets, so
+ * clerk.signIn() cannot work there. Requires a seeded Clerk test member
+ * (scripts/seed-clerk-test-users.js) and the DEV Supabase project — never a
+ * preview/prod DB.
+ */
+
+const MEMBER_EMAIL = process.env.E2E_CLERK_MEMBER_EMAIL ?? 'e2e-member-tevd-portal@example.com'
+const TEST_RUN_ID = randomUUID().slice(0, 8)
+const EVENT_TITLE = `E2E Role Cancel ${TEST_RUN_ID}`
+const ROLE_LABEL = 'HOST'
+
+function svc(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (url === undefined || url === '' || key === undefined || key === '') return null
+  return createClient(url, key)
+}
+
+let sb: SupabaseClient | null = null
+let eventId: string | null = null
+let memberProfileId: string | null = null
+
+test.beforeAll(async () => {
+  sb = svc()
+  if (!sb) return
+
+  const { data: profile } = await sb
+    .from('profiles')
+    .select('id, role')
+    .eq('contact_email', MEMBER_EMAIL)
+    .maybeSingle()
+
+  // Guests are 403 on this route — the seeded member must already be promoted.
+  if (!profile || profile.role === 'guest') return
+  memberProfileId = profile.id
+
+  const now = Date.now()
+  // +6h, comfortably outside the 60-minute cutoff (ROLE_CUTOFF_MS). At +30m the
+  // role buttons would render locked and every assertion below would fail for
+  // the wrong reason.
+  const { data: event, error: insertError } = await sb
+    .from('calendar_events')
+    .insert({
+      title: EVENT_TITLE,
+      start_time: new Date(now + 6 * 3600_000).toISOString(),
+      end_time: new Date(now + 7 * 3600_000).toISOString(),
+      week_number: 1,
+      allow_guest_registration: true,
+      // The slot-sync trigger (20260512000600) materialises event_role_slots
+      // from this array — inserting slots by hand would bypass the real path.
+      available_roles: [ROLE_LABEL],
+    })
+    .select('id')
+    .single()
+
+  if (insertError || !event) {
+    throw new Error(`Failed to seed event for member-role-cancel-auth: ${insertError?.message ?? 'no row returned'}`)
+  }
+  eventId = event.id
+})
+
+test.afterAll(async () => {
+  if (!sb || !eventId) return
+  // event_role_requests.event_id has no ON DELETE CASCADE (baseline.sql:158),
+  // unlike event_role_slots — so the requests must go first or the event delete
+  // fails on the FK. Approval also leaves a guest_registrations row behind
+  // (2608-DEV-710); cancelling a role deliberately does not remove it.
+  await sb.from('event_role_requests').delete().eq('event_id', eventId)
+  await sb.from('guest_registrations').delete().eq('event_id', eventId)
+  await sb.from('calendar_events').delete().eq('id', eventId)
+})
+
+function skipIfUnseeded() {
+  test.skip(
+    sb === null || eventId === null || memberProfileId === null,
+    'no SUPABASE_SERVICE_ROLE_KEY, or no member profile for E2E_CLERK_MEMBER_EMAIL — run: npm run e2e:seed-clerk',
+  )
+}
+
+// CalendarClient renders the mobile AND desktop trees at once (one hidden per
+// breakpoint via CSS, not unmounted) — see e2e/calendar.spec.ts. Scope every
+// grid query to the visible tree or `.first()` can lock onto the hidden twin.
+function visible(page: Page, locator: Locator): Locator {
+  return locator.and(page.locator(':visible'))
+}
+
+async function openEventPopup(page: Page) {
+  await gotoProtected(page, '/calendar')
+  const eventButton = visible(page, page.locator('[role="row"] button', { hasText: EVENT_TITLE })).first()
+  await expect(eventButton, `seeded event "${EVENT_TITLE}" not visible on the current month view`)
+    .toBeVisible({ timeout: 15_000 })
+  await eventButton.click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await expect(dialog).toContainText(EVENT_TITLE, { timeout: 15_000 })
+  return dialog
+}
+
+async function readRequest() {
+  const { data } = await sb!
+    .from('event_role_requests')
+    .select('id, status, cancelled_at, cancelled_by')
+    .eq('event_id', eventId!)
+    .eq('profile_id', memberProfileId!)
+    .maybeSingle()
+  return data
+}
+
+test.describe('member role withdraw @auth', () => {
+  // 390px: every new UI surface must render there (CLAUDE.md hard constraint),
+  // and the withdraw confirm is a new one.
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('request -> admin approves -> member withdraws -> slot open again', async ({ page }) => {
+    skipIfUnseeded()
+
+    await page.goto('/')
+    await clerk.signIn({ page, emailAddress: MEMBER_EMAIL })
+
+    let dialog = await openEventPopup(page)
+
+    // The cutoff copy is new in 749 — the window used to be entirely silent.
+    await expect(dialog.getByText(/sign-ups close 1 hour before start/i)).toBeVisible()
+
+    // 1. Request the role.
+    await dialog.getByRole('button', { name: ROLE_LABEL }).click()
+    await expect(dialog.getByText(/your request/i)).toBeVisible({ timeout: 15_000 })
+
+    const requested = await readRequest()
+    expect(requested?.status).toBe('pending')
+
+    // 2. Admin approves — through the real RPC the admin route calls.
+    const { error: approveError } = await sb!.rpc('approve_event_role_request', {
+      p_request_id: requested!.id,
+    })
+    expect(approveError).toBeNull()
+    expect((await readRequest())?.status).toBe('approved')
+
+    // 3. Reopen the popup so the client sees the approved state.
+    await page.reload()
+    dialog = await openEventPopup(page)
+
+    // 4. Withdraw. An approved slot is destructive to give up, so it sits behind
+    //    an AlertDialog — role="alertdialog", distinct from the popup's dialog.
+    await dialog.getByRole('button', { name: ROLE_LABEL }).click()
+    const confirm = page.getByRole('alertdialog')
+    await expect(confirm).toBeVisible()
+    await expect(confirm.getByText(/the slot reopens for other members/i)).toBeVisible()
+    await confirm.getByRole('button', { name: /give up role/i }).click()
+
+    // 5. The request is gone from the member's view — /api/events/[id] stops
+    //    sending a cancelled row as caller_request.
+    await expect(dialog.getByText(/your request/i)).toHaveCount(0, { timeout: 15_000 })
+
+    const cancelled = await readRequest()
+    expect(cancelled?.status).toBe('cancelled')
+    expect(cancelled?.cancelled_at).not.toBeNull()
+    // Self-withdraw stamps the holder as the actor, which is also what
+    // suppresses the "your role was cancelled" notification to themselves.
+    expect(cancelled?.cancelled_by).toBe(memberProfileId)
+
+    // 6. The slot is claimable again rather than stuck at 'filled'.
+    const roleButton = dialog.getByRole('button', { name: ROLE_LABEL })
+    await expect(roleButton).toBeEnabled()
+
+    // 7. Decision 2: cancelling the ROLE does not cancel event attendance.
+    const { data: registration } = await sb!
+      .from('guest_registrations')
+      .select('status, cancelled_at')
+      .eq('event_id', eventId!)
+      .eq('profile_id', memberProfileId!)
+      .maybeSingle()
+    expect(registration?.status).toBe('confirmed')
+    expect(registration?.cancelled_at).toBeNull()
+
+    // html { overflow-x: hidden } clips visually without shrinking scrollWidth,
+    // so this still detects a real 390px overflow.
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    )
+    expect(overflow).toBeLessThanOrEqual(0)
+  })
+})

--- a/lib/email/templates/EventRoleRequestEmail.tsx
+++ b/lib/email/templates/EventRoleRequestEmail.tsx
@@ -3,15 +3,19 @@ import { Section, Text } from '@react-email/components'
 import * as React from 'react'
 import { EmailShell, bodyPadding } from './_shell'
 
-type RoleStatus = 'approved' | 'denied'
+type RoleStatus = 'approved' | 'denied' | 'cancelled'
 
 const STATUS_LABEL: Record<RoleStatus, string> = {
-  approved: 'Approved ✓',
-  denied:   'Declined',
+  approved:  'Approved ✓',
+  denied:    'Declined',
+  cancelled: 'Cancelled',
 }
 const STATUS_COLOR: Record<RoleStatus, string> = {
-  approved: '#1a3c2e',
-  denied:   '#bc4749',
+  approved:  '#1a3c2e',
+  denied:    '#bc4749',
+  // Neutral grey, not the alert red used for `denied`: a revoke is an
+  // administrative change, not a rejection of the member (2608-DEV-749).
+  cancelled: '#6b7280',
 }
 
 export type EventRoleRequestEmailProps = {
@@ -69,6 +73,14 @@ export function EventRoleRequestEmail({
         {status === 'denied' && (
           <Text style={{ margin: '0 0 16px', fontSize: 15, color: '#374151' }}>
             Your role request was not approved for this event. You can submit a new request from the calendar.
+          </Text>
+        )}
+
+        {status === 'cancelled' && (
+          <Text style={{ margin: '0 0 16px', fontSize: 15, color: '#374151' }}>
+            An administrator has cancelled your participation in this role, and the slot is open
+            again for other members. Your registration for the event itself is unaffected — you are
+            still expected to attend.
           </Text>
         )}
 

--- a/lib/events/role-cutoff.ts
+++ b/lib/events/role-cutoff.ts
@@ -1,0 +1,40 @@
+/**
+ * 2608-DEV-749 — the single definition of the event-role sign-up window.
+ *
+ * Before this module the window was a bare `15 * 60 * 1000` literal duplicated
+ * in the route (`app/api/events/[id]/request-role/route.ts`) and in the popup
+ * (`app/(dashboard)/calendar/components/EventPopup.tsx`), so the server gate and
+ * the UI could drift apart silently. Both import from here now.
+ *
+ * Isomorphic on purpose — no `server-only`, no React, no env access — because
+ * the route handler and the client component both need it.
+ *
+ * The window is 60 minutes (was 15). Admins bypass it; that decision belongs to
+ * the caller, not here, so nothing in this file knows about roles.
+ */
+
+/** How long before `start_time` role sign-ups and withdrawals close. */
+export const ROLE_CUTOFF_MS = 60 * 60 * 1000
+
+/** Epoch ms at which the window closes for an event starting at `startTime`. */
+export function roleCutoffAt(startTime: string): number {
+  return new Date(startTime).getTime() - ROLE_CUTOFF_MS
+}
+
+/**
+ * True once the window has closed. An unparseable `start_time` yields NaN, and
+ * every comparison against NaN is false — so a bad timestamp leaves the window
+ * OPEN rather than locking every member out of an event nobody can fix.
+ */
+export function isRoleWindowClosed(startTime: string, now = Date.now()): boolean {
+  return now >= roleCutoffAt(startTime)
+}
+
+/**
+ * Whole minutes left before the window closes, rounded UP so the label never
+ * reads "0m" while the slot is still claimable. May be <= 0 once closed; call
+ * `isRoleWindowClosed` for the boolean rather than testing this for sign.
+ */
+export function minutesUntilRoleCutoff(startTime: string, now = Date.now()): number {
+  return Math.ceil((roleCutoffAt(startTime) - now) / 60_000)
+}

--- a/lib/hooks/useMinuteTick.ts
+++ b/lib/hooks/useMinuteTick.ts
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * 2608-DEV-749 — re-renders the caller roughly twice a minute so a
+ * minutes-granularity countdown stays honest without a per-second timer.
+ *
+ * `enabled` is the whole point: the calendar popup only mounts this inside the
+ * final hour before an event's role cutoff, so the interval does not run for
+ * every open popup on the calendar. Passing `false` clears any live interval —
+ * the effect re-runs on the flag, and its cleanup tears the old one down.
+ *
+ * Returns a monotonically increasing tick count. Callers normally ignore the
+ * value and just read `Date.now()` during render; the return exists so the
+ * hook's result can be used as a dependency when that is more convenient.
+ */
+export function useMinuteTick(enabled = true, intervalMs = 30_000): number {
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    if (!enabled) return
+    const id = setInterval(() => setTick(t => t + 1), intervalMs)
+    return () => clearInterval(id)
+  }, [enabled, intervalMs])
+
+  return tick
+}

--- a/lib/i18n/domains/admin/operations.ts
+++ b/lib/i18n/domains/admin/operations.ts
@@ -29,6 +29,10 @@ export const adminOperations = {
 
   'admin.approval.events.btn.allEvents': { en: 'All events', bg: 'Всички събития' },
   'admin.approval.events.noPending': { en: 'No pending role requests.', bg: 'Няма чакащи заявки за роли.' },
+  // revoking an already-approved role (2608-DEV-749)
+  'admin.approval.events.btn.revoke': { en: 'Revoke', bg: 'Отнеми' },
+  'admin.approval.events.revokeTitle': { en: 'Revoke this role?', bg: 'Отнемане на тази роля?' },
+  'admin.approval.events.revokeDesc': { en: 'The slot reopens and the member is emailed. Their event registration is not affected.', bg: 'Мястото се освобождава и членът получава имейл. Регистрацията му за събитието не се променя.' },
 
   // -- Operations: Trips --
   'admin.operations.trips.btn.new': { en: '+ New trip', bg: '+ Ново пътуване' },

--- a/lib/i18n/domains/admin/operations.ts
+++ b/lib/i18n/domains/admin/operations.ts
@@ -33,6 +33,11 @@ export const adminOperations = {
   'admin.approval.events.btn.revoke': { en: 'Revoke', bg: 'Отнеми' },
   'admin.approval.events.revokeTitle': { en: 'Revoke this role?', bg: 'Отнемане на тази роля?' },
   'admin.approval.events.revokeDesc': { en: 'The slot reopens and the member is emailed. Their event registration is not affected.', bg: 'Мястото се освобождава и членът получава имейл. Регистрацията му за събитието не се променя.' },
+  // resolved-row status badge — the raw enum value was rendered before
+  'admin.approval.events.status.pending': { en: 'Pending', bg: 'Чакаща' },
+  'admin.approval.events.status.approved': { en: 'Approved', bg: 'Одобрена' },
+  'admin.approval.events.status.denied': { en: 'Denied', bg: 'Отказана' },
+  'admin.approval.events.status.cancelled': { en: 'Cancelled', bg: 'Отменена' },
 
   // -- Operations: Trips --
   'admin.operations.trips.btn.new': { en: '+ New trip', bg: '+ Ново пътуване' },

--- a/lib/i18n/domains/calendar.ts
+++ b/lib/i18n/domains/calendar.ts
@@ -41,6 +41,16 @@ export const calendar = {
   // 2608-DEV-707 — the attending-state CTA row
   'cal.joinRecordsAttendance': { en: 'Records your attendance',     bg: 'Отбелязва присъствието ви'      },
   'cal.attendSuccessEmailed':  { en: "You're attending. Confirmation sent to your email.", bg: 'Ще присъствате. Изпратихме потвърждение на имейла ви.' },
+
+  // role request / cancel toasts (2608-DEV-749) — keyed off the route's
+  // RoleRequestFailureCode, never off the English error string
+  'cal.cancelRoleSuccess':   { en: 'Your role was cancelled and the slot is open again.', bg: 'Ролята ви беше отказана и мястото е свободно отново.' },
+  'cal.cancelRoleError':     { en: 'Could not cancel your role. Please try again.',       bg: 'Ролята не можа да бъде отказана. Опитайте отново.'    },
+  'cal.cancelRoleGone':      { en: 'You have no active role request for this event.',     bg: 'Нямате активна заявка за роля за това събитие.'       },
+  'cal.roleWindowClosed':    { en: 'Role sign-ups closed 1 hour before this event.',      bg: 'Заявките за роли се затвориха 1 час преди събитието.'  },
+  'cal.roleSlotFilled':      { en: 'Someone else already has this role.',                 bg: 'Някой друг вече е зает с тази роля.'                  },
+  'cal.roleAlreadyRequested': { en: 'You already have a request for this event.',         bg: 'Вече имате заявка за това събитие.'                   },
+  'cal.requestRoleError':    { en: 'Could not request this role. Please try again.',      bg: 'Заявката за роля не бе успешна. Опитайте отново.'     },
   // 2608-DEV-709 — the tiered Registrations tab. "via"/"Direct" are NOT
   // duplicated here: profile.invites.via / profile.invites.direct already carry
   // them and keys are globally unique (lib/i18n/index.ts).

--- a/lib/i18n/domains/calendar.ts
+++ b/lib/i18n/domains/calendar.ts
@@ -50,6 +50,7 @@ export const calendar = {
   'cal.roleWindowClosed':    { en: 'Role sign-ups closed 1 hour before this event.',      bg: 'Заявките за роли се затвориха 1 час преди събитието.'  },
   'cal.roleSlotFilled':      { en: 'Someone else already has this role.',                 bg: 'Някой друг вече е зает с тази роля.'                  },
   'cal.roleAlreadyRequested': { en: 'You already have a request for this event.',         bg: 'Вече имате заявка за това събитие.'                   },
+  'cal.roleStateChanged':    { en: 'This request changed while you were acting on it.',   bg: 'Заявката се промени, докато действахте върху нея.'    },
   'cal.requestRoleError':    { en: 'Could not request this role. Please try again.',      bg: 'Заявката за роля не бе успешна. Опитайте отново.'     },
   // 2608-DEV-709 — the tiered Registrations tab. "via"/"Direct" are NOT
   // duplicated here: profile.invites.via / profile.invites.direct already carry

--- a/lib/i18n/domains/events.ts
+++ b/lib/i18n/domains/events.ts
@@ -13,6 +13,16 @@ export const events = {
   'event.slot.filled':      { en: 'Filled',            bg: 'Заета'                           },
   'event.slot.yourRequest': { en: 'Your request',      bg: 'Вашата заявка'                   },
 
+  // sign-up cutoff (2608-DEV-749) — the window was never surfaced before
+  'event.cutoff.hint':      { en: 'Sign-ups close 1 hour before start', bg: 'Заявките се затварят 1 час преди началото' },
+  'event.cutoff.countdown': { en: 'Sign-ups close in {{minutes}}m',     bg: 'Заявките се затварят след {{minutes}} мин' },
+  'event.cutoff.closed':    { en: 'Sign-ups closed',                    bg: 'Заявките са затворени'                     },
+
+  // withdrawing from a role you already hold (2608-DEV-749)
+  'event.withdrawRoleTitle':   { en: 'Give up this role?', bg: 'Отказ от тази роля?' },
+  'event.withdrawRoleDesc':    { en: 'The slot reopens for other members. You stay registered for the event.', bg: 'Ролята се освобождава за други членове. Оставате регистрирани за събитието.' },
+  'event.withdrawRoleConfirm': { en: 'Give up role',      bg: 'Откажи ролята'       },
+
   // profile name gate
   'event.nameRequiredToRequest': { en: 'To request a role, please complete your name in your profile.', bg: 'За да заявите роля, моля попълнете името си в профила.' },
   'event.goToProfile':           { en: 'Go to profile',                                                  bg: 'Към профила'                                                                  },

--- a/supabase/migrations/20260816000000_2608_feat_749_role_cancel_enum.sql
+++ b/supabase/migrations/20260816000000_2608_feat_749_role_cancel_enum.sql
@@ -1,0 +1,20 @@
+-- 2608-DEV-749: add 'cancelled' to public.registration_status.
+--
+-- This file exists SOLELY for the ALTER TYPE. `ALTER TYPE ... ADD VALUE` cannot
+-- be used in the same transaction that adds it, and the Supabase CLI wraps each
+-- migration file in its own transaction — so the columns, the trigger function
+-- and everything else that references the new value live in the sibling file
+-- 20260816000100_2608_feat_749_role_cancel.sql.
+--
+-- NOTE, accepted knowingly: `registration_status` is shared with
+-- trip_registrations.status (20260315000000_baseline.sql:75) and
+-- event_role_requests.status (:153). Postgres cannot DROP an enum value, so
+-- this migration is IRREVERSIBLE — see the ROLLBACK note below.
+--
+-- ROLLBACK: not possible. Postgres has no `ALTER TYPE ... DROP VALUE`. Reverting
+-- this feature means leaving 'cancelled' present but unused; the only true
+-- removal is a full type swap (create a new enum, ALTER every dependent column
+-- with a USING cast, drop the old type), which is not worth doing for an unused
+-- label. Undo the behaviour in the sibling migration instead.
+
+ALTER TYPE public.registration_status ADD VALUE IF NOT EXISTS 'cancelled';

--- a/supabase/migrations/20260816000100_2608_feat_749_role_cancel.sql
+++ b/supabase/migrations/20260816000100_2608_feat_749_role_cancel.sql
@@ -1,0 +1,269 @@
+-- 2608-DEV-749: soft-cancel for event role participation.
+--
+-- Companion to 20260816000000_2608_feat_749_role_cancel_enum.sql, which adds
+-- 'cancelled' to public.registration_status. Everything that REFERENCES the new
+-- enum value has to live here: Postgres refuses to use an enum label in the same
+-- transaction that added it, and the Supabase CLI runs one transaction per file.
+--
+-- Why soft-cancel and not a DELETE: the audit trail is the point. The two roles
+-- views (member_roles_history, v_roles_history) and lib/server/event-capacity.ts
+-- all filter `status = 'approved'`, so a cancelled row drops out of the
+-- leaderboard, the history and the capacity exclusion with no view changes at
+-- all — while still recording who gave up which slot, and when.
+--
+-- ROLLBACK:
+--   ALTER TABLE public.event_role_requests
+--     DROP COLUMN IF EXISTS cancelled_at,
+--     DROP COLUMN IF EXISTS cancelled_by;
+--   -- then re-run the notify_role_request_status_change() body from
+--   -- 20260705000800_notification_triggers.sql:261-283 verbatim, and the
+--   -- approve_event_role_request() body from
+--   -- 20260811000000_2608_feat_710_approve_role_creates_registration.sql verbatim.
+--   -- The enum label 'cancelled' cannot be removed (see the sibling migration).
+
+-- ── 1. Audit columns ─────────────────────────────────────────────────────────
+-- Mirrors trip_registrations, which already carries this exact pair
+-- (20260315000000_baseline.sql:76-77). cancelled_by is the ACTOR: the holder
+-- themself on a self-withdraw, the acting admin on a revoke.
+
+ALTER TABLE public.event_role_requests
+  ADD COLUMN IF NOT EXISTS cancelled_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS cancelled_by uuid NULL
+    REFERENCES public.profiles(id);
+
+COMMENT ON COLUMN public.event_role_requests.cancelled_at IS
+  '2608-DEV-749: when status moved to cancelled. NULL for every other status.';
+COMMENT ON COLUMN public.event_role_requests.cancelled_by IS
+  '2608-DEV-749: profile that performed the cancellation — the holder on a '
+  'self-withdraw, the acting admin on a revoke.';
+
+-- ── 2. Status-change notification ────────────────────────────────────────────
+-- Body copied verbatim from the LIVE definition at
+-- 20260705000800_notification_triggers.sql:261-283 (which retargeted the insert
+-- from public.notifications to public.member_notifications — do NOT copy the
+-- older baseline.sql:785 version, it writes to the wrong table), with two
+-- additions:
+--
+--   a) a 'cancelled' branch in both case expressions, and
+--   b) two early returns, so this feature does not notify a member about their
+--      own click: a self-withdraw (cancelled_by = profile_id) and a re-request
+--      (the revive branch in app/api/events/[id]/request-role/route.ts moves a
+--      denied/cancelled row back to 'pending', which previously fell through to
+--      the generic "has been updated" message).
+--
+-- An admin revoke has cancelled_by = the admin's profile id, so it still
+-- notifies. CREATE OR REPLACE preserves the ACLs set by
+-- 20260707120400_tighten_definer_grants.sql.
+
+CREATE OR REPLACE FUNCTION public.notify_role_request_status_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+declare
+  v_event_title text;
+begin
+  if OLD.status = NEW.status then return NEW; end if;
+
+  -- The member re-requested the slot themselves — nothing to tell them.
+  if NEW.status = 'pending' then return NEW; end if;
+
+  -- The member withdrew their own role — nothing to tell them either.
+  if NEW.status = 'cancelled'
+     and NEW.cancelled_by is not null
+     and NEW.cancelled_by = NEW.profile_id then
+    return NEW;
+  end if;
+
+  select title into v_event_title from public.calendar_events where id = NEW.event_id;
+  insert into public.member_notifications (profile_id, type, title, message, action_url)
+  values (
+    NEW.profile_id, 'role_request',
+    case NEW.status when 'approved' then 'Role request approved'
+      when 'denied' then 'Role request declined'
+      when 'cancelled' then 'Role participation cancelled' else 'Role request updated' end,
+    case NEW.status when 'approved' then 'Your ' || NEW.role_label || ' request for ' || v_event_title || ' has been approved.'
+      when 'denied' then 'Your ' || NEW.role_label || ' request for ' || v_event_title || ' has been declined.'
+      when 'cancelled' then 'Your ' || NEW.role_label || ' role for ' || v_event_title || ' has been cancelled. The slot is open again.'
+      else 'Your role request for ' || v_event_title || ' has been updated.' end,
+    '/calendar'
+  );
+  return NEW;
+end;
+$$;
+
+-- ── 3. Approval clears the cancellation markers ──────────────────────────────
+-- Body copied verbatim from
+-- 20260811000000_2608_feat_710_approve_role_creates_registration.sql with ONE
+-- change: the "Approve the target request" UPDATE now also nulls cancelled_at /
+-- cancelled_by. Without it, approving a row that was previously cancelled would
+-- leave a row that is simultaneously 'approved' and carrying a cancellation
+-- stamp. Everything else — the service-role/admin guard, the slot-already-filled
+-- guard, the deny-competitors UPDATE, the whole 2608-DEV-710 D2 registration
+-- block and the jsonb return shape — is unchanged.
+
+CREATE OR REPLACE FUNCTION approve_event_role_request(p_request_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_id    uuid;
+  v_role_label  text;
+  v_profile_id  uuid;
+  v_result      jsonb;
+BEGIN
+  -- Service-role / admin guard
+  IF auth.role() <> 'service_role' AND NOT is_admin() THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  -- Load target request
+  SELECT event_id, role_label, profile_id
+    INTO v_event_id, v_role_label, v_profile_id
+    FROM event_role_requests
+   WHERE id = p_request_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Request not found: %', p_request_id;
+  END IF;
+
+  -- Guard: slot must not already be filled
+  IF EXISTS (
+    SELECT 1 FROM event_role_requests
+     WHERE event_id   = v_event_id
+       AND role_label = v_role_label
+       AND status     = 'approved'
+       AND id         <> p_request_id
+  ) THEN
+    RAISE EXCEPTION 'Slot already filled for role "%" on event %', v_role_label, v_event_id;
+  END IF;
+
+  -- Approve the target request. 2608-DEV-749: clear any cancellation stamp, so
+  -- an approved row never carries cancelled_at/cancelled_by.
+  UPDATE event_role_requests
+     SET status       = 'approved',
+         cancelled_at = NULL,
+         cancelled_by = NULL,
+         updated_at   = now()
+   WHERE id = p_request_id;
+
+  -- Deny all other pending requests for the same slot
+  UPDATE event_role_requests
+     SET status     = 'denied',
+         updated_at = now()
+   WHERE event_id   = v_event_id
+     AND role_label = v_role_label
+     AND id         <> p_request_id
+     AND status     = 'pending';
+
+  -- 2608-DEV-710 (D2): an approved role holder attends by definition, so give
+  -- them a registration row — that is what grants the meeting link, the
+  -- reminders, and a place on the Registrations tab.
+  --
+  -- Step 1 — adopt. A holder who already signed up for this event as an
+  -- external guest has a row with (profile_id IS NULL, email = contact_email).
+  -- Inserting on (event_id, profile_id) alone would leave TWO rows for one
+  -- human: two reminder emails, and the guest row still consuming capacity.
+  -- Same adopt-don't-duplicate rule attendEvent applies at
+  -- lib/server/member-registration.ts:232-267 (D9).
+  --
+  -- The NOT EXISTS guard is what attendEvent gets for free by only adopting
+  -- when it found no member row: without it, a holder carrying BOTH a guest row
+  -- and a member row on this event would collide on
+  -- guest_registrations_event_profile_uniq and the approval would RAISE.
+  --
+  -- The match is LOWER()-folded: registerGuest stores the address verbatim
+  -- (lib/actions/guest-registration.ts:37 is z.string().email() with no
+  -- .toLowerCase()), so someone who signed up as Ivan@Example.com against a
+  -- contact_email of ivan@example.com would otherwise miss the adopt and get a
+  -- SECOND row — the exact outcome this block exists to prevent.
+  --
+  -- ...but the pre-existing UNIQUE (event_id, email) is CASE-SENSITIVE, so
+  -- Ivan@Example.com and ivan@example.com can both exist as separate guest rows
+  -- on one event. A bare LOWER() predicate would match BOTH and try to give
+  -- them the same (event_id, profile_id), violating
+  -- guest_registrations_event_profile_uniq. Hence the scalar subquery: adopt
+  -- exactly ONE row, oldest first, id as a deterministic tie-break. Any further
+  -- case-variant rows stay as orphan guest rows — visible and fixable, unlike a
+  -- failed approval.
+  UPDATE public.guest_registrations gr
+     SET profile_id   = v_profile_id,
+         email        = NULL,
+         token        = NULL,
+         expires_at   = NULL,
+         cancelled_at = NULL,
+         status       = 'confirmed'
+    FROM public.profiles p
+   WHERE p.id  = v_profile_id
+     AND gr.id = (
+           SELECT g.id
+             FROM public.guest_registrations g
+            WHERE g.event_id     = v_event_id
+              AND g.profile_id   IS NULL
+              AND LOWER(g.email) = LOWER(p.contact_email)
+            ORDER BY g.created_at, g.id
+            LIMIT 1
+         )
+     AND NOT EXISTS (
+       SELECT 1 FROM public.guest_registrations g2
+        WHERE g2.event_id   = v_event_id
+          AND g2.profile_id = v_profile_id
+     );
+
+  -- Step 2 — insert. A no-op re-confirm when step 1 already claimed the row.
+  -- DO UPDATE rather than DO NOTHING so an approval reactivates a holder who
+  -- had self-cancelled. status = 'confirmed' is what fires
+  -- trg_schedule_guest_reminders (20260705000800:158, AFTER INSERT OR UPDATE OF
+  -- status, email, name), on both the insert and the adopt/reactivate path.
+  -- The triple COALESCE protects the name NOT NULL constraint; email/token/
+  -- expires_at stay NULL, satisfying guest_registrations_guest_xor_member_chk.
+  --
+  -- 2608-DEV-749 note: cancelling a ROLE deliberately does not touch this row —
+  -- the person may still attend. So the approve → cancel → re-request → approve
+  -- sequence re-runs this upsert against the SAME registration id, and
+  -- fn_schedule_guest_reminders_record upserts the queue rows
+  -- ON CONFLICT (registration_id, type) — no duplicate reminder emails.
+  INSERT INTO public.guest_registrations (event_id, profile_id, name, status, lang)
+  SELECT v_event_id,
+         v_profile_id,
+         COALESCE(NULLIF(TRIM(COALESCE(p.first_name, '') || ' ' || COALESCE(p.last_name, '')), ''),
+                  p.contact_email,
+                  'Member'),
+         'confirmed'::public.guest_registration_status,
+         'en'
+    FROM public.profiles p
+   WHERE p.id = v_profile_id
+      ON CONFLICT (event_id, profile_id) WHERE profile_id IS NOT NULL
+      DO UPDATE SET cancelled_at = NULL,
+                    status       = 'confirmed';
+  -- end of D2 block
+
+  -- Return the approved request + profile for email dispatch
+  SELECT jsonb_build_object(
+    'id',          r.id,
+    'role_label',  r.role_label,
+    'profile_id',  r.profile_id,
+    'event_id',    r.event_id,
+    'status',      r.status,
+    'profile',     jsonb_build_object(
+                     'first_name',    p.first_name,
+                     'last_name',     p.last_name,
+                     'contact_email', p.contact_email
+                   ),
+    'event',       jsonb_build_object(
+                     'title',      e.title,
+                     'start_time', e.start_time
+                   )
+  )
+    INTO v_result
+    FROM event_role_requests r
+    JOIN profiles           p ON p.id = r.profile_id
+    JOIN calendar_events    e ON e.id = r.event_id
+   WHERE r.id = p_request_id;
+
+  RETURN v_result;
+END;
+$$;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -265,6 +265,8 @@ export type Database = {
       }
       event_role_requests: {
         Row: {
+          cancelled_at: string | null
+          cancelled_by: string | null
           created_at: string
           event_id: string
           id: string
@@ -275,6 +277,8 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          cancelled_at?: string | null
+          cancelled_by?: string | null
           created_at?: string
           event_id: string
           id?: string
@@ -285,6 +289,8 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          cancelled_at?: string | null
+          cancelled_by?: string | null
           created_at?: string
           event_id?: string
           id?: string
@@ -295,6 +301,20 @@ export type Database = {
           updated_at?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "event_role_requests_cancelled_by_fkey"
+            columns: ["cancelled_by"]
+            isOneToOne: false
+            referencedRelation: "member_roles_history"
+            referencedColumns: ["profile_id"]
+          },
+          {
+            foreignKeyName: "event_role_requests_cancelled_by_fkey"
+            columns: ["cancelled_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "event_role_requests_event_id_fkey"
             columns: ["event_id"]
@@ -2547,7 +2567,7 @@ export type Database = {
         | "trip_message"
         | "trip_attachment"
         | "spouse_link_request"
-      registration_status: "pending" | "approved" | "denied"
+      registration_status: "pending" | "approved" | "denied" | "cancelled"
       reminder_type: "1_hour" | "15_min"
       user_role: "admin" | "core" | "member" | "guest"
     }
@@ -3151,7 +3171,7 @@ export const Constants = {
         "trip_attachment",
         "spouse_link_request",
       ],
-      registration_status: ["pending", "approved", "denied"],
+      registration_status: ["pending", "approved", "denied", "cancelled"],
       reminder_type: ["1_hour", "15_min"],
       user_role: ["admin", "core", "member", "guest"],
     },


### PR DESCRIPTION
Closes #749

## What this fixes

QA: *"There is no way to cancel calendar role participation. Neither can the admin nor the person who requested it undo it."*

Confirmed at `app/api/events/[id]/request-role/route.ts:85` — the member self-cancel route filtered `.eq('status', 'pending')`, so an approved holder's DELETE matched zero rows **and the route still answered `{cancelled: true}` 200**, so the UI reported success and nothing happened. The admin hub rendered resolved requests as read-only badges with no revoke. A member who could no longer host was stuck holding the slot, and the role kept counting in `member_roles_history` and `v_roles_history` forever.

Second problem from the same QA pass: sign-ups closed 15 minutes before start and **that cutoff was never shown** — a closed slot rendered as a bare lock icon with no explanation.

## Approach

**Soft cancel.** `registration_status` gains `'cancelled'`; `event_role_requests` gains `cancelled_at` / `cancelled_by`. The two roles views and `lib/server/event-capacity.ts` already filter `status = 'approved'`, so a cancelled role drops out of all three with **no view changes** — while the audit trail survives.

> **Tradeoff, accepted knowingly.** `registration_status` is shared with `trip_registrations.status`, and `ALTER TYPE … ADD VALUE` is **irreversible** — Postgres cannot drop an enum value. Both migrations carry `-- ROLLBACK:` blocks; the enum one documents why it has no true rollback.

## Two corrections to the issue's plan, found at BUILD

1. **The issue named the wrong source for the trigger body.** It said to copy `notify_role_request_status_change()` from `baseline.sql:785`. That is *not* the live definition — `20260705000800_notification_triggers.sql:261` retargeted the insert from `public.notifications` to `public.member_notifications`. Copying the baseline body would have silently reverted that. The migration copies the 20260705000800 version.
2. **The issue's "must be checked at BUILD" question is answered: no duplicate reminders.** `fn_schedule_guest_reminders_record` (`20260705000800:53-75`) upserts `ON CONFLICT (registration_id, type) DO UPDATE`, and re-approval reuses the same `guest_registrations.id`. Nothing to fix.

## Concurrency

Both new write paths re-assert their precondition **at write time** via `.in('status', …)`, not by reading then writing:

- **Revive** (`POST`, denied/cancelled → pending) — `.eq('id', row.id)` alone would let a member reviving their denied row while an admin approves it clobber `approved` back to `pending`, and `idx_event_role_requests_one_approved_per_slot` would not catch it (approved-vs-approved only).
- **Cancel** (`DELETE`, pending/approved → cancelled) — one conditional UPDATE, no read-then-write.

Zero rows matched ⇒ the state moved under us ⇒ **409/404 with a code, never a silent retry.** Both race cases are covered by tests.

## Deliberate behaviour changes beyond the QA report

1. **Every previously-denied member can request again.** Making `denied` stop blocking is what lets a passed-over member claim a reopened slot — and that is not scoped to cancelled slots. On ship day, anyone ever denied on any *future* event sees request buttons return. Past events stay locked by the cutoff.
2. **The sign-up window quadruples, 15 → 60 min**, and now binds **withdrawals** too (it was client-only before, so a crafted request could free a slot minutes before start). Members used to claiming a role half an hour out will be locked out and must ask an admin — admins keep their bypass. The new cutoff copy + countdown is the mitigation.
3. **`DELETE` is a contract change**: soft-cancel returning `{cancelled, id}` / 404, replacing the fake 200. Only `EventPopup.tsx` calls it and no e2e asserted the old 200.

## Accepted side effects (not fixed here)

- `lib/server/event-capacity.ts:41-45` excludes approved role holders from the guest headcount. After a cancel the person keeps their registration and starts counting, so an at-capacity event can end up one over. Derived count, tolerable.
- `event_role_requests.event_id` has no `ON DELETE CASCADE` (`baseline.sql:158`), unlike `event_role_slots` — deleting a calendar event that has requests still fails on the FK. Pre-existing.
- `fn_schedule_guest_reminders_record`'s `ON CONFLICT … DO UPDATE SET status='pending', attempts=0` has no `WHERE`, so re-confirming resets an **already-sent** reminder. Reachable today via attend → cancel → attend, so this PR does not open the door.

## Migrations

`20260816000000_…_role_cancel_enum.sql` (the `ALTER TYPE` alone — it cannot be *used* in the transaction that adds it) and `20260816000100_…_role_cancel.sql` (columns, trigger fn, `approve_event_role_request` clearing the cancel stamp).

**Applied to DEV `iymwxdewcpvpjgzewtzk`** with the user's approval. The Supabase MCP recorded HHMMSS-style ledger versions; both rows were rewritten in place to match the repo filenames, so the DEV ledger reads `20260816000000` / `20260816000100`.

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — **507 passed / 36 files** (baseline 494/35). The 13 new cases in `app/api/events/[id]/request-role/route.test.ts` are this route's **first coverage ever**, including both race cases.
- `npx eslint` on all 16 changed files — 0 findings
- DEV probe: `enum_range(registration_status)` = `{approved,cancelled,denied,pending}`, both `cancelled_*` columns present, both functions recompiled with the new bodies
- `/code-review low` — four findings, one fixed (stale `isClosed` in the countdown), three dispositioned as by-design
- `types/supabase.ts` regenerated from DEV — the MCP generator emits `public` only, so its four deltas were spliced into the committed file rather than taken wholesale, which would have deleted the `graphql_public` and `storage` schemas

**Not done locally:** no visual check, and `e2e/member-role-cancel-auth.spec.ts` has not been run (needs a warm dev server against DEV plus the seeded Clerk member). CI's Authenticated E2E covers it.

## Session State
**Status:** DONE
**Completed:**
- [x] Two migrations, applied + verified on DEV only
- [x] `lib/events/role-cutoff.ts` — single definition of the window, shared by route and client
- [x] Member self-withdraw (pending + approved), revive-on-re-request, admin revoke
- [x] Cutoff copy + minutes-only countdown, code-keyed toasts, 390px
- [x] Reference sweep: `memberDetailFormat.ts` pill, popup styles, admin badge, `types/supabase.ts`
- [x] 13 route tests + a 390px e2e spec
- [x] `/code-review low` findings resolved
**Next:** wait for CI green + Vercel preview READY, then the CodeRabbit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XPn7pRLyPMuvAmypTJdSj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Members can withdraw approved event roles with confirmation.
  - Cancelled requests are clearly identified, and reopened slots can be requested again.
  - Role sign-up windows now show a countdown and close 60 minutes before events.
  - Admins can revoke approved role assignments.
  - Cancellation confirmations and status-specific notifications are available in English and Bulgarian.

- **Bug Fixes**
  - Improved handling of duplicate, expired, unavailable, and outdated role requests.
  - Cancelled requests no longer appear as active assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->