### PR TITLE
[2608-DEV-741] C2 phase 1: components/ui/* colour literals to tokens

### DIFF
--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -17,7 +17,7 @@ const AlertDialogOverlay = React.forwardRef<
       "fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
-    style={{ backgroundColor: "rgba(0,0,0,0.35)" }}
+    style={{ backgroundColor: "var(--overlay)" }}
     {...props}
     ref={ref}
   />

--- a/components/ui/expand-map.tsx
+++ b/components/ui/expand-map.tsx
@@ -56,9 +56,9 @@ const PARCHMENT = 'var(--brand-parchment)'
 const STONE = 'var(--brand-stone)'
 const MOSS = 'var(--brand-moss)'
 const ACCENT = 'var(--brand-sienna)'
-const ACCENT_RGB = '224, 122, 95'
+const ACCENT_RGB = 'var(--brand-sienna-rgb)'
 
-const stone = (alpha: number) => `rgba(138, 133, 119, ${alpha})`
+const stone = (alpha: number) => `rgba(var(--brand-stone-rgb), ${alpha})`
 
 // Skyline blocks: [top, left|right, width, height, fill alpha, entrance delay].
 const BUILDINGS: {

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -19,7 +19,7 @@ const SheetOverlay = React.forwardRef<
       "fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
-    style={{ backgroundColor: "rgba(0,0,0,0.35)" }}
+    style={{ backgroundColor: "var(--overlay)" }}
     {...props}
     ref={ref}
   />

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-control font-semibold transition-all hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2 text-[var(--text-secondary)] bg-[rgba(0,0,0,0.05)] data-[state=on]:text-white data-[state=on]:bg-[var(--brand-teal)]",
+  "inline-flex items-center justify-center rounded-control font-semibold transition-all hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2 text-[var(--text-secondary)] bg-[var(--hover-surface)] data-[state=on]:text-white data-[state=on]:bg-[var(--brand-teal)]",
   {
     variants: {
       variant: {

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -21,7 +21,7 @@ function TooltipContent({
           backgroundColor: 'var(--bg-global)',
           border: '1px solid var(--border-default)',
           borderRadius: 'var(--radius)',
-          boxShadow: '0 8px 32px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.06)',
+          boxShadow: 'var(--shadow-modal)',
           outline: 'none',
           maxWidth: '320px',
           padding: '8px 10px',

--- a/components/ui/vaul-drawer.tsx
+++ b/components/ui/vaul-drawer.tsx
@@ -43,7 +43,7 @@ export function VaulDrawer({
           style={{
             position: 'fixed',
             inset: 0,
-            backgroundColor: 'rgba(0,0,0,0.4)',
+            backgroundColor: 'var(--overlay)',
             zIndex: 49,
           }}
         />
@@ -58,7 +58,7 @@ export function VaulDrawer({
             flexDirection: 'column',
             borderRadius: 'var(--radius) var(--radius) 0 0',
             backgroundColor: 'var(--bg-global)',
-            boxShadow: '0 -4px 32px rgba(0,0,0,0.18)',
+            boxShadow: 'var(--shadow-modal)',
             outline: 'none',
             maxHeight: '92dvh',
           }}
@@ -79,7 +79,7 @@ export function VaulDrawer({
                 width: 32,
                 height: 4,
                 borderRadius: 9999,
-                backgroundColor: 'rgba(0,0,0,0.15)',
+                backgroundColor: 'var(--bento-border-hover)',
               }}
             />
           </div>

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #742 | `dev/2608-DEV-742` | **migration: no** — `app/api/profile/route.ts`, `app/(dashboard)/profile/types.ts`, `app/(dashboard)/components/tiles/ProfileTile.tsx`, `app/(dashboard)/components/VerifyNudgeDialog.tsx` (new), `app/(dashboard)/page.tsx`, `lib/i18n/domains/home.ts` | 2026-08-17 |
+| #741 | `dev/2608-DEV-741` | **migration: no** — `components/ui/alert-dialog.tsx`, `components/ui/sheet.tsx`, `components/ui/vaul-drawer.tsx`, `components/ui/tooltip.tsx`, `components/ui/toggle.tsx`, `components/ui/expand-map.tsx`, `styles/brand-tokens.css` | 2026-08-17 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,7 +6,9 @@ co-owner path — plus the two data defects that made its target population invi
 
 ## Now
 
-BUILD complete and locally verified (`d8994e9`); next action is the PR.
+#741 C2 phase 1 (`components/ui/*`) BUILD complete, pushed, PR #754 open as DRAFT on
+`dev/2608-DEV-741`. Next action: wait for CI green + Vercel preview READY, do the manual
+light/dark 390px check listed in the PR body, then mark ready for review.
 
 ### #742 — what this branch does
 
@@ -112,6 +114,23 @@ value cannot serve a 200px card and a 19px badge. Now:
 `--radius-sm` is 2px (hairline). `--radius-md/lg/xl` are pinned to the control tier and
 `--radius-2xl` to the container tier as a **legacy landing zone**, so unmigrated code lands sanely —
 that is not a scale, and new code must use the named utilities.
+
+### #741 C2 phase 1 — what landed
+Commits `f9a2e00` (CLAIM) + `f0773d3` (BUILD) on `dev/2608-DEV-741`, PR #754 (draft).
+
+`components/ui/*` colour literals migrated to tokens: overlay scrims (`alert-dialog`,
+`sheet`, `vaul-drawer`) → `var(--overlay)`; ad hoc `box-shadow` literals (`tooltip`,
+`vaul-drawer` content) → `var(--shadow-modal)` (adopts the existing elevation system rather
+than inventing per-component shadows — a deliberate geometry-consolidation call, not a
+literal-preserving one); `toggle`'s inline hover wash → `var(--hover-surface)`; drawer drag
+handle → `var(--bento-border-hover)` (0.16 alpha, closest existing token to the 0.15 literal).
+`expand-map`'s `stone()`/`ACCENT_RGB` were raw RGB decompositions of
+`--brand-stone`/`--brand-sienna` — added `--brand-stone-rgb` / `--brand-sienna-rgb`
+companion tokens (same pattern as `--bg-global-rgb`) so they source from tokens, pixel-identical.
+**Verified:** `npx tsc --noEmit` clean; `npm test` 529 passed / 37 files (no regression);
+`npm run lint` 0 errors; `/code-review low` — no correctness findings (one soft note on the
+drag-handle token's semantic name, accepted as the closest existing match). **NOT visually
+verified locally** — Vercel preview is the gate.
 
 ### #741 C1 — what landed
 Commits `09b4280` + `bc60cf2` on `dev/2608-DEV-741`.

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -18,6 +18,12 @@
   --brand-moss:      #252B23;
   --brand-stone:     #8A8577;
 
+  /* RGB channel companions — needed where a caller composites a variable
+     alpha via rgba(...) in JS (template literals can't call color-mix()).
+     Same pattern as --bg-global-rgb below. Keep in sync with the hex above. */
+  --brand-stone-rgb:  138, 133, 119;
+  --brand-sienna-rgb: 224, 122, 95;
+
   /* ── Primitive aliases — legacy callers use bare token names ── */
   --sienna: var(--brand-sienna);
   --forest: var(--brand-forest);


### PR DESCRIPTION
## Summary
- First slice of #741's phased colour-literal migration (C1 foundation merged in #745): `components/ui/*`, the smallest and highest-leverage phase since it fixes every consumer at once.
- Overlay scrims (`alert-dialog`, `sheet`, `vaul-drawer`) → `var(--overlay)`.
- Ad hoc `box-shadow` literals (`tooltip`, `vaul-drawer` content) → `var(--shadow-modal)`, consolidating onto the elevation system C1 already established instead of inventing per-component shadows.
- `toggle`'s inline `rgba(0,0,0,0.05)` wash → `var(--hover-surface)` — the exact case that token was created for.
- `vaul-drawer`'s drag handle → `var(--bento-border-hover)` (0.16 alpha, closest existing token to the 0.15 literal it replaces).
- `expand-map`'s `stone()`/`ACCENT_RGB` were raw RGB decompositions of `--brand-stone`/`--brand-sienna` (needed for variable-alpha `rgba()` compositing in template literals). Added `--brand-stone-rgb` / `--brand-sienna-rgb` companion tokens (same pattern as the existing `--bg-global-rgb`) so those constants source from tokens instead of repeating the hex as literal channel numbers — pixel-identical output.
- `docs/CLAIMS.md`: pruned the stale merged-#742 row, registered #741.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 529 passed / 37 files (no regression)
- [x] `npm run lint` — 0 errors (464 pre-existing warnings, unchanged class)
- [x] `/code-review low` — no correctness findings
- [ ] Vercel preview READY + CI green (this PR's actual visual gate — not verified locally)
- [ ] Manual check in preview: alert dialog / sheet / drawer overlay, tooltip shadow, toggle rest state, LocationMap pin glow — light and dark, 390px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V7Ke7Qprky95gR3UAW1AD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated overlays, drawers, dialogs, and tooltips to use consistent theme-based colors and shadows.
  * Improved toggle styling with the shared hover-surface theme.
  * Aligned map colors and drag handles with brand color tokens.
  * Added brand color support for transparent and blended UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->