### PR TITLE
dev/2608 DEV 751

### DIFF
--- a/app/admin/approval-hub/components/EventRolesTab.tsx
+++ b/app/admin/approval-hub/components/EventRolesTab.tsx
@@ -17,6 +17,7 @@ import { toast } from '@/lib/toast'
 import { useLanguage } from '@/lib/hooks/useLanguage'
 import { formatDate, formatTime } from '@/lib/format'
 import { fetchJson } from '@/lib/utils/fetchJson'
+import { ApiError } from '@/lib/api-error'
 import type { TranslationKey } from '@/lib/i18n'
 
 // ── Types ────────────────────────────────────────────────────────
@@ -136,9 +137,17 @@ export function EventRolesTab() {
       )
       return { prev }
     },
-    onError: (_e, _v, ctx) => {
+    // Same code-keyed branching the calendar popup uses (2608-DEV-733): switch on
+    // the route's `code`, never on `message`, which is English developer copy.
+    // Until 2608-DEV-751 `fetchJson` threw a bare Error, so the code was lost and
+    // every failure — including a 409 `state_changed` — showed one hardcoded
+    // English string.
+    onError: (err: unknown, _v, ctx) => {
       if (ctx?.prev) qc.setQueryData(['role-requests', 'all'], ctx.prev)
-      toast.error('Failed to update role request. Please try again.')
+      const code = err instanceof ApiError ? err.code : undefined
+      toast.error(t(code === 'state_changed'
+        ? 'admin.approval.events.stateChanged'
+        : 'admin.approval.events.updateError'))
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: ['role-requests', 'all'] })

--- a/app/api/admin/event-role-requests/[id]/route.ts
+++ b/app/api/admin/event-role-requests/[id]/route.ts
@@ -67,7 +67,14 @@ export async function PATCH(
     const { data: rpcResult, error: rpcError } = await supabase
       .rpc('approve_event_role_request', { p_request_id: id })
 
-    if (rpcError) return Response.json({ error: rpcError.message }, { status: 500 })
+    // Log the whole driver error, not just `.message` (2608-DEV-751): a
+    // PostgrestError's `code`/`details`/`hint` are what identify an
+    // infrastructure fault, and without them a missing column reached the admin
+    // as an untraceable generic toast.
+    if (rpcError) {
+      console.error('[event-role-requests] approve RPC failed:', rpcError)
+      return Response.json({ error: rpcError.message }, { status: 500 })
+    }
 
     const result = rpcResult as {
       id: string
@@ -121,7 +128,10 @@ export async function PATCH(
     .select('id, role_label, profile_id, profile:profiles!profile_id(first_name, contact_email), event:calendar_events!event_id(title, start_time)')
     .maybeSingle()
 
-  if (error) return Response.json({ error: error.message }, { status: 500 })
+  if (error) {
+    console.error(`[event-role-requests] ${status} update failed:`, error)
+    return Response.json({ error: error.message }, { status: 500 })
+  }
   if (!data) {
     return Response.json(
       { error: 'This request is no longer in a state that can be changed', code: 'state_changed' },

--- a/app/api/events/[id]/request-role/route.ts
+++ b/app/api/events/[id]/request-role/route.ts
@@ -78,7 +78,15 @@ export async function POST(
     .eq('status', 'approved')
     .maybeSingle()
 
-  if (slotError) return Response.json({ error: slotError.message }, { status: 500 })
+  // Log the whole driver error, not just `.message` (2608-DEV-751). A
+  // PostgrestError carries `code`/`details`/`hint`, and those are what identify
+  // an infrastructure fault: when production was missing the `cancelled_*`
+  // columns, the PGRST204 reached no log and the failure surfaced only as a
+  // generic "please try again" toast.
+  if (slotError) {
+    console.error('[request-role] slot-filled lookup failed:', slotError)
+    return Response.json({ error: slotError.message }, { status: 500 })
+  }
   if (slotRequests) {
     return Response.json(
       { error: 'This role is already filled', code: 'slot_filled' },
@@ -97,7 +105,10 @@ export async function POST(
     .eq('profile_id', profile.id)
     .maybeSingle()
 
-  if (existingError) return Response.json({ error: existingError.message }, { status: 500 })
+  if (existingError) {
+    console.error('[request-role] existing-row lookup failed:', existingError)
+    return Response.json({ error: existingError.message }, { status: 500 })
+  }
 
   if (existing) {
     if (existing.status === 'pending' || existing.status === 'approved') {
@@ -127,7 +138,10 @@ export async function POST(
       .select()
       .maybeSingle()
 
-    if (reviveError) return Response.json({ error: reviveError.message }, { status: 500 })
+    if (reviveError) {
+      console.error('[request-role] revive update failed:', reviveError)
+      return Response.json({ error: reviveError.message }, { status: 500 })
+    }
     if (!revived) {
       // Zero rows means the state moved under us. Never retry silently.
       return Response.json(
@@ -152,6 +166,7 @@ export async function POST(
         { status: 409 },
       )
     }
+    console.error('[request-role] insert failed:', error)
     return Response.json({ error: error.message }, { status: 500 })
   }
 
@@ -199,7 +214,10 @@ export async function DELETE(
     .select('id, status')
     .maybeSingle()
 
-  if (error) return Response.json({ error: error.message }, { status: 500 })
+  if (error) {
+    console.error('[request-role] cancel update failed:', error)
+    return Response.json({ error: error.message }, { status: 500 })
+  }
   if (!data) {
     return Response.json(
       { error: 'No active role request to cancel', code: 'nothing_to_cancel' },

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #749 | `dev/2608-DEV-749` | `supabase/migrations/` (**migration: yes** — enum + columns + trigger fn), `app/api/events/[id]/request-role/route.ts`, `app/api/events/[id]/route.ts`, `app/api/admin/event-role-requests/[id]/route.ts`, `app/(dashboard)/calendar/components/popup/**`, `app/admin/approval-hub/components/EventRolesTab.tsx`, `app/admin/members/[id]/components/memberDetailFormat.ts`, `lib/events/role-cutoff.ts` (new), `lib/hooks/useMinuteTick.ts` (new), `lib/email/templates/EventRoleRequestEmail.tsx`, `lib/i18n/domains/{events,calendar}.ts` | 2026-08-16 |
+| #751 | `dev/2608-DEV-751` | **migration: no** — `lib/api-error.ts` (new), `lib/apiClient.ts`, `lib/utils/fetchJson.ts` (+ test), `app/admin/approval-hub/components/EventRolesTab.tsx`, `lib/i18n/domains/admin/operations.ts`, `app/api/events/[id]/request-role/route.ts`, `app/api/admin/event-role-requests/[id]/route.ts` | 2026-08-17 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,11 +1,26 @@
 ## Goal
-**#749** (`dev/2608-DEV-749`, cut from `main` @ `915a7e8`): make an approved calendar role
-revocable — member self-withdraw and admin revoke, as a soft `cancelled` status — and move the
-sign-up cutoff 15 min → 60 min with the deadline actually surfaced. **Migration: yes (two files).**
+**#751** (`dev/2608-DEV-751`, cut from `main` @ `b6b856a`): the two observability defects found while
+diagnosing #749 in production — `fetchJson` dropping the route's `code` (so the admin approval hub
+showed one hardcoded English toast for every failure), and both role routes swallowing the driver
+error on their DB-error branches. **Migration: no.**
 
 ## Now
 
-BUILD complete and locally verified; next action is the draft PR.
+BUILD complete and locally verified (`7a57f8b`); next action is the draft PR. Not pushed — no push
+grant exists in this conversation.
+
+**Production cancel/revoke was broken for a reason that is NOT a code defect.** PR #750 merged
+2026-08-16 21:54 and Vercel shipped the code, but the gated `Migrate Prod` run
+[31974848811](https://github.com/teamenjoyvd/tevd-portal/actions/runs/31974848811) is still
+`waiting` at the `Production` environment approval. Verified against `ynykjpnetfwqzdnsgkkg`:
+`registration_status` = pending/approved/denied only, no `cancelled`; `event_role_requests` has
+neither `cancelled_at` nor `cancelled_by`; ledger head is still `20260811000100`. So every
+cancel/revoke write 400s (`PGRST204`) while role SIGN-UP still works, because the insert touches
+none of the new schema. **Approving that run is the fix; #751 changes nothing about it.**
+The same UPDATE was probed against DEV in a rollback-only `DO` block and succeeded
+(`rows_updated_id=331af8ff… status=cancelled`), confirming the code path itself is sound.
+
+### #749 — what landed (merged as PR #750)
 
 **Migrations are already applied to DEV `iymwxdewcpvpjgzewtzk`** (user approved this session).
 The Supabase MCP recorded HHMMSS-style ledger versions (`20260816203117` / `...203152`); both rows
@@ -69,9 +84,13 @@ for both themes; `@custom-variant dark` registered against `[data-theme="dark"]`
 blanket ban with the doc updated in the same commit.
 
 ## Next
-1. Push `dev/2608-DEV-749`, open the PR as a DRAFT, wait for CI green + Vercel preview READY, then
+1. **Approve the pending `Migrate Prod` run 31974848811** (Actions → `Production` gate). This is
+   what actually restores cancel/revoke in production; it is independent of #751. Both migration
+   files are idempotent (`ADD VALUE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`), so a re-run is safe.
+   Smoke-check `https://www.teamenjoyvd.com` afterwards.
+2. Push `dev/2608-DEV-751`, open the PR as a DRAFT, wait for CI green + Vercel preview READY, then
    mark it ready for review (one CodeRabbit pass).
-2. `npm run verify` deliberately NOT run locally: its `next build` runs under `NODE_ENV=production`,
+3. `npm run verify` deliberately NOT run locally: its `next build` runs under `NODE_ENV=production`,
    which on this box resolves `.env.local` = PROD. CI builds it on the PR.
 3. **DEV cleanup pending from #743** (carried, not done in this ticket): `social_posts` holds 6
    seeded variants (`post_url like '%dev-seed-743-variant-%'`) plus three objects in the DEV
@@ -144,6 +163,15 @@ blanket ban with the doc updated in the same commit.
   (`iymwxdewcpvpjgzewtzk`). Only a warm-server run is evidence.
 
 ## Done
+- #751 PLAN + CLAIM + BUILD (`040d822`, `7a57f8b`). Verified: `npm run check-types` clean;
+  `npx vitest run` **511 passed / 36 files** (main baseline 507 — the +4 are new `fetchJson` cases
+  pinning `status`/`code`/`ApiError`); `npx eslint` on all 8 changed files → 0 errors. `ApiError`
+  moved to `lib/api-error.ts` with `apiClient` re-exporting it, so all four existing import sites
+  are untouched. **The shared `parseErrorBody` helper was written and then deleted**: `apiClient`
+  falls back to `json.message` and `fetchJson` deliberately does not, so sharing it would have
+  silently changed `fetchJson`'s message and broken its existing "no error field" test. Route
+  changes are log lines only — every status code and response body is byte-identical.
+  **NOT visually verified**; no live 500 was exercised to observe the new log output.
 - #749 CLAIM + BUILD. Verified: `npx tsc --noEmit` clean; `npm test` **507 passed / 36 files**
   (baseline 494/35 — the 13 new cases are `app/api/events/[id]/request-role/route.test.ts`, the
   route's first coverage ever); `npx eslint` on all 15 changed files → 0 findings; DEV DB probe

--- a/lib/api-error.ts
+++ b/lib/api-error.ts
@@ -1,0 +1,30 @@
+/**
+ * The error both client fetch wrappers throw on a non-ok response.
+ *
+ * It lives here rather than in `lib/apiClient.ts` — where it was defined until
+ * 2608-DEV-751 — so that `lib/utils/fetchJson.ts` can throw it too. `apiClient`
+ * imports `getToken` from `@clerk/nextjs` and carries module-level 401-redirect
+ * state; `fetchJson` is deliberately minimal, and importing `apiClient` just to
+ * reach this class would pull all of that into every `fetchJson` call site.
+ *
+ * Only the class moved. The two wrappers keep their own body parsing on
+ * purpose: `apiClient` falls back to `json.message` and `fetchJson` does not,
+ * and collapsing that difference would change `fetchJson`'s message for every
+ * caller.
+ *
+ * `lib/apiClient.ts` re-exports this, so `import { ApiError } from '@/lib/apiClient'`
+ * keeps working.
+ */
+export class ApiError extends Error {
+  /**
+   * `code` is the machine-readable failure discriminant a route may send
+   * alongside its error string (2608-DEV-733), e.g. `event_full` from
+   * `/api/events/[id]/attend`. Optional because most routes send only a
+   * message; a client that needs to branch should switch on this and never on
+   * `message`, which is English developer copy and free to be reworded.
+   */
+  constructor(public status: number, message: string, public code?: string) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -12,20 +12,12 @@
  */
 
 import { getToken } from '@clerk/nextjs'
+import { ApiError } from '@/lib/api-error'
 
-export class ApiError extends Error {
-  /**
-   * `code` is the machine-readable failure discriminant a route may send
-   * alongside its error string (2608-DEV-733), e.g. `event_full` from
-   * `/api/events/[id]/attend`. Optional because most routes send only a
-   * message; a client that needs to branch should switch on this and never on
-   * `message`, which is English developer copy and free to be reworded.
-   */
-  constructor(public status: number, message: string, public code?: string) {
-    super(message)
-    this.name = 'ApiError'
-  }
-}
+// Defined in `lib/api-error.ts` since 2608-DEV-751 so `lib/utils/fetchJson.ts`
+// can throw it without importing this module (and with it Clerk). Re-exported
+// here because every existing call site imports it from '@/lib/apiClient'.
+export { ApiError }
 
 /**
  * 2608-DEV-727. A 401 is NOT proof that the session ended.

--- a/lib/i18n/domains/admin/operations.ts
+++ b/lib/i18n/domains/admin/operations.ts
@@ -38,6 +38,11 @@ export const adminOperations = {
   'admin.approval.events.status.approved': { en: 'Approved', bg: 'Одобрена' },
   'admin.approval.events.status.denied': { en: 'Denied', bg: 'Отказана' },
   'admin.approval.events.status.cancelled': { en: 'Cancelled', bg: 'Отменена' },
+  // failure toasts (2608-DEV-751) — this tab showed one hardcoded English string
+  // for every failure, so an admin on Bulgarian read English and a 409 was
+  // indistinguishable from a 500
+  'admin.approval.events.updateError': { en: 'Could not update the role request. Please try again.', bg: 'Заявката за роля не можа да бъде обновена. Опитайте отново.' },
+  'admin.approval.events.stateChanged': { en: 'This request changed while you were acting on it.', bg: 'Заявката се промени, докато действахте върху нея.' },
 
   // -- Operations: Trips --
   'admin.operations.trips.btn.new': { en: '+ New trip', bg: '+ Ново пътуване' },

--- a/lib/utils/fetchJson.test.ts
+++ b/lib/utils/fetchJson.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { fetchJson } from '@/lib/utils/fetchJson'
+import { ApiError } from '@/lib/api-error'
 
 function mockFetchOnce(response: Response): ReturnType<typeof vi.fn> {
   const mock = vi.fn().mockResolvedValue(response)
@@ -42,5 +43,35 @@ describe('fetchJson', () => {
   it('does not treat a JSON error body on a 200 as a failure', async () => {
     mockFetchOnce(new Response(JSON.stringify({ error: 'soft error payload' }), { status: 200 }))
     await expect(fetchJson('/api/x')).resolves.toEqual({ error: 'soft error payload' })
+  })
+
+  // 2608-DEV-751 — the admin approval hub could not tell a 409 `state_changed`
+  // from a 500 because a plain Error carried neither the status nor the code.
+  it('throws an ApiError carrying the response status', async () => {
+    mockFetchOnce(new Response(JSON.stringify({ error: 'Nope' }), { status: 409 }))
+    await expect(fetchJson('/api/x')).rejects.toBeInstanceOf(ApiError)
+    mockFetchOnce(new Response(JSON.stringify({ error: 'Nope' }), { status: 409 }))
+    await expect(fetchJson('/api/x')).rejects.toMatchObject({ status: 409, message: 'Nope' })
+  })
+
+  it('carries a string `code` from the error body onto the ApiError', async () => {
+    mockFetchOnce(new Response(
+      JSON.stringify({ error: 'Gone', code: 'state_changed' }), { status: 409 },
+    ))
+    await expect(fetchJson('/api/x')).rejects.toMatchObject({ code: 'state_changed' })
+  })
+
+  it('leaves `code` undefined when the body has none or a non-string one', async () => {
+    mockFetchOnce(new Response(JSON.stringify({ error: 'Boom' }), { status: 500 }))
+    await expect(fetchJson('/api/x')).rejects.toMatchObject({ code: undefined })
+    mockFetchOnce(new Response(JSON.stringify({ error: 'Boom', code: 42 }), { status: 500 }))
+    await expect(fetchJson('/api/x')).rejects.toMatchObject({ code: undefined })
+  })
+
+  it('still throws an ApiError when the body is not JSON at all', async () => {
+    mockFetchOnce(new Response('<html>Bad Gateway</html>', { status: 502 }))
+    await expect(fetchJson('/api/x')).rejects.toMatchObject({
+      status: 502, message: 'Request failed: 502', code: undefined,
+    })
   })
 })

--- a/lib/utils/fetchJson.ts
+++ b/lib/utils/fetchJson.ts
@@ -6,11 +6,23 @@
 // Minimal by design: unlike `lib/apiClient.ts` it performs no 401 redirect and
 // sets no headers, so converting a call site changes nothing but the non-ok
 // path (which now throws instead of returning the error body as data).
+//
+// It throws `ApiError` rather than a bare `Error` (2608-DEV-751) so callers can
+// branch on the route's machine-readable `code` — the admin approval hub used to
+// show one hardcoded English string for every failure because a plain `Error`
+// dropped it. `ApiError extends Error` and the message is unchanged, so the
+// twelve existing call sites are unaffected.
+import { ApiError } from '@/lib/api-error'
+
 export async function fetchJson<T>(input: string, init?: RequestInit): Promise<T> {
   const res = await fetch(input, init)
   if (!res.ok) {
     const body = await res.json().catch(() => null)
-    throw new Error(body?.error ?? `Request failed: ${res.status}`)
+    // Deliberately `body?.error` only, with no `body?.message` fallback: that is
+    // this wrapper's long-standing contract (see its tests) and differs from
+    // apiClient's on purpose.
+    const code = typeof body?.code === 'string' ? body.code : undefined
+    throw new ApiError(res.status, body?.error ?? `Request failed: ${res.status}`, code)
   }
   return res.json()
 }


### PR DESCRIPTION
- **[2608-DEV-751] CLAIM: register claim row for admin toast + route error logging**
- **[2608-DEV-751] fix: translated code-keyed admin toast; log swallowed DB errors**
- **[2608-DEV-751] docs: retarget STATE.md to #751; record the prod migration gate**

Closes #751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role-request error handling across approval, denial, revocation, and event role-request actions.
  * Added clearer messages when a request changes state before an update completes.
  * Preserved optimistic updates and rollback behavior when operations fail.

* **Localization**
  * Added Bulgarian and English translations for role-request update errors and concurrent state changes.

* **Reliability**
  * Improved error details for failed requests while maintaining existing response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->