### PR TITLE
[2608-DEV-741] C2 phase 3 (calendar): colour literals to tokens

### DIFF
--- a/app/(dashboard)/calendar/components/AgendaView.tsx
+++ b/app/(dashboard)/calendar/components/AgendaView.tsx
@@ -75,8 +75,8 @@ export function AgendaView({
       <div className="px-4 py-4 space-y-4">
         {[...Array(4)].map((_, i) => (
           <div key={i} className="space-y-2">
-            <div className="h-6 w-32 rounded-control animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
-            <div className="h-16 rounded-container animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.04)' }} />
+            <div className="h-6 w-32 rounded-control animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
+            <div className="h-16 rounded-container animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
           </div>
         ))}
       </div>
@@ -108,8 +108,8 @@ export function AgendaView({
               <div
                 className="flex items-center gap-2 px-3 py-1 rounded-control text-xs font-semibold"
                 style={{
-                  backgroundColor: isToday ? 'var(--crimson)' : 'rgba(0,0,0,0.06)',
-                  color: isToday ? 'white' : 'var(--text-primary)',
+                  backgroundColor: isToday ? 'var(--crimson)' : 'var(--hover-surface)',
+                  color: isToday ? 'var(--on-accent)' : 'var(--text-primary)',
                 }}
               >
                 {formatShortDate(date)}
@@ -130,8 +130,8 @@ export function AgendaView({
                     className="w-full text-left rounded-container border overflow-hidden hover:shadow-sm transition-shadow flex scroll-mt-20 md:scroll-mt-0"
                     style={{
                       backgroundColor: 'var(--bg-card)',
-                      borderColor: isHighlighted ? 'var(--brand-crimson)' : 'rgba(0,0,0,0.05)',
-                      boxShadow: isHighlighted ? '0 0 0 2px rgba(188,71,73,0.25)' : undefined,
+                      borderColor: isHighlighted ? 'var(--brand-crimson)' : 'var(--border-default)',
+                      boxShadow: isHighlighted ? '0 0 0 2px rgba(var(--brand-crimson-rgb), 0.25)' : undefined,
                     }}
                   >
                     <div className="w-1 flex-shrink-0" style={{ backgroundColor: c.bg }} />

--- a/app/(dashboard)/calendar/components/AgendaView.tsx
+++ b/app/(dashboard)/calendar/components/AgendaView.tsx
@@ -76,7 +76,7 @@ export function AgendaView({
         {[...Array(4)].map((_, i) => (
           <div key={i} className="space-y-2">
             <div className="h-6 w-32 rounded-control animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
-            <div className="h-16 rounded-container animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
+            <div className="h-16 rounded-container animate-pulse" style={{ backgroundColor: 'var(--bg-card-raised)' }} />
           </div>
         ))}
       </div>

--- a/app/(dashboard)/calendar/components/CalendarClient.tsx
+++ b/app/(dashboard)/calendar/components/CalendarClient.tsx
@@ -162,7 +162,7 @@ export default function CalendarClient({
       <Dialog open={!!selectedEventId} onOpenChange={open => { if (!open) handleClose() }}>
         <DialogPortal>
           <DialogOverlay
-            style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}
+            style={{ backgroundColor: 'var(--overlay)' }}
           />
           <DialogContent
             className="fixed flex flex-col overflow-hidden p-0
@@ -170,7 +170,7 @@ export default function CalendarClient({
               md:inset-x-auto md:bottom-auto md:top-1/2 md:left-1/2 md:w-[360px] md:max-h-[80vh] md:rounded-container md:-translate-x-1/2 md:-translate-y-1/2"
             style={{
               backgroundColor: 'var(--bg-global)',
-              boxShadow: '0 8px 40px rgba(0,0,0,0.22)',
+              boxShadow: 'var(--shadow-modal)',
             }}
           >
             {selectedEventId && (

--- a/app/(dashboard)/calendar/components/FilterControls.tsx
+++ b/app/(dashboard)/calendar/components/FilterControls.tsx
@@ -49,7 +49,7 @@ export function FilterControls({
           <div className="flex items-center justify-between gap-2 py-2.5">
             <div className="flex items-center gap-1 min-w-0">
               <button onClick={() => navigate(-1)} aria-label={t('cal.prevMonth')}
-                className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-black/5 flex-shrink-0"
+                className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-hover-surface flex-shrink-0"
                 style={{ color: 'var(--text-primary)' }}>
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                   stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -62,7 +62,7 @@ export function FilterControls({
                 {t('cal.today')}
               </button>
               <button onClick={() => navigate(1)} aria-label={t('cal.nextMonth')}
-                className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-black/5 flex-shrink-0"
+                className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-hover-surface flex-shrink-0"
                 style={{ color: 'var(--text-primary)' }}>
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
                   stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -73,14 +73,14 @@ export function FilterControls({
                 {periodLabel}
               </p>
             </div>
-            <div className="flex gap-0.5 p-0.5 rounded-lg flex-shrink-0" style={{ backgroundColor: 'rgba(0,0,0,0.05)' }}>
+            <div className="flex gap-0.5 p-0.5 rounded-lg flex-shrink-0" style={{ backgroundColor: 'var(--hover-surface)' }}>
               {VIEWS.map(v => (
                 <button key={v.key} onClick={() => setView(v.key)}
                   className="px-2.5 py-1 rounded-md text-xs font-medium transition-all"
                   style={{
-                    backgroundColor: view === v.key ? 'white' : 'transparent',
+                    backgroundColor: view === v.key ? 'var(--bg-card)' : 'transparent',
                     color: view === v.key ? 'var(--text-primary)' : 'var(--text-secondary)',
-                    boxShadow: view === v.key ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
+                    boxShadow: view === v.key ? 'var(--shadow-rest)' : 'none',
                   }}>
                   {v.label(t)}
                 </button>
@@ -98,12 +98,12 @@ export function FilterControls({
               aria-pressed={showN21}
               className="flex items-center gap-1 px-2.5 py-1 rounded-control text-xs font-semibold flex-shrink-0 transition-all"
               style={{
-                backgroundColor: showN21 ? 'var(--forest)' : 'rgba(0,0,0,0.05)',
-                color: showN21 ? 'white' : 'var(--text-secondary)',
+                backgroundColor: showN21 ? 'var(--forest)' : 'var(--hover-surface)',
+                color: showN21 ? 'var(--on-accent)' : 'var(--text-secondary)',
               }}
             >
               <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                style={{ backgroundColor: showN21 ? 'rgba(255,255,255,0.6)' : 'var(--forest)' }} />
+                style={{ backgroundColor: showN21 ? 'rgba(var(--white-rgb), 0.6)' : 'var(--forest)' }} />
               N21
             </button>
             {canSeePersonal && (
@@ -112,12 +112,12 @@ export function FilterControls({
                 aria-pressed={showPersonal}
                 className="flex items-center gap-1 px-2.5 py-1 rounded-control text-xs font-semibold flex-shrink-0 transition-all"
                 style={{
-                  backgroundColor: showPersonal ? 'var(--sienna)' : 'rgba(0,0,0,0.05)',
-                  color: showPersonal ? 'white' : 'var(--text-secondary)',
+                  backgroundColor: showPersonal ? 'var(--sienna)' : 'var(--hover-surface)',
+                  color: showPersonal ? 'var(--on-accent)' : 'var(--text-secondary)',
                 }}
               >
                 <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                  style={{ backgroundColor: showPersonal ? 'rgba(255,255,255,0.6)' : 'var(--sienna)' }} />
+                  style={{ backgroundColor: showPersonal ? 'rgba(var(--white-rgb), 0.6)' : 'var(--sienna)' }} />
                 {t('cal.personal')}
               </button>
             )}
@@ -129,8 +129,8 @@ export function FilterControls({
                 aria-pressed={filterType === type}
                 className="px-2.5 py-1 rounded-control text-xs font-semibold flex-shrink-0 transition-all"
                 style={{
-                  backgroundColor: filterType === type ? 'var(--brand-teal)' : 'rgba(0,0,0,0.05)',
-                  color: filterType === type ? 'white' : 'var(--text-secondary)',
+                  backgroundColor: filterType === type ? 'var(--brand-teal)' : 'var(--hover-surface)',
+                  color: filterType === type ? 'var(--on-accent)' : 'var(--text-secondary)',
                 }}
               >
                 {typeLabel(type, t)}
@@ -151,7 +151,7 @@ export function FilterControls({
           </p>
           <div className="flex gap-1 mt-2">
             <button onClick={() => navigate(-1)} aria-label={t('cal.prevMonth')}
-              className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-black/5 transition-colors flex-shrink-0"
+              className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-hover-surface transition-colors flex-shrink-0"
               style={{ color: 'var(--text-primary)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -159,7 +159,7 @@ export function FilterControls({
               </svg>
             </button>
             <button onClick={() => navigate(1)} aria-label={t('cal.nextMonth')}
-              className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-black/5 transition-colors flex-shrink-0"
+              className="w-11 h-11 flex items-center justify-center rounded-lg hover:bg-hover-surface transition-colors flex-shrink-0"
               style={{ color: 'var(--text-primary)' }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                 stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -168,7 +168,7 @@ export function FilterControls({
             </button>
           </div>
           <button onClick={goToday}
-            className="mt-2 w-full px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors hover:bg-black/[0.02]"
+            className="mt-2 w-full px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors hover:bg-hover-surface"
             style={{ borderColor: 'var(--crimson)', color: 'var(--crimson)' }}>
             {t('cal.today')}
           </button>
@@ -181,7 +181,7 @@ export function FilterControls({
               <button key={v.key} onClick={() => setView(v.key)}
                 className="w-full text-left px-3 py-2 rounded-lg text-xs font-medium transition-all"
                 style={{
-                  backgroundColor: view === v.key ? 'rgba(188,71,73,0.08)' : 'transparent',
+                  backgroundColor: view === v.key ? 'rgba(var(--brand-crimson-rgb), 0.08)' : 'transparent',
                   color: view === v.key ? 'var(--brand-crimson)' : 'var(--text-secondary)',
                   fontWeight: view === v.key ? 600 : 400,
                 }}>
@@ -197,22 +197,22 @@ export function FilterControls({
             <button onClick={() => setShowN21(v => !v)} aria-pressed={showN21}
               className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-semibold transition-all"
               style={{
-                backgroundColor: showN21 ? 'var(--forest)' : 'rgba(0,0,0,0.04)',
-                color: showN21 ? 'white' : 'var(--text-secondary)',
+                backgroundColor: showN21 ? 'var(--forest)' : 'var(--bg-card-raised)',
+                color: showN21 ? 'var(--on-accent)' : 'var(--text-secondary)',
               }}>
               <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                style={{ backgroundColor: showN21 ? 'rgba(255,255,255,0.6)' : 'var(--forest)' }} />
+                style={{ backgroundColor: showN21 ? 'rgba(var(--white-rgb), 0.6)' : 'var(--forest)' }} />
               N21
             </button>
             {canSeePersonal && (
               <button onClick={() => setShowPersonal(v => !v)} aria-pressed={showPersonal}
                 className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-semibold transition-all"
                 style={{
-                  backgroundColor: showPersonal ? 'var(--sienna)' : 'rgba(0,0,0,0.04)',
-                  color: showPersonal ? 'white' : 'var(--text-secondary)',
+                  backgroundColor: showPersonal ? 'var(--sienna)' : 'var(--bg-card-raised)',
+                  color: showPersonal ? 'var(--on-accent)' : 'var(--text-secondary)',
                 }}>
                 <span className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                  style={{ backgroundColor: showPersonal ? 'rgba(255,255,255,0.6)' : 'var(--sienna)' }} />
+                  style={{ backgroundColor: showPersonal ? 'rgba(var(--white-rgb), 0.6)' : 'var(--sienna)' }} />
                 {t('cal.personal')}
               </button>
             )}
@@ -226,8 +226,8 @@ export function FilterControls({
               <button key={type} onClick={() => setFilterType(filterType === type ? null : type)} aria-pressed={filterType === type}
                 className="w-full text-left px-3 py-2 rounded-lg text-xs font-semibold transition-all"
                 style={{
-                  backgroundColor: filterType === type ? 'var(--brand-teal)' : 'rgba(0,0,0,0.04)',
-                  color: filterType === type ? 'white' : 'var(--text-secondary)',
+                  backgroundColor: filterType === type ? 'var(--brand-teal)' : 'var(--bg-card-raised)',
+                  color: filterType === type ? 'var(--on-accent)' : 'var(--text-secondary)',
                 }}>
                 {typeLabel(type, t)}
               </button>

--- a/app/(dashboard)/calendar/components/popup/AttendSection.tsx
+++ b/app/(dashboard)/calendar/components/popup/AttendSection.tsx
@@ -52,7 +52,7 @@ export default function AttendSection({
       <div className="flex items-center gap-3">
         <span
           className="flex items-center gap-1 text-[10px] font-semibold px-2 py-0.5 rounded-control"
-          style={{ backgroundColor: 'var(--status-success-bg, rgba(129,178,154,0.18))', color: 'var(--status-success-fg, #2d6a4f)' }}
+          style={{ backgroundColor: 'var(--status-success-bg)', color: 'var(--status-success-fg)' }}
         >
           <Check size={10} />
           {t('cal.attending')}

--- a/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
+++ b/app/(dashboard)/calendar/components/popup/EventPopupShell.tsx
@@ -83,12 +83,12 @@ export default function EventPopupShell({
   return (
     <>
       {/* Header */}
-      <div className="px-4 pt-3 pb-3 border-b border-black/5 flex-shrink-0">
+      <div className="px-4 pt-3 pb-3 border-b border-border-default flex-shrink-0">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-1.5 flex-wrap mb-1.5">
               <span className="text-[10px] font-semibold px-2 py-0.5 rounded-xl"
-                style={{ backgroundColor: event?.category === 'N21' ? 'var(--brand-forest)' : 'var(--brand-sienna)', color: 'rgba(255,255,255,0.9)' }}>
+                style={{ backgroundColor: event?.category === 'N21' ? 'var(--brand-forest)' : 'var(--brand-sienna)', color: 'var(--on-accent)' }}>
                 {event?.category ?? '…'}
               </span>
               {eventTypeStyle && (
@@ -139,7 +139,7 @@ export default function EventPopupShell({
                 container so the Roles tab renders exactly as before — a sibling
                 block would add a second divider to a screen that has no bug. */}
             {(showMeta || showActions) && (
-              <div className="px-4 py-3 border-b border-black/5">
+              <div className="px-4 py-3 border-b border-border-default">
                 {showMeta && (
                   <>
                     <div className="flex items-center gap-2 text-xs mb-1" style={{ color: 'var(--text-primary)' }}>
@@ -257,7 +257,7 @@ export default function EventPopupShell({
 
       <Dialog open={qrDataUrl !== null} onOpenChange={(open) => { if (!open) onQrDismiss() }}>
         <DialogPortal>
-          <DialogOverlay className="z-[60]" style={{ backgroundColor: 'rgba(0,0,0,0.32)' }} />
+          <DialogOverlay className="z-[60]" style={{ backgroundColor: 'var(--overlay)' }} />
           <DialogContent
             className="left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 p-5 z-[60]"
             style={{ width: 320, maxWidth: '90vw', border: '1px solid var(--border-default)' }}
@@ -293,7 +293,7 @@ export default function EventPopupShell({
                 />
                 <button
                   onClick={downloadQr}
-                  className="flex items-center gap-1.5 rounded-xl px-5 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+                  className="flex items-center gap-1.5 rounded-xl px-5 py-2 text-sm font-semibold text-on-accent transition-opacity hover:opacity-90"
                   style={{ backgroundColor: 'var(--brand-teal)' }}
                 >
                   <Download size={14} />

--- a/app/(dashboard)/calendar/components/popup/PendingPopover.tsx
+++ b/app/(dashboard)/calendar/components/popup/PendingPopover.tsx
@@ -26,7 +26,7 @@ export function PendingPopover({ profiles, color }: { profiles: PendingProfile[]
         side="top"
         align="center"
         className="p-2 min-w-0 w-auto max-w-[200px]"
-        style={{ backgroundColor: 'var(--bg-card)', border: '1px solid rgba(0,0,0,0.08)' }}
+        style={{ backgroundColor: 'var(--bg-card)', border: '1px solid var(--border-default)' }}
       >
         <p className="text-[10px] font-semibold tracking-wider uppercase mb-1.5" style={{ color: 'var(--text-secondary)' }}>
           Requested by

--- a/app/(dashboard)/calendar/utils.ts
+++ b/app/(dashboard)/calendar/utils.ts
@@ -11,8 +11,8 @@ export const HOURS = Array.from({ length: 24 }, (_, i) => i)
 export const HOUR_HEIGHT = 60
 
 export const CATEGORY_COLOR: Record<string, { bg: string; text: string }> = {
-  N21:      { bg: 'var(--brand-forest)',  text: 'rgba(255,255,255,0.95)' },
-  Personal: { bg: 'var(--brand-sienna)', text: 'rgba(255,255,255,0.95)' },
+  N21:      { bg: 'var(--brand-forest)',  text: 'rgba(var(--white-rgb), 0.95)' },
+  Personal: { bg: 'var(--brand-sienna)', text: 'rgba(var(--white-rgb), 0.95)' },
 }
 
 // Moved to lib/calendar-dates.ts (shared with app/api/calendar/feed.ics) —

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #741 | `dev/2608-DEV-741` | **migration: no** — `components/layout/Header.tsx`, `components/layout/Footer.tsx`, `components/layout/UserDropdown.tsx`, `components/layout/BellButton.tsx`, `components/layout/NotificationPopup.tsx`, `styles/brand-tokens.css`, `app/globals.css`, `docs/design/DESIGN-SYSTEM.md` | 2026-08-17 |
+| #741 | `dev/2608-DEV-741` | **migration: no** — `app/(dashboard)/calendar/**` (sub-slice of C2 phase 3), `styles/brand-tokens.css` | 2026-08-17 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,11 +6,14 @@ co-owner path — plus the two data defects that made its target population invi
 
 ## Now
 
-#741 C2 phase 2 (`components/layout/*`) BUILD complete on `dev/2608-DEV-741` (branch reset off
-`main` after phase 1's squash-merge as `cac8eb4` — the local branch's 3 pre-merge commits were
-superseded, not lost). `/code-review low` running in background. Next action: address any findings,
-then push and open PR as DRAFT, wait for CI green + Vercel preview READY, do the manual light/dark
-390px check, then mark ready for review.
+#741 C2 phase 2 merged as PR #755. Phase 3 (`app/(dashboard)/**`, 158 literals / 28 files) is too
+large for one PR, so it's sub-split by feature directory — one PR per directory. First sub-slice,
+`calendar/**`, BUILD complete on `dev/2608-DEV-741` (branch reset off `main` @ `8fa4c67` after
+phase 2's squash-merge). `/code-review low` running in background. Next action: address any
+findings, then push and open PR, wait for CI green + Vercel preview READY, do the manual light/dark
+390px check, then mark ready for review. Remaining phase 3 sub-slices (not started):
+`components/tiles/*`, `guides/` + `library/[slug]/`, `profile/*`, `roles/*`, `trips/*`,
+`los/page.tsx` + `notifications/page.tsx`.
 
 ### #742 — what this branch does
 
@@ -116,6 +119,34 @@ value cannot serve a 200px card and a 19px badge. Now:
 `--radius-sm` is 2px (hairline). `--radius-md/lg/xl` are pinned to the control tier and
 `--radius-2xl` to the container tier as a **legacy landing zone**, so unmigrated code lands sanely —
 that is not a scale, and new code must use the named utilities.
+
+### #741 C2 phase 3 (calendar sub-slice) — what landed
+Commit `bfa2c31` on `dev/2608-DEV-741`, on top of `a0d1582` (CLAIM).
+
+`app/(dashboard)/calendar/**` (utils.ts + 6 components) migrated. `CalendarClient.tsx:165`'s
+`rgba(0,0,0,0.4)` → `var(--overlay)` is the exact call site C1's foundation table named as
+`--overlay`'s origin case — C1 only added the token, this is the first place it's actually applied.
+Same pattern for the QR-share dialog scrim and the mobile drawer shadow → `var(--overlay)` /
+`var(--shadow-modal)`. FilterControls' view-switcher active tab was a bare `'white'` — a real
+dark-mode bug (failed to darken), not just an untidy literal — now `var(--bg-card)`. New
+`--brand-crimson-rgb` companion (matches phase 2's `--white-rgb`/`--brand-oyster-rgb` pattern) for
+two call sites needing crimson at an alpha with no exact existing token. `AttendSection.tsx` also
+had a `var(--x, rgba(...))` CSS fallback whose fallback value didn't even match the current token
+and could never render (the var always resolves) — removed as dead code, not migrated.
+
+**Verified:** `npx tsc --noEmit` clean; `npx vitest run` 529 passed / 37 files (no regression);
+`npx eslint` on all changed files → 0 errors; real `app/globals.css` compiled through
+`@tailwindcss/postcss` confirms `.border-border-default` emits. **NOT visually verified locally**
+— Vercel preview is the gate.
+
+`/code-review low` (`c05b868`) flagged 4 items; 3 were false positives from diff-only context
+(`--shadow-modal` already existed pre-diff in C1; the removed `var(x, fallback)` in
+`AttendSection.tsx` was dead code with a stale fallback value, consistent with the fallback-free
+usage already in this same PR's `EventPopupShell.tsx`; the mobile/desktop inactive-pill tokens
+were already two different literal values pre-migration, not a new inconsistency). One was real
+and fixed: AgendaView's two skeleton bars had collapsed onto one shared token, losing their
+original two-tier opacity — now `--skeleton-base` / `--bg-card-raised` respectively (the latter an
+exact value match).
 
 ### #741 C2 phase 2 — what landed
 Commit `e4dde07` on `dev/2608-DEV-741`, on top of `8bec163` (CLAIM).

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -25,6 +25,7 @@
   --brand-sienna-rgb: 224, 122, 95;
   --white-rgb:        255, 255, 255;
   --brand-oyster-rgb: 240, 237, 230;
+  --brand-crimson-rgb: 188, 71, 73;
 
   /* ── Primitive aliases — legacy callers use bare token names ── */
   --sienna: var(--brand-sienna);


### PR DESCRIPTION
## Summary
- #741 C2 phase 3, calendar sub-slice. `app/(dashboard)/**` is 158 literals across 28 files — too large for one PR — so phase 3 is split by feature directory; this is the first slice (`calendar/**`), chosen because the calendar popup's contrast bug is the issue's original motivating case.
- `CalendarClient.tsx:165`'s `rgba(0,0,0,0.4)` → `var(--overlay)` is the exact call site C1's foundation table named as `--overlay`'s origin case — C1 only added the token, this is the first place it's actually applied. Same pattern for the QR-share dialog scrim and the mobile drawer shadow.
- `FilterControls.tsx`'s view-switcher active tab was a bare `'white'` — a real dark-mode bug (never darkened), not just an untidy literal — now `var(--bg-card)`.
- New `--brand-crimson-rgb` companion (matches phase 2's `--white-rgb`/`--brand-oyster-rgb` pattern) for two call sites needing crimson at an alpha with no exact existing token.
- `AttendSection.tsx` had a `var(--x, rgba(...))` CSS fallback whose fallback value didn't match the live token and could never render (the var always resolves) — removed as dead code.
- `/code-review low` flagged 4 items; 3 were false positives from diff-only context (details in STATE.md); one was real and fixed — AgendaView's two skeleton bars had collapsed onto one shared token, now restored to their original two-tier opacity via exact-matching tokens.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 529 passed / 37 files (no regression vs baseline)
- [x] `npx eslint` on all changed files — 0 errors
- [x] Real `app/globals.css` compiled through `@tailwindcss/postcss` — confirms `.border-border-default` emits
- [x] `/code-review low` — 1 real finding, fixed
- [ ] Manual light/dark 390px check against the Vercel preview (calendar agenda/month views, filter pills, event popup, QR share dialog) — zero intended visual change in light mode is the review invariant
- [ ] CI green + Vercel preview READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V7Ke7Qprky95gR3UAW1AD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated calendar views, filters, dialogs, popovers, badges, and event categories to use consistent theme-based colors.
  * Improved visual consistency across light and dark themes.
  * Added a shared brand color token for more reliable styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->