### PR TITLE
[2608-DEV-741] C2 phase 2: components/layout/* colour literals to tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -101,6 +101,7 @@
   --color-on-accent:      var(--on-accent);
   --color-overlay:        var(--overlay);
   --color-hover-surface:  var(--hover-surface);
+  --color-on-accent-hover: var(--on-accent-hover);
   --color-focus-ring:     var(--focus-ring);
   --color-skeleton-base:  var(--skeleton-base);
 

--- a/components/layout/BellButton.tsx
+++ b/components/layout/BellButton.tsx
@@ -19,7 +19,7 @@ export default function BellButton() {
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
-          className="interactive relative w-8 h-8 flex items-center justify-center rounded-lg hover:bg-black/5 transition-colors"
+          className="interactive relative w-8 h-8 flex items-center justify-center rounded-lg hover:bg-hover-surface transition-colors"
           aria-label="Notifications"
         >
           <svg width="17" height="17" viewBox="0 0 24 24" fill="none"
@@ -30,7 +30,7 @@ export default function BellButton() {
           </svg>
           {unread > 0 && (
             <span
-              className="absolute top-0.5 right-0.5 min-w-[15px] h-[15px] text-white text-[9px] font-bold rounded-full flex items-center justify-center px-1"
+              className="absolute top-0.5 right-0.5 min-w-[15px] h-[15px] text-on-accent text-[9px] font-bold rounded-full flex items-center justify-center px-1"
               style={{ backgroundColor: 'var(--brand-crimson)' }}
             >
               {unread > 99 ? '99+' : unread}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -22,7 +22,7 @@ export default function Footer() {
           {/* Col 1 — Brand */}
           <div className="flex items-center gap-2.5">
             <div className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0"
-              style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
+              style={{ border: '1px solid rgba(var(--white-rgb), 0.15)' }}>
               <Image
                 src="/logo.png"
                 alt="teamenjoyVD"
@@ -56,10 +56,10 @@ export default function Footer() {
             {/* Tickets */}
             <a href="https://epaygo.bg/3640737494" target="_blank" rel="noopener noreferrer"
               aria-label="Tickets"
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
-              style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
+              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-on-accent-hover"
+              style={{ border: '1px solid rgba(var(--white-rgb), 0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-                stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                stroke="rgba(var(--brand-oyster-rgb), 0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
                 <rect x="1" y="7" width="22" height="10" rx="2" ry="2"/>
                 <path d="M1 12h3M20 12h3"/>
                 <circle cx="4" cy="12" r="1.5" fill="transparent"/>
@@ -70,10 +70,10 @@ export default function Footer() {
             {/* Mail */}
             <a href="mailto:teamenjoyvd@gmail.com"
               aria-label="Email"
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
-              style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
+              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-on-accent-hover"
+              style={{ border: '1px solid rgba(var(--white-rgb), 0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-                stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                stroke="rgba(var(--brand-oyster-rgb), 0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
                 <rect width="20" height="16" x="2" y="4" rx="2"/>
                 <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
               </svg>
@@ -82,10 +82,10 @@ export default function Footer() {
             {/* Instagram */}
             <a href="https://www.instagram.com/teamenjoyvd/" target="_blank" rel="noopener noreferrer"
               aria-label="Instagram"
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
-              style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
+              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-on-accent-hover"
+              style={{ border: '1px solid rgba(var(--white-rgb), 0.15)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
-                stroke="rgba(242,239,232,0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                stroke="rgba(var(--brand-oyster-rgb), 0.6)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
                 <rect width="20" height="20" x="2" y="2" rx="5" ry="5"/>
                 <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/>
                 <line x1="17.5" x2="17.51" y1="6.5" y2="6.5"/>
@@ -95,9 +95,9 @@ export default function Footer() {
             {/* Facebook */}
             <a href="https://www.facebook.com/teamenjoyvd/" target="_blank" rel="noopener noreferrer"
               aria-label="Facebook"
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-white/10"
-              style={{ border: '1px solid rgba(255,255,255,0.15)' }}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="rgba(242,239,232,0.6)">
+              className="w-8 h-8 rounded-full flex items-center justify-center transition-colors hover:bg-on-accent-hover"
+              style={{ border: '1px solid rgba(var(--white-rgb), 0.15)' }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="rgba(var(--brand-oyster-rgb), 0.6)">
                 <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"/>
               </svg>
             </a>
@@ -108,9 +108,9 @@ export default function Footer() {
       </div>
 
       {/* Bottom bar */}
-      <div style={{ borderTop: '1px solid rgba(255,255,255,0.07)' }}>
+      <div style={{ borderTop: '1px solid rgba(var(--white-rgb), 0.07)' }}>
         <div className="max-w-[1440px] mx-auto px-8 xl:px-12 2xl:px-16 py-3 flex items-center justify-between gap-4">
-          <p className="text-[11px]" style={{ color: 'rgba(242,239,232,0.3)' }}>
+          <p className="text-[11px]" style={{ color: 'rgba(var(--brand-oyster-rgb), 0.3)' }}>
             © {new Date().getFullYear()} teamenjoyvd.com · {t('footer.allRightsReserved')} ·{' '}
             <a
               href="https://tally.so/r/BzAl5Q"
@@ -121,7 +121,7 @@ export default function Footer() {
               {t('footer.feedback')}
             </a>
           </p>
-          <p className="text-[11px]" style={{ color: 'rgba(242,239,232,0.3)' }}>
+          <p className="text-[11px]" style={{ color: 'rgba(var(--brand-oyster-rgb), 0.3)' }}>
             {t('footer.builtBy')}
           </p>
         </div>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -53,7 +53,7 @@ export default function Header() {
 
             <Link href="/" className="flex items-center gap-2.5 flex-shrink-0 interactive">
               <div className="w-8 h-8 rounded-full overflow-hidden flex items-center justify-center flex-shrink-0"
-                style={{ border: '1px solid rgba(0,0,0,0.08)' }}>
+                style={{ border: '1px solid var(--border-default)' }}>
                 <Image
                   src="/logo.png"
                   alt="teamenjoyVD"
@@ -77,7 +77,7 @@ export default function Header() {
                   key={href}
                   href={href}
                   className="interactive pill-link-crimson text-xs font-semibold tracking-widest uppercase"
-                  style={isActive(href) ? { backgroundColor: 'rgba(188,71,73,0.12)' } : undefined}
+                  style={isActive(href) ? { backgroundColor: 'var(--status-alert-bg)' } : undefined}
                 >
                   {labels[lang]}
                 </Link>
@@ -88,7 +88,7 @@ export default function Header() {
               {/* Hamburger — visible below lg (covers portrait + landscape phones, portrait tablet) */}
               <SheetTrigger asChild>
                 <button
-                  className="interactive lg:hidden w-8 h-8 flex items-center justify-center rounded-lg hover:bg-black/5 transition-colors"
+                  className="interactive lg:hidden w-8 h-8 flex items-center justify-center rounded-lg hover:bg-hover-surface transition-colors"
                   aria-label="Toggle navigation"
                   aria-expanded={mobileNavOpen}
                 >
@@ -128,7 +128,7 @@ export default function Header() {
                   trigger={
                     <button
                       aria-label="Sign in or change language"
-                      className="interactive w-8 h-8 flex items-center justify-center rounded-lg hover:bg-black/5 transition-colors"
+                      className="interactive w-8 h-8 flex items-center justify-center rounded-lg hover:bg-hover-surface transition-colors"
                     >
                       <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
                         stroke="var(--text-nav)" strokeWidth="1.8"
@@ -153,7 +153,7 @@ export default function Header() {
         style={{
           backgroundColor: 'rgba(var(--bg-global-rgb), 0.97)',
           border: '1px solid var(--nav-border)',
-          boxShadow: '0 8px 32px rgba(0,0,0,0.10)',
+          boxShadow: 'var(--shadow-modal)',
           backdropFilter: 'blur(12px)',
         }}
       >
@@ -166,7 +166,7 @@ export default function Header() {
               href={href}
               onClick={() => setMobileNavOpen(false)}
               className="interactive flex items-center gap-3 pill-link-crimson text-xs font-semibold tracking-widest uppercase w-full min-h-[44px] py-3"
-              style={isActive(href) ? { backgroundColor: 'rgba(188,71,73,0.12)' } : undefined}
+              style={isActive(href) ? { backgroundColor: 'var(--status-alert-bg)' } : undefined}
             >
               {Icon && <Icon size={18} strokeWidth={1.75} className="flex-shrink-0" />}
               {labels[lang]}

--- a/components/layout/NotificationPopup.tsx
+++ b/components/layout/NotificationPopup.tsx
@@ -72,7 +72,7 @@ export default function NotificationPopup({ onClose }: Props) {
               <button
                 key={n.id}
                 onClick={() => handleItemClick(n.id, n.action_url)}
-                className="w-full text-left px-4 py-3 flex items-start gap-3 transition-colors hover:bg-black/[0.03]"
+                className="w-full text-left px-4 py-3 flex items-start gap-3 transition-colors hover:bg-hover-surface"
               >
                 {/* Unread dot */}
                 <div className="flex-shrink-0 mt-1.5">
@@ -109,7 +109,7 @@ export default function NotificationPopup({ onClose }: Props) {
         <Link
           href="/notifications"
           onClick={onClose}
-          className="flex items-center justify-center px-4 py-3 text-xs font-semibold tracking-wide transition-colors hover:bg-black/[0.03]"
+          className="flex items-center justify-center px-4 py-3 text-xs font-semibold tracking-wide transition-colors hover:bg-hover-surface"
           style={{ color: 'var(--brand-crimson)' }}
         >
           {t('notif.view')}

--- a/components/layout/UserDropdown.tsx
+++ b/components/layout/UserDropdown.tsx
@@ -77,8 +77,8 @@ export default function UserDropdown() {
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <button
-          className="w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-bold text-white transition-opacity hover:opacity-80 active:opacity-60 flex-shrink-0"
-          style={{ backgroundColor: 'var(--brand-forest)', border: '1.5px solid rgba(0,0,0,0.1)' }}
+          className="w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-bold text-on-accent transition-opacity hover:opacity-80 active:opacity-60 flex-shrink-0"
+          style={{ backgroundColor: 'var(--brand-forest)', border: '1.5px solid var(--border-default)' }}
           aria-label="Account menu"
         >
           {initials}
@@ -90,7 +90,7 @@ export default function UserDropdown() {
         <div className="px-4 py-4" style={{ borderBottom: '1px solid var(--border-default)' }}>
           <div className="flex items-center gap-3">
             <div
-              className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold text-white flex-shrink-0"
+              className="w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold text-on-accent flex-shrink-0"
               style={{ backgroundColor: 'var(--brand-forest)' }}
             >
               {initials}

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #741 | `dev/2608-DEV-741` | **migration: no** — `components/ui/alert-dialog.tsx`, `components/ui/sheet.tsx`, `components/ui/vaul-drawer.tsx`, `components/ui/tooltip.tsx`, `components/ui/toggle.tsx`, `components/ui/expand-map.tsx`, `styles/brand-tokens.css` | 2026-08-17 |
+| #741 | `dev/2608-DEV-741` | **migration: no** — `components/layout/Header.tsx`, `components/layout/Footer.tsx`, `components/layout/UserDropdown.tsx`, `components/layout/BellButton.tsx`, `components/layout/NotificationPopup.tsx`, `styles/brand-tokens.css`, `app/globals.css`, `docs/design/DESIGN-SYSTEM.md` | 2026-08-17 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,9 +6,11 @@ co-owner path — plus the two data defects that made its target population invi
 
 ## Now
 
-#741 C2 phase 1 (`components/ui/*`) BUILD complete, pushed, PR #754 open as DRAFT on
-`dev/2608-DEV-741`. Next action: wait for CI green + Vercel preview READY, do the manual
-light/dark 390px check listed in the PR body, then mark ready for review.
+#741 C2 phase 2 (`components/layout/*`) BUILD complete on `dev/2608-DEV-741` (branch reset off
+`main` after phase 1's squash-merge as `cac8eb4` — the local branch's 3 pre-merge commits were
+superseded, not lost). `/code-review low` running in background. Next action: address any findings,
+then push and open PR as DRAFT, wait for CI green + Vercel preview READY, do the manual light/dark
+390px check, then mark ready for review.
 
 ### #742 — what this branch does
 
@@ -114,6 +116,33 @@ value cannot serve a 200px card and a 19px badge. Now:
 `--radius-sm` is 2px (hairline). `--radius-md/lg/xl` are pinned to the control tier and
 `--radius-2xl` to the container tier as a **legacy landing zone**, so unmigrated code lands sanely —
 that is not a scale, and new code must use the named utilities.
+
+### #741 C2 phase 2 — what landed
+Commit `e4dde07` on `dev/2608-DEV-741`, on top of `8bec163` (CLAIM).
+
+`components/layout/*` (Header, Footer, UserDropdown, BellButton, NotificationPopup) colour
+literals migrated to tokens. Header's active nav-pill background (`rgba(188,71,73,0.12)`) reuses
+`var(--status-alert-bg)` — an exact value match in both themes. Black-rgba border/shadow literals
+(logo ring, mobile drawer) consolidated onto `var(--border-default)` / `var(--shadow-modal)` —
+deliberate deviation (black → forest-tinted default at the same alpha), same pattern as phase 1's
+drag-handle call. `hover:bg-black/[x]` → `hover:bg-hover-surface` throughout.
+
+**Footer needed a different treatment**: its `--brand-forest` fill is fixed in both themes (not a
+swapped surface token), so its white/oyster-tinted borders, icon strokes, hover wash and copyright
+text needed RGB-channel compositing helpers, not a theme-swapped token pair. Added `--white-rgb`
+and `--brand-oyster-rgb` (same pattern as phase 1's `--brand-stone-rgb`/`--brand-sienna-rgb`) plus
+a new `--on-accent-hover` token (`rgba(255,255,255,0.10)`, no dark override needed) mapped into
+Tailwind via `@theme inline`, replacing `hover:bg-white/10`. `text-white` on crimson/forest badge
+fills → `text-on-accent`, C1's existing token for exactly that case.
+
+**Deliberately not touched**: `Footer.tsx:32`'s `filter: brightness(0) invert(1)` logo forcing and
+the 4 JS theme branches are C3 scope. `app/(dashboard)/**` and `app/admin/**` are phases 3/4.
+
+**Verified:** `npx tsc --noEmit` clean; `npx vitest run` 529 passed / 37 files (no regression);
+`npx eslint` on all changed files → 0 errors; real `app/globals.css` compiled through
+`@tailwindcss/postcss` confirms `hover:bg-on-accent-hover` emits
+`background-color: var(--on-accent-hover)` and `text-on-accent` resolves. **NOT visually verified
+locally** — Vercel preview is the gate. `/code-review low` run, pending result at time of writing.
 
 ### #741 C2 phase 1 — what landed
 Commits `f9a2e00` (CLAIM) + `f0773d3` (BUILD) on `dev/2608-DEV-741`, PR #754 (draft).

--- a/docs/design/DESIGN-SYSTEM.md
+++ b/docs/design/DESIGN-SYSTEM.md
@@ -75,6 +75,7 @@ literals 513 times, and every one of them is wrong in dark mode.
 | `--on-accent` | parchment | parchment | Text/icons on a crimson / forest / teal fill |
 | `--overlay` | `rgba(26,31,24,.40)` | `rgba(0,0,0,.60)` | Dialog and sheet scrims |
 | `--hover-surface` | `rgba(45,51,42,.05)` | `rgba(250,248,243,.08)` | Hover tints |
+| `--on-accent-hover` | `rgba(255,255,255,.10)` | same | Hover wash on a fill that does not swap with theme (footer icon buttons) |
 | `--focus-ring` | crimson | `#6FAEBE` | Focus rings |
 
 `color-scheme` is set alongside them (`light` on `:root`, `dark` on

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -23,6 +23,8 @@
      Same pattern as --bg-global-rgb below. Keep in sync with the hex above. */
   --brand-stone-rgb:  138, 133, 119;
   --brand-sienna-rgb: 224, 122, 95;
+  --white-rgb:        255, 255, 255;
+  --brand-oyster-rgb: 240, 237, 230;
 
   /* ── Primitive aliases — legacy callers use bare token names ── */
   --sienna: var(--brand-sienna);
@@ -111,6 +113,11 @@
 
   /* The single biggest source of dark-mode invisibility: hover:bg-black/[0.02-0.05]. */
   --hover-surface:   rgba(45, 51, 42, 0.05);
+
+  /* Hover wash for controls on a fill that does NOT swap with theme (footer's
+     --brand-forest is constant in both themes) — distinct from --hover-surface,
+     which is for the surfaces that DO swap. No dark override needed. */
+  --on-accent-hover: rgba(255, 255, 255, 0.10);
 
   /* Must clear 3:1 against BOTH the page and card surface of its own theme.
      Crimson does in light (4.78 / 4.34) but only 2.86 on the dark card, which


### PR DESCRIPTION
## Summary
- #741 C2 phase 2 (of the phased colour-literal migration; phase 1 merged as #754): `components/layout/*` (Header, Footer, UserDropdown, BellButton, NotificationPopup) hardcoded colour literals migrated to semantic tokens.
- Header's active nav-pill background reuses the existing `--status-alert-bg` (exact value match in both themes). Black-rgba border/shadow literals consolidated onto `--border-default` / `--shadow-modal` (deliberate deviation — same alpha, colour shifts from pure black to the forest-tinted default; same pattern as phase 1's drag-handle call). `hover:bg-black/[x]` → `hover:bg-hover-surface` throughout.
- Footer's `--brand-forest` fill is fixed in both themes (not a swapped surface token), so its white/oyster-tinted borders, icon strokes, hover wash and copyright text needed RGB-channel compositing helpers rather than a theme-swapped pair: added `--white-rgb` / `--brand-oyster-rgb` (same pattern as phase 1's `--brand-stone-rgb`/`--brand-sienna-rgb`) and a new `--on-accent-hover` token, mapped into Tailwind via `@theme inline`.
- **Deliberately not touched**: `Footer.tsx:32`'s `filter: brightness(0) invert(1)` logo forcing and the 4 JS theme branches are C3 scope. `app/(dashboard)/**` and `app/admin/**` are phases 3/4.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 529 passed / 37 files (no regression vs baseline)
- [x] `npx eslint` on all changed files — 0 errors
- [x] Real `app/globals.css` compiled through `@tailwindcss/postcss` — confirms `hover:bg-on-accent-hover` emits `background-color: var(--on-accent-hover)` and `text-on-accent` resolves
- [x] `/code-review low` — no findings
- [ ] Manual light/dark 390px check against the Vercel preview (Header logo ring + active pill, Footer borders/icons/hover/copyright text, BellButton/UserDropdown badges, NotificationPopup hover rows) — zero intended visual change in light mode is the review invariant
- [ ] CI green + Vercel preview READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved theme support across headers, footers, notifications, user menus, and notification controls.
  * Updated hover states, borders, icons, text, badges, and navigation highlights to use consistent theme-aware colors.
  * Added color tokens to ensure accent and surface styling displays consistently across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->