### PR TITLE
[2608-DEV-741] C2 phase 3 (tiles): colour literals to tokens

### DIFF
--- a/app/(dashboard)/components/tiles/CalendarTile.tsx
+++ b/app/(dashboard)/components/tiles/CalendarTile.tsx
@@ -135,7 +135,7 @@ export default function CalendarTile({ events = [], colSpan, mobileColSpan, rowS
                     {pipLabel && (
                       <span
                         className="ml-1.5 text-[9px] font-bold tracking-widest align-middle"
-                        style={{ color: '#bc4749' }}
+                        style={{ color: 'var(--brand-crimson)' }}
                       >
                         {pipLabel}
                       </span>
@@ -160,7 +160,7 @@ export default function CalendarTile({ events = [], colSpan, mobileColSpan, rowS
                   >
                     <span
                       className="text-[10px] font-medium tracking-widest uppercase leading-none"
-                      style={{ color: 'rgba(255,255,255,0.92)' }}
+                      style={{ color: 'rgba(var(--white-rgb), 0.92)' }}
                     >
                       {monthLabel}
                     </span>

--- a/app/(dashboard)/components/tiles/ProfileTile.tsx
+++ b/app/(dashboard)/components/tiles/ProfileTile.tsx
@@ -25,10 +25,10 @@ type Profile = {
 }
 
 const ROLE_STYLES: Record<string, { bg: string; color: string }> = {
-  admin:  { bg: 'rgba(250,248,243,0.20)', color: 'var(--brand-parchment)' },
-  core:   { bg: 'rgba(250,248,243,0.20)', color: 'var(--brand-parchment)' },
-  member: { bg: 'rgba(250,248,243,0.20)', color: 'var(--brand-parchment)' },
-  guest:  { bg: 'rgba(250,248,243,0.12)', color: 'rgba(250,248,243,0.70)' },
+  admin:  { bg: 'rgba(var(--brand-parchment-rgb), 0.20)', color: 'var(--brand-parchment)' },
+  core:   { bg: 'rgba(var(--brand-parchment-rgb), 0.20)', color: 'var(--brand-parchment)' },
+  member: { bg: 'rgba(var(--brand-parchment-rgb), 0.20)', color: 'var(--brand-parchment)' },
+  guest:  { bg: 'rgba(var(--brand-parchment-rgb), 0.12)', color: 'rgba(var(--brand-parchment-rgb), 0.70)' },
 }
 
 export default function ProfileTile({
@@ -99,9 +99,9 @@ export default function ProfileTile({
     return (
       <BentoCard variant="teal" colSpan={colSpan} mobileColSpan={mobileColSpan} rowSpan={rowSpan} style={style} className="flex flex-col justify-between">
         <div className="flex items-center justify-end">
-          <div className="h-3 w-16 rounded animate-pulse" style={{ backgroundColor: 'rgba(250,248,243,0.15)' }} />
+          <div className="h-3 w-16 rounded animate-pulse" style={{ backgroundColor: 'rgba(var(--brand-parchment-rgb), 0.15)' }} />
         </div>
-        <div className="h-6 w-24 rounded-container animate-pulse" style={{ backgroundColor: 'rgba(250,248,243,0.15)' }} />
+        <div className="h-6 w-24 rounded-container animate-pulse" style={{ backgroundColor: 'rgba(var(--brand-parchment-rgb), 0.15)' }} />
       </BentoCard>
     )
   }
@@ -119,7 +119,7 @@ export default function ProfileTile({
           <h2 className="font-display text-2xl font-semibold mt-3" style={{ color: 'var(--brand-parchment)' }}>
             {t('profile.heyGuest')}
           </h2>
-          <p className="text-sm mt-2 font-body" style={{ color: 'rgba(250,248,243,0.70)' }}>
+          <p className="text-sm mt-2 font-body" style={{ color: 'rgba(var(--brand-parchment-rgb), 0.70)' }}>
             {t('profile.signInDesc')}
           </p>
         </div>
@@ -150,10 +150,10 @@ export default function ProfileTile({
             Hey, {displayName ?? t('home.profile.there')}.
           </h2>
           <span className="inline-block mt-2 text-xs font-semibold px-2.5 py-1 rounded-control"
-            style={{ backgroundColor: 'rgba(250,248,243,0.15)', color: 'var(--brand-parchment)' }}>
+            style={{ backgroundColor: 'rgba(var(--brand-parchment-rgb), 0.15)', color: 'var(--brand-parchment)' }}>
             {t(badgeKey)}
           </span>
-          <p className="text-xs mt-2 font-body" style={{ color: 'rgba(250,248,243,0.70)' }}>
+          <p className="text-xs mt-2 font-body" style={{ color: 'rgba(var(--brand-parchment-rgb), 0.70)' }}>
             {t(descKey)}
           </p>
         </div>
@@ -184,7 +184,7 @@ export default function ProfileTile({
             {t(('role.' + role) as TranslationKey)}
           </span>
           {uplineData?.upline_name && (
-            <span className="text-xs font-body" style={{ color: 'rgba(250,248,243,0.70)' }}>
+            <span className="text-xs font-body" style={{ color: 'rgba(var(--brand-parchment-rgb), 0.70)' }}>
               ↑ {uplineData.upline_name}
             </span>
           )}
@@ -197,7 +197,7 @@ export default function ProfileTile({
           <Link
             href="/profile/spouse-link"
             className="flex items-center gap-2 mt-3 px-3 py-2 rounded-control"
-            style={{ backgroundColor: 'rgba(250,248,243,0.15)', textDecoration: 'none' }}
+            style={{ backgroundColor: 'rgba(var(--brand-parchment-rgb), 0.15)', textDecoration: 'none' }}
           >
             <span className="text-xs font-medium" style={{ color: 'var(--brand-parchment)' }}>
               {pendingSpouseLinkCount === 1

--- a/app/(dashboard)/components/tiles/SocialsTile.tsx
+++ b/app/(dashboard)/components/tiles/SocialsTile.tsx
@@ -106,7 +106,7 @@ export default function SocialsTile({
     >
       {isLoading && (
         <div className="flex-1 flex flex-col justify-center gap-3 mt-3 md:mt-0">
-          <div className="h-14 rounded-container animate-pulse" style={{ backgroundColor: 'rgba(0,0,0,0.06)' }} />
+          <div className="h-14 rounded-container animate-pulse" style={{ backgroundColor: 'var(--skeleton-base)' }} />
         </div>
       )}
 
@@ -156,7 +156,7 @@ export default function SocialsTile({
           <div className="absolute top-0 left-0 right-0 flex items-start justify-between gap-2 px-5 pt-5 z-20 pointer-events-none">
             <span
               className="inline-flex items-center gap-1.5 font-body text-[11px] font-medium capitalize px-2 py-1 rounded-control min-w-0"
-              style={{ backgroundColor: 'rgba(26,31,24,0.55)', color: 'var(--on-accent)' }}
+              style={{ backgroundColor: 'rgba(var(--brand-void-rgb), 0.55)', color: 'var(--on-accent)' }}
             >
               {post.platform === 'instagram' ? <InstagramIcon /> : <FacebookIcon />}
               <span className="truncate">{post.platform}</span>
@@ -171,7 +171,7 @@ export default function SocialsTile({
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-body text-[11px] font-bold tracking-widest uppercase pill-link-parchment pointer-events-auto whitespace-nowrap shrink-0"
-                style={{ backgroundColor: 'rgba(26,31,24,0.55)' }}
+                style={{ backgroundColor: 'rgba(var(--brand-void-rgb), 0.55)' }}
               >
                 {t('home.socials.followLink')}
               </a>

--- a/app/(dashboard)/components/tiles/TripHeroTile.tsx
+++ b/app/(dashboard)/components/tiles/TripHeroTile.tsx
@@ -55,7 +55,7 @@ export default function TripHeroTile({ trip }: Props) {
       <div className="absolute bottom-0 left-0 right-0 px-5 pb-5 z-10 pointer-events-none">
         <span
           className="inline-block font-body text-[9px] font-bold tracking-widest uppercase px-2.5 py-1 rounded-xl mb-2"
-          style={{ backgroundColor: 'rgba(255,255,255,0.18)', color: 'var(--brand-parchment)', opacity: 0.55 }}
+          style={{ backgroundColor: 'rgba(var(--white-rgb), 0.18)', color: 'var(--brand-parchment)', opacity: 0.55 }}
         >
           {t('home.trips.nextTrip')}
         </span>
@@ -68,11 +68,11 @@ export default function TripHeroTile({ trip }: Props) {
         <div className="flex items-center gap-2 mt-1">
           <span
             className="font-body text-[11px] font-bold px-2.5 py-1 rounded-xl"
-            style={{ backgroundColor: 'rgba(255,255,255,0.18)', color: 'var(--brand-parchment)' }}
+            style={{ backgroundColor: 'rgba(var(--white-rgb), 0.18)', color: 'var(--brand-parchment)' }}
           >
             {trip.destination}
           </span>
-          <p className="font-body text-[12px]" style={{ color: 'rgba(242,239,232,0.65)' }}>
+          <p className="font-body text-[12px]" style={{ color: 'rgba(var(--brand-oyster-rgb), 0.65)' }}>
             {formatDate(trip.start_date)}
           </p>
         </div>

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #741 | `dev/2608-DEV-741` | **migration: no** — `app/(dashboard)/calendar/**` (sub-slice of C2 phase 3), `styles/brand-tokens.css` | 2026-08-17 |
+| #741 | `dev/2608-DEV-741` | **migration: no** — `app/(dashboard)/components/tiles/*` (sub-slice of C2 phase 3), `styles/brand-tokens.css` | 2026-08-18 |
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,13 +6,12 @@ co-owner path — plus the two data defects that made its target population invi
 
 ## Now
 
-#741 C2 phase 2 merged as PR #755. Phase 3 (`app/(dashboard)/**`, 158 literals / 28 files) is too
-large for one PR, so it's sub-split by feature directory — one PR per directory. First sub-slice,
-`calendar/**`, BUILD complete on `dev/2608-DEV-741` (branch reset off `main` @ `8fa4c67` after
-phase 2's squash-merge). `/code-review low` running in background. Next action: address any
+#741 C2 phase 3, calendar sub-slice merged as PR #756. Second sub-slice, `components/tiles/*`,
+BUILD complete on `dev/2608-DEV-741` (branch reset off `main` @ `9f2d2c6` after the calendar
+slice's squash-merge). `/code-review low` running in background. Next action: address any
 findings, then push and open PR, wait for CI green + Vercel preview READY, do the manual light/dark
 390px check, then mark ready for review. Remaining phase 3 sub-slices (not started):
-`components/tiles/*`, `guides/` + `library/[slug]/`, `profile/*`, `roles/*`, `trips/*`,
+`guides/` + `library/[slug]/`, `profile/*`, `roles/*`, `trips/*`,
 `los/page.tsx` + `notifications/page.tsx`.
 
 ### #742 — what this branch does
@@ -119,6 +118,32 @@ value cannot serve a 200px card and a 19px badge. Now:
 `--radius-sm` is 2px (hairline). `--radius-md/lg/xl` are pinned to the control tier and
 `--radius-2xl` to the container tier as a **legacy landing zone**, so unmigrated code lands sanely —
 that is not a scale, and new code must use the named utilities.
+
+### #741 C2 phase 3 (tiles sub-slice) — what landed
+Commit `5752c78` on `dev/2608-DEV-741`, on top of `d96a7ef` (CLAIM), on top of `9f2d2c6`
+(the calendar sub-slice's squash-merge — branch was reset here, discarding its now-redundant
+local CLAIM/BUILD/fix/docs commits, all already captured in that squash).
+
+`app/(dashboard)/components/tiles/*` (ProfileTile, SocialsTile, TripHeroTile, CalendarTile)
+migrated; the other 9 tile files had no colour literals. Two new RGB-channel companion tokens in
+`styles/brand-tokens.css`: `--brand-parchment-rgb` (ProfileTile's `variant="teal"` card is a fixed
+fill in both themes, like phase 2's Footer forest fill — parchment-on-teal needed a composited
+alpha, not a swapped surface token) and `--brand-void-rgb` (SocialsTile's platform-badge/
+follow-link scrim sits over a user photo, also fixed both themes). Neither is mapped through
+`@theme inline` — confirmed by grep that the three existing companions
+(`--white-rgb`/`--brand-oyster-rgb`/`--brand-crimson-rgb`) aren't either; all four are consumed
+directly as CSS custom properties via `rgba(var(--x-rgb), α)`, never as Tailwind utility classes.
+
+SocialsTile's loading-skeleton `rgba(0,0,0,0.06)` was a real dark-mode bug (plain black is
+invisible on a dark card) — same failure class as phase 3 calendar's `FilterControls` bare
+`'white'` tab — now `var(--skeleton-base)`. TripHeroTile's `rgba(242,239,232,0.65)` doesn't
+exactly match `--brand-oyster-rgb` (240,237,230) — a 2-unit-per-channel drift, imperceptible —
+consolidated onto the existing token rather than adding a near-duplicate, same call as phase 1's
+drag-handle deviation.
+
+**Verified:** `npx tsc --noEmit` clean; `npx vitest run` 529 passed / 37 files (no regression);
+`npx eslint` on all changed files → 0 errors (3 pre-existing unrelated warnings). **NOT visually
+verified locally** — Vercel preview is the gate. `/code-review low` running in background.
 
 ### #741 C2 phase 3 (calendar sub-slice) — what landed
 Commit `bfa2c31` on `dev/2608-DEV-741`, on top of `a0d1582` (CLAIM).

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -26,6 +26,8 @@
   --white-rgb:        255, 255, 255;
   --brand-oyster-rgb: 240, 237, 230;
   --brand-crimson-rgb: 188, 71, 73;
+  --brand-parchment-rgb: 250, 248, 243;
+  --brand-void-rgb:   26, 31, 24;
 
   /* ── Primitive aliases — legacy callers use bare token names ── */
   --sienna: var(--brand-sienna);


### PR DESCRIPTION
## Summary
- Converts colour literals in `app/(dashboard)/components/tiles/*` (CalendarTile, ProfileTile, SocialsTile, TripHeroTile) to brand tokens, adding the needed token(s) to `styles/brand-tokens.css`
- Registers the C2 phase 3 tiles sub-slice CLAIM row and records progress in STATE.md

## Test plan
- [ ] CI green
- [ ] Vercel PR preview READY
- [ ] Visual check of dashboard tiles in light/dark mode at 390px

https://claude.ai/code/session_011D8YUQXzjrrvMHB9NQSAia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved color consistency across dashboard calendar, profile, social, and trip tiles.
  * Updated badges, loading placeholders, overlays, descriptions, and supporting text to follow the active brand theme.
  * Enhanced theme color handling for more consistent visual results, including translucent UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->