### PR TITLE
[2608-DEV-741] C2 phase 3 (guides+library): colour literals to tokens

### DIFF
--- a/app/(dashboard)/library/[slug]/components/GuideBody.tsx
+++ b/app/(dashboard)/library/[slug]/components/GuideBody.tsx
@@ -67,7 +67,7 @@ export default function GuideBody({
                   target="_blank"
                   rel="noopener noreferrer"
                   download
-                  className="flex items-center gap-3 px-4 py-3 rounded-xl border transition-all hover:bg-black/5"
+                  className="flex items-center gap-3 px-4 py-3 rounded-xl border transition-all hover:bg-hover-surface"
                   style={{ borderColor: 'var(--border-default)', textDecoration: 'none' }}
                 >
                   <AttachmentIcon type={att.file_type} />
@@ -84,7 +84,7 @@ export default function GuideBody({
 
       {/* Lightbox — triggered programmatically if needed in future */}
       <Dialog open={!!lightboxUrl} onOpenChange={open => { if (!open) setLightboxUrl(null) }}>
-        <DialogOverlay style={{ backgroundColor: 'rgba(0,0,0,0.85)' }} />
+        <DialogOverlay style={{ backgroundColor: 'var(--overlay-strong)' }} />
         <DialogContent
           className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-transparent border-none shadow-none p-0 max-w-[90vw] flex flex-col items-center gap-3 [&>button]:text-white [&>button]:opacity-100 [&>button]:bg-black/40 [&>button]:rounded-full [&>button]:p-1"
           aria-label="Image lightbox"

--- a/app/globals.css
+++ b/app/globals.css
@@ -100,6 +100,7 @@
   --color-link-hover:     var(--link-hover);
   --color-on-accent:      var(--on-accent);
   --color-overlay:        var(--overlay);
+  --color-overlay-strong: var(--overlay-strong);
   --color-hover-surface:  var(--hover-surface);
   --color-on-accent-hover: var(--on-accent-hover);
   --color-focus-ring:     var(--focus-ring);

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -6,5 +6,5 @@ Checked at CLAIM time (see `docs/guardrails/PROJECT.md` Workflow commands) befor
 
 | Issue | Branch | Files/areas | Claimed at |
 |---|---|---|---|
-| #741 | `dev/2608-DEV-741` | **migration: no** — `app/(dashboard)/components/tiles/*` (sub-slice of C2 phase 3), `styles/brand-tokens.css` | 2026-08-18 |
+| #741 | `dev/2608-DEV-741` | **migration: no** — `app/(dashboard)/guides/*` + `app/(dashboard)/library/[slug]/*` (sub-slice of C2 phase 3), `styles/brand-tokens.css` | 2026-08-18 |
 

--- a/styles/brand-tokens.css
+++ b/styles/brand-tokens.css
@@ -100,6 +100,13 @@
   /* Dialog and sheet scrims. */
   --overlay:         rgba(26, 31, 24, 0.40);
 
+  /* Image lightbox backdrop — flat black at fixed alpha regardless of theme.
+     Not --overlay: that's tuned to sit over a themed surface. Not
+     --image-scrim: that's a gradient sized for text over an unknown photo.
+     This darkens a photo itself, so no dark override is needed (see
+     --on-accent-hover for the same reasoning). */
+  --overlay-strong:  rgba(0, 0, 0, 0.85);
+
   /* Bottom-up scrim for text laid over a photo (image-hero tiles). Not
      --overlay: that is a flat sheet over a KNOWN surface, this is a gradient
      over an UNKNOWN photo, so it is sized for the worst case — a bright sky


### PR DESCRIPTION
## Summary
- Converts the colour literal in `app/(dashboard)/library/[slug]/components/GuideBody.tsx` (image lightbox scrim + hover surface) to tokens
- Adds `--overlay-strong` to `styles/brand-tokens.css` (+ Tailwind mapping in `app/globals.css`) for a flat, theme-invariant black backdrop over an unknown photo — distinct from `--overlay` (tuned to a themed surface) and `--image-scrim` (a gradient)
- `guides/GuidesClient.tsx` is a dead stub (redirected to `/library`); its only literal-scan hit was `PR #115` in a comment, no real change needed
- Registers the C2 phase 3 guides+library sub-slice CLAIM row

## Session State
**Status:** DONE
**Completed:**
- [x] `GuideBody.tsx` literals converted
- [x] `--overlay-strong` token added, WCAG N/A (flat black backdrop over a photo, not a text/surface pair)
- [x] `guides/` confirmed dead-code, no conversion needed
- [x] CI green (Authenticated E2E confirmed to have actually run its steps, not skipped)
- [x] Vercel preview READY, base page checked live at 390px dark mode — no regression
**Next:** remaining C2 phase 3 sub-slices — `profile/*`, `roles/*`, `trips/*`, `los/page.tsx` + `notifications/page.tsx`

## Test plan
- [x] CI green
- [x] Vercel PR preview READY
- [ ] Visual check of the guide attachment list + image lightbox — **not reachable**: DEV's only seeded guide (`e2e-smoke-guide`) has zero attachments, so the `hover-surface`/`overlay-strong` token paths aren't exercised by any live UI right now. Verified by code inspection instead (values preserved exactly: hover-surface matches the existing token, overlay-strong is a new token that keeps the original `rgba(0,0,0,0.85)` unchanged).
- [ ] Light-mode check — no in-app theme toggle exists (theme follows OS `prefers-color-scheme` via the pre-paint script); only dark mode was checked live this session.

https://claude.ai/code/session_011D8YUQXzjrrvMHB9NQSAia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved guide attachment hover styling for better theme consistency.
  * Updated image lightbox backdrops with a consistent, high-contrast overlay across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->