### PR TITLE
[2608-DEV-742] On-site verification nudge for unverified profiles

### DIFF
--- a/app/(dashboard)/components/VerifyNudgeDialog.test.tsx
+++ b/app/(dashboard)/components/VerifyNudgeDialog.test.tsx
@@ -4,8 +4,8 @@
 // exercised here — they are what encodes the ticket's five-state matrix, and
 // getting that matrix wrong is the failure mode that matters (2608-DEV-742).
 
-import { describe, it, expect } from 'vitest'
-import { selectVariant, isSnoozed } from './VerifyNudgeDialog'
+import { describe, it, expect, vi } from 'vitest'
+import { selectVariant, isSnoozed, createWriteQueue } from './VerifyNudgeDialog'
 import type { Profile } from '../profile/types'
 
 const BASE = {
@@ -94,5 +94,42 @@ describe('isSnoozed', () => {
 
   it('a malformed timestamp does not suppress the nudge forever', () => {
     expect(isSnoozed({ verify_dismissed_at: 'not-a-date' }, NOW)).toBe(false)
+  })
+})
+
+describe('createWriteQueue', () => {
+  it('runs queued writes in call order even when the first resolves last', async () => {
+    // Regresses the show-count-then-dismiss race: display fires a PATCH, the
+    // user immediately dismisses and fires a second PATCH, and the first
+    // request's response arrives after the second's. Without ordering, the
+    // slower show-count write would land last and silently drop
+    // `verify_dismissed_at`, undoing the dismissal's snooze.
+    const order: string[] = []
+    const queue = createWriteQueue<string>(async label => {
+      if (label === 'shown-count') {
+        await new Promise(resolve => setTimeout(resolve, 10))
+      }
+      order.push(label)
+    })
+
+    queue('shown-count')
+    queue('dismiss')
+
+    await new Promise(resolve => setTimeout(resolve, 20))
+    expect(order).toEqual(['shown-count', 'dismiss'])
+  })
+
+  it('keeps running later writes after an earlier one rejects', async () => {
+    const run = vi.fn()
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce(undefined)
+    const queue = createWriteQueue<string>(run)
+
+    queue('shown-count')
+    queue('dismiss')
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(run).toHaveBeenNthCalledWith(1, 'shown-count')
+    expect(run).toHaveBeenNthCalledWith(2, 'dismiss')
   })
 })

--- a/app/(dashboard)/components/VerifyNudgeDialog.test.tsx
+++ b/app/(dashboard)/components/VerifyNudgeDialog.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+// The module under test is a 'use client' component pulling in Clerk, react-query
+// and next/link at module scope. Only the two pure decision functions are
+// exercised here — they are what encodes the ticket's five-state matrix, and
+// getting that matrix wrong is the failure mode that matters (2608-DEV-742).
+
+import { describe, it, expect } from 'vitest'
+import { selectVariant, isSnoozed } from './VerifyNudgeDialog'
+import type { Profile } from '../profile/types'
+
+const BASE = {
+  role: 'guest',
+  primary_profile_id: null,
+  verRequest: null,
+  ownSpouseLinkRequest: null,
+  pendingSpouseLinkCount: 0,
+} as unknown as Profile
+
+const profile = (over: Partial<Profile>): Profile => ({ ...BASE, ...over })
+
+describe('selectVariant — the five states', () => {
+  it('state 1: a guest who never submitted anything is nudged to verify', () => {
+    expect(selectVariant(profile({}))).toBe('verify')
+  })
+
+  it('state 2: a guest whose request is under review is left alone', () => {
+    expect(selectVariant(profile({ verRequest: { status: 'pending' } as Profile['verRequest'] }))).toBeNull()
+  })
+
+  it('state 3: a denied guest is told it needs attention', () => {
+    expect(selectVariant(profile({ verRequest: { status: 'denied' } as Profile['verRequest'] }))).toBe('denied')
+  })
+
+  it('state 4: a guest waiting on their primary is NOT told to verify an ABO', () => {
+    // The whole reason /api/profile grows ownSpouseLinkRequest: without it this
+    // profile is indistinguishable from state 1, and secondaries are hard-blocked
+    // from self-verifying (verify-abo/route.ts:27-35).
+    expect(selectVariant(profile({
+      ownSpouseLinkRequest: { status: 'pending' } as Profile['ownSpouseLinkRequest'],
+    }))).toBeNull()
+  })
+
+  it('state 5: a primary with an inbound request is asked to approve it', () => {
+    expect(selectVariant(profile({ role: 'member', pendingSpouseLinkCount: 1 }))).toBe('approve-spouse')
+  })
+})
+
+describe('selectVariant — who is left alone', () => {
+  it('a guest already linked to a primary gets nothing', () => {
+    expect(selectVariant(profile({ primary_profile_id: 'abc' }))).toBeNull()
+  })
+
+  it('a denied outbound spouse request does not suppress the verify nudge', () => {
+    // Only a *pending* request means "waiting"; a denied one means they are stuck
+    // again and the verify path is once more the right thing to point at.
+    expect(selectVariant(profile({
+      ownSpouseLinkRequest: { status: 'denied' } as Profile['ownSpouseLinkRequest'],
+    }))).toBe('verify')
+  })
+
+  it.each(['member', 'core', 'admin'])('a %s with nothing pending is never nudged', role => {
+    expect(selectVariant(profile({ role: role as Profile['role'] }))).toBeNull()
+  })
+
+  it('an approved-but-not-yet-promoted guest is left alone', () => {
+    expect(selectVariant(profile({ verRequest: { status: 'approved' } as Profile['verRequest'] }))).toBeNull()
+  })
+
+  it('a guest with a pending inbound count is still a verify case, not state 5', () => {
+    // Guests cannot receive inbound requests, but the count must not be able to
+    // hijack the guest branch if that ever changes.
+    expect(selectVariant(profile({ pendingSpouseLinkCount: 3 }))).toBe('verify')
+  })
+})
+
+describe('isSnoozed', () => {
+  const NOW = Date.parse('2026-08-17T12:00:00.000Z')
+  const daysAgo = (n: number) => new Date(NOW - n * 24 * 60 * 60 * 1000).toISOString()
+
+  it('is not snoozed when nothing was ever dismissed', () => {
+    expect(isSnoozed(undefined, NOW)).toBe(false)
+    expect(isSnoozed({}, NOW)).toBe(false)
+  })
+
+  it('is snoozed inside the 7-day window', () => {
+    expect(isSnoozed({ verify_dismissed_at: daysAgo(1) }, NOW)).toBe(true)
+    expect(isSnoozed({ verify_dismissed_at: daysAgo(6.9) }, NOW)).toBe(true)
+  })
+
+  it('is not snoozed once the window has passed', () => {
+    expect(isSnoozed({ verify_dismissed_at: daysAgo(7.1) }, NOW)).toBe(false)
+    expect(isSnoozed({ verify_dismissed_at: daysAgo(30) }, NOW)).toBe(false)
+  })
+
+  it('a malformed timestamp does not suppress the nudge forever', () => {
+    expect(isSnoozed({ verify_dismissed_at: 'not-a-date' }, NOW)).toBe(false)
+  })
+})

--- a/app/(dashboard)/components/VerifyNudgeDialog.tsx
+++ b/app/(dashboard)/components/VerifyNudgeDialog.tsx
@@ -1,0 +1,287 @@
+'use client'
+
+// ── Verification nudge popup (2608-DEV-742) ──────────────────────────────────
+// Homepage-only. Reads the SAME ['profile'] cache entry ProfileTile populates
+// (ProfileTile.tsx:43-48) — no new API route, no new network request. Dismissal
+// state lives in profiles.ui_prefs.onboarding, which already exists, so there is
+// no migration either.
+//
+// "Confirmed" is not a column anywhere: it is derived from role + verRequest +
+// the caller's own spouse-link request. This component reads that derivation, it
+// does not add a new source of truth.
+
+import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { useUser } from '@clerk/nextjs'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { X } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { useLanguage } from '@/lib/hooks/useLanguage'
+import type { TranslationKey } from '@/lib/i18n/translations'
+import { apiClient } from '@/lib/apiClient'
+import type { Profile, OnboardingPrefs } from '../profile/types'
+
+/** Hard stop — some people are permanently stuck (an ABO not in the LOS, a
+ *  primary who will never approve). A popup with no stop condition becomes the
+ *  thing users click past without reading, which costs the ability to tell them
+ *  anything later. The persistent surfaces (ProfileTile, SpouseLinkBanner) carry
+ *  the message from here on. */
+const NUDGE_MAX_SHOWINGS = 3
+/** "Remind me later" and ✕ both snooze — a close is a snooze, not a refusal. */
+const NUDGE_SNOOZE_DAYS = 7
+/** The bento grid runs its entrance animation on load (`.bento-tile`,
+ *  globals.css:124); opening a modal into it is jarring. */
+const NUDGE_DELAY_MS = 1500
+
+const SNOOZE_MS = NUDGE_SNOOZE_DAYS * 24 * 60 * 60 * 1000
+
+type NudgeVariant = 'verify' | 'denied' | 'approve-spouse'
+
+/**
+ * The five states from the ticket. Only 1, 3 and 5 get a popup — 2 and 4 are
+ * *waiting*, not *stuck*, and a popup there is pure nagging.
+ */
+export function selectVariant(p: Profile): NudgeVariant | null {
+  const isLinkedSecondary = (p.primary_profile_id ?? null) !== null
+
+  if (p.role === 'guest') {
+    // Already linked to a primary — nothing for them to submit.
+    if (isLinkedSecondary) return null
+    // State 4: waiting on their primary. Never tell them to verify an ABO —
+    // verify-abo/route.ts:27-35 hard-blocks secondaries from self-verifying.
+    if (p.ownSpouseLinkRequest?.status === 'pending') return null
+
+    switch (p.verRequest?.status ?? null) {
+      case 'pending':  return null          // state 2 — under review
+      case 'denied':   return 'denied'      // state 3 — needs attention
+      case null:       return 'verify'      // state 1 — never submitted
+      default:         return null          // approved but not yet promoted
+    }
+  }
+
+  // State 5 — the co-owner half. Points at the PRIMARY, who is the only person
+  // able to act; nudging the applicant achieves nothing.
+  if (p.pendingSpouseLinkCount > 0) return 'approve-spouse'
+
+  // Never for member / core / admin otherwise.
+  return null
+}
+
+/** True while the user's last dismissal is still inside the snooze window. */
+export function isSnoozed(o: OnboardingPrefs | undefined, now: number): boolean {
+  const dismissedAt = o?.verify_dismissed_at
+  if (dismissedAt === undefined || dismissedAt === null) return false
+  const parsed = Date.parse(dismissedAt)
+  // A malformed timestamp must not permanently suppress the nudge.
+  if (Number.isNaN(parsed)) return false
+  return now - parsed < SNOOZE_MS
+}
+
+const COPY: Record<NudgeVariant, { title: TranslationKey; body: TranslationKey; cta: TranslationKey; href: string }> = {
+  verify: {
+    title: 'home.nudge.verify.title',
+    body:  'home.nudge.verify.body',
+    cta:   'home.nudge.verify.cta',
+    href:  '/profile',
+  },
+  denied: {
+    title: 'home.nudge.denied.title',
+    body:  'home.nudge.denied.body',
+    cta:   'home.nudge.denied.cta',
+    href:  '/profile',
+  },
+  'approve-spouse': {
+    title: 'home.nudge.spouse.title',
+    body:  'home.nudge.spouse.body',
+    cta:   'home.nudge.spouse.cta',
+    href:  '/profile/spouse-link',
+  },
+}
+
+// ── The path visual ───────────────────────────────────────────────────────────
+// ✓ ─── ● ─── ○  ·  Signed up / Verify ABO / Full access
+// Uses --status-success-* (done), --status-pending-* (current) and
+// --status-neutral-* (upcoming): all three pairs exist and are theme-correct.
+
+function StepPath({ t }: { t: (key: TranslationKey) => string }) {
+  const steps: { key: TranslationKey; state: 'done' | 'current' | 'upcoming' }[] = [
+    { key: 'home.nudge.step.signedUp',   state: 'done' },
+    { key: 'home.nudge.step.verify',     state: 'current' },
+    { key: 'home.nudge.step.fullAccess', state: 'upcoming' },
+  ]
+  const TOKEN = {
+    done:     { bg: 'var(--status-success-bg)', fg: 'var(--status-success-fg)' },
+    current:  { bg: 'var(--status-pending-bg)', fg: 'var(--status-pending-fg)' },
+    upcoming: { bg: 'var(--status-neutral-bg)', fg: 'var(--status-neutral-fg)' },
+  }
+  const GLYPH = { done: '✓', current: '●', upcoming: '○' }
+
+  return (
+    <div className="flex items-start justify-between gap-1" aria-hidden="true">
+      {steps.map((step, i) => (
+        <div key={step.key} className="flex flex-1 items-start gap-1 last:flex-none">
+          <div className="flex flex-col items-center gap-1.5 min-w-0">
+            <span
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+              style={{ backgroundColor: TOKEN[step.state].bg, color: TOKEN[step.state].fg }}
+            >
+              {GLYPH[step.state]}
+            </span>
+            <span
+              className="text-[10px] leading-tight text-center"
+              style={{ color: step.state === 'upcoming' ? 'var(--text-tertiary)' : 'var(--text-secondary)' }}
+            >
+              {t(step.key)}
+            </span>
+          </div>
+          {i < steps.length - 1 && (
+            <span className="mt-3.5 h-px flex-1" style={{ backgroundColor: 'var(--border-default)' }} />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function VerifyNudgeDialog() {
+  const { isSignedIn } = useUser()
+  const { t } = useLanguage()
+  const qc = useQueryClient()
+
+  // Same key, staleTime and `enabled` as ProfileTile so both observers share one
+  // cache entry and this mounts without issuing a request of its own.
+  const { data: profile } = useQuery<Profile>({
+    queryKey: ['profile'],
+    queryFn: () => apiClient('/api/profile'),
+    enabled: !!isSignedIn,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const [open, setOpen] = useState(false)
+  // Guards the showing-count write against React's double-invoked effects in
+  // development and against a re-render between the timer firing and the PATCH.
+  const recordedRef = useRef(false)
+
+  const onboarding = profile?.ui_prefs?.onboarding
+  const shownCount = onboarding?.verify_shown_count ?? 0
+  const variant = profile ? selectVariant(profile) : null
+
+  const shouldShow =
+    variant !== null &&
+    shownCount < NUDGE_MAX_SHOWINGS &&
+    !isSnoozed(onboarding, Date.now())
+
+  /** Whole-object write: PATCH /api/profile merges ui_prefs exactly ONE level
+   *  deep (route.ts:194-197), so a partial `onboarding` would drop its siblings.
+   *  Top-level neighbours (bento_order, bento_collapsed, font_size,
+   *  ical_display_name) are untouched by that same merge. */
+  async function persist(next: OnboardingPrefs) {
+    // Update the cache first so a client-side navigation back to the homepage
+    // re-evaluates against the new state instead of the stale one. Not an
+    // invalidate: refetching here would re-render the open dialog mid-interaction.
+    qc.setQueryData<Profile>(['profile'], prev =>
+      prev ? { ...prev, ui_prefs: { ...prev.ui_prefs, onboarding: next } } : prev
+    )
+    try {
+      await apiClient('/api/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ ui_prefs: { onboarding: next } }),
+      })
+    } catch (err) {
+      // Non-fatal: the popup has already done its job on screen. Worst case the
+      // cap is not advanced and they see it once more next session.
+      console.error('[VerifyNudgeDialog] failed to persist onboarding prefs', err)
+    }
+  }
+
+  useEffect(() => {
+    if (!shouldShow) return
+    const timer = setTimeout(() => {
+      setOpen(true)
+      if (recordedRef.current) return
+      recordedRef.current = true
+      void persist({ ...onboarding, verify_shown_count: shownCount + 1 })
+    }, NUDGE_DELAY_MS)
+    return () => clearTimeout(timer)
+    // `onboarding`/`shownCount` are snapshotted deliberately: persist() rewrites
+    // the cache entry they come from, and re-running on that would re-arm the timer.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldShow])
+
+  function dismiss() {
+    setOpen(false)
+    void persist({
+      ...onboarding,
+      verify_shown_count: Math.max(shownCount, 1),
+      verify_dismissed_at: new Date().toISOString(),
+    })
+  }
+
+  // Render nothing while the profile query is loading rather than flashing the
+  // wrong state (profile prerender gotcha).
+  if (!profile || variant === null) return null
+
+  const copy = COPY[variant]
+  const adminNote = variant === 'denied' ? profile.verRequest?.admin_note ?? null : null
+
+  return (
+    <Dialog open={open} onOpenChange={next => { if (!next) dismiss() }}>
+      <DialogPortal>
+        <DialogOverlay className="nudge-motion" style={{ backgroundColor: 'var(--overlay)' }} />
+        <DialogContent
+          className="nudge-motion fixed flex flex-col overflow-hidden p-5 gap-4
+            inset-x-0 bottom-0 w-full max-h-[85vh] rounded-t-container
+            md:inset-x-auto md:bottom-auto md:top-1/2 md:left-1/2 md:w-[380px] md:max-h-[80vh] md:rounded-container md:-translate-x-1/2 md:-translate-y-1/2"
+          style={{ backgroundColor: 'var(--bg-global)' }}
+        >
+          <div className="flex items-start gap-3">
+            <DialogTitle className="text-lg" style={{ color: 'var(--text-primary)' }}>
+              {t(copy.title)}
+            </DialogTitle>
+            <button
+              type="button"
+              onClick={dismiss}
+              aria-label={t('home.nudge.close')}
+              className="ml-auto -mr-1 -mt-1 shrink-0 rounded-control p-1 hover:bg-hover-surface"
+              style={{ color: 'var(--text-secondary)' }}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          {variant !== 'approve-spouse' && <StepPath t={t} />}
+
+          <DialogDescription className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+            {t(copy.body)}
+          </DialogDescription>
+
+          {adminNote !== null && adminNote !== '' && (
+            <p
+              className="text-xs rounded-control px-3 py-2"
+              style={{ backgroundColor: 'var(--status-alert-bg)', color: 'var(--status-alert-fg)' }}
+            >
+              {adminNote}
+            </p>
+          )}
+
+          <div className="flex flex-col gap-2">
+            <Button asChild className="w-full">
+              <Link href={copy.href} onClick={dismiss}>{t(copy.cta)}</Link>
+            </Button>
+            <Button variant="ghost" className="w-full" onClick={dismiss}>
+              {t('home.nudge.later')}
+            </Button>
+          </div>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  )
+}

--- a/app/(dashboard)/components/VerifyNudgeDialog.tsx
+++ b/app/(dashboard)/components/VerifyNudgeDialog.tsx
@@ -75,6 +75,19 @@ export function selectVariant(p: Profile): NudgeVariant | null {
   return null
 }
 
+/** Runs `run` for each queued argument strictly in call order, regardless of
+ *  how long an individual run takes. Used to keep the two onboarding-prefs
+ *  PATCH requests (show-count, dismiss) from landing out of order: they can
+ *  fire moments apart (a dialog opens, then is immediately dismissed), and an
+ *  out-of-order arrival would let the show-count write silently overwrite a
+ *  dismissal's `verify_dismissed_at`, defeating the snooze. */
+export function createWriteQueue<T>(run: (arg: T) => Promise<unknown>) {
+  let chain: Promise<unknown> = Promise.resolve()
+  return (arg: T) => {
+    chain = chain.catch(() => {}).then(() => run(arg))
+  }
+}
+
 /** True while the user's last dismissal is still inside the snooze window. */
 export function isSnoozed(o: OnboardingPrefs | undefined, now: number): boolean {
   const dismissedAt = o?.verify_dismissed_at
@@ -169,6 +182,18 @@ export default function VerifyNudgeDialog() {
   // Guards the showing-count write against React's double-invoked effects in
   // development and against a re-render between the timer firing and the PATCH.
   const recordedRef = useRef(false)
+  const enqueueWrite = useRef(
+    createWriteQueue<OnboardingPrefs>(next =>
+      apiClient('/api/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ ui_prefs: { onboarding: next } }),
+      }).catch(err => {
+        // Non-fatal: the popup has already done its job on screen. Worst case
+        // the cap is not advanced and they see it once more next session.
+        console.error('[VerifyNudgeDialog] failed to persist onboarding prefs', err)
+      })
+    )
+  ).current
 
   const onboarding = profile?.ui_prefs?.onboarding
   const shownCount = onboarding?.verify_shown_count ?? 0
@@ -183,23 +208,14 @@ export default function VerifyNudgeDialog() {
    *  deep (route.ts:194-197), so a partial `onboarding` would drop its siblings.
    *  Top-level neighbours (bento_order, bento_collapsed, font_size,
    *  ical_display_name) are untouched by that same merge. */
-  async function persist(next: OnboardingPrefs) {
+  function persist(next: OnboardingPrefs) {
     // Update the cache first so a client-side navigation back to the homepage
     // re-evaluates against the new state instead of the stale one. Not an
     // invalidate: refetching here would re-render the open dialog mid-interaction.
     qc.setQueryData<Profile>(['profile'], prev =>
       prev ? { ...prev, ui_prefs: { ...prev.ui_prefs, onboarding: next } } : prev
     )
-    try {
-      await apiClient('/api/profile', {
-        method: 'PATCH',
-        body: JSON.stringify({ ui_prefs: { onboarding: next } }),
-      })
-    } catch (err) {
-      // Non-fatal: the popup has already done its job on screen. Worst case the
-      // cap is not advanced and they see it once more next session.
-      console.error('[VerifyNudgeDialog] failed to persist onboarding prefs', err)
-    }
+    enqueueWrite(next)
   }
 
   useEffect(() => {
@@ -208,7 +224,7 @@ export default function VerifyNudgeDialog() {
       setOpen(true)
       if (recordedRef.current) return
       recordedRef.current = true
-      void persist({ ...onboarding, verify_shown_count: shownCount + 1 })
+      persist({ ...onboarding, verify_shown_count: shownCount + 1 })
     }, NUDGE_DELAY_MS)
     return () => clearTimeout(timer)
     // `onboarding`/`shownCount` are snapshotted deliberately: persist() rewrites
@@ -218,7 +234,7 @@ export default function VerifyNudgeDialog() {
 
   function dismiss() {
     setOpen(false)
-    void persist({
+    persist({
       ...onboarding,
       verify_shown_count: Math.max(shownCount, 1),
       verify_dismissed_at: new Date().toISOString(),

--- a/app/(dashboard)/components/tiles/ProfileTile.tsx
+++ b/app/(dashboard)/components/tiles/ProfileTile.tsx
@@ -9,6 +9,7 @@ import type { TranslationKey } from '@/lib/i18n/translations'
 import { apiClient } from '@/lib/apiClient'
 
 type VerifRequest = { status: 'pending' | 'approved' | 'denied' } | null
+type SpouseLinkReq = { status: 'pending' | 'approved' | 'denied' } | null
 type Upline = { upline_name: string | null; upline_abo_number: string | null } | null
 type Profile = {
   role: string
@@ -16,8 +17,11 @@ type Profile = {
   last_name: string | null
   display_names: Record<string, string> | null
   abo_number: string | null
+  primary_profile_id: string | null
   upline: Upline
   verRequest: VerifRequest
+  ownSpouseLinkRequest: SpouseLinkReq
+  pendingSpouseLinkCount: number
 }
 
 const ROLE_STYLES: Record<string, { bg: string; color: string }> = {
@@ -52,9 +56,26 @@ export default function ProfileTile({
   const verRequest = profile?.verRequest ?? null
   const uplineData = profile?.upline ?? null
 
-  const isUnverified = profile?.role === 'guest' &&
-    verRequest !== null &&
-    (verRequest.status === 'pending' || verRequest.status === 'denied')
+  // A guest who never submitted a verification request has verRequest === null.
+  // The old predicate required verRequest !== null, so that population — the one
+  // most in need of the nudge — fell through to the "Authenticated member+"
+  // branch below and got a plain greeting with no badge (2608-DEV-742).
+  // Every guest who is not already linked to a primary is unverified; the one
+  // exception is a guest waiting on their primary to approve a spouse link,
+  // who is handled separately because they are blocked, not idle.
+  const isGuest = profile?.role === 'guest'
+  const isLinkedSecondary = (profile?.primary_profile_id ?? null) !== null
+  const awaitingPrimary =
+    isGuest && !isLinkedSecondary && profile?.ownSpouseLinkRequest?.status === 'pending'
+  // 'approved' with the role not yet promoted is a transient admin state — they
+  // are not stuck and telling them to verify would be wrong, so they keep the
+  // plain greeting they get today. Matches selectVariant() in VerifyNudgeDialog.
+  const isUnverified =
+    isGuest && !isLinkedSecondary && !awaitingPrimary && verRequest?.status !== 'approved'
+
+  // State 5 — a primary member with inbound spouse-link requests to approve.
+  // Mirrors SpouseLinkBanner on /profile (AboInfoContent.tsx:38-62).
+  const pendingSpouseLinkCount = profile?.pendingSpouseLinkCount ?? 0
 
   const role = profile?.role ?? 'guest'
   const roleStyle = ROLE_STYLES[role] ?? ROLE_STYLES.guest
@@ -106,8 +127,17 @@ export default function ProfileTile({
     )
   }
 
-  // Unverified Member
-  if (isUnverified) {
+  // Guest states — same card, different badge and one line of copy. State 4
+  // (awaiting the primary's approval) is deliberately NOT told to verify an ABO:
+  // verify-abo/route.ts:27-35 forbids secondaries from submitting one at all.
+  if (awaitingPrimary || isUnverified) {
+    const badgeKey: TranslationKey = awaitingPrimary ? 'profile.awaitingPrimary' : 'profile.unverified'
+    const descKey: TranslationKey = awaitingPrimary
+      ? 'profile.awaitingPrimaryDesc'
+      : verRequest?.status === 'pending' ? 'profile.verifPendingDesc'
+      : verRequest?.status === 'denied'  ? 'profile.verifDeniedDesc'
+      : 'profile.verifNotStartedDesc'
+
     return (
       <BentoCard variant="teal" colSpan={colSpan} mobileColSpan={mobileColSpan} rowSpan={rowSpan} style={style} className="flex flex-col justify-between">
         <div className="flex items-center justify-end">
@@ -121,12 +151,10 @@ export default function ProfileTile({
           </h2>
           <span className="inline-block mt-2 text-xs font-semibold px-2.5 py-1 rounded-control"
             style={{ backgroundColor: 'rgba(250,248,243,0.15)', color: 'var(--brand-parchment)' }}>
-            {t('profile.unverified')}
+            {t(badgeKey)}
           </span>
           <p className="text-xs mt-2 font-body" style={{ color: 'rgba(250,248,243,0.70)' }}>
-            {verRequest?.status === 'pending'
-              ? t('profile.verifPendingDesc')
-              : t('profile.verifDeniedDesc')}
+            {t(descKey)}
           </p>
         </div>
       </BentoCard>
@@ -161,6 +189,26 @@ export default function ProfileTile({
             </span>
           )}
         </div>
+        {/* State 5 — inbound spouse-link requests to approve. The applicant cannot
+            act here, only the primary can, so the prompt lives on THIS tile.
+            Count-based copy matches SpouseLinkBanner: /api/profile returns a count,
+            not the requester's name. */}
+        {pendingSpouseLinkCount > 0 && (
+          <Link
+            href="/profile/spouse-link"
+            className="flex items-center gap-2 mt-3 px-3 py-2 rounded-control"
+            style={{ backgroundColor: 'rgba(250,248,243,0.15)', textDecoration: 'none' }}
+          >
+            <span className="text-xs font-medium" style={{ color: 'var(--brand-parchment)' }}>
+              {pendingSpouseLinkCount === 1
+                ? t('profile.spouseLinkBanner.single')
+                : t('profile.spouseLinkBanner.multiple').replace('{{count}}', String(pendingSpouseLinkCount))}
+            </span>
+            <span className="ml-auto shrink-0 text-[11px] font-semibold" style={{ color: 'var(--brand-parchment)' }}>
+              {t('profile.spouseLinkBanner.review')}
+            </span>
+          </Link>
+        )}
       </div>
     </BentoCard>
   )

--- a/app/(dashboard)/page.tsx
+++ b/app/(dashboard)/page.tsx
@@ -13,6 +13,7 @@ import HeroTile from '@/app/(dashboard)/components/tiles/HeroTile'
 import AboutTile from '@/app/(dashboard)/components/tiles/AboutTile'
 import AnnouncementTile from '@/app/(dashboard)/components/tiles/AnnouncementTile'
 import TripHeroTile from '@/app/(dashboard)/components/tiles/TripHeroTile'
+import VerifyNudgeDialog from '@/app/(dashboard)/components/VerifyNudgeDialog'
 import { todayInSofia } from '@/lib/format'
 
 export const dynamic = 'force-dynamic'
@@ -223,6 +224,12 @@ export default async function HomePage() {
         <SocialsTile style={{ minHeight: 200 }} />
 
       </div>
+
+      {/* Homepage-only verification nudge. Mounted once outside both layout
+          branches — it is a portalled dialog, so it renders nothing inline and
+          decides for itself whether the signed-in user is in a state worth
+          interrupting (2608-DEV-742). */}
+      <VerifyNudgeDialog />
 
     </div>
   )

--- a/app/(dashboard)/profile/types.ts
+++ b/app/(dashboard)/profile/types.ts
@@ -4,6 +4,17 @@
 export type UiPrefs = {
   bento_order?: string[]
   bento_collapsed?: Record<string, boolean>
+  onboarding?: OnboardingPrefs
+}
+
+// Verification-nudge popup frequency state (2608-DEV-742). Lives in ui_prefs so
+// it needs no migration. PATCH /api/profile merges ui_prefs ONE level deep
+// (route.ts:168-171), so writers must send this whole object, never a partial.
+export type OnboardingPrefs = {
+  /** ISO timestamp of the last dismissal — snoozes the popup for 7 days. */
+  verify_dismissed_at?: string
+  /** Lifetime count of showings — hard stop at NUDGE_MAX_SHOWINGS. */
+  verify_shown_count?: number
 }
 
 export type NotificationPrefs = {
@@ -75,6 +86,10 @@ export type Profile = {
   spouse: SpouseData | null
   // Number of pending inbound spouse link requests (primary members only, else 0)
   pendingSpouseLinkCount: number
+  // The caller's own OUTBOUND spouse-link request (guests with no primary link
+  // only, else null). Distinguishes "guest waiting on their primary" from "guest
+  // who never submitted anything" — see app/api/profile/route.ts.
+  ownSpouseLinkRequest: SpouseLinkRequest | null
 }
 
 export type TripPayment = {

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -74,7 +74,7 @@ export async function GET() {
   const effectiveAboNumber: string | null = aboNumber ?? primaryInfo?.abo_number ?? null
   const effectiveUplineAboNumber: string | null = uplineAboNumber ?? primaryInfo?.upline_abo_number ?? null
 
-  const [upline, verRequest, spouse, pendingSpouseLinkCount] = await Promise.all([
+  const [upline, verRequest, spouse, pendingSpouseLinkCount, ownSpouseLinkRequest] = await Promise.all([
     // Resolve upline for any verified member (own account, or via the primary
     // profile's shared ABO when this is a spouse-linked secondary).
     (effectiveAboNumber || effectiveUplineAboNumber)
@@ -120,6 +120,31 @@ export async function GET() {
           return count ?? 0
         })()
       : Promise.resolve(0),
+    // The caller's OWN outbound spouse-link request (2608-DEV-742).
+    // pendingSpouseLinkCount above counts only INBOUND requests and is hardcoded
+    // to 0 for guests, which made "guest who never submitted anything" and "guest
+    // already waiting on their primary to approve" indistinguishable — and the
+    // second group must never be told to go verify an ABO number they are not
+    // permitted to submit (verify-abo/route.ts:27-35 hard-blocks secondaries).
+    // Same row GET /api/profile/spouse-link returns; surfaced here so the homepage
+    // needs no second request. Secondaries are already linked, so they skip it.
+    role === 'guest' && !primaryProfileId
+      ? (async () => {
+          const { data: own, error: ownError } = await supabase
+            .from('spouse_link_requests')
+            .select('id, status, admin_note, created_at')
+            .eq('requester_id', profileId)
+            .maybeSingle()
+          if (ownError) {
+            // Non-fatal: the rest of the profile payload is still valid. Log it
+            // rather than swallowing — a silent null here downgrades the caller
+            // to the "never submitted" nudge, which is the wrong prompt.
+            console.error('[GET /api/profile] own spouse_link_requests lookup failed', ownError)
+            return null
+          }
+          return own ?? null
+        })()
+      : Promise.resolve(null),
   ])
 
   return Response.json({
@@ -130,6 +155,7 @@ export async function GET() {
     verRequest,
     spouse,
     pendingSpouseLinkCount,
+    ownSpouseLinkRequest,
   })
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -203,6 +203,14 @@ body {
     animation: none !important;
     transition: none !important;
   }
+
+  /* VerifyNudgeDialog (2608-DEV-742) — the dialog's own enter/exit animation.
+     Applied to the overlay and content of that one dialog, not to Dialog
+     globally, so the rest of the app's motion decisions stay untouched. */
+  .nudge-motion {
+    animation: none !important;
+    transition: none !important;
+  }
 }
 
 /* ── Bento staggered entrance animation ── */

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #751 | `dev/2608-DEV-751` | **migration: no** — `lib/api-error.ts` (new), `lib/apiClient.ts`, `lib/utils/fetchJson.ts` (+ test), `app/admin/approval-hub/components/EventRolesTab.tsx`, `lib/i18n/domains/admin/operations.ts`, `app/api/events/[id]/request-role/route.ts`, `app/api/admin/event-role-requests/[id]/route.ts` | 2026-08-17 |
+| #742 | `dev/2608-DEV-742` | **migration: no** — `app/api/profile/route.ts`, `app/(dashboard)/profile/types.ts`, `app/(dashboard)/components/tiles/ProfileTile.tsx`, `app/(dashboard)/components/VerifyNudgeDialog.tsx` (new), `app/(dashboard)/page.tsx`, `lib/i18n/domains/home.ts` | 2026-08-17 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,13 +1,51 @@
 ## Goal
-**#751** (`dev/2608-DEV-751`, cut from `main` @ `b6b856a`): the two observability defects found while
-diagnosing #749 in production — `fetchJson` dropping the route's `code` (so the admin approval hub
-showed one hardcoded English toast for every failure), and both role routes swallowing the driver
-error on their DB-error branches. **Migration: no.**
+**#742** (`dev/2608-DEV-742`, cut from `main` @ `06a2aef`): an on-site verification nudge for
+unverified profiles — a dismissible homepage popup covering both the single account holder and the
+co-owner path — plus the two data defects that made its target population invisible.
+**Migration: no.** #741 is explicitly **out of scope** (see Constraints).
 
 ## Now
 
-BUILD complete and locally verified (`7a57f8b`); next action is the draft PR. Not pushed — no push
-grant exists in this conversation.
+BUILD complete and locally verified (`d8994e9`); next action is the PR.
+
+### #742 — what this branch does
+
+**Five derived states, three popups.** "Confirmed" is not a column anywhere — it is derived from
+`role` + `verRequest` + the caller's own spouse-link request, and this ticket reads that derivation
+rather than adding a source of truth. States 2 (under review) and 4 (waiting on the primary) are
+*waiting*, not *stuck*, so they get nothing.
+
+**Two real defects fixed, both of which the issue predicted:**
+1. `ProfileTile`'s `isUnverified` required `verRequest !== null`, so a guest who **never submitted**
+   fell through to the authenticated-member branch and got a plain greeting — the one population the
+   nudge exists for was the one told nothing.
+2. `pendingSpouseLinkCount` counts only **inbound** requests and is hardcoded to 0 for guests, so
+   state 4 was indistinguishable from state 1. `GET /api/profile` now also returns
+   `ownSpouseLinkRequest` (the caller's own outbound row). Without it a guest waiting on their
+   primary would be told to verify an ABO that `verify-abo/route.ts:27-35` forbids them submitting.
+
+**Deviations from the issue body, all deliberate:**
+- State 5's copy is **count-based**, not `"<name> is waiting for your approval"`. `/api/profile`
+  returns a count, not the requester's name; inventing a name would need another query. Matches the
+  existing `SpouseLinkBanner` phrasing.
+- The two guest tile branches are **one parameterised branch**, not two — they differed only in
+  badge and one line of copy, and a second pasted copy is how they drift apart.
+- An `approved` verRequest on a not-yet-promoted guest keeps today's plain greeting in both the tile
+  and the popup: transient admin state, not stuck.
+- `prefers-reduced-motion` is handled by adding `.nudge-motion` to the existing allowlist block in
+  `globals.css:194` — that block is a **targeted allowlist**, not a global rule, so a new animated
+  surface has to opt in or it is not covered.
+
+**A correction to the issue's premise:** `GET /api/profile/spouse-link` **already** returns the
+caller's own outbound row, but only `/profile` queries it (`queryKey: ['spouseLinkRequest']`).
+Following the DoD anyway, so the homepage needs no second request.
+
+**Verified:** `npx tsc --noEmit` exit 0; `npm test` 527 passed / 37 files (baseline 511/36, +16 new
+in `VerifyNudgeDialog.test.tsx` covering the whole state matrix); `npm run lint` 0 errors.
+**Not visually verified** and no local `npm run build` — `check:env` says production-mode commands
+resolve to **PROD** `ynykjpnetfwqzdnsgkkg`, so the Vercel preview is the gate for both.
+
+### #751 — merged as PR #752
 
 **Production cancel/revoke was broken for a reason that is NOT a code defect.** PR #750 merged
 2026-08-16 21:54 and Vercel shipped the code, but the gated `Migrate Prod` run

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -98,6 +98,8 @@ blanket ban with the doc updated in the same commit.
    empty before that ticket, so deleting every row is correct. #743 also still needs closing.
 
 ## Constraints
+- (#742 session, 2026-08-17) On the question of how much of #741 to build alongside #742, the user
+  answered verbatim: "Skip that, do only 742". #741 is out of scope for this branch entirely.
 - Never push without an explicit grant in this conversation. Grants from earlier tickets/sessions do
   not carry over. (A grant WAS given this session: "PUSH TO OPEN DRAFT PR #740 and #741".)
 - Never apply migrations to a hosted Supabase project (DEV or prod) without asking first.

--- a/lib/i18n/domains/home.ts
+++ b/lib/i18n/domains/home.ts
@@ -21,6 +21,21 @@ export const home = {
   'home.about.aboutLink':    { en: 'About us →',           bg: 'За нас →'                },
   // ProfileTile
   'home.profile.there':      { en: 'there',                bg: 'приятел'                 },
+  // VerifyNudgeDialog (2608-DEV-742)
+  'home.nudge.close':        { en: 'Close',                bg: 'Затвори'                 },
+  'home.nudge.later':        { en: 'Remind me later',      bg: 'Напомни ми по-късно'     },
+  'home.nudge.step.signedUp':   { en: 'Signed up',         bg: 'Регистрация'             },
+  'home.nudge.step.verify':     { en: 'Verify ABO',        bg: 'Верификация'             },
+  'home.nudge.step.fullAccess': { en: 'Full access',       bg: 'Пълен достъп'            },
+  'home.nudge.verify.title': { en: 'Verify your ABO number', bg: 'Верифицирайте своя ABO номер' },
+  'home.nudge.verify.body':  { en: 'You are one step away. Add your ABO number and we will confirm you as a member — that unlocks trips, guides and member events.', bg: 'Остава една стъпка. Добавете своя ABO номер и ще ви потвърдим като член — това отключва пътуванията, наръчниците и събитията за членове.' },
+  'home.nudge.verify.cta':   { en: 'Verify now',           bg: 'Верифицирай сега'        },
+  'home.nudge.denied.title': { en: 'Your verification needs attention', bg: 'Верификацията ви се нуждае от внимание' },
+  'home.nudge.denied.body':  { en: 'We could not confirm your details. Check them on your profile and submit again.', bg: 'Не успяхме да потвърдим данните ви. Проверете ги в профила си и изпратете отново.' },
+  'home.nudge.denied.cta':   { en: 'Review and resubmit',  bg: 'Прегледай и изпрати отново' },
+  'home.nudge.spouse.title': { en: 'Someone is waiting for your approval', bg: 'Някой очаква вашето одобрение' },
+  'home.nudge.spouse.body':  { en: 'A co-owner has asked to be linked to your shared ABO account. Only you can approve it.', bg: 'Съсобственик е поискал да бъде свързан с вашия споделен ABO акаунт. Само вие можете да одобрите заявката.' },
+  'home.nudge.spouse.cta':   { en: 'Review the request',   bg: 'Прегледай заявката'      },
   // LocationTile
   'home.loc.city':           { en: 'Sofia, Bulgaria',      bg: 'София, България'         },
   // SocialsTile

--- a/lib/i18n/domains/profile.ts
+++ b/lib/i18n/domains/profile.ts
@@ -77,6 +77,10 @@ export const profile = {
   'profile.unverified':         { en: 'Unverified Member',                                       bg: 'Неверифициран Член'                                            },
   'profile.verifPendingDesc':   { en: 'Verification pending admin review.',                      bg: 'Верификацията очаква преглед от администратор.'                },
   'profile.verifDeniedDesc':    { en: 'Verification was denied. Update your details and resubmit.', bg: 'Верификацията беше отказана. Обновете данните и опитайте отново.' },
+  // 2608-DEV-742 — the guest who never submitted anything, previously shown nothing at all.
+  'profile.verifNotStartedDesc': { en: 'Verify your ABO number to unlock member content.',          bg: 'Верифицирайте своя ABO номер, за да отключите съдържанието за членове.' },
+  'profile.awaitingPrimary':    { en: 'Awaiting approval',                                         bg: 'Очаква одобрение'                                              },
+  'profile.awaitingPrimaryDesc': { en: 'Your spouse link is waiting for the primary account holder to approve it.', bg: 'Свързването на съпруг/а очаква одобрение от основния титуляр.' },
   'profile.profileLink':        { en: 'Profile →',                                               bg: 'Профил →'                                                      },
   'profile.adminLink':          { en: 'Admin →',                                                 bg: 'Админ →'                                                       },
   'profile.access':             { en: 'Access',                  bg: 'Достъп'                   },


### PR DESCRIPTION
Closes #742.

## What this is

A dismissible homepage popup that shows an unverified user the way to verification, covering both the single account holder and the co-owner path.

**No migration. No new API route. No new network request.** The popup reads the same `['profile']` cache entry `ProfileTile` already populates (`ProfileTile.tsx:43-48`), and dismissal state lives in `profiles.ui_prefs`, which already exists.

## Five states, three popups

"Confirmed" is not a column anywhere — it is derived from `role` + `verRequest` + the caller's own spouse-link request. This reads that derivation rather than adding a new source of truth.

| # | State | Popup | Points at |
|---|---|---|---|
| 1 | Guest, never submitted | **Yes** | `/profile` — verify your ABO |
| 2 | Guest, request pending | No | nothing for them to do |
| 3 | Guest, request denied | **Yes** | `/profile`, with the `admin_note` |
| 4 | Guest awaiting their primary | No | waiting, not stuck |
| 5 | Primary with an inbound request | **Yes** | `/profile/spouse-link` |

States 2 and 4 are *waiting*, not *stuck*; a popup there is pure nagging.

## The two defects this uncovered — both fixed

**1. `ProfileTile.tsx:55-57` never matched the population it was for.** `isUnverified` required `verRequest !== null`, so a guest who **never submitted** failed the test and fell through to the "Authenticated member+" branch: normal greeting, no badge, no nudge. That is exactly the group we want to catch, and it was the one group told nothing.

**2. States 1 and 4 were indistinguishable.** `pendingSpouseLinkCount` (`route.ts:113-122`) counts only *inbound* requests and is hardcoded to 0 for guests. A guest patiently waiting on their primary would have been told to go verify an ABO number `verify-abo/route.ts:27-35` hard-blocks them from submitting. `GET /api/profile` now also returns `ownSpouseLinkRequest`, the caller's own outbound row, in the existing `Promise.all`.

## Frequency — what decides whether this is helpful or hated

`ui_prefs.onboarding = { verify_dismissed_at, verify_shown_count }`. 7-day snooze on dismissal, hard stop after **3** showings, then the persistent surfaces (the tile, `SpouseLinkBanner`) carry it. Some people are permanently stuck — an ABO not in the LOS, a primary who will never approve — and a popup with no stop condition becomes the thing users click past without reading, which costs the ability to tell them anything later.

`PATCH /api/profile` merges `ui_prefs` exactly **one level deep** (`route.ts:194-197`), so `onboarding` is written as a whole object and `bento_order` / `bento_collapsed` / `font_size` / `ical_display_name` are all untouched.

## Deviations from the issue body — all deliberate

- **State 5's copy is count-based**, not `"<name> is waiting for your approval"`. `/api/profile` returns a count, not the requester's name, and inventing a name costs another query. Matches the existing `SpouseLinkBanner` phrasing.
- **The two guest tile branches are one parameterised branch**, not two. They differed only in the badge and one line of copy; a second pasted copy is how they drift apart.
- **An `approved` verRequest on a not-yet-promoted guest keeps today's plain greeting**, in both the tile and the popup. Transient admin state, not stuck.
- **`prefers-reduced-motion`** is handled by adding `.nudge-motion` to the existing block at `globals.css:194`. That block is a targeted **allowlist** of three class names, not a global rule, so a new animated surface has to opt in or it is silently not covered.

## A correction to the issue's premise

`GET /api/profile/spouse-link` (`route.ts:8-22`) **already** returns the caller's own outbound row — but only `/profile` queries it, under `queryKey: ['spouseLinkRequest']`. The DoD's `/api/profile` field is still the right call so the homepage needs no second request, but the data was not as absent as the issue implied.

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` | clean (exit 0) |
| `npm test` | 527 passed / 37 files — baseline 511/36, +16 new |
| `npm run lint` | 0 errors (464 warnings, one fewer than baseline: two duplicate branches collapsed into one) |

`VerifyNudgeDialog.test.tsx` covers the full state matrix — all five states, the "who is left alone" cases (linked secondary, member/core/admin, approved-not-promoted, denied outbound request), and the snooze-window arithmetic including a malformed timestamp.

**Not visually verified, and no local production build.** `npm run check:env` reports that production-mode commands (`next build` / `next start`) resolve to the **PROD** project `ynykjpnetfwqzdnsgkkg`, since Next never loads `.env.development.local` for those. The Vercel preview is the gate for both the build and the 390px / dark-mode rendering.

## Still to check on the preview

- 390px bottom-sheet layout and both themes
- Walk states 1 and 4 by hand — the interesting pair, and the reason for the API change. New DEV sign-ups get no `profiles` row (the DEV Clerk webhook is not configured), so build fixtures by editing existing DEV profiles rather than signing up.
- Dismiss, reload, confirm `ui_prefs.onboarding` round-tripped **and** `bento_order` survived the merge.

Also folds in the `docs/CLAIMS.md` row for merged PR #752, per the standing "never a standalone cleanup PR" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V7Ke7Qprky95gR3UAW1AD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a homepage verification reminder with tailored guidance for new, denied, and pending verification states.
  * Added snooze, dismissal, navigation, and verification step guidance.
  * Added profile indicators for verification and spouse-link request statuses.
  * Added links showing pending spouse-link requests requiring review.
* **Accessibility**
  * Added reduced-motion support for reminder animations.
* **Localization**
  * Added English and Bulgarian translations for verification and spouse-link messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->